### PR TITLE
refactor(server): D1.5 — single-input unroll of #singleAttemptCommit

### DIFF
--- a/packages/server/src/log-conflict-adoption.test.ts
+++ b/packages/server/src/log-conflict-adoption.test.ts
@@ -20,7 +20,6 @@ const makeEntry = (overrides: Partial<LogEntry> = {}): LogEntry => ({
 const ctxOf = (parts: Partial<AdoptionContext>): AdoptionContext => ({
   self: makeEntry(),
   existing: makeEntry(),
-  batchSize: 1,
   ...parts,
 });
 
@@ -54,22 +53,6 @@ describe("tryAdoptOwnSessionLogEntry", () => {
     expect(decision).toEqual({ adopt: false, reason: "wrong-seq" });
   });
 
-  test("clause (3) fails: batched commit → reject with reason 'batch'", () => {
-    const decision = tryAdoptOwnSessionLogEntry(ctxOf({ batchSize: 2 }));
-    expect(decision).toEqual({ adopt: false, reason: "batch" });
-  });
-
-  test("clause (3) is checked first — batch + foreign session still reports 'batch'", () => {
-    // Evaluation order matters for the patent-disclosure narrative:
-    // a batched commit must NEVER reach the field comparison, so
-    // even a same-session same-seq existing entry inside a batch
-    // surfaces as 'batch' (not as adopt: true).
-    const decision = tryAdoptOwnSessionLogEntry(
-      ctxOf({ batchSize: 2, existing: makeEntry({ session: SESSION_B }) }),
-    );
-    expect(decision).toEqual({ adopt: false, reason: "batch" });
-  });
-
   test("clause (1) is checked before clause (2)", () => {
     // Foreign session + wrong seq → reason MUST be 'foreign-session'.
     // Documents the precedence so a future refactor can't silently
@@ -78,13 +61,5 @@ describe("tryAdoptOwnSessionLogEntry", () => {
       ctxOf({ existing: makeEntry({ session: SESSION_B, seq: 99 }) }),
     );
     expect(decision).toEqual({ adopt: false, reason: "foreign-session" });
-  });
-
-  test("batchSize: 0 (empty inputs, defensive) → reject with reason 'batch'", () => {
-    // The single-input commit path never reaches this helper with a
-    // batchSize other than 1, but the helper itself MUST refuse a
-    // non-1 batchSize unconditionally.
-    const decision = tryAdoptOwnSessionLogEntry(ctxOf({ batchSize: 0 }));
-    expect(decision).toEqual({ adopt: false, reason: "batch" });
   });
 });

--- a/packages/server/src/log-conflict-adoption.ts
+++ b/packages/server/src/log-conflict-adoption.ts
@@ -19,7 +19,7 @@
  *
  * ## Soundness invariant
  *
- * Adoption is sound iff all four hold:
+ * Adoption is sound iff all three hold:
  *
  *   1. **Same session.** `existing.session === self.session`. The
  *      session id is a per-commit, in-RAM-only secret minted at
@@ -36,16 +36,15 @@
  *      Same session + same seq alone is not sufficient: a collision,
  *      test seam, or out-of-model bucket writer must not be able to
  *      make this writer adopt a different logical mutation.
- *   4. **Single-input commit.** `self.batchSize === 1`. Every
- *      commit is single-input now, so this always holds; the guard
- *      is retained as a defensive invariant (its removal is the
- *      deferred follow-up tracked as D1.5). It is sound only for a single-input
- *      commit because per-input adoption decisions would not
- *      compose with the single-key single-write commit (the one
- *      `log/<seq>` create is the all-or-nothing commit point).
  *
- * When any of (1)/(2)/(3)/(4) fails, the caller MUST refuse adoption
+ * When any of (1)/(2)/(3) fails, the caller MUST refuse adoption
  * and treat the occupant as a conflicting committed entry.
+ *
+ * A fourth precondition — single-input commit — is now structural,
+ * not a runtime check: `#singleAttemptCommit` takes one `CommitInput`,
+ * so a multi-input commit is unrepresentable. It matters because the
+ * single `log/<seq>` create is the all-or-nothing commit point, so
+ * per-input adoption decisions could not compose.
  *
  * ## Threat model
  *
@@ -55,7 +54,7 @@
  * bucket. The adversary may NOT (d) read the writer's local RAM
  * and therefore cannot learn the per-commit `session` id before
  * observing the writer's own `/log/<seq>.json` PUT. Under these
- * constraints, conditions (1)+(2)+(3)+(4) close every attack path in
+ * constraints, conditions (1)+(2)+(3) close every attack path in
  * the adversarial-replay property test
  * (`tests/integration/log-conflict-adversarial.test.ts`).
  *
@@ -72,7 +71,7 @@
  * commit-protocol skeleton. SlateDB's scenario 3 — "conflicting SST
  * has same `writer_epoch` as me" — is explicitly labelled an
  * **illegal state that should panic**. The three-clause adoption
- * decision encoded here (same session ∧ matching seq ∧ matching intent ∧ single-input)
+ * decision encoded here (same session ∧ matching seq ∧ matching intent)
  * recognises that case as the writer's own prior in-flight attempt
  * and adopts it as success rather than aborting, closing the recovery
  * gap SlateDB leaves to operator intervention.
@@ -106,14 +105,6 @@ export interface AdoptionContext {
    * function is pure, no I/O).
    */
   readonly existing: LogEntry;
-  /**
-   * Input count of the parent commit attempt. Always `1` now —
-   * `Writer.commit` is the only commit path and is single-input.
-   * Adoption is only safe when this is exactly `1`; the field is
-   * retained as a defensive invariant (removing it is the deferred
-   * follow-up tracked as D1.5).
-   */
-  readonly batchSize: number;
 }
 
 /**
@@ -129,7 +120,7 @@ export type AdoptionDecision =
   | { readonly adopt: true; readonly entry: LogEntry }
   | {
       readonly adopt: false;
-      readonly reason: "foreign-session" | "wrong-seq" | "intent-mismatch" | "batch";
+      readonly reason: "foreign-session" | "wrong-seq" | "intent-mismatch";
     };
 
 /**
@@ -151,12 +142,6 @@ export type AdoptionDecision =
  * @see The soundness invariant in this module's header docstring.
  */
 export const tryAdoptOwnSessionLogEntry = (ctx: AdoptionContext): AdoptionDecision => {
-  // Clause (4) — single-input commit. Always holds now (every commit
-  // is single-input); evaluated first as a defensive guard before any
-  // field comparison.
-  if (ctx.batchSize !== 1) {
-    return { adopt: false, reason: "batch" };
-  }
   // Clause (1) — same session.
   if (ctx.existing.session !== ctx.self.session) {
     return { adopt: false, reason: "foreign-session" };

--- a/packages/server/src/writer.ts
+++ b/packages/server/src/writer.ts
@@ -344,7 +344,7 @@ export class Writer {
     for (let attempt = 1; attempt <= this.#maxRetries; attempt++) {
       let success: SingleAttemptSuccess;
       try {
-        success = await this.#singleAttemptCommit([input], session, logPrefix, "Writer");
+        success = await this.#singleAttemptCommit(input, session, logPrefix, "Writer");
       } catch (error) {
         // Only a retryable `Conflict` (see NOTE above — currently none)
         // backs off and retries. Anything else propagates.
@@ -381,9 +381,8 @@ export class Writer {
    * (single-write commit; no `current.json` CAS follows it). Stale index
    * keys are DELETE'd after the commit. Returns the success payload.
    *
-   * Called only as `#singleAttemptCommit([input], …)`: the array shape
-   * is retained dead-generality (D1.5), but every call commits exactly
-   * one entry.
+   * Commits exactly one {@link CommitInput} — the numbered log create is
+   * the single linearization point per call.
    *
    * A log-create 412 is disambiguated by session read-back: own session
    * / own seq ⇒ our crashed-or-lost-ack commit is already durable ⇒
@@ -404,7 +403,7 @@ export class Writer {
    * committed doc — is never produced.
    */
   async #singleAttemptCommit(
-    inputs: readonly CommitInput[],
+    input: CommitInput,
     session: string,
     logPrefix: string,
     errorPrefix: string,
@@ -460,17 +459,16 @@ export class Writer {
     const commitNowMs = Date.now();
     const commitTs = new Date(commitNowMs).toISOString();
     const lsnTimestamp = timestamp(commitNowMs);
-    const input0 = inputs[0]!;
     const mintEntry = (atSeq: number): LogEntry => ({
       lsn: `${lsnTimestamp}_${session}_${countKey(atSeq)}`,
       commit_ts: commitTs,
-      op: input0.op,
-      collection: input0.collection,
-      doc_id: input0.docId,
+      op: input.op,
+      collection: input.collection,
+      doc_id: input.docId,
       session,
       seq: atSeq,
-      ...(input0.op !== "D" && input0.body !== undefined ? { after: input0.body } : {}),
-      ...(input0.origin !== undefined ? { origin: input0.origin } : {}),
+      ...(input.op !== "D" && input.body !== undefined ? { after: input.body } : {}),
+      ...(input.origin !== undefined ? { origin: input.origin } : {}),
     });
     let entry = mintEntry(seq);
 
@@ -499,16 +497,35 @@ export class Writer {
     let contentPutCount = 0;
     let newKeysClassA = 0;
     const parallelPuts: Array<Promise<unknown>> = [];
-    for (const input of inputs) {
-      if (input.op !== "D" && input.body !== undefined) {
-        contentPutCount++;
-        const bytes = encodeJsonBytes(input.body);
-        const version = await versionFromContent(bytes);
-        const contentKey = `${logPrefix}/content/${version}.json`;
-        assertKeyWithinLimit(contentKey);
+    if (input.op !== "D" && input.body !== undefined) {
+      contentPutCount++;
+      const bytes = encodeJsonBytes(input.body);
+      const version = await versionFromContent(bytes);
+      const contentKey = `${logPrefix}/content/${version}.json`;
+      assertKeyWithinLimit(contentKey);
+      parallelPuts.push(
+        this.#storage
+          .put(contentKey, bytes, { ifNoneMatch: "*", contentType: APPLICATION_JSON })
+          .catch((error: unknown) => {
+            this.#observe429(error, input.collection);
+            if (isPreconditionFailed(error)) {
+              return;
+            }
+            throw error;
+          }),
+      );
+    }
+    // Additive index keys for the NEW value — emitted before the
+    // commit on I/U (a D has no new value). `op:"D"` and a missing
+    // body project to no keys. Empty `#indexes` short-circuits.
+    if (this.#indexes.length > 0 && input.op !== "D") {
+      const newKeys = allIndexKeysFor(logPrefix, this.#indexes, input.body, input.docId);
+      for (const k of newKeys) {
+        assertKeyWithinLimit(k);
+        newKeysClassA++;
         parallelPuts.push(
           this.#storage
-            .put(contentKey, bytes, { ifNoneMatch: "*", contentType: APPLICATION_JSON })
+            .put(k, EMPTY_BODY, { ifNoneMatch: "*", contentType: APPLICATION_JSON })
             .catch((error: unknown) => {
               this.#observe429(error, input.collection);
               if (isPreconditionFailed(error)) {
@@ -517,27 +534,6 @@ export class Writer {
               throw error;
             }),
         );
-      }
-      // Additive index keys for the NEW value — emitted before the
-      // commit on I/U (a D has no new value). `op:"D"` and a missing
-      // body project to no keys. Empty `#indexes` short-circuits.
-      if (this.#indexes.length > 0 && input.op !== "D") {
-        const newKeys = allIndexKeysFor(logPrefix, this.#indexes, input.body, input.docId);
-        for (const k of newKeys) {
-          assertKeyWithinLimit(k);
-          newKeysClassA++;
-          parallelPuts.push(
-            this.#storage
-              .put(k, EMPTY_BODY, { ifNoneMatch: "*", contentType: APPLICATION_JSON })
-              .catch((error: unknown) => {
-                this.#observe429(error, input.collection);
-                if (isPreconditionFailed(error)) {
-                  return;
-                }
-                throw error;
-              }),
-          );
-        }
       }
     }
     await Promise.all(parallelPuts);
@@ -602,7 +598,7 @@ export class Writer {
       const decision = tryAdoptOwnSessionLogEntry({
         self: entry,
         existing,
-        batchSize: inputs.length,
+        batchSize: 1,
       });
       if (decision.adopt) {
         // Own crashed/lost-ack commit already durable at `seq`. Adopt it
@@ -657,8 +653,7 @@ export class Writer {
     // The pre-image is read at the RESOLVED committing `seq` (Step 5
     // may have advanced `seq` past a foreign winner): `#readPreImage`
     // back-walks from `seq - 1`, so it skips the just-committed entry
-    // and finds the prior same-doc image. For a same-`docId` input
-    // earlier in this batch the in-batch image takes precedence.
+    // and finds the prior same-doc image.
     //
     // Filter-aware projection (T4): `allIndexKeysFor` short-circuits on
     // `def.predicate` miss. The diff `oldKeys \ newKeys` covers all four
@@ -667,7 +662,7 @@ export class Writer {
     // pinned by a named test in `writer.test.ts` ("Writer — filtered
     // index").
     const staleKeysClassA = await this.#cleanupStaleIndexKeysBestEffort({
-      inputs,
+      input,
       logPrefix,
       seq,
     });
@@ -676,7 +671,7 @@ export class Writer {
     const indexClassA = newKeysClassA + staleKeysClassA;
     if (this.#indexes.length > 0 && indexClassA > 0) {
       ctxMetrics().histogram("db.write.index_ops_per_logical_write", indexClassA, {
-        collection: input0.collection,
+        collection: input.collection,
       });
     }
 
@@ -818,7 +813,7 @@ export class Writer {
   }
 
   async #cleanupStaleIndexKeysBestEffort(args: {
-    inputs: readonly CommitInput[];
+    input: CommitInput;
     logPrefix: string;
     seq: number;
   }): Promise<number> {
@@ -826,54 +821,52 @@ export class Writer {
       return 0;
     }
 
-    let staleKeysClassA = 0;
-    const indexDeletes: Array<Promise<unknown>> = [];
-    // Per-docId in-batch image map: a later input on the same docId
-    // reads the in-batch pre-image, not the on-disk one.
-    const inBatchImage = new Map<string, DocumentData | undefined>();
-    for (const input of args.inputs) {
-      let staleKeys: readonly string[] = [];
-      try {
-        if (input.op === "U") {
-          const preImage = inBatchImage.has(input.docId)
-            ? inBatchImage.get(input.docId)
-            : await this.#readPreImage(args.logPrefix, input.collection, input.docId, args.seq);
-          const oldKeys = allIndexKeysFor(args.logPrefix, this.#indexes, preImage, input.docId);
-          const newSet = new Set(
-            allIndexKeysFor(args.logPrefix, this.#indexes, input.body, input.docId),
-          );
-          staleKeys = oldKeys.filter((k) => !newSet.has(k));
-        } else if (input.op === "D") {
-          const preImage = inBatchImage.has(input.docId)
-            ? inBatchImage.get(input.docId)
-            : await this.#readPreImage(args.logPrefix, input.collection, input.docId, args.seq);
-          staleKeys = allIndexKeysFor(args.logPrefix, this.#indexes, preImage, input.docId);
-        }
-      } catch {
-        ctxMetrics().counter("db.write.index_cleanup_errors_total", 1, {
-          collection: input.collection,
-          step: "pre-image-read",
-        });
-        inBatchImage.set(input.docId, input.op === "D" ? undefined : input.body);
-        continue;
-      }
-
-      // (op:"I" has no pre-image → no stale keys.)
-      for (const k of staleKeys) {
-        indexDeletes.push(
-          this.#storage.delete(k).catch(() => {
-            ctxMetrics().counter("db.write.index_cleanup_errors_total", 1, {
-              collection: input.collection,
-              step: "delete",
-            });
-          }),
+    const { input } = args;
+    let staleKeys: readonly string[] = [];
+    try {
+      if (input.op === "U") {
+        const preImage = await this.#readPreImage(
+          args.logPrefix,
+          input.collection,
+          input.docId,
+          args.seq,
         );
+        const oldKeys = allIndexKeysFor(args.logPrefix, this.#indexes, preImage, input.docId);
+        const newSet = new Set(
+          allIndexKeysFor(args.logPrefix, this.#indexes, input.body, input.docId),
+        );
+        staleKeys = oldKeys.filter((k) => !newSet.has(k));
+      } else if (input.op === "D") {
+        const preImage = await this.#readPreImage(
+          args.logPrefix,
+          input.collection,
+          input.docId,
+          args.seq,
+        );
+        staleKeys = allIndexKeysFor(args.logPrefix, this.#indexes, preImage, input.docId);
       }
-      staleKeysClassA += staleKeys.length;
-      inBatchImage.set(input.docId, input.op === "D" ? undefined : input.body);
+    } catch {
+      ctxMetrics().counter("db.write.index_cleanup_errors_total", 1, {
+        collection: input.collection,
+        step: "pre-image-read",
+      });
+      return 0;
+    }
+
+    // (op:"I" has no pre-image → no stale keys.)
+    const indexDeletes: Array<Promise<unknown>> = [];
+    for (const k of staleKeys) {
+      indexDeletes.push(
+        this.#storage.delete(k).catch(() => {
+          ctxMetrics().counter("db.write.index_cleanup_errors_total", 1, {
+            collection: input.collection,
+            step: "delete",
+          });
+        }),
+      );
     }
     await Promise.all(indexDeletes);
-    return staleKeysClassA;
+    return staleKeys.length;
   }
 
   /**

--- a/packages/server/src/writer.ts
+++ b/packages/server/src/writer.ts
@@ -598,7 +598,6 @@ export class Writer {
       const decision = tryAdoptOwnSessionLogEntry({
         self: entry,
         existing,
-        batchSize: 1,
       });
       if (decision.adopt) {
         // Own crashed/lost-ack commit already durable at `seq`. Adopt it

--- a/tests/integration/log-conflict-forgery.test.ts
+++ b/tests/integration/log-conflict-forgery.test.ts
@@ -78,7 +78,6 @@ const makeEntry = (overrides: Partial<LogEntry> = {}): LogEntry => ({
 const ctxOf = (parts: Partial<AdoptionContext>): AdoptionContext => ({
   self: makeEntry(),
   existing: makeEntry(),
-  batchSize: 1,
   ...parts,
 });
 
@@ -138,7 +137,6 @@ describe("C2 session-id-unguessability under ForgeryStorage adversary", () => {
           const decision = tryAdoptOwnSessionLogEntry({
             self,
             existing: forged,
-            batchSize: 1,
           });
           return decision.adopt === false && decision.reason === "foreign-session";
         },


### PR DESCRIPTION
## What

Removes the dead multi-input generality from the commit fence, left behind when **D1** removed `Db.transaction` / `Writer.commitBatch`. `commit()` is the sole caller and always commits exactly one doc, so the array-shaped commit path and the always-true `batchSize` adoption clause were unreachable ceremony on the kernel's most safety-critical code.

Behavior-preserving by construction — the array path was already correct for N=1; this makes N=1 the only representable shape.

## Commits

1. **`bb7edb70` unroll `#singleAttemptCommit` to a single `CommitInput`** — collapses `readonly CommitInput[]` → `CommitInput` on `#singleAttemptCommit` + `#cleanupStaleIndexKeysBestEffort`; drops the two `for (const input of inputs)` loops and the per-docId `inBatchImage` pre-image map (at N=1 the pre-image is always `#readPreImage(...)`). Return shape (`CommitResult.entries`) stays an array.
2. **`cb7c8604` drop the always-true `batchSize` adoption clause** — after commit 1 the writer passed `batchSize: 1` as a hardcoded literal, so `ctx.batchSize !== 1` guarded a caller-fixed constant (dead code, not a backstop). Removes `AdoptionContext.batchSize`, the guard, and the `"batch"` reason; adoption now rests on three runtime clauses (same session ∧ matching seq ∧ matching intent). Soundness header rewritten 4→3 clauses, with single-input noted as the **structural** fourth precondition. Three `"batch"`-reason unit tests deleted (they asserted an unrepresentable state).

D1.5 citations / dead-generality comments were scrubbed inline as each block was rewritten (no separate docs commit needed).

## Verification

| Gate | Result |
|---|---|
| `verify:agent` + `verify:docs` | ✅ |
| `build` + `test:agent` | ✅ 2149 pass (−3 = deleted batch tests) |
| Bundle budgets | ✅ shrinking (e.g. `index.js` raw −814) |
| Crash fuzzer `test:fuzz-phase5` @ `FC_NUM_RUNS=1000` | ✅ 17 pass |
| Property fuzzer `test:randomize` | ✅ 2149 pass, 0 failed |
| Adversarial adoption + forgery | ✅ 14 pass |
| Cloudflare cascade `test:adapter-cloudflare` | ✅ 111 pass |
| Minio cascade | ⊘ gated out (no Docker in this env) — run `pnpm test:minio` with `pnpm dev:storage` up before merge if desired |

## ⚠️ Patent touch-point (owner's call — not edited here)

`docs/spec/prior-art.md` and the disclosure describe the C2 adoption test as a **four-clause runtime check**, clause (4) being "single-input commit shape." This PR shifts clause (4) from a runtime `batchSize` guard to a **type-level invariant** of the `CommitInput` signature. The adoption *property* is unchanged, and the decision is byte-identical for every reachable input. Wording may want a tweak from "runtime check" to "structural invariant." Owner-gated docs were deliberately left untouched.