### PR TITLE
feat(errors): actionable error metadata + troubleshooting recipes

### DIFF
--- a/packages/adapter-node/AGENTS.md
+++ b/packages/adapter-node/AGENTS.md
@@ -1,3 +1,10 @@
+## When NOT to use this package
+
+On Cloudflare Workers, do NOT use `@baerly/adapter-node`'s S3-credentials
+factory — use `r2BindingStorage` from `@gusto/baerly-storage/cloudflare`
+(the native R2 binding). This package is for Node hosts that talk to an
+S3-compatible endpoint over HTTP.
+
 ## Credentials
 
 All four storage factories (`s3Storage`, `r2Storage`, `minioStorage`,

--- a/packages/adapter-node/src/body-cap.test.ts
+++ b/packages/adapter-node/src/body-cap.test.ts
@@ -150,7 +150,12 @@ describe("applyBodyCap", () => {
     const response = result as Response;
     expect(response.status).toBe(413);
     await expect(response.json()).resolves.toEqual({
-      error: { code: "PayloadTooLarge", message: `Body exceeds ${CAP} bytes` },
+      error: {
+        code: "PayloadTooLarge",
+        message: `Body exceeds ${CAP} bytes`,
+        retriable: false,
+        resolution: "Reduce the request body below the server's body-size cap (1 MiB default).",
+      },
     });
     expect(incoming.resumed).toBe(1);
   });

--- a/packages/adapter-node/src/middleware/body-cap.ts
+++ b/packages/adapter-node/src/middleware/body-cap.ts
@@ -1,5 +1,6 @@
 import type { HttpBindings } from "@hono/node-server";
 import { BaerlyError } from "@baerly/protocol";
+import { errorEnvelope } from "@baerly/server/http";
 
 /**
  * Body-cap enforcement for Node-hosted requests. Replaces the
@@ -81,9 +82,10 @@ export function applyBodyCap(req: Request, env: unknown, max: number): Request |
 
 function cap413(max: number): Response {
   return new Response(
-    JSON.stringify({
-      error: { code: "PayloadTooLarge", message: `Body exceeds ${max} bytes` },
-    }),
-    { status: 413, headers: { "content-type": "application/json" } },
+    JSON.stringify(errorEnvelope("PayloadTooLarge", `Body exceeds ${max} bytes`)),
+    {
+      status: 413,
+      headers: { "content-type": "application/json" },
+    },
   );
 }

--- a/packages/adapter-node/src/s3-http.ts
+++ b/packages/adapter-node/src/s3-http.ts
@@ -23,6 +23,11 @@ import { parseListObjectsV2CommandOutput, parseS3Error } from "./xml.ts";
  * `Conflict` (CAS guard lost — retrying would just re-lose against
  * the same state). `NetworkError` is intentionally absent — it covers
  * transient transport faults and stays retryable.
+ *
+ * Transport-layer set, distinct from `RETRIABLE_CODES` in `@baerly/protocol`'s
+ * `errors.ts` (the default wire `retriable` hint). `Conflict` is "permanent"
+ * here (a blind re-PUT re-loses the CAS race) yet retryable for logical CAS
+ * callers that can fresh-read + re-apply. Same code, two different questions.
  */
 const PERMANENT_ERROR_CODES: ReadonlySet<string> = new Set([
   "AccessDenied",

--- a/packages/cli/src/admin/restore.ts
+++ b/packages/cli/src/admin/restore.ts
@@ -135,6 +135,11 @@ const bundle = defineBaerlySubcommand({
       throw new BaerlyError(
         "Conflict",
         `baerly admin restore: ${currentJsonKey} exists; pass --force to truncate`,
+        undefined,
+        undefined,
+        undefined,
+        "Pass --force to truncate the existing collection, or choose an empty target.",
+        false,
       );
     }
     if (head !== null) {

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -117,6 +117,18 @@ describe("createBaerlyClient", () => {
     });
   });
 
+  test("wire resolution is rebuilt onto BaerlyError.resolution", async () => {
+    const mock = new MockFetch();
+    mock.on("POST", "/v1/c/tickets", () =>
+      jsonResponse({ error: { code: "InvalidConfig", message: "bad", resolution: "do X" } }, 400),
+    );
+    const client = createBaerlyClient({ baseUrl: "http://x", fetch: mock.fetch });
+    await expect(client.collection("tickets").insert({ x: 1 })).rejects.toMatchObject({
+      code: "InvalidConfig",
+      resolution: "do X",
+    });
+  });
+
   test("count() issues GET /v1/count and returns scalar (does not download rows)", async () => {
     const mock = new MockFetch();
     let sawListGet = false;
@@ -204,6 +216,80 @@ describe("createBaerlyClient", () => {
     const client = createBaerlyClient({ baseUrl: "http://x", fetch: mock.fetch });
     await expect(client.collection("tickets").where({}).all()).rejects.toMatchObject({
       code: "InvalidResponse",
+    });
+  });
+
+  // §3.9 — wire decoder preserves issues + surfaces retriable
+  test("client rebuilds issues + retriable from the error envelope", async () => {
+    const mock = new MockFetch();
+    mock.on("POST", "/v1/c/tickets", () =>
+      jsonResponse(
+        {
+          error: {
+            code: "SchemaError",
+            message: "bad",
+            retriable: false,
+            issues: [{ path: ["title"], message: "required" }],
+          },
+        },
+        400,
+      ),
+    );
+    const client = createBaerlyClient({ baseUrl: "http://x", fetch: mock.fetch });
+    await expect(client.collection("tickets").insert({ x: 1 })).rejects.toMatchObject({
+      name: "BaerlyError",
+      code: "SchemaError",
+      status: 400,
+      retriable: false,
+      issues: [{ path: ["title"], message: "required" }],
+    });
+  });
+
+  test("client surfaces retriable:true on Conflict", async () => {
+    const mock = new MockFetch();
+    mock.on("POST", "/v1/c/tickets", () =>
+      jsonResponse({ error: { code: "Conflict", message: "CAS lost", retriable: true } }, 409),
+    );
+    const client = createBaerlyClient({ baseUrl: "http://x", fetch: mock.fetch });
+    await expect(client.collection("tickets").insert({ x: 1 })).rejects.toMatchObject({
+      name: "BaerlyError",
+      code: "Conflict",
+      status: 409,
+      retriable: true,
+    });
+  });
+
+  test("client preserves retriable:false on terminal Conflict", async () => {
+    const mock = new MockFetch();
+    mock.on("POST", "/v1/c/tickets", () =>
+      jsonResponse(
+        { error: { code: "Conflict", message: "duplicate _id", retriable: false } },
+        409,
+      ),
+    );
+    const client = createBaerlyClient({ baseUrl: "http://x", fetch: mock.fetch });
+    await expect(client.collection("tickets").insert({ _id: "x" })).rejects.toMatchObject({
+      name: "BaerlyError",
+      code: "Conflict",
+      status: 409,
+      retriable: false,
+    });
+  });
+
+  test("client falls back to the code default when the server omits retriable", async () => {
+    // Older server: the envelope carries no `retriable` field. The client
+    // must fall back to the code-derived default (Conflict → retriable),
+    // not silently treat the missing field as non-retriable.
+    const mock = new MockFetch();
+    mock.on("POST", "/v1/c/tickets", () =>
+      jsonResponse({ error: { code: "Conflict", message: "CAS lost" } }, 409),
+    );
+    const client = createBaerlyClient({ baseUrl: "http://x", fetch: mock.fetch });
+    await expect(client.collection("tickets").insert({ x: 1 })).rejects.toMatchObject({
+      name: "BaerlyError",
+      code: "Conflict",
+      status: 409,
+      retriable: true,
     });
   });
 });

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -34,6 +34,30 @@ export interface HttpErrorEnvelope {
   readonly error: {
     readonly code: BaerlyErrorCode;
     readonly message: string;
+    /**
+     * Whether this error instance is retriable. Servers always send it;
+     * older servers may omit it. The client preserves the wire hint when
+     * present and otherwise falls back to the code-derived default.
+     * Mirrors `HttpErrorEnvelope.error.retriable` in
+     * `packages/server/src/contract.ts`.
+     */
+    readonly retriable?: boolean;
+    /**
+     * Field-path issues, present only when `code === "SchemaError"`.
+     * Mirrors the server contract. Older servers omit this field.
+     */
+    readonly issues?: ReadonlyArray<{
+      readonly path: ReadonlyArray<string | number>;
+      readonly message: string;
+    }>;
+    /**
+     * Human-readable remediation hint. Mirrors the server contract:
+     * present when the code has a per-code default or a site override
+     * (e.g. `PayloadTooLarge`, `Unauthorized`, `AccessDenied`, `NotFound`,
+     * or a context-specific `Conflict`); absent for opaque/transient codes.
+     * Older servers may omit it.
+     */
+    readonly resolution?: string;
   };
 }
 

--- a/packages/client/src/request.ts
+++ b/packages/client/src/request.ts
@@ -80,7 +80,15 @@ export const request = async <T>(ctx: RequestContext, opts: RequestOptions): Pro
     }
     const code: BaerlyErrorCode = envelope?.error?.code ?? "Internal";
     const message = envelope?.error?.message ?? `HTTP ${res.status}`;
-    throw new BaerlyError(code, message, undefined, undefined, res.status);
+    throw new BaerlyError(
+      code,
+      message,
+      undefined,
+      envelope?.error?.issues,
+      res.status,
+      envelope?.error?.resolution,
+      envelope?.error?.retriable,
+    );
   }
 
   // 200 — only GET reads ship `HttpOkEnvelope<T>`. PATCH (and any

--- a/packages/protocol/src/auth-resolution.ts
+++ b/packages/protocol/src/auth-resolution.ts
@@ -1,0 +1,11 @@
+/** Corrective action for a `sharedSecret(...)` preset misconfig; crosses the wire. */
+export const SHARED_SECRET_CONFIG_RESOLUTION: string =
+  'Pass a non-empty `secret` and a non-empty `tenantPrefix` with no "/" to sharedSecret({ secret, tenantPrefix }).';
+
+/** Corrective action for a `bearerJwt(...)` preset misconfig; crosses the wire. */
+export const BEARER_JWT_CONFIG_RESOLUTION: string =
+  'Provide non-empty `issuer`, `audience`, and at least one `algorithms` entry; `tenantClaim` and `tenantPrefix` are mutually exclusive and `tenantPrefix` must be non-empty with no "/".';
+
+/** Corrective action for a `cloudflareAccess(...)` preset misconfig; crosses the wire. */
+export const CLOUDFLARE_ACCESS_CONFIG_RESOLUTION: string =
+  "Pass a non-empty `teamDomain` and a 64-char lowercase-hex `audienceTag` (the Application Audience (AUD) tag from the CF Access app config).";

--- a/packages/protocol/src/code-resolution.test.ts
+++ b/packages/protocol/src/code-resolution.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import {
+  CODE_RESOLUTIONS,
+  WHERE_ORDER_JSON_RESOLUTION,
+  WRITE_BODY_SHAPE_RESOLUTION,
+} from "./code-resolution.ts";
+
+describe("CODE_RESOLUTIONS", () => {
+  test("covers the actionable codes with a non-empty string", () => {
+    for (const code of ["PayloadTooLarge", "Unauthorized", "AccessDenied", "NotFound"] as const) {
+      expect(CODE_RESOLUTIONS[code]).toBeTypeOf("string");
+      expect(CODE_RESOLUTIONS[code]!.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("omits transient/opaque and context-dependent codes", () => {
+    for (const code of [
+      "Conflict",
+      "NetworkError",
+      "InvalidResponse",
+      "Internal",
+      "InvalidConfig",
+      "SchemaError",
+    ] as const) {
+      expect(CODE_RESOLUTIONS[code]).toBeUndefined();
+    }
+  });
+
+  test("reusable request-path strings are non-empty", () => {
+    expect(WHERE_ORDER_JSON_RESOLUTION.length).toBeGreaterThan(0);
+    expect(WRITE_BODY_SHAPE_RESOLUTION.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/protocol/src/code-resolution.ts
+++ b/packages/protocol/src/code-resolution.ts
@@ -1,0 +1,17 @@
+import type { BaerlyErrorCode } from "./errors.ts";
+
+/** Canonical per-code corrective action; `errorEnvelope` falls back to this and it crosses the wire as `resolution`. Actionable codes only — context-sensitive codes use throw-site overrides. */
+export const CODE_RESOLUTIONS: Partial<Record<BaerlyErrorCode, string>> = {
+  PayloadTooLarge: "Reduce the request body below the server's body-size cap (1 MiB default).",
+  Unauthorized: "Send a valid Authorization header for the server's configured auth method.",
+  AccessDenied: "These credentials are denied for this tenant prefix or bucket policy.",
+  NotFound: "No row matches this id; create it first or treat this as a miss.",
+};
+
+/** Resolution for a malformed `?where=` / `?order=` query value. */
+export const WHERE_ORDER_JSON_RESOLUTION: string =
+  "Pass a URL-encoded JSON object as the ?where= / ?order= value.";
+
+/** Resolution for an empty / malformed / unwrapped write body. */
+export const WRITE_BODY_SHAPE_RESOLUTION: string =
+  'Send a JSON body shaped { "doc": { ... } } for POST/PUT, or { "patch": { ... } } for PATCH.';

--- a/packages/protocol/src/constants.test.ts
+++ b/packages/protocol/src/constants.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
 import {
+  BEARER_JWT_CONFIG_RESOLUTION,
+  CLOUDFLARE_ACCESS_CONFIG_RESOLUTION,
+  SHARED_SECRET_CONFIG_RESOLUTION,
+} from "./auth-resolution.ts";
+import {
   CURRENT_JSON_CONTENT_TYPE,
   GC_PENDING_CONTENT_TYPE,
   MANIFEST_POINTER_EMPTY_SNAPSHOT,
@@ -42,6 +47,24 @@ describe("wire-contract constants", () => {
     // contract that operators and tools match against.
     expect(SHARED_SECRET_MISSING_MESSAGE).toBe(
       'baerly: auth="shared-secret" but SHARED_SECRET env is empty/unset. Cloudflare: `wrangler secret put SHARED_SECRET`, or add to .dev.vars for local dev. Node: set in process env.',
+    );
+  });
+
+  test("SHARED_SECRET_CONFIG_RESOLUTION is locked corrective-action wording", () => {
+    expect(SHARED_SECRET_CONFIG_RESOLUTION).toBe(
+      'Pass a non-empty `secret` and a non-empty `tenantPrefix` with no "/" to sharedSecret({ secret, tenantPrefix }).',
+    );
+  });
+
+  test("BEARER_JWT_CONFIG_RESOLUTION is locked corrective-action wording", () => {
+    expect(BEARER_JWT_CONFIG_RESOLUTION).toBe(
+      'Provide non-empty `issuer`, `audience`, and at least one `algorithms` entry; `tenantClaim` and `tenantPrefix` are mutually exclusive and `tenantPrefix` must be non-empty with no "/".',
+    );
+  });
+
+  test("CLOUDFLARE_ACCESS_CONFIG_RESOLUTION is locked corrective-action wording", () => {
+    expect(CLOUDFLARE_ACCESS_CONFIG_RESOLUTION).toBe(
+      "Pass a non-empty `teamDomain` and a 64-char lowercase-hex `audienceTag` (the Application Audience (AUD) tag from the CF Access app config).",
     );
   });
 });

--- a/packages/protocol/src/errors.test.ts
+++ b/packages/protocol/src/errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { BaerlyError } from "./errors.ts";
+import { BaerlyError, RETRIABLE_CODES, isRetriableCode } from "./errors.ts";
 
 describe("BaerlyError", () => {
   test("is an Error carrying name, code, and message", () => {
@@ -35,5 +35,49 @@ describe("BaerlyError", () => {
   test("leaves status undefined when not provided", () => {
     const e = new BaerlyError("NotFound", "x");
     expect(e.status).toBeUndefined();
+  });
+
+  test("sets resolution when provided", () => {
+    const e = new BaerlyError("InvalidConfig", "bad", undefined, undefined, undefined, "do X");
+    expect(e.resolution).toBe("do X");
+  });
+
+  test("leaves resolution undefined when not provided", () => {
+    expect(new BaerlyError("InvalidConfig", "bad").resolution).toBeUndefined();
+  });
+});
+
+describe("retriable classification", () => {
+  test("RETRIABLE_CODES is exactly {NetworkError, Conflict}", () => {
+    expect([...RETRIABLE_CODES].toSorted()).toEqual(["Conflict", "NetworkError"]);
+  });
+  test("isRetriableCode reflects the set", () => {
+    expect(isRetriableCode("NetworkError")).toBe(true);
+    expect(isRetriableCode("Conflict")).toBe(true);
+    expect(isRetriableCode("SchemaError")).toBe(false);
+    expect(isRetriableCode("NotFound")).toBe(false);
+  });
+  test("BaerlyError.retriable defaults from code", () => {
+    expect(new BaerlyError("Conflict", "x").retriable).toBe(true);
+    expect(new BaerlyError("NetworkError", "x").retriable).toBe(true);
+    expect(new BaerlyError("SchemaError", "x").retriable).toBe(false);
+  });
+
+  test("BaerlyError.retriable can be overridden per instance", () => {
+    expect(
+      new BaerlyError(
+        "Conflict",
+        "duplicate _id",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        false,
+      ).retriable,
+    ).toBe(false);
+    expect(
+      new BaerlyError("SchemaError", "temporary", undefined, undefined, undefined, undefined, true)
+        .retriable,
+    ).toBe(true);
   });
 });

--- a/packages/protocol/src/errors.ts
+++ b/packages/protocol/src/errors.ts
@@ -26,8 +26,10 @@ export type BaerlyErrorCode =
    */
   | "SchemaError"
   /**
-   * CAS lost on `current.json`. Caller decides whether to retry.
-   * Surfaces in the collection API and HTTP layer.
+   * Write conflicted with current state: CAS retry budget exhausted,
+   * duplicate caller-supplied `_id`, or an already-existing guarded
+   * storage key. Check `BaerlyError.retriable` to decide whether the
+   * same logical operation should be retried.
    */
   | "Conflict"
   /**
@@ -107,6 +109,19 @@ export type BaerlyErrorCode =
   | "MutationFailed";
 
 /**
+ * Codes whose default failure class is resolved by retrying with a fresh read.
+ * Throw sites may override this when the same code is context-sensitive
+ * (notably caller-supplied `_id` collisions, which also use `Conflict`).
+ */
+export const RETRIABLE_CODES: ReadonlySet<BaerlyErrorCode> = new Set<BaerlyErrorCode>([
+  "NetworkError",
+  "Conflict",
+]);
+
+/** True iff this error code's default failure class is retriable. */
+export const isRetriableCode = (code: BaerlyErrorCode): boolean => RETRIABLE_CODES.has(code);
+
+/**
  * The single error class thrown by baerly-storage. Discriminate by `code`, not
  * `instanceof`: the code string survives `JSON.stringify` round-trips
  * across Worker / iframe / postMessage realm boundaries, where each
@@ -120,7 +135,7 @@ export type BaerlyErrorCode =
  *   await db.collection("tickets").insert({ title: "hi" });
  * } catch (err) {
  *   if (err instanceof BaerlyError && err.code === "Conflict") {
- *     // ... CAS lost; retry
+ *     // Check err.retriable; CAS can retry, duplicate _id cannot.
  *   }
  *   throw err;
  * }
@@ -153,6 +168,17 @@ export class BaerlyError extends Error {
    * you genuinely need the wire value.
    */
   readonly status?: number;
+  /** Canonical corrective action; crosses the wire via `HttpErrorEnvelope.error.resolution`. */
+  readonly resolution?: string;
+  private readonly retriableOverride: boolean | undefined;
+
+  /**
+   * Whether this error instance is retriable. Defaults from `code`, but
+   * context-sensitive throw sites can override it.
+   */
+  get retriable(): boolean {
+    return this.retriableOverride ?? isRetriableCode(this.code);
+  }
 
   constructor(
     code: BaerlyErrorCode,
@@ -163,11 +189,14 @@ export class BaerlyError extends Error {
       readonly message: string;
     }>,
     status?: number,
+    resolution?: string,
+    retriableOverride?: boolean,
   ) {
     super(message);
     this.name = "BaerlyError";
     this.code = code;
     this.cause = cause;
+    this.retriableOverride = retriableOverride;
     // Stryker disable next-line ConditionalExpression: field declaration creates property with undefined value; mutation to true is equivalent
     if (issues !== undefined) {
       this.issues = issues;
@@ -175,6 +204,10 @@ export class BaerlyError extends Error {
     // Stryker disable next-line ConditionalExpression: field declaration creates property with undefined value; mutation to true is equivalent
     if (status !== undefined) {
       this.status = status;
+    }
+    // Stryker disable next-line ConditionalExpression: field declaration creates property with undefined value; mutation to true is equivalent
+    if (resolution !== undefined) {
+      this.resolution = resolution;
     }
   }
 }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,4 +1,6 @@
 export * from "./app-config.ts";
+export * from "./auth-resolution.ts";
+export * from "./code-resolution.ts";
 export * from "./bytes.ts";
 export * from "./constants.ts";
 export {

--- a/packages/server/API.md
+++ b/packages/server/API.md
@@ -81,6 +81,8 @@ import { LocalFsStorage } from "@gusto/baerly-storage/dev";
 
 ## `Db.create({ storage, app, tenant, config? })`
 
+*When NOT to use: in a browser/SPA — use `createBaerlyClient` (HTTP) instead; `Db` is the in-process server surface.*
+
 One `Db` per `(app, tenant)` request. The constructor is private —
 always go through `Db.create`. Collections are auto-provisioned on first
 write (no `ensureCollection` step).
@@ -140,6 +142,8 @@ overloads as the inferred return; `Db` (no parameter) widens to
 `Db<UnboundConfig>` and accepts any string collection name.
 
 ## `db.collection(name)` → `Collection<T>`
+
+*When NOT to use: from the browser — call collection verbs over HTTP via `createBaerlyClient`.*
 
 `Collection<T>` carries the common-case verbs directly (collection-level
 reads plus by-primary-key mutations). Modifiers (`where`, `order`,
@@ -330,7 +334,7 @@ try {
   await db.collection("tickets").insert({ title: "hi" });
 } catch (err) {
   if (err instanceof BaerlyError && err.code === "Conflict") {
-    // CAS lost; caller decides whether to retry
+    // Check err.retriable: CAS conflicts can retry; duplicate _id cannot.
   }
 }
 ```
@@ -442,6 +446,8 @@ mismatches fall back to the full scan with a metric bump (correctness
 preserved).
 
 ## `createBaerlyClient` (browser / Node HTTP client)
+
+*When NOT to use: server-side in the same process as `Db` — call `Db`/`Collection` directly; the client is for out-of-process / browser callers.*
 
 ```ts
 import type config from "./baerly.config"; // type-only — server adapter stays out of the SPA bundle
@@ -647,6 +653,8 @@ client.
 
 ## Adapter factories
 
+*On Cloudflare Workers use `r2BindingStorage(env.BUCKET)` (the R2 binding), NOT the S3-credentials factory — credential-based factories assume `fetch` + Node TLS, not the Workers runtime.*
+
 ```ts
 // Cloudflare Worker entry
 import { baerlyWorker } from "@gusto/baerly-storage/cloudflare";
@@ -709,12 +717,7 @@ export default baerlyWorker(() => ({ config }));
 `s3Storage` / `r2Storage` / `minioStorage` / `gcsStorage` from
 `@gusto/baerly-storage/node` are re-exports of one factory family — same
 shape (bucket + credentials), all hide `aws4fetch` / `@xmldom/xmldom`
-behind the package boundary. **Don't confuse them with
-`r2BindingStorage` from `@gusto/baerly-storage/cloudflare`**: that one takes
-the platform-bound `R2Bucket` directly (`r2BindingStorage(env.BUCKET)`)
-and is the only storage factory a Worker should reach for — the
-credential-based factories assume `fetch` + Node TLS, not the Workers
-runtime.
+behind the package boundary.
 
 ### Verifier presets
 
@@ -1046,17 +1049,11 @@ once. Pick by what you want to observe.
 
 ## Anti-patterns
 
-- Don't reach into `node_modules/@gusto/baerly-storage/dist/` at runtime —
-  consume the published exports.
-- Don't widen branded types (`UUID`, `ContentVersionId`) with
-  `as string`. The brand exists to prevent confusion bugs.
-- Don't put `SHARED_SECRET` in the SPA bundle. It's
-  server-to-server-only; the dev path uses `baerlyDevAuth` to inject
-  it server-side, the prod path uses CF Access (CF target) or
-  `bearerJwt` (Node target).
-- Don't mutate `VerifierResult.tenantPrefix` between the verifier
-  and `Db.create`. The dispatcher pins the tenant from the
-  verifier's return value.
+A few that compile but are wrong (full list, keyed by the exact error
+string you see: `cat node_modules/@gusto/baerly-storage/dist/RECIPES.md`):
+
+- Don't widen branded types (`UUID`, `ContentVersionId`) with `as string`.
+- Don't put `SHARED_SECRET` in the SPA bundle — it's server-to-server only.
 
 ## Where to look next
 
@@ -1069,4 +1066,4 @@ once. Pick by what you want to observe.
   splits them; `cat dist/*.d.ts` gives the union.
 - Theoretical foundations + cost model: the repository's `docs/`
   tree (`docs/about/`, `docs/spec/`).
-- Recipes: `docs/guide/` (auth, observability, backups, troubleshooting).
+- Common mistakes & recipes: `cat node_modules/@gusto/baerly-storage/dist/RECIPES.md`; deeper guides in the repo's `docs/guide/`.

--- a/packages/server/RECIPES.md
+++ b/packages/server/RECIPES.md
@@ -1,0 +1,101 @@
+# baerly-storage — common mistakes & recipes
+
+> Companion to `dist/API.md`. API.md is the surface; this file is the
+> "why did my call fail" lookup, keyed by the exact error string you
+> see. If a fix here disagrees with the `.d.ts` types, the types win.
+
+## Common mistakes (keyed by the error you see)
+
+### `Request body must be { doc: object }` (HTTP 400, `code="SchemaError"`)
+
+**Cause:** POSTed a flat document body to `/v1/c/<collection>`.
+**Fix:** Wrap it: `{ "doc": { ...yourFields } }`. The insert verb reads
+`body.doc`, not the body itself. Same pattern for PATCH (`patch:`) and
+PUT (`doc:`).
+The wire `resolution` says: `Send a JSON body shaped { "doc": { ... } } for POST/PUT, or { "patch": { ... } } for PATCH.`
+
+### `BaerlyError code="SchemaError"` on insert/update/replace
+
+**Cause:** the document failed schema validation, OR the body is not
+valid JSON / contains an array where `DocumentValue` is required, OR a
+`null` field value (use `.optional()`; `null` in an *update patch* is the
+RFC 7386 deletion sentinel, not a storable value).
+**Fix:** read `error.issues` (each `{ path, message }`) for the offending
+field path. Declare `_id: z.string()` (required) in your schema — the
+validator runs on the post-image, so optional `_id` is wrong.
+
+### `BaerlyError code="Conflict"` (HTTP 409)
+
+**Cause:** the write conflicted with existing state. CAS conflicts are
+retryable (`retriable: true`); duplicate caller-supplied `_id` inserts are
+terminal (`retriable: false`).
+**Fix:** follow the wire `resolution`. For retryable CAS conflicts, re-read,
+re-apply, and retry with bounded backoff. For duplicate `_id` conflicts,
+choose a different `_id`, or omit `_id` so baerly-storage can mint one.
+The in-process writer already retries a bounded number of CAS attempts; a
+remote client that sees `retriable: true` should apply its own bounded backoff.
+
+### `db.collection(name).insertOne(...)` / `.find(...)` is not a function
+
+**Cause:** Mongo muscle memory. No such method.
+**Fix:** `db.collection(name).insert(row)` and
+`.where({ field: value }).all()` / `.where(q => q.gte("count", 1)).all()`.
+
+### `.useIndex(...)` / `.hint(...)` is not a function
+
+**Cause:** SQL/ORM muscle memory. No such method.
+**Fix:** the planner picks the index automatically from the
+`IndexDefinition`s registered in `baerly.config.ts`.
+
+### `BaerlyError code="InvalidConfig"` — `baerly: no auth configured`
+
+**Full message:** `baerly: no auth configured. Set \`auth\` in baerly.config.ts ("none", "shared-secret") or pass \`verifier\` on the adapter factory.`
+
+**Cause:** the adapter resolved no `Verifier`.
+**Fix:** set `auth` in `baerly.config.ts` (`"none"` or `"shared-secret"`)
+or pass `verifier:` on the adapter factory.
+
+### `BaerlyError code="InvalidConfig"` — `SHARED_SECRET env is empty/unset`
+
+**Full message:** `baerly: auth="shared-secret" but SHARED_SECRET env is empty/unset. Cloudflare: \`wrangler secret put SHARED_SECRET\`, or add to .dev.vars for local dev. Node: set in process env.`
+
+**Cause:** `auth: "shared-secret"` was set but the `SHARED_SECRET`
+environment variable is missing or empty at startup.
+**Fix:** set the `SHARED_SECRET` env (`wrangler secret put SHARED_SECRET`
+on Cloudflare, `.dev.vars` for local dev, process env on Node).
+
+### `BaerlyError code="UseQueryAwaitedRecorder"`
+
+**Cause:** awaited a terminal (`.get`/`.first`/`.all`/`.count`) inside a
+`useQuery` callback. The recorder is synchronous; awaiting it yields a
+sentinel and the next property access throws.
+**Fix:** don't `await` in `useQuery` — for compound reads use
+`Promise.all` (parallel) or compose two `useQuery` calls with
+`useQuery.skip` (dependent). For writes use `useMutation()`.
+
+### `BaerlyError code="UnexpectedWriteInQuery"`
+
+**Cause:** called a write verb (`insert`/`update`/`replace`/`delete`)
+inside a `useQuery` callback.
+**Fix:** reads go in `useQuery`, writes go in `useMutation()`.
+
+## Anti-patterns (compile-clean but wrong)
+
+- Don't reach into `node_modules/@gusto/baerly-storage/dist/` at runtime —
+  consume the published exports.
+- Don't widen branded types (`UUID`, `ContentVersionId`) with `as string`.
+- Don't put `SHARED_SECRET` in the SPA bundle — it is server-to-server
+  only.
+- Don't mutate `VerifierResult.tenantPrefix` between the verifier and
+  `Db.create` — the dispatcher pins the tenant from the verifier's return.
+- `z.string().nullable()` in a schema — `DocumentValue` excludes `null`.
+- Raw SQL / `WHERE` clauses / hand-built query AST — the only query
+  surface is the `.where(...)` method chain.
+- `.all()` on a hot path — page or cursor-iterate; `.all()` is for
+  bounded result sets.
+
+## Where to look next
+
+- Public API surface: `dist/API.md` (`cat node_modules/@gusto/baerly-storage/dist/API.md`).
+- Per-symbol types: the `dist/*.d.ts` chunks.
+- A remembered call no longer type-checks: `dist/CHANGELOG.md`.

--- a/packages/server/src/auth/presets/bearer-jwt.test.ts
+++ b/packages/server/src/auth/presets/bearer-jwt.test.ts
@@ -274,6 +274,12 @@ describe("bearerJwt — config validation", () => {
       BaerlyError,
     );
   });
+
+  test("InvalidConfig throws carry a resolution string", () => {
+    expect(() => bearerJwt({ jwks, issuer: "", audience: AUDIENCE })).toThrowError(
+      expect.objectContaining({ resolution: expect.any(String) }),
+    );
+  });
 });
 
 describe("bearerJwt — idempotence", () => {

--- a/packages/server/src/auth/presets/bearer-jwt.ts
+++ b/packages/server/src/auth/presets/bearer-jwt.ts
@@ -1,4 +1,9 @@
-import { BaerlyError, type Verifier, type VerifierResult } from "@baerly/protocol";
+import {
+  BEARER_JWT_CONFIG_RESOLUTION,
+  BaerlyError,
+  type Verifier,
+  type VerifierResult,
+} from "@baerly/protocol";
 import {
   createLocalJWKSet,
   createRemoteJWKSet,
@@ -127,14 +132,35 @@ const JWKS_KID_REFRESH_MIN_INTERVAL_MS = 60_000;
  */
 export const bearerJwt = (opts: BearerJwtOptions): Verifier => {
   if (opts.issuer.length === 0) {
-    throw new BaerlyError("InvalidConfig", "bearerJwt: issuer must be non-empty");
+    throw new BaerlyError(
+      "InvalidConfig",
+      "bearerJwt: issuer must be non-empty",
+      undefined,
+      undefined,
+      undefined,
+      BEARER_JWT_CONFIG_RESOLUTION,
+    );
   }
   if (opts.audience.length === 0) {
-    throw new BaerlyError("InvalidConfig", "bearerJwt: audience must be non-empty");
+    throw new BaerlyError(
+      "InvalidConfig",
+      "bearerJwt: audience must be non-empty",
+      undefined,
+      undefined,
+      undefined,
+      BEARER_JWT_CONFIG_RESOLUTION,
+    );
   }
   const algorithms: readonly JwtAlgorithm[] = opts.algorithms ?? DEFAULT_ALGORITHMS;
   if (algorithms.length === 0) {
-    throw new BaerlyError("InvalidConfig", "bearerJwt: algorithms must be non-empty");
+    throw new BaerlyError(
+      "InvalidConfig",
+      "bearerJwt: algorithms must be non-empty",
+      undefined,
+      undefined,
+      undefined,
+      BEARER_JWT_CONFIG_RESOLUTION,
+    );
   }
 
   if (opts.tenantPrefix !== undefined) {
@@ -142,12 +168,20 @@ export const bearerJwt = (opts: BearerJwtOptions): Verifier => {
       throw new BaerlyError(
         "InvalidConfig",
         "bearerJwt: tenantPrefix and tenantClaim are mutually exclusive",
+        undefined,
+        undefined,
+        undefined,
+        BEARER_JWT_CONFIG_RESOLUTION,
       );
     }
     if (opts.tenantPrefix.length === 0 || opts.tenantPrefix.includes("/")) {
       throw new BaerlyError(
         "InvalidConfig",
         `bearerJwt: tenantPrefix must be non-empty and contain no "/" (got ${JSON.stringify(opts.tenantPrefix)})`,
+        undefined,
+        undefined,
+        undefined,
+        BEARER_JWT_CONFIG_RESOLUTION,
       );
     }
   }

--- a/packages/server/src/auth/presets/cloudflare-access.test.ts
+++ b/packages/server/src/auth/presets/cloudflare-access.test.ts
@@ -164,4 +164,10 @@ describe("cloudflareAccess", () => {
       cloudflareAccess({ teamDomain: TEAM_DOMAIN, audienceTag: "A".repeat(64) }),
     ).toThrow(BaerlyError);
   });
+
+  test("InvalidConfig throws carry a resolution string", () => {
+    expect(() => cloudflareAccess({ teamDomain: "", audienceTag: AUDIENCE_TAG })).toThrowError(
+      expect.objectContaining({ resolution: expect.any(String) }),
+    );
+  });
 });

--- a/packages/server/src/auth/presets/cloudflare-access.ts
+++ b/packages/server/src/auth/presets/cloudflare-access.ts
@@ -1,4 +1,4 @@
-import { BaerlyError, type Verifier } from "@baerly/protocol";
+import { CLOUDFLARE_ACCESS_CONFIG_RESOLUTION, BaerlyError, type Verifier } from "@baerly/protocol";
 import { bearerJwt } from "./bearer-jwt.ts";
 
 /**
@@ -75,7 +75,14 @@ export interface CloudflareAccessOptions {
  */
 export const cloudflareAccess = (opts: CloudflareAccessOptions): Verifier => {
   if (opts.teamDomain.length === 0) {
-    throw new BaerlyError("InvalidConfig", "cloudflareAccess: teamDomain must be non-empty");
+    throw new BaerlyError(
+      "InvalidConfig",
+      "cloudflareAccess: teamDomain must be non-empty",
+      undefined,
+      undefined,
+      undefined,
+      CLOUDFLARE_ACCESS_CONFIG_RESOLUTION,
+    );
   }
   if (!/^[0-9a-f]{64}$/.test(opts.audienceTag)) {
     throw new BaerlyError(
@@ -83,6 +90,10 @@ export const cloudflareAccess = (opts: CloudflareAccessOptions): Verifier => {
       `cloudflareAccess: audienceTag must be 64 lowercase-hex chars (got ${JSON.stringify(
         opts.audienceTag,
       )})`,
+      undefined,
+      undefined,
+      undefined,
+      CLOUDFLARE_ACCESS_CONFIG_RESOLUTION,
     );
   }
   const issuer = `https://${opts.teamDomain}.cloudflareaccess.com`;

--- a/packages/server/src/auth/presets/shared-secret.test.ts
+++ b/packages/server/src/auth/presets/shared-secret.test.ts
@@ -48,6 +48,12 @@ describe("sharedSecret", () => {
     }
   });
 
+  test("InvalidConfig throws carry a resolution string", () => {
+    expect(() => sharedSecret({ secret: "", tenantPrefix: "acme" })).toThrowError(
+      expect.objectContaining({ resolution: expect.any(String) }),
+    );
+  });
+
   test("throws BaerlyError{InvalidConfig} on empty tenantPrefix", () => {
     try {
       sharedSecret({ secret: "s3cret", tenantPrefix: "" });

--- a/packages/server/src/auth/presets/shared-secret.ts
+++ b/packages/server/src/auth/presets/shared-secret.ts
@@ -1,4 +1,4 @@
-import { BaerlyError, type Verifier } from "@baerly/protocol";
+import { BaerlyError, SHARED_SECRET_CONFIG_RESOLUTION, type Verifier } from "@baerly/protocol";
 import { timingSafeEqual } from "../internal/timing-safe-equal.ts";
 
 /**
@@ -53,12 +53,23 @@ export interface SharedSecretOptions {
  */
 export const sharedSecret = (opts: SharedSecretOptions): Verifier => {
   if (opts.secret.length === 0) {
-    throw new BaerlyError("InvalidConfig", "sharedSecret: secret must be non-empty");
+    throw new BaerlyError(
+      "InvalidConfig",
+      "sharedSecret: secret must be non-empty",
+      undefined,
+      undefined,
+      undefined,
+      SHARED_SECRET_CONFIG_RESOLUTION,
+    );
   }
   if (opts.tenantPrefix.length === 0 || opts.tenantPrefix.includes("/")) {
     throw new BaerlyError(
       "InvalidConfig",
       `sharedSecret: tenantPrefix must be non-empty and "/"-free (got ${JSON.stringify(opts.tenantPrefix)})`,
+      undefined,
+      undefined,
+      undefined,
+      SHARED_SECRET_CONFIG_RESOLUTION,
     );
   }
   const expected = new TextEncoder().encode(`Bearer ${opts.secret}`);

--- a/packages/server/src/contract.test.ts
+++ b/packages/server/src/contract.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import { errorEnvelope } from "./contract.ts";
+
+describe("errorEnvelope", () => {
+  test("carries retriable derived from code", () => {
+    expect(errorEnvelope("Conflict", "x").error.retriable).toBe(true);
+    expect(errorEnvelope("NetworkError", "x").error.retriable).toBe(true);
+    expect(errorEnvelope("SchemaError", "x").error.retriable).toBe(false);
+  });
+
+  test("non-retriable codes carry retriable: false", () => {
+    expect(errorEnvelope("NotFound", "not found").error.retriable).toBe(false);
+    expect(errorEnvelope("Internal", "boom").error.retriable).toBe(false);
+    expect(errorEnvelope("Unauthorized", "no auth").error.retriable).toBe(false);
+  });
+
+  test("retriable is always present (never undefined)", () => {
+    const env = errorEnvelope("Conflict", "x");
+    expect(typeof env.error.retriable).toBe("boolean");
+  });
+
+  test("retriable can be overridden per error instance", () => {
+    expect(
+      errorEnvelope("Conflict", "duplicate _id", undefined, undefined, false).error.retriable,
+    ).toBe(false);
+    expect(
+      errorEnvelope("SchemaError", "temporary", undefined, undefined, true).error.retriable,
+    ).toBe(true);
+  });
+
+  test("resolution is included when provided", () => {
+    const env = errorEnvelope("InvalidConfig", "x", undefined, "do X");
+    expect(env.error.resolution).toBe("do X");
+  });
+
+  test("resolution is absent when not provided", () => {
+    const env = errorEnvelope("InvalidConfig", "x");
+    expect(env.error.resolution).toBeUndefined();
+  });
+
+  test("falls back to the per-code default resolution", () => {
+    expect(errorEnvelope("NotFound", "No such row: x").error.resolution).toBe(
+      "No row matches this id; create it first or treat this as a miss.",
+    );
+  });
+
+  test("a site-provided resolution wins over the per-code default", () => {
+    expect(errorEnvelope("Conflict", "x", undefined, "custom fix").error.resolution).toBe(
+      "custom fix",
+    );
+  });
+
+  test("codes without a default and without a site value omit resolution", () => {
+    expect(errorEnvelope("Conflict", "CAS lost").error.resolution).toBeUndefined();
+    expect(errorEnvelope("NetworkError", "x").error.resolution).toBeUndefined();
+    expect(errorEnvelope("Internal", "boom").error.resolution).toBeUndefined();
+  });
+
+  test("CAS conflict resolution is supplied by the throw site", () => {
+    const resolution = "Re-read and re-apply your change.";
+    expect(errorEnvelope("Conflict", "CAS lost", undefined, resolution).error.resolution).toBe(
+      resolution,
+    );
+  });
+});

--- a/packages/server/src/contract.ts
+++ b/packages/server/src/contract.ts
@@ -1,4 +1,9 @@
-import type { LogEntry, BaerlyErrorCode } from "@baerly/protocol";
+import {
+  CODE_RESOLUTIONS,
+  isRetriableCode,
+  type LogEntry,
+  type BaerlyErrorCode,
+} from "@baerly/protocol";
 
 /**
  * Wire envelope for every error response. Mirrors `BaerlyError` so
@@ -10,6 +15,8 @@ export interface HttpErrorEnvelope {
   readonly error: {
     readonly code: BaerlyErrorCode;
     readonly message: string;
+    /** Whether this error instance is retriable. Always present; defaults from `code`, with throw-site overrides. Additive. */
+    readonly retriable: boolean;
     /**
      * Field-path issues, present only when `code === "SchemaError"`.
      * Each entry is `{ path, message }` where `path` is the dotted
@@ -21,25 +28,35 @@ export interface HttpErrorEnvelope {
       readonly path: ReadonlyArray<string | number>;
       readonly message: string;
     }>;
+    /** Human-readable remediation hint. Present when the code has a per-code default or a site override; absent for opaque/transient codes. */
+    readonly resolution?: string;
   };
 }
 
 /**
  * Single drift surface for the {@link HttpErrorEnvelope} shape. The
  * router and both adapters call this — adding or renaming a field on
- * the wire is a one-edit change here.
+ * the wire is a one-edit change here. `retriable` is additive (always
+ * present, defaulted from `code`); older clients ignore it.
  */
 export const errorEnvelope = (
   code: BaerlyErrorCode,
   message: string,
   issues?: ReadonlyArray<{ path: ReadonlyArray<string | number>; message: string }>,
-): HttpErrorEnvelope => ({
-  error: {
-    code,
-    message,
-    ...(issues !== undefined && issues.length > 0 ? { issues } : {}),
-  },
-});
+  resolution?: string,
+  retriable?: boolean,
+): HttpErrorEnvelope => {
+  const resolved = resolution ?? CODE_RESOLUTIONS[code];
+  return {
+    error: {
+      code,
+      message,
+      retriable: retriable ?? isRetriableCode(code),
+      ...(issues !== undefined && issues.length > 0 ? { issues } : {}),
+      ...(resolved !== undefined ? { resolution: resolved } : {}),
+    },
+  };
+};
 
 /**
  * Metadata embedded in every successful read response.
@@ -111,7 +128,7 @@ export type Routes =
  * | 401    | `Verifier` returned null → `code:"Unauthorized"`, `message: "Missing or invalid Authorization header"`. |
  * | 403    | Auth ok but tenant prefix denied → `code:"AccessDenied"`.        |
  * | 404    | Doc not found → `code:"NotFound"`. NOT used for "tenant unknown" (→ 401). |
- * | 409    | CAS lost → `code:"Conflict"`.                                    |
+ * | 409    | Write conflict → `code:"Conflict"` (`retriable` says whether to retry). |
  * | 413    | Request body exceeded `MAX_BODY_BYTES` → `code:"PayloadTooLarge"`. |
  * | 500    | Anything else → `code:"Internal"`.                               |
  */

--- a/packages/server/src/http/index.ts
+++ b/packages/server/src/http/index.ts
@@ -5,3 +5,4 @@ export {
   listEventsSince,
   longPollSince,
 } from "./since.ts";
+export { type HttpErrorEnvelope, errorEnvelope } from "../contract.ts";

--- a/packages/server/src/http/no-handbuilt-envelope.test.ts
+++ b/packages/server/src/http/no-handbuilt-envelope.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+// Walk the three packages that emit wire responses; flag any hand-built
+// `error: { code` object literal in non-test source. The single sanctioned
+// constructor is `errorEnvelope` (packages/server/src/contract.ts). WS4's
+// body-cap bug was a hand-built envelope that silently dropped a wire field —
+// this guard makes that class of bug a red test, not a review miss.
+const ROOTS = [
+  "packages/server/src",
+  "packages/adapter-node/src",
+  "packages/adapter-cloudflare/src",
+];
+// `contract.ts` is where errorEnvelope itself lives.
+const ALLOW = new Set(["packages/server/src/contract.ts"]);
+// Repo root is four levels up from packages/server/src/http.
+const REPO_ROOT = join(import.meta.dirname, "..", "..", "..", "..");
+
+function tsFiles(dir: string): string[] {
+  const abs = join(REPO_ROOT, dir);
+  const out: string[] = [];
+  for (const name of readdirSync(abs)) {
+    const rel = join(dir, name);
+    const full = join(REPO_ROOT, rel);
+    if (statSync(full).isDirectory()) {
+      out.push(...tsFiles(rel));
+    } else if (name.endsWith(".ts") && !name.endsWith(".test.ts")) {
+      out.push(rel);
+    }
+  }
+  return out;
+}
+
+describe("no hand-built wire error envelopes", () => {
+  test("every error payload is built by errorEnvelope", () => {
+    const offenders: string[] = [];
+    // 80-char window avoids false positives from unrelated {error:…}/{code:…} coincidences; an offender placing 80+ chars before `code:` would slip through (acceptable — catches the realistic compact shape).
+    const pattern = /error\s*:\s*\{[\s\S]{0,80}?\bcode\s*:/;
+    for (const root of ROOTS) {
+      for (const rel of tsFiles(root)) {
+        if (ALLOW.has(rel)) {
+          continue;
+        }
+        if (pattern.test(readFileSync(join(REPO_ROOT, rel), "utf8"))) {
+          offenders.push(rel);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/server/src/http/router.test.ts
+++ b/packages/server/src/http/router.test.ts
@@ -1,4 +1,9 @@
-import { BaerlyError, MemoryStorage } from "@baerly/protocol";
+import {
+  BaerlyError,
+  MemoryStorage,
+  WHERE_ORDER_JSON_RESOLUTION,
+  WRITE_BODY_SHAPE_RESOLUTION,
+} from "@baerly/protocol";
 import { reset, type LogRecord, type Sink } from "@logtape/logtape";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { Db } from "../db.ts";
@@ -42,14 +47,43 @@ describe("mapError", () => {
     const err = new BaerlyError("NotFound", "No such row: doc-42");
     const { status, envelope } = mapError(err);
     expect(status).toBe(404);
-    expect(envelope.error).toEqual({ code: "NotFound", message: "No such row: doc-42" });
+    expect(envelope.error).toEqual({
+      code: "NotFound",
+      message: "No such row: doc-42",
+      retriable: false,
+      resolution: "No row matches this id; create it first or treat this as a miss.",
+    });
   });
 
   test("unmapped BaerlyError code falls through to 500 with its own message", () => {
     const err = new BaerlyError("InvalidResponse", "GET k: missing ETag");
     const { status, envelope } = mapError(err);
     expect(status).toBe(500);
-    expect(envelope.error).toEqual({ code: "InvalidResponse", message: "GET k: missing ETag" });
+    expect(envelope.error).toEqual({
+      code: "InvalidResponse",
+      message: "GET k: missing ETag",
+      retriable: false,
+    });
+  });
+
+  test("BaerlyError retriable override reaches the wire envelope", () => {
+    const err = new BaerlyError(
+      "Conflict",
+      "duplicate _id",
+      undefined,
+      undefined,
+      undefined,
+      "Choose a different `_id`.",
+      false,
+    );
+    const { status, envelope } = mapError(err);
+    expect(status).toBe(409);
+    expect(envelope.error).toEqual({
+      code: "Conflict",
+      message: "duplicate _id",
+      retriable: false,
+      resolution: "Choose a different `_id`.",
+    });
   });
 
   test("unknown thrown value is sanitized and emitted via the observability channel", () => {
@@ -57,7 +91,11 @@ describe("mapError", () => {
     const { status, envelope } = mapError(err);
     expect(status).toBe(500);
     // No internal detail in the wire envelope.
-    expect(envelope.error).toEqual({ code: "Internal", message: "internal error" });
+    expect(envelope.error).toEqual({
+      code: "Internal",
+      message: "internal error",
+      retriable: false,
+    });
     // The original error reaches the structured server-side channel
     // at error level on the http category.
     expect(records).toHaveLength(1);
@@ -72,7 +110,11 @@ describe("mapError", () => {
   test("non-Error thrown value is sanitized identically", () => {
     const { status, envelope } = mapError("naked string with /etc/secret");
     expect(status).toBe(500);
-    expect(envelope.error).toEqual({ code: "Internal", message: "internal error" });
+    expect(envelope.error).toEqual({
+      code: "Internal",
+      message: "internal error",
+      retriable: false,
+    });
     expect(records).toHaveLength(1);
     expect(records[0]!.level).toBe("error");
     const serialized = records[0]!.properties["error"] as { code: string; message: string };
@@ -243,6 +285,33 @@ describe("router is silent without a wrapping observability scope", () => {
     );
     expect(res.status).toBe(200);
     expect(canonical()).toHaveLength(0);
+  });
+});
+
+describe("request-path 400s carry a resolution hint", () => {
+  test("flat-body 400 teaches the wrap-it resolution", async () => {
+    const app = buildApp();
+    const res = await app.request("/v1/c/notes", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "hi" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      readonly error: { readonly code: string; readonly resolution?: string };
+    };
+    expect(body.error.code).toBe("SchemaError");
+    expect(body.error.resolution).toBe(WRITE_BODY_SHAPE_RESOLUTION);
+  });
+
+  test("invalid ?where= JSON teaches the URL-encoded-JSON resolution", async () => {
+    const app = buildApp();
+    const res = await app.request("/v1/c/notes?where=not-json");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      readonly error: { readonly code: string; readonly resolution?: string };
+    };
+    expect(body.error.resolution).toBe(WHERE_ORDER_JSON_RESOLUTION);
   });
 });
 

--- a/packages/server/src/http/router.ts
+++ b/packages/server/src/http/router.ts
@@ -31,6 +31,8 @@ import {
   type OrderSpec,
   type PredicateWire,
   validateWire,
+  WHERE_ORDER_JSON_RESOLUTION,
+  WRITE_BODY_SHAPE_RESOLUTION,
 } from "@baerly/protocol";
 import type { Db } from "../db.ts";
 import {
@@ -201,7 +203,14 @@ export function createRouter(options: CreateRouterOptions): Hono {
   app.get("/v1/count", async (c) => {
     const collection = c.req.query("collection");
     if (collection === undefined || collection.length === 0) {
-      throw new BaerlyError("SchemaError", "GET /v1/count requires ?collection=<name>");
+      throw new BaerlyError(
+        "SchemaError",
+        "GET /v1/count requires ?collection=<name>",
+        undefined,
+        undefined,
+        undefined,
+        "Add ?collection=<name> to the request URL.",
+      );
     }
     const wire = parseWhereParam(c);
     const { rows, manifestPointer, fresh } = await runAllWithMeta(
@@ -295,7 +304,14 @@ const assertJsonBodyField = (body: unknown, field: string): Record<string, unkno
       ? (body as Record<string, unknown>)[field]
       : undefined;
   if (value === undefined || typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new BaerlyError("SchemaError", `Request body must be { ${field}: object }`);
+    throw new BaerlyError(
+      "SchemaError",
+      `Request body must be { ${field}: object }`,
+      undefined,
+      undefined,
+      undefined,
+      WRITE_BODY_SHAPE_RESOLUTION,
+    );
   }
   return value as Record<string, unknown>;
 };
@@ -327,7 +343,14 @@ const parseWhereParam = (c: Context): PredicateWire => {
   try {
     parsed = JSON.parse(whereParam);
   } catch {
-    throw new BaerlyError("SchemaError", "Invalid JSON in ?where=");
+    throw new BaerlyError(
+      "SchemaError",
+      "Invalid JSON in ?where=",
+      undefined,
+      undefined,
+      undefined,
+      WHERE_ORDER_JSON_RESOLUTION,
+    );
   }
   return validateWire(parsed as PredicateWire);
 };
@@ -369,10 +392,24 @@ function parseOrder(raw: string | undefined): OrderSpec<DocumentData> | undefine
   try {
     parsed = JSON.parse(raw);
   } catch {
-    throw new BaerlyError("SchemaError", "Invalid JSON in ?order=");
+    throw new BaerlyError(
+      "SchemaError",
+      "Invalid JSON in ?order=",
+      undefined,
+      undefined,
+      undefined,
+      WHERE_ORDER_JSON_RESOLUTION,
+    );
   }
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-    throw new BaerlyError("SchemaError", "?order= must encode a JSON object");
+    throw new BaerlyError(
+      "SchemaError",
+      "?order= must encode a JSON object",
+      undefined,
+      undefined,
+      undefined,
+      WHERE_ORDER_JSON_RESOLUTION,
+    );
   }
   return parsed as OrderSpec<DocumentData>;
 }
@@ -405,7 +442,10 @@ const ERROR_TO_STATUS: ReadonlyMap<BaerlyErrorCode, HttpStatus> = new Map<
 export function mapError(err: unknown): { status: HttpStatus; envelope: HttpErrorEnvelope } {
   if (err instanceof BaerlyError) {
     const status = ERROR_TO_STATUS.get(err.code) ?? 500;
-    return { status, envelope: errorEnvelope(err.code, err.message, err.issues) };
+    return {
+      status,
+      envelope: errorEnvelope(err.code, err.message, err.issues, err.resolution, err.retriable),
+    };
   }
   // Unknown thrown value: the message may carry internal detail
   // (file paths, bucket names, upstream response bodies). Log on the
@@ -471,11 +511,25 @@ async function readJsonBody(c: Context, maxBytes: number): Promise<unknown> {
     );
   }
   if (raw.length === 0) {
-    throw new BaerlyError("SchemaError", "Empty request body");
+    throw new BaerlyError(
+      "SchemaError",
+      "Empty request body",
+      undefined,
+      undefined,
+      undefined,
+      WRITE_BODY_SHAPE_RESOLUTION,
+    );
   }
   try {
     return JSON.parse(raw);
   } catch {
-    throw new BaerlyError("SchemaError", "Invalid JSON in request body");
+    throw new BaerlyError(
+      "SchemaError",
+      "Invalid JSON in request body",
+      undefined,
+      undefined,
+      undefined,
+      WRITE_BODY_SHAPE_RESOLUTION,
+    );
   }
 }

--- a/packages/server/src/query.mutations.test.ts
+++ b/packages/server/src/query.mutations.test.ts
@@ -115,6 +115,8 @@ describe("Collection.insert", () => {
     }
     expect(thrown).toBeInstanceOf(BaerlyError);
     expect((thrown as BaerlyError).code).toBe("Conflict");
+    expect((thrown as BaerlyError).retriable).toBe(false);
+    expect((thrown as BaerlyError).resolution).toContain("different `_id`");
     // Cardinality / id should appear in the message so callers can
     // distinguish "duplicate id" from a generic CAS conflict.
     expect((thrown as BaerlyError).message).toContain("dup");

--- a/packages/server/src/query.ts
+++ b/packages/server/src/query.ts
@@ -60,6 +60,8 @@ import { type IndexWalkPlan, planQuery, type QueryPlan } from "./query-planner.t
 import { type SchemaValidator, validateOrThrow } from "./schema.ts";
 import { Writer } from "./writer.ts";
 
+const DUPLICATE_ID_RESOLUTION = "Use different `_id` or omit it.";
+
 /**
  * What a `Query<T>` needs to issue a read against the bucket. The
  * `Db` builds this once and hands it to `Collection` / `Query`; the chain
@@ -396,6 +398,11 @@ export const runInsert = async <T extends DocumentData>(
     throw new BaerlyError(
       "Conflict",
       `Query.insert: _id ${JSON.stringify(_id)} already exists in collection ${JSON.stringify(ctx.collectionName)}`,
+      undefined,
+      undefined,
+      undefined,
+      DUPLICATE_ID_RESOLUTION,
+      false,
     );
   }
 

--- a/packages/server/src/writer.ts
+++ b/packages/server/src/writer.ts
@@ -81,6 +81,8 @@ import {
 } from "./maintenance.ts";
 import { getCurrentContext } from "./observability/context.ts";
 
+const CAS_CONFLICT_RESOLUTION = "Re-read and retry.";
+
 const ctxMetrics = (): MetricsRecorder => getCurrentContext()?.recorder ?? noopMetricsRecorder;
 
 /**
@@ -370,6 +372,11 @@ export class Writer {
     throw new BaerlyError(
       "Conflict",
       `Writer: CAS conflict on ${this.#currentJsonKey} after ${this.#maxRetries} attempts`,
+      undefined,
+      undefined,
+      undefined,
+      CAS_CONFLICT_RESOLUTION,
+      true,
     );
   }
 

--- a/rolldown.config.ts
+++ b/rolldown.config.ts
@@ -5,20 +5,24 @@ import { createRollupLicensePlugin } from "rollup-license-plugin";
 import { licensePluginOptions, PARTIAL_LIB_FILENAME } from "./scripts/third-party-licenses.mjs";
 
 /**
- * Copy the hand-authored markdown artifacts (the public-API quickref and
- * the changelog) into `dist/` so a
- * freshly-installed `node_modules/@gusto/baerly-storage/dist/API.md` gives a
- * CLI agent (no TS LS) the entire public surface in one read. Named
- * `API.md` — not `AGENTS.md` — to avoid colliding with the scaffolded
- * app's own `AGENTS.md` at the user's project root. The `.d.ts` files
- * are split into hash-suffixed shared chunks by the bundler's type
- * splitter; the quickref is the flat sibling.
+ * Copy the hand-authored markdown artifacts (the public-API quickref,
+ * the common-mistakes companion RECIPES.md, and the changelog) into
+ * `dist/` so a freshly-installed
+ * `node_modules/@gusto/baerly-storage/dist/API.md` gives a CLI agent
+ * (no TS LS) the entire public surface in one read, and RECIPES.md
+ * gives a fast "why did my call fail" lookup keyed by exact error
+ * string. Named `API.md` — not `AGENTS.md` — to avoid colliding with
+ * the scaffolded app's own `AGENTS.md` at the user's project root. The
+ * `.d.ts` files are split into hash-suffixed shared chunks by the
+ * bundler's type splitter; the quickref and recipe files are flat
+ * siblings.
  */
 const copyApiQuickref = () => ({
   name: "copy-api-quickref",
   closeBundle() {
     mkdirSync("dist", { recursive: true });
     copyFileSync("packages/server/API.md", "dist/API.md");
+    copyFileSync("packages/server/RECIPES.md", "dist/RECIPES.md");
     // Ship the changelog too: a stranded agent that remembers an older
     // API reads `node_modules/@gusto/baerly-storage/dist/CHANGELOG.md`
     // to recover the current call. Maintained by Changesets at the repo

--- a/tests/fixtures/http-conformance-cascade.ts
+++ b/tests/fixtures/http-conformance-cascade.ts
@@ -29,7 +29,11 @@
 
 import { fc, test as fcTest } from "@fast-check/vitest";
 import { describe, expect, test } from "vitest";
-import type { DocumentData } from "@baerly/protocol";
+import {
+  type DocumentData,
+  WHERE_ORDER_JSON_RESOLUTION,
+  WRITE_BODY_SHAPE_RESOLUTION,
+} from "@baerly/protocol";
 import { CONFORMANCE_BEARER, CONFORMANCE_TENANT } from "./test-verifier.ts";
 
 /**
@@ -203,7 +207,12 @@ const base64ToBytes = (b64: string): Uint8Array => {
 };
 
 interface ErrorEnvelope {
-  readonly error?: { readonly code?: string; readonly message?: string };
+  readonly error?: {
+    readonly code?: string;
+    readonly message?: string;
+    readonly resolution?: string;
+    readonly retriable?: boolean;
+  };
 }
 
 /**
@@ -336,6 +345,28 @@ export const runHttpConformanceCascade = (opts: {
         expect(res.status).toBe(404);
         const env = (await res.json()) as ErrorEnvelope;
         expect(env.error?.code).toBe("NotFound");
+        // `retriable` rides on every error envelope (errorEnvelope() in
+        // contract.ts derives it from the code). NotFound is terminal —
+        // re-issuing the same GET will 404 again — so it MUST be false.
+        expect(env.error?.retriable).toBe(false);
+      });
+
+      test("POST duplicate caller-supplied _id returns terminal 409 Conflict", async () => {
+        const table = await mintTable("rt-duplicate-id");
+        const first = await postDoc(table, { _id: "user-chosen-id", seed: 1 });
+        expect(first.status).toBe(201);
+        expect(first.id).toBe("user-chosen-id");
+
+        const res = await doFetch(
+          authedRequest("POST", `/v1/c/${table}`, {
+            doc: { _id: "user-chosen-id", seed: 2 },
+          }),
+        );
+        expect(res.status).toBe(409);
+        const env = (await res.json()) as ErrorEnvelope;
+        expect(env.error?.code).toBe("Conflict");
+        expect(env.error?.retriable).toBe(false);
+        expect(env.error?.resolution).toContain("different `_id`");
       });
 
       test("PATCH of missing _id returns 404 with NotFound", async () => {
@@ -561,6 +592,7 @@ export const runHttpConformanceCascade = (opts: {
         expect(res.status).toBe(400);
         const env = (await res.json()) as ErrorEnvelope;
         expect(env.error?.code).toBe("SchemaError");
+        expect(env.error?.resolution).toBe(WHERE_ORDER_JSON_RESOLUTION);
       });
 
       test("?order=<JSON spec> sorts the row set", async () => {
@@ -690,6 +722,7 @@ export const runHttpConformanceCascade = (opts: {
         expect(res.status).toBe(400);
         const env = (await res.json()) as ErrorEnvelope;
         expect(env.error?.code).toBe("SchemaError");
+        expect(env.error?.resolution).toBe(WRITE_BODY_SHAPE_RESOLUTION);
       });
     });
 

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -274,7 +274,23 @@ const BUDGETS: readonly Budget[] = [
   //   → raw −1 KiB (2026-06-23): trimmed the duplicated @example recipe from the
   //     CLOUDFLARE_PAID_TIER JSDoc (kept a terse pointer); reclaims one of the two
   //     KiB above (measured 225667 raw). The constant's code holds the other KiB.
-  { entry: "index.js", raw: 221 * 1024, gz: 69 * 1024, minGz: 19 * 1024 },
+  //   → raw −1 KiB / gz −1 KiB (2026-06-24): W4-5 bundle hygiene — moved the 3
+  //     RESOLUTION constants out of constants.ts into a zero-import leaf
+  //     (auth-resolution.ts), eliminating the constants chunk from closures that
+  //     only need the resolution strings. Trimmed verbose JSDoc in errors.ts +
+  //     contract.ts. Measured: 226812 raw / 70586 gz.
+  //   → gz −1 KiB (2026-06-24): WS4.1 T5 A1 JSDoc trim (CODE_RESOLUTIONS comment)
+  //     shed bytes from the index closure; tighten gz to the smallest KiB that clears.
+  //     Measured: 70586 gz (69*1024 = 70656 ≥ 70586). // WS4.1
+  //   → gz +1 KiB (2026-06-24): the 69 KiB line did not reproduce on a clean build
+  //     (measured 70712 gz, +56 over), and the `retriable`/resolution metadata is
+  //     worth the bytes. Rebaseline gz to 70 KiB rather than golf source to fit.
+  //     POLICY: min-gz is the hard ceiling — it is the real shipped-to-browser cost
+  //     after a consumer bundler minifies (stripping the un-stripped JSDoc and
+  //     mangling locals that this unminified-gz axis still counts). Treat raw/gz as
+  //     creep tripwires, NOT hard limits; do not trim explanatory comments or golf
+  //     identifiers to satisfy them. min-gz here is 19104 / 19456 (−352, healthy).
+  { entry: "index.js", raw: 222 * 1024, gz: 70 * 1024, minGz: 19 * 1024 },
   // The three auth verifier factories (bearerJwt, sharedSecret,
   // cloudflareAccess) plus the transitive jose closure pulled in by
   // bearerJwt's createRemoteJWKSet + jwtVerify. Adding a fourth
@@ -292,7 +308,17 @@ const BUDGETS: readonly Budget[] = [
   //     ship `sub`/`email` but no `tenant` claim. Measured: 54746 raw.
   //   → +min+gz axis 10 KiB (2026-06-01): consumer-facing artifact proxy
   //     baselined / measured 8909.
-  { entry: "auth.js", raw: 54 * 1024, gz: 15 * 1024, minGz: 10 * 1024 },
+  //   → raw +1 KiB (2026-06-24): RETRIABLE_CODES + isRetriableCode + BaerlyError.retriable
+  //     getter in errors.ts; JSDoc ships un-stripped (measured 55803 raw).
+  //   → raw +2 KiB / gz +1 KiB (2026-06-24): 3 resolution string constants in
+  //     constants.ts dragged the whole constants chunk into auth's closure
+  //     (measured 67752 raw / 19398 gz). WS4 anti-pattern: constants chunk
+  //     has ~10 KiB of heavy kernel-tuning JSDoc unused by auth.
+  //   → raw −10 KiB / gz −4 KiB (2026-06-24): W4-5 bundle hygiene — moved the 3
+  //     RESOLUTION constants to zero-import leaf auth-resolution.ts; constants chunk
+  //     no longer in auth closure. Trimmed verbose JSDoc. Measured: 57120 raw /
+  //     15182 gz / 9164 min-gz.
+  { entry: "auth.js", raw: 56 * 1024, gz: 15 * 1024, minGz: 9 * 1024 },
   // `BaerlyAppConfig` types + the identity `defineConfig` helper.
   // No runtime closure — the types erase entirely and the function
   // is `<C>(c: C) => c`. Measured: 162 raw / 141 gz. Budget is a
@@ -394,7 +420,16 @@ const BUDGETS: readonly Budget[] = [
   //   → raw +1 KiB (2026-06-22): CLOUDFLARE_PAID_TIER constant + JSDoc in
   //     maintenance.ts lands in the request-path writer → maintenance closure
   //     (measured 341936 raw); gz/min-gz unaffected.
-  { entry: "http.js", raw: 334 * 1024, gz: 99 * 1024, minGz: 34 * 1024 },
+  //   → gz +1 KiB (2026-06-24): RETRIABLE_CODES + isRetriableCode + BaerlyError.retriable
+  //     getter in errors.ts (measured 101414 gz).
+  //   → raw −2 KiB / gz −1 KiB (2026-06-24): W4-5 bundle hygiene — constants chunk no
+  //     longer in http closure (moved RESOLUTION constants to zero-import leaf; JSDoc trim).
+  //     Measured: 341579 raw / 101395 gz / 34178 min-gz.
+  //   → raw +1 KiB (2026-06-24): WS4.1 T1 CODE_RESOLUTIONS + WHERE_ORDER/WRITE_BODY strings
+  //     reach http.js via the protocol barrel → errorEnvelope. Measured: 342699 raw.
+  //   → raw +1 KiB (2026-06-24): WS4.1 T2 WHERE_ORDER/WRITE_BODY_SHAPE_RESOLUTION wired into
+  //     router.ts throw sites (7 new resolution strings inline). Measured: 343596 raw.
+  { entry: "http.js", raw: 336 * 1024, gz: 100 * 1024, minGz: 34 * 1024 },
   // Observability primitives — ObservabilityContext, the
   // request-scoped MetricsRecorder, LogTape config + the
   // JSON sink only (the pretty sink + picocolors now live in
@@ -430,7 +465,17 @@ const BUDGETS: readonly Budget[] = [
   //     left at 25 KiB; its 765 B slack is already tight.
   //   → +min+gz axis 12 KiB (2026-06-01): consumer-facing artifact proxy
   //     baselined / measured 11284.
-  { entry: "observability.js", raw: 91 * 1024, gz: 25 * 1024, minGz: 12 * 1024 },
+  //   → raw −1 KiB (2026-06-24): W4-5 bundle hygiene — JSDoc trim in errors.ts reclaims
+  //     bytes. Measured: 92686 raw / 25244 gz / 11399 min-gz.
+  //   → raw +1 KiB / gz +1 KiB (2026-06-24): WS4.1 T1 CODE_RESOLUTIONS + resolution strings
+  //     reach observability.js via the errors chunk (canonicalLine + errorEnvelope paths).
+  //     Measured: 93806 raw / 25709 gz.
+  //   → raw +1 KiB (2026-06-24): WS4.1 T2 WHERE_ORDER/WRITE_BODY_SHAPE_RESOLUTION wired into
+  //     router.ts throw sites. Measured: 94247 raw.
+  //   → raw −1 KiB (2026-06-24): WS4.1 T5 A1 JSDoc trim (CODE_RESOLUTIONS comment) sheds
+  //     bytes from the observability closure; tighten to the smallest KiB that clears.
+  //     Measured: 93936 raw (92*1024 = 94208 ≥ 93936). // WS4.1
+  { entry: "observability.js", raw: 92 * 1024, gz: 26 * 1024, minGz: 12 * 1024 },
   // Maintenance loop — compactor + GC + sweep driver. Pulls
   // compactor.ts + gc.ts + the observability subgraph
   // transitively (storage decorator + logger config + canonical
@@ -509,7 +554,12 @@ const BUDGETS: readonly Budget[] = [
   //   → raw −1 KiB (2026-06-23): trimmed the duplicated @example recipe from the
   //     CLOUDFLARE_PAID_TIER JSDoc (measured 123841 raw). gz stays at 38 KiB —
   //     the trim narrowed but didn't cross the KiB boundary (measured 37916 gz).
-  { entry: "maintenance.js", raw: 121 * 1024, gz: 38 * 1024, minGz: 11 * 1024 },
+  //   → raw +1 KiB (2026-06-24): RETRIABLE_CODES + isRetriableCode + BaerlyError.retriable
+  //     getter in errors.ts (measured 124817 raw).
+  //   → raw −2 KiB / gz −1 KiB (2026-06-24): W4-5 bundle hygiene — constants chunk no
+  //     longer in maintenance closure (moved RESOLUTION constants to leaf; JSDoc trim).
+  //     Measured: 124579 raw / 38165 gz / 11113 min-gz.
+  { entry: "maintenance.js", raw: 122 * 1024, gz: 38 * 1024, minGz: 11 * 1024 },
   // Cloudflare Workers adapter — re-exports the kernel barrel
   // (Db, Writer, etc.) plus the R2-binding `Storage` impl
   // and the `baerlyCloudflare` helper. Aggregator: closure
@@ -603,7 +653,19 @@ const BUDGETS: readonly Budget[] = [
   //   → raw +1 KiB (2026-06-22): CLOUDFLARE_PAID_TIER constant + JSDoc (~23 lines)
   //     in maintenance.ts reaches the cloudflare closure via the maintenance shared
   //     chunk (measured 399144 raw); gz/min-gz unaffected.
-  { entry: "cloudflare.js", raw: 390 * 1024, gz: 117 * 1024, minGz: 40 * 1024 },
+  //   → raw −1 KiB (2026-06-24): W4-5 bundle hygiene — constants chunk no longer in
+  //     cloudflare closure (moved RESOLUTION constants to leaf; JSDoc trim).
+  //     Measured: 399974 raw / 120229 gz / 40569 min-gz.
+  //   → raw +1 KiB (2026-06-24): WS4.1 T1 CODE_RESOLUTIONS + resolution strings reach
+  //     cloudflare.js via the protocol barrel → errorEnvelope. Measured: 401094 raw.
+  //   → raw +1 KiB / gz +1 KiB (2026-06-24): WS4.1 T2 WHERE_ORDER/WRITE_BODY_SHAPE_RESOLUTION
+  //     wired into router.ts throw sites. Measured: 401991 raw / 121051 gz.
+  //   → min-gz +1 KiB (2026-06-24): renamed `BaerlyError`'s private `r` field to
+  //     `retriableOverride` for clarity. Soft-private TS field names survive
+  //     minification (no prop-mangle), so this lands +2 B on the min-gz axis
+  //     (measured 40962 / 40960). A clearer field is worth two shipped bytes —
+  //     rebaseline min-gz to 41 KiB.
+  { entry: "cloudflare.js", raw: 393 * 1024, gz: 119 * 1024, minGz: 41 * 1024 },
   // Client surface — `BaerlyClient<TConfig>` + fetcher plumbing.
   // Browser/runtime-agnostic; no kernel modules in the closure.
   // Budget history:
@@ -660,7 +722,11 @@ const BUDGETS: readonly Budget[] = [
   //     8534 gz — net +2541 raw / +1272 gz vs. pre-collapse.
   //   → +min+gz axis 4 KiB (2026-06-01): consumer-facing artifact proxy
   //     baselined / measured 3380.
-  { entry: "client-react.js", raw: 26 * 1024, gz: 9 * 1024, minGz: 4 * 1024 },
+  //   → raw +1 KiB (2026-06-24): RETRIABLE_CODES + isRetriableCode + BaerlyError.retriable
+  //     getter in errors.ts (measured 26916 raw).
+  //   → gz −1 KiB (2026-06-24): W4-5 bundle hygiene — JSDoc trim in errors.ts.
+  //     Measured: 26724 raw / 8979 gz / 3469 min-gz.
+  { entry: "client-react.js", raw: 27 * 1024, gz: 9 * 1024, minGz: 4 * 1024 },
   // `@baerly/dev` surface — `LocalFsStorage`, `printDevBanner`,
   // `ensureTable`, `renderDevLanding`. NO longer an aggregator over
   // the kernel barrel: the only kernel surfaces these helpers touch
@@ -726,7 +792,12 @@ const BUDGETS: readonly Budget[] = [
   //   → 37 KiB raw / 14 KiB gz (2026-06-22): MAINTENANCE_PROFILE_CF_PAID JSDoc
   //     (~23 lines) in constants.ts lands in the protocol chunk this dev barrel
   //     pulls; comments ship un-stripped (gz 13→14).
-  { entry: "dev.js", raw: 37 * 1024, gz: 14 * 1024 },
+  //   → raw +1 KiB (2026-06-24): RETRIABLE_CODES + isRetriableCode + BaerlyError.retriable
+  //     getter in errors.ts (measured 38173 raw).
+  //   → raw −2 KiB (2026-06-24): W4-5 bundle hygiene — constants chunk no longer
+  //     in dev closure (moved RESOLUTION constants to leaf; JSDoc trim).
+  //     Measured: 37935 raw / 13618 gz.
+  { entry: "dev.js", raw: 38 * 1024, gz: 14 * 1024 },
 ];
 
 // Static-import specifiers only. Dynamic `import(...)` is intentionally

--- a/tests/integration/dist-docs.test.ts
+++ b/tests/integration/dist-docs.test.ts
@@ -2,15 +2,17 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 
-// The published package ships two hand-authored markdown artifacts in
-// `dist/` so an agent reading `node_modules/@gusto/baerly-storage/dist/`
-// gets the current API surface (API.md) and a migration-shaped record of
-// what changed across versions (CHANGELOG.md) without a TS language server.
-// rolldown's `copy-api-quickref` closeBundle step copies both verbatim.
+// The published package ships hand-authored markdown artifacts in `dist/`
+// so an agent reading `node_modules/@gusto/baerly-storage/dist/` gets the
+// current API surface (API.md), common-mistakes reference (RECIPES.md), and
+// a migration-shaped record of what changed across versions (CHANGELOG.md)
+// without a TS language server. rolldown's `copy-api-quickref` closeBundle
+// step copies all three verbatim.
 const ROOT = resolve(__dirname, "../..");
 
 const SHIPPED = [
   { dist: "dist/API.md", source: "packages/server/API.md" },
+  { dist: "dist/RECIPES.md", source: "packages/server/RECIPES.md" },
   { dist: "dist/CHANGELOG.md", source: "CHANGELOG.md" },
 ];
 
@@ -24,4 +26,21 @@ describe("shipped doc artifacts", () => {
       expect(readFileSync(distAbs, "utf8")).toBe(readFileSync(resolve(ROOT, source), "utf8"));
     });
   }
+});
+
+// API.md is the zero-shot public-API quickref an agent reads from
+// `node_modules/@gusto/baerly-storage/dist/API.md`. It sits at the
+// ~12k-token soft ceiling (CLAUDE.md): net-new prose must land in
+// RECIPES.md, not here. This guard fails the build if API.md creeps
+// past the ceiling so the budget can't erode silently.
+const API_MD_MAX_BYTES = 46_000;
+
+describe("API.md token budget", () => {
+  test(`packages/server/API.md stays under ${API_MD_MAX_BYTES} bytes`, () => {
+    const bytes = Buffer.byteLength(
+      readFileSync(resolve(ROOT, "packages/server/API.md"), "utf8"),
+      "utf8",
+    );
+    expect(bytes).toBeLessThanOrEqual(API_MD_MAX_BYTES);
+  });
 });


### PR DESCRIPTION
## What

Make baerly-storage's errors **actionable** for the LLM-first audience — terse but helpful, in the Elm tradition — and add a troubleshooting reference keyed on the real error strings.

### `feat(errors)`
- `BaerlyError` gains `retriable` (defaulted per-code from `RETRIABLE_CODES`, overridable at context-sensitive throw sites) and `resolution` (a canonical corrective action).
- Both fields cross the wire via the single `HttpErrorEnvelope` surface (`errorEnvelope`) and are rebuilt onto `BaerlyError` by the client decoder, so in-process and over-the-wire errors are shape-identical.
- Conflict retryability is now context-specific: CAS-exhaustion → `retriable: true` (re-read and retry); duplicate `_id` → `retriable: false` (terminal).
- Body-cap (413) and request-shape (400) failures route through the shared envelope helper instead of hand-built JSON; a guard test (`no-handbuilt-envelope.test.ts`) keeps it that way.
- Auth-preset config errors carry resolution strings; conformance asserts the new wire fields across the cascade.

### `docs(api)`
- Extracts "common mistakes" out of `API.md` (keeping it under its byte budget) into a sibling `RECIPES.md`, copied to `dist/` on build and guarded byte-exact by `dist-docs.test.ts`.

## Notes
- The `retriable` getter's backing field is named `retriableOverride` for clarity (the few shipped bytes are bumped on the affected min-gz budget rather than golfing the name).
- `index.js` gz budget rebaselined to the value a clean build produces; the bundle-size comment now states the policy: **min-gz is the hard ceiling; raw/gz are creep tripwires, not a reason to trim comments or golf identifiers.**

## Verification
- `pnpm bundle-sizes` — 16/16 budgets pass
- `pnpm verify:agent` — typecheck / lint / format / docs clean
- `pnpm test:agent` — 2206 passed, 0 failed (includes a new older-server `retriable`-omitted fallback test)