### PR TITLE
docs: launch-readiness README restructure + ADR/spec accuracy pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,65 +2,31 @@
 
 **No database server. No daemon. No database runtime. Just your app and a bucket.**
 
-baerly-storage targets software real enough to need shared state, but
-not yet important enough to deserve a database service, migration stack,
-pager rotation, and idle bill. It is not a database service whose
-storage layer happens to be S3. It is a bucket layout and commit
-protocol for turning AWS S3 or Cloudflare R2 into a document database,
-plus a TypeScript library that applies that protocol from your app.
-
-baerly-storage runs wherever the bucket credentials safely live. For a
-browser-facing app, that is usually a Worker, Node server, or
-Lambda-style handler. The handler is trusted app code: it handles auth,
-validates writes, and applies the protocol. The bucket is the durable
-state. When the request ends, baerly-storage is gone. The bucket
-remains.
-
 ```text
-before: browser -> app handler -> database server
-after:  browser -> app handler with baerly-storage -> S3/R2 bucket
+before: browser → app handler → database  (a server)
+after:  browser → app handler → bucket    (just storage)
 ```
 
-No lock table, catalog, mandatory scheduler, connection pool, resident
-compactor, or idle database bill.
+A document database that _is_ an S3 or Cloudflare R2 bucket — no server
+to run, no idle bill, no migration stack. baerly-storage runs wherever
+the bucket credentials safely live: a Worker, a Node server, a
+Lambda-style handler. When the request ends, baerly-storage is gone. The
+bucket remains.
 
-A bucket can store objects; it cannot run a transaction coordinator.
-The hard part is the commit: one writer must win, and every reader must
-be able to tell what won. [S3's strong consistency][s3-strong] makes
-object storage usable as shared state; conditional writes supply the
-one-writer-wins operation.
+- **An API an LLM can use first try.** No DDL, no raw SQL — 8 verbs and
+  a ~12k-token API surface that fits in context.
+- **Idle rounds to zero.** No $5/mo floors across a fleet of small
+  internal tools. ~$18/mo all-in on R2 at a sustained 30 writes/min.
+- **No exit tax.** `baerly export --target=postgres` dumps any
+  collection to SQL. Crossing the envelope is the success signal, not a
+  hostage situation.
+- **Built like git** — content-addressed documents, an immutable
+  numbered log, one conditional log create as the commit, per collection.
 
-Concretely, a collection is a table-like set of JSON documents. Each
-collection has content-addressed documents, immutable numbered log
-entries, and rolled-up snapshots. A write prepares the document and
-lookup objects, then tries to create the next log entry with a
-create-if-absent write. That create is the commit. If two writers race,
-one claims the log slot; the loser reads the winner and tries the next
-empty slot. Reads fold snapshot + committed log entries into rows.
-
-[s3-strong]: https://aws.amazon.com/blogs/aws/amazon-s3-update-strong-read-after-write-consistency/
-
-This repo ships TypeScript for Worker and Node apps, but the idea is a
-protocol, not a JavaScript-only database. Only the TypeScript
-implementation ships today; another language could speak the same
-protocol by writing the same bucket layout and using the same
-conditional-write rules. The hot write path is one exactly-one-winner
-conditional log create per collection. The full storage contract also
-needs strong read/list consistency and `If-Match` compare-and-swap for
-compaction. AWS S3 and Cloudflare R2 are the supported production
-backends; other S3-compatible endpoints need a green
-`baerly doctor --bucket=<uri>` and owner validation. See
-[`storage-compatibility.md`](./docs/spec/storage-compatibility.md).
-
-Bundle gzip budgets stay small: the Node HTTP closure is 99 KiB, the
-Cloudflare closure is 117 KiB, the base browser client is 6 KiB, and
-the React hooks are 9 KiB. The whole public API fits in a single
-~12k-token `dist/API.md` — small enough that a human or an LLM can hold
-the surface in context.
-
-Most teams already have approved object storage for exports, backups,
-and archives. The security review happened years ago; the budget
-exists.
+<!-- Hero demo: render `docs/assets/demo.gif` from `docs/assets/demo.tape`
+     (`vhs docs/assets/demo.tape`) against a real bucket, then uncomment:
+![baerly-storage in 15 seconds — write a row, then list the bucket](./docs/assets/demo.gif)
+-->
 
 ## Quick start
 
@@ -69,25 +35,35 @@ pnpm create @gusto/baerly-storage@latest -- my-app --target=cloudflare --starter
 cd my-app && pnpm install && pnpm dev
 ```
 
-For the Cloudflare target, `pnpm dev` boots Vite + workerd on `:5173`,
-so `/v1/*` and the React UI share one origin. No S3 creds are needed
-in development.
-
-For Node, scaffold with `--target=node --starter=react`; `pnpm dev`
-also runs on `:5173` through Vite middleware over `LocalFsStorage`.
-Production uses `pnpm start` to run the Node listener on any Node 24+
-host with bucket credentials in its environment — Railway, Render, Fly,
-Docker, bare VMs, on-prem boxes.
+For the Cloudflare target, `pnpm dev` boots Vite + workerd on `:5173`, so
+`/v1/*` and the React UI share one origin — no S3 creds needed in
+development. For Node, scaffold with `--target=node --starter=react`;
+`pnpm dev` runs on `:5173` through Vite middleware over `LocalFsStorage`,
+and `pnpm start` runs the Node listener on any Node 24+ host with bucket
+credentials in its environment — Railway, Render, Fly, Docker, bare VMs.
 
 For a runnable multi-tab demo see
 [`examples/react-node/`](./examples/react-node); for the full set of
 production-shaped scaffolds see [`examples/`](./examples).
 
-## What changes
+## In code
+
+The scaffolds wire `db` on the server and `useQuery` in React; the calls
+look like this:
+
+```ts
+// server — writes land in your object-storage bucket
+await db.collection("tickets").insert({ title: "Onboard Alex", status: "open" });
+
+// client — reactive across every open tab
+const open = useQuery((c) => c.collection("tickets").where({ status: "open" }).all(), []);
+// open.status → "loading" | "refreshing" | "ok" | "skipped" | "error"
+// open.data is present for "ok" / "refreshing"
+```
 
 You keep the request handler, auth boundary, bucket binding or
 credentials, and any frontend you already had. The database service goes
-away.
+away:
 
 ```diff
 - docker-compose.yml
@@ -109,24 +85,42 @@ away.
 + });
 ```
 
-Your data lives in your bucket. Ordinary schema shape changes are
-TypeScript or config edits — no DDL, no SQL strings, no generated
-migration ceremony.
+Ordinary schema shape changes are TypeScript or config edits — no DDL, no
+SQL strings, no generated migration ceremony.
 
-## In code
+## How it works
 
-The scaffolds wire `db` on the server and `useQuery` in React; the
-calls look like this:
+**Built like git: content-addressed documents, immutable numbered log
+entries, and one conditional log create as the commit, per collection.**
 
-```ts
-// server — writes land in your object-storage bucket
-await db.collection("tickets").insert({ title: "Onboard Alex", status: "open" });
+A bucket can store objects; it cannot run a transaction coordinator. The
+hard part is the commit: one writer must win, and every reader must be
+able to tell what won. [S3's strong consistency][s3-strong] makes object
+storage usable as shared state; conditional writes supply the
+one-writer-wins operation.
 
-// client — reactive across every open tab
-const open = useQuery((c) => c.collection("tickets").where({ status: "open" }).all(), []);
-// open.status → "loading" | "refreshing" | "ok" | "skipped" | "error"
-// open.data is present for "ok" / "refreshing"
-```
+A bucket cannot run a database server, but it _can_ atomically create one
+object. A write drops new immutable objects in the bucket and then
+atomically creates the next numbered log entry for that collection —
+using S3's create-if-absent (`If-None-Match`) so two writers can't claim
+the same slot; the loser reads the winner and retries at the next slot.
+That create _is_ the commit. A read follows `current.json` to the
+snapshot and folds the committed log tail into rows.
+
+Each collection has its own ordered log, so **writes are per-collection
+linearizable** — the `If-None-Match` log create linearizes every commit.
+Cross-collection writes are unordered and non-atomic; that boundary is
+part of the contract (see [When (not) to use it](#when-not-to-use-it)).
+
+This repo ships TypeScript for Worker and Node apps, but the idea is a
+protocol, not a JavaScript-only database: another language could speak it
+by writing the same bucket layout and using the same conditional-write
+rules. AWS S3 and Cloudflare R2 are the supported production backends;
+other S3-compatible endpoints need a green `baerly doctor --bucket=<uri>`
+and owner validation. See
+[`storage-compatibility.md`](./docs/spec/storage-compatibility.md).
+
+[s3-strong]: https://aws.amazon.com/blogs/aws/amazon-s3-update-strong-read-after-write-consistency/
 
 ## Cheat sheet
 
@@ -147,52 +141,66 @@ db.collection("tickets").where({ status: "closed" }).delete();
 | Surface       | Vocabulary                                                                            |
 | ------------- | ------------------------------------------------------------------------------------- |
 | **Verbs**     | `first` `all` `count` `get` · `insert` `update` `replace` `delete`                    |
-| **Modifiers** | `where` `order` `limit`                                                               |
-| **Operators** | `eq` `gt` `gte` `lt` `lte` `in`                                                       |
+| **Modifiers** | `where` `order` `limit`                                                                |
+| **Operators** | `eq` `gt` `gte` `lt` `lte` `in`                                                        |
 | **Errors**    | one `BaerlyError`, discriminate by `.code` (`Conflict`, `NotFound`, `SchemaError`, …) |
 
-Full reference: [`docs/guide/cheatsheet.md`](./docs/guide/cheatsheet.md), or
-`cat node_modules/@gusto/baerly-storage/dist/API.md` in an installed app.
+Full reference: [`docs/guide/cheatsheet.md`](./docs/guide/cheatsheet.md),
+or `cat node_modules/@gusto/baerly-storage/dist/API.md` in an installed
+app.
 
-## Why?
+## When (not) to use it
 
-- **An API an LLM can use first try.** No DDL. No raw SQL.
-  Discriminated string errors. Provisioning is `pnpm install`, not a
-  cloud-console detour. The vocabulary is intentionally small enough to
-  hold in context.
-- **Idle rounds to zero.** No $5/mo floors multiplied across small
-  internal tools and low-traffic apps. There is no per-app database
-  service bill; the request-handler work is a rounding error against
-  the bucket.
-- **Mechanical graduation.** Per-collection snapshot export is shipped:
-  `baerly export --target=postgres` with `--bucket=<uri>`,
-  `--app=<app>`, `--tenant=<tenant>`, and `--collection=<name>` dumps a
-  collection to SQL — run it per collection to hand off a whole app. Log
-  entries already carry a change-data-capture (CDC) envelope with
-  Debezium-style field names, so an incremental CDC exit stays
-  mechanical. That format may narrow before the first production
-  consumer; after that, incompatible changes require a major version.
-  The incremental exporter itself is future work.
-- **Honest about its envelope.** ~30 writes/min/collection sustained
-  (throughput ceiling), ~100 collections/tenant (soft fan-out guideline —
-  cost grows linearly, not a cliff), >10 GB/tenant stored (R2 free-tier
-  storage line — a cost signal, not a protocol ceiling). Here, a tenant is
-  one isolated app/customer namespace; a collection is a table-like document
-  set. At M-size (~30 writes/min) the projected cost is ~$18/mo on R2. See
-  [workload-fit.md](./docs/about/workload-fit.md#scale-at-a-glance) for the
-  full envelope table.
-  Crossing any of those is the success signal to graduate.
+Before you count rows or price reads, ask one question:
+
+> Can the app's most important screen be answered from one collection?
+
+If yes, baerly-storage fits. A todo list, a single board's kanban, an
+event's RSVPs, one channel's chat — each maps to one collection. If the
+core screen is a view _across_ many collections, users, or tenants ("my
+pull requests," "all code search," a cross-org dashboard), baerly-storage
+should not be the only query engine for it.
+
+It is **deliberately not** a few things:
+
+- **No SQL, no joins.** Equality + dotted-path predicates, operators
+  added one at a time. The small surface is part of the contract.
+- **Not a D1 / Postgres replacement.** Those are graduation targets, not
+  competitors — baerly-storage keeps the experiment cheap until you know
+  whether it's worth graduating.
+- **Browser-direct multi-writer is out.** Trusted server-side app code is
+  the design center.
+- **Realtime is long-poll first.** Polling is always correct; a WebSocket
+  tier would be a future opt-in.
+
+### Scale at a glance
+
+| Dimension           | Number                                                                                                                  | Notes                                                                                                                              |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Shape               | 1 important screen = 1 collection                                                                                       | The fit test above; fails before size matters                                                                                     |
+| Throughput          | ~30 writes/min/collection sustained                                                                                     | M-size operating point — model/estimate, pending real-infra measurement on Cloudflare R2                                          |
+| Per-collection size | ~100–500 docs (~512 KB snapshot) before compaction defers on CF free                                                    | A fold fits the free-tier CPU budget at ~512 KB; erosion, not a cliff — model/estimate, pending real CF-isolate measurement       |
+| Fan-out             | ~100 collections/tenant (soft guideline)                                                                                | Bench-grounded linear cost (`pnpm bench:collection-fanout`); nothing in the protocol enforces a cap — cost grows linearly with N   |
+| Storage             | >10 GB/tenant stored = R2 free-tier boundary                                                                            | A cost line, not a protocol ceiling; billing begins above 10 GB-mo on R2                                                          |
+| Cost                | ~$18/mo all-in on R2 (~$13 object-storage ops + $5 Workers Paid floor), ~$26/mo on S3 at M-size                         | At ~30 writes/min/collection; `baerly cost` projects the object-storage-ops portion only (no platform floor)                       |
+
+**Graduation is the success path, not a failure mode.** Crossing any of
+these is the signal to graduate the workload — `baerly export
+--target=postgres` makes the exit mechanical. See
+[workload-fit.md](./docs/about/workload-fit.md) for the shape test and
+[graduation.md](./docs/about/graduation.md) for the full envelope.
 
 ## Go deeper
 
-- 🧭 **How it works** — [`docs/about/how-it-works.md`](./docs/about/how-it-works.md)
-  (bucket + conditional log create)
+- 🧭 **How it works** —
+  [`docs/about/how-it-works.md`](./docs/about/how-it-works.md) (bucket +
+  conditional log create)
 - 🧱 **Product thesis** — [`docs/about/thesis.md`](./docs/about/thesis.md)
-- 🏗️ **Architecture** — [`docs/contributing/architecture.md`](./docs/contributing/architecture.md)
+- 🏗️ **Architecture** —
+  [`docs/contributing/architecture.md`](./docs/contributing/architecture.md)
 - 🔧 **Embed by hand** —
-  [`packages/server/API.md`](./packages/server/API.md) (the
-  embed-by-hand + custom-routes recipes — `baerlyNode().fetch` is the
-  canonical shape; ships as `dist/API.md` in the package)
+  [`packages/server/API.md`](./packages/server/API.md) (embed-by-hand +
+  custom-routes recipes; ships as `dist/API.md` in the package)
 
 ## Where things live
 

--- a/docs/about/thesis.md
+++ b/docs/about/thesis.md
@@ -103,7 +103,9 @@ The criteria the rest of this document is shaped around:
      paths not type-check. The additive-only lock on the public
      surface is codified in
      [ADR-002](../adr/002-api-surface-lock.md), which scopes
-     "additive" to _capabilities_, not _forms_.
+     "additive" to _capabilities_, not _forms_. The lock is soft
+     until v1.0 — removals are allowed only through the staged
+     deprecation lifecycle in that ADR, never as a silent break.
 5. **No DDL.** The moment the loop requires `CREATE TABLE`, "invent
    and preserve a schema across edits" is inserted into the part of
    the loop LLMs are worst at (`category` vs `categories` four

--- a/docs/about/thesis.md
+++ b/docs/about/thesis.md
@@ -354,11 +354,11 @@ starts makes graduation a feature rather than a surprise.
 
 The envelope:
 
-- **~30 logical writes / minute / collection** sustained. This
-  ceiling reflects the CAS-livelock regime documented in the
-  S3-as-database literature; per-collection commit scope
-  ([ADR-001](../adr/001-tenant-cas-isolation.md)) is what buys the
-  operating headroom.
+- **~30 logical writes / minute / collection** sustained. This ceiling
+  follows from the raw S3-CAS conditional-PUT rate divided by baerly's
+  measured write-amplification (see [ADR-001](../adr/001-tenant-cas-isolation.md)
+  and [cost-model.md](cost-model.md)); per-collection commit scope is what
+  buys the operating headroom.
 - **>10 GB / tenant stored** — the R2 free-tier storage line (a cost
   signal, not a protocol ceiling). A tenant is a key prefix; baerly-storage
   enforces no per-tenant byte limit. Once stored bytes cross the R2

--- a/docs/adr/001-tenant-cas-isolation.md
+++ b/docs/adr/001-tenant-cas-isolation.md
@@ -2,7 +2,7 @@
 title: Tenant CAS isolation
 audience: adr
 summary: ADR 001 — Tenant CAS isolation.
-last-reviewed: 2026-06-14
+last-reviewed: 2026-06-22
 tags: [decision, adr]
 related: [README.md]
 ---
@@ -34,10 +34,14 @@ For scope, three options were considered:
 
 - **Per-tenant CAS.** One `current.json` per tenant; every commit across
   every collection serializes through that one key. Simple topology,
-  but the published prior-art ceiling on the S3-CAS pattern is roughly
-  five writes per second; a 100-collection tenant at the documented
-  30-writes-per-minute-per-collection target lands about 10× over the
-  ceiling.
+  but the prior-art ceiling on the S3-CAS pattern is roughly five logical
+  writes per second per key. That figure is an estimate, not a published
+  AWS number: an order-~10 conditional-PUT/s same-key ceiling (single-region
+  S3 serialises conditional writes on a hot key well below the ~3,500 PUT/s
+  per-prefix wall) divided by baerly's measured effective write-amplification
+  (≈3–4× — see [cost-model.md](../about/cost-model.md)). It wants real-infra
+  confirmation; meanwhile a 100-collection tenant at the documented
+  30-writes-per-minute-per-collection target lands about 10× over it.
 - **Per-collection commit scope.** One `current.json` plus one
   numbered log per `(tenant, collection)` pair. More objects per
   tenant, but commit contention stays inside its own collection. Matches

--- a/docs/adr/002-api-surface-lock.md
+++ b/docs/adr/002-api-surface-lock.md
@@ -2,7 +2,7 @@
 title: API surface lock
 audience: adr
 summary: ADR 002 — API surface lock.
-last-reviewed: 2026-05-28
+last-reviewed: 2026-06-22
 tags: [decision, adr]
 related: [README.md]
 ---
@@ -183,6 +183,23 @@ LLMs — this design closes that surface structurally.
   making `update` upsert instead of no-op-on-missing).
 - Adding boolean connectives (`or` / `not`) to the predicate
   algebra — see *Predicates are conjunction-only* above.
+
+## Deprecation lifecycle
+
+Now that the package is published with real consumers, removing a
+capability is no longer free. A removal proceeds in stages: (1) a
+supersession ADR records the decision and the replacement; (2) the
+capability is marked `@deprecated` in JSDoc — with a pointer to the
+replacement — for at least one minor release, where it still works
+and still type-checks; (3) it is removed in the next semver-major.
+A capability is never removed in the same release it is deprecated.
+
+**Hardening trigger.** The lock is "soft" (additive-only, removals
+allowed via the lifecycle above) until v1.0. At v1.0 the surface
+hardens: removals and signature-narrowings require a major bump
+_and_ a migration note in `CHANGELOG.md`, and the bar for accepting
+a removal rises from "clean narrowing" to "demonstrated harm in
+keeping it."
 
 ## Consequences
 

--- a/docs/adr/004-ephemeral-coordination.md
+++ b/docs/adr/004-ephemeral-coordination.md
@@ -2,7 +2,7 @@
 title: Ephemeral coordination
 audience: adr
 summary: ADR 004 — coordination runs in request-bounded compute, not in a persistent process.
-last-reviewed: 2026-06-13
+last-reviewed: 2026-06-22
 tags: [decision, adr, runtime-model]
 related:
   [
@@ -287,6 +287,13 @@ are the entire handoff to Postgres (`baerly export --target=postgres`).
    no lease, two writers can both fold the same tail; the CAS
    loser's work is discarded. Accepted; measured by
    `db.compaction.cas_lost_total`.
+5. **No fairness.** Lock-free CAS gives no queueing or fairness
+   guarantee: under sustained contention a slow writer can lose
+   every race and exhaust its retry budget, surfacing as a
+   `Conflict` at the app edge. This is bounded liveness loss,
+   never data loss — the app retries or backs off. A fair queue
+   would require exactly the external coordinator this ADR exists
+   to avoid.
 
 Independent of maintenance: readers may see a stale
 `current.json` until the in-isolate cache invalidates; the
@@ -315,3 +322,12 @@ that re-validate against an ETag, and write-tick-paced
 maintenance all preserve the property. The test is whether
 _removing the in-memory state_ breaks correctness. If it does,
 the feature violates this ADR.
+
+**Backing-store consistency.** The CAS property requires
+read-after-write strong consistency on the control object. It
+holds on single-region S3 and on R2 (globally strongly
+consistent). It does **not** hold across an S3 Multi-Region
+Access Point or active-active cross-region replication, where a
+replica's stale read can let two writers both believe they won
+the CAS. Run baerly against a single-region bucket (or R2); do
+not point it at an MRAP / cross-region-replication endpoint.

--- a/docs/adr/009-schema-validator-shape.md
+++ b/docs/adr/009-schema-validator-shape.md
@@ -1,0 +1,90 @@
+---
+title: Schema-validator function shape
+audience: adr
+summary: ADR 009 — the collection schema validator runs against the post-image (document after merge-patch), requires `_id`, and accepts any StandardSchemaV1-compatible library; rejects on failure with BaerlyError{code:"SchemaError"}.
+last-reviewed: 2026-06-22
+tags: [decision, adr, schema, validation]
+related:
+  [
+    README.md,
+    005-verifier-function-shape.md,
+    002-api-surface-lock.md,
+  ]
+---
+
+# ADR-009: Schema-validator function shape
+
+## Status
+
+Accepted (2026-06-22). Implemented and shipped; this record documents a
+decision that was already in the codebase but never written down.
+
+## Context
+
+`CollectionDefinition.schema` validates documents on write. This is a
+distinct seam from the auth `Verifier` of ADR-005 — that one authorizes a
+_request_; this one validates a _document_. The decision was made and
+shipped but never recorded; its rationale lived only in `query.ts` comments.
+
+Two design questions needed answers before the seam could be considered
+stable enough to lock:
+
+1. **When does the validator run — against the incoming patch or against
+   the resulting document?** Writes are RFC 7386 merge-patches: a partial
+   update merges onto the existing document. Validating the incoming patch
+   would reject any schema that declares required fields the patch doesn't
+   restate, making partial updates useless with schemas.
+
+2. **Which interface?** A baerly-proprietary validator signature would
+   require adapters for every schema library; the ecosystem's Standard
+   Schema initiative (`StandardSchemaV1`) already solves this.
+
+## Decision
+
+1. **Validate the post-image, not the patch.** Writes are merge-patches; the
+   validator runs against the document _after_ the patch is folded onto the
+   prior state, so a partial update is checked as the resulting whole. A patch
+   that omits a required field is valid iff the merged document still has it.
+2. **`_id` is part of the validated shape and is required.** The post-image
+   always carries `_id`, so the schema must assert it (e.g.
+   `_id: z.string()`). This is consistent with the canonical example in
+   `packages/server/src/schema.ts`.
+3. **The accepted type is `SchemaValidator` (from `@baerly/protocol`), which
+   is structurally compatible with the StandardSchemaV1 contract.** The interface
+   inlines the `~standard.validate` shape with no runtime dependency on the spec
+   package. Any Standard-Schema-compatible library (Zod, Valibot, ArkType, …)
+   works without a baerly-specific adapter. Unlike the auth `Verifier` (whose
+   result is deliberately opaque — ADR-005), the schema validator is
+   introspectable through the Standard Schema contract.
+
+## Consequences
+
+- **Validation cost sits on the write path, before the commit fires.**
+  `validateOrThrow` is called in `runInsert`, `runUpdate`, and
+  `runReplaceById` (`packages/server/src/query.ts:374–378`, `:463–466`,
+  `:518–521`) before `Writer.commit()`. A schema rejection is cheap: it
+  aborts before any storage round-trip.
+- **Partial updates are safe with strict schemas.** Because validation runs
+  on the _merged_ post-image (`:447–464`), a patch that only touches `status`
+  passes a schema that also requires `title` — as long as the merged document
+  carries `title`. Validating the patch instead would have made `update()` and
+  strict schemas mutually exclusive.
+- **On failure an app receives `BaerlyError{code:"SchemaError"}` with a
+  structured `.issues` array** (`packages/protocol/src/errors.ts:18–27`,
+  `packages/server/src/schema.ts:69–74`). The HTTP layer maps this to 400.
+  The issues carry `(string | number)[]` paths and human-readable messages,
+  normalised from the raw `StandardSchemaV1` issue segments.
+- **The validator does not run on reads or during export/replay.** The log
+  stores post-images produced at write time; replay folds them directly
+  without re-validating. This means a schema change does not retroactively
+  reject existing documents — existing rows remain readable regardless.
+- **`update()` atomicity is per-row.** If a multi-row update fails schema
+  validation on row N, rows 0..N-1 are already committed (`:457–466`). The
+  per-row atomicity contract is locked; the schema seam inherits it.
+
+## Alternatives considered
+
+- **Validate the incoming patch.** Rejected: a valid partial update would fail
+  any schema with required fields the patch doesn't restate.
+- **A baerly-proprietary validator signature.** Rejected: Standard Schema is
+  the ecosystem-neutral contract; no reason to fork it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,6 +31,7 @@ rules live in
 - [006 — Package layer invariant](./006-package-layer-invariant.md)
 - [007 — Layout versioning cordon](./007-layout-versioning-cordon.md)
 - [008 — Single-write commit](./008-single-write-commit.md)
+- [009 — Schema-validator function shape](./009-schema-validator-shape.md)
 
 ## Template
 

--- a/docs/assets/demo.tape
+++ b/docs/assets/demo.tape
@@ -1,0 +1,60 @@
+# baerly-storage hero demo — "it's just a bucket"
+#
+# Render with VHS (https://github.com/charmbracelet/vhs):
+#   vhs docs/assets/demo.tape   ->   docs/assets/demo.gif
+#
+# The payoff is the final frame: a write went through, and the entire
+# database is visible as plain objects in the bucket. No database server
+# saw any of it. Run against a real (or local Minio) bucket so `aws s3 ls`
+# shows the actual log/snapshot/content objects.
+#
+# The write/read steps hit the kernel's real HTTP surface
+# (`POST`/`GET /v1/c/<collection>`, body `{ doc }`, `{ data, _meta }`
+# response — see packages/server/src/contract.ts) — i.e. exactly what
+# `db.collection("tickets").insert(...)` compiles to over the wire.
+#
+# Prereqs the recorder stages: a scaffolded app **running** with its `db`
+# pointed at $DEMO_BUCKET and reachable at $BASE_URL, a bearer $TOKEN its
+# verifier accepts, and `aws` configured for that bucket (or swap the
+# final command for `baerly inspect`).
+
+Output docs/assets/demo.gif
+
+Set Shell "bash"
+Set FontSize 18
+Set Width 1100
+Set Height 640
+Set Padding 24
+Set Theme "Catppuccin Mocha"
+Set TypingSpeed 45ms
+Set PlaybackSpeed 1.0
+
+# --- write a row ---------------------------------------------------------
+Type "# 1. write a row — a normal request to your app handler, no database server"
+Enter
+Sleep 600ms
+Type `curl -s "$BASE_URL/v1/c/tickets" -H "Authorization: Bearer $TOKEN" -d '{"doc":{"title":"Onboard Alex","status":"open"}}'`
+Enter
+Sleep 2s
+# → 201 { "_id": "..." }
+
+# --- read it back --------------------------------------------------------
+Type "# 2. read it back"
+Enter
+Sleep 400ms
+Type `curl -s "$BASE_URL/v1/c/tickets" -H "Authorization: Bearer $TOKEN"`
+Enter
+Sleep 2s
+# → 200 { "data": [ { "_id": "...", "title": "Onboard Alex", "status": "open" } ], "_meta": { ... } }
+# (filtered reads use ?where=<urlencoded JSON>, e.g. {"clauses":[{"op":"eq","field":"status","value":"open"}]})
+
+# --- the reveal ----------------------------------------------------------
+Type "# 3. now look in the bucket — that's the whole database"
+Enter
+Sleep 600ms
+Type "aws s3 ls --recursive s3://$DEMO_BUCKET/"
+Enter
+Sleep 1s
+# Expect: tickets/.../log/00000000, the content-addressed doc, snapshot,
+# current.json — plain objects. No database server saw any of this.
+Sleep 4s

--- a/docs/spec/prior-art.md
+++ b/docs/spec/prior-art.md
@@ -2,7 +2,7 @@
 title: Prior-art differentiation
 audience: spec
 summary: Technical differentiation against known prior art for baerly-storage's live object-store protocol mechanisms.
-last-reviewed: 2026-06-17
+last-reviewed: 2026-06-22
 tags: [protocol, patent, prior-art]
 related:
   [
@@ -288,6 +288,15 @@ Differentiation:
 
 The product distinction is not "serverless" in the broad sense. It is "no
 resident runtime required for correctness."
+
+- **Neon** — Postgres with storage disaggregated onto S3-backed pageservers;
+  a managed control plane owns consistency, so it is the _opposite_ pole from
+  baerly's catalog-free, killable-compute stance (Neon needs always-on
+  pageserver compute; baerly needs none).
+- **Cloudflare D1** — SQLite-on-a-Durable-Object; single-writer serialization
+  via the DO, not via object-store CAS. Same "no external lock service" spirit,
+  but it relies on DO compute being live, where baerly relies only on the
+  bucket.
 
 ## Other Object-Store Database and Log Families
 

--- a/docs/spec/s3-xml-escaping-cases.md
+++ b/docs/spec/s3-xml-escaping-cases.md
@@ -2,7 +2,7 @@
 title: S3 XML escaping edge cases
 audience: spec
 summary: Why baerly-storage requests encoding-type=url, what that turns key escaping into, and the XML-1.0 control-char rule that makes it mandatory.
-last-reviewed: 2026-06-14
+last-reviewed: 2026-06-22
 tags: [protocol, s3, xml, edge-cases]
 related: [storage-compatibility.md]
 ---
@@ -19,7 +19,7 @@ not a convenience.
 ## The cause: baerly-storage requests `encoding-type=url`
 
 baerly-storage sets `encoding-type=url` on every list request
-(`packages/adapter-node/src/s3-http.ts:362`). This moves the entire
+(`packages/adapter-node/src/s3-http.ts:376`). This moves the entire
 escaping problem **out of XML and into percent-decoding**. With the marker
 set, S3 returns the key family — `Key` / `Prefix` / `Delimiter` /
 `StartAfter` — percent-encoded as `x-www-form-urlencoded`:

--- a/scripts/lint-format-coverage.mjs
+++ b/scripts/lint-format-coverage.mjs
@@ -47,11 +47,13 @@ const UNFORMATTED_EXT = new Set([
   "yml",
   "sh",
   "png",
+  "gif", // rendered demo assets (docs/assets/demo.gif from a .tape script)
   "svg",
   "ico",
   "txt",
   "example",
   "toml",
+  "tape", // VHS terminal-demo scripts (docs/assets/*.tape) — no formatter owns these
 ]);
 
 // Exact basenames that are extension-less or dotfiles (no meaningful ext).


### PR DESCRIPTION
## What

A launch-readiness documentation pass, in five atomic commits:

1. **`docs(readme)`** — restructure the README for skimmability: before/after diagram + four benefit bullets up top, body split into *In code* / *How it works* / *When (not) to use it*, and a *Scale at a glance* table. Adds a VHS hero-demo script (`docs/assets/demo.tape`) driven against the kernel's real HTTP surface (`POST`/`GET /v1/c/<collection>`).
2. **`docs(adr-009)`** — record the (already-shipped) schema-validator function shape: post-image validation, required `_id`, `StandardSchemaV1`-compatible `SchemaValidator`, `SchemaError`→400.
3. **`docs(adr-002)`** — add a post-launch deprecation lifecycle (`@deprecated` ≥1 minor → remove in next major) and a v1.0 hardening trigger; the additive-only lock is soft until then.
4. **`docs(adr-004)`** — document CAS fairness loss (bounded liveness, never data loss) and the single-region requirement (no MRAP / cross-region replication).
5. **`docs(spec)`** — reground the ~30 writes/min/collection ceiling on measured write-amp (thesis + ADR-001), with the raw conditional-PUT/s figure marked an estimate; add Neon/D1 prior-art; fix a stale `s3-http.ts` line ref.

## Verification

Docs-only. `pnpm verify:agent` green (typecheck, format, lint, package-layers, format-coverage, and `verify:docs` link/anchor/mermaid validation).