### PR TITLE
fix(http): scrub internal transport details

### DIFF
--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -9,7 +9,7 @@ import { MockFetch } from "./testing/index.ts";
 
 const okEnvelope = <T>(data: T): HttpOkEnvelope<T> => ({
   data,
-  _meta: { manifest_pointer: "none@0", fresh: true },
+  _meta: { manifest_pointer: "mock-cursor", fresh: true },
 });
 
 const jsonResponse = (body: unknown, status = 200): Response =>
@@ -144,7 +144,7 @@ describe("createBaerlyClient", () => {
       );
       return jsonResponse({
         data: { count: 42 },
-        _meta: { manifest_pointer: "none@0", fresh: true },
+        _meta: { manifest_pointer: "mock-cursor", fresh: true },
       });
     });
     const client = createBaerlyClient({ baseUrl: "http://x", fetch: mock.fetch });
@@ -161,7 +161,7 @@ describe("createBaerlyClient", () => {
       expect(url.searchParams.has("where")).toBe(false);
       return jsonResponse({
         data: { count: 7 },
-        _meta: { manifest_pointer: "none@0", fresh: true },
+        _meta: { manifest_pointer: "mock-cursor", fresh: true },
       });
     });
     const client = createBaerlyClient({ baseUrl: "http://x", fetch: mock.fetch });

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -13,7 +13,8 @@ import type { BaerlyErrorCode, LogEntry } from "@baerly/protocol";
  *
  * - `manifest_pointer` — opaque-to-the-consumer string cursor
  *   identifying the `current.json` generation this read folded over.
- *   Treat as opaque on the wire.
+ *   It is a digest of manifest state, not a bucket key. Treat as
+ *   opaque on the wire.
  * - `fresh` — `true` iff this read advanced the locally-cached
  *   pointer on the server (cold path); `false` iff it served from the
  *   cached view.

--- a/packages/client/src/react/use-query.test.ts
+++ b/packages/client/src/react/use-query.test.ts
@@ -10,7 +10,7 @@ import { useQuery, type UseQueryResult } from "./use-query.ts";
 
 const okEnvelope = <T>(data: T) => ({
   data,
-  _meta: { manifest_pointer: "none@0", fresh: true },
+  _meta: { manifest_pointer: "mock-cursor", fresh: true },
 });
 
 const jsonResponse = (body: unknown, status = 200): Response =>

--- a/packages/client/src/testing/index.ts
+++ b/packages/client/src/testing/index.ts
@@ -20,7 +20,7 @@ import type { Fetcher } from "../request.ts";
  * mock.on("GET", "/v1/c/tickets", () =>
  *   new Response(JSON.stringify({
  *     data: [{ _id: "a" }],
- *     _meta: { manifest_pointer: "none@0", fresh: true },
+ *     _meta: { manifest_pointer: "mock-cursor", fresh: true },
  *   })),
  * );
  * const client = createBaerlyClient({ baseUrl: "http://x", fetch: mock.fetch });

--- a/packages/protocol/src/constants.test.ts
+++ b/packages/protocol/src/constants.test.ts
@@ -26,9 +26,8 @@ describe("wire-contract constants", () => {
   });
 
   test("MANIFEST_POINTER_EMPTY_SNAPSHOT is an on-wire cursor contract", () => {
-    // Serialised into _meta.manifest_pointer on HTTP read responses as
-    // "<snapshot>@<tail_hint>" — null snapshots use this literal so the
-    // cursor is byte-stable and never empty (e.g. "none@0").
+    // Used as the stable null-snapshot seed for the opaque
+    // _meta.manifest_pointer digest.
     expect(MANIFEST_POINTER_EMPTY_SNAPSHOT).toBe("none");
   });
 

--- a/packages/protocol/src/constants.ts
+++ b/packages/protocol/src/constants.ts
@@ -520,11 +520,11 @@ export const MAINTENANCE_WARN_INTERVAL_WRITES: number = 1000;
 export const MAINTENANCE_TAIL_HINT_REFRESH_WRITES: number = 128;
 
 /**
- * Placeholder for `CurrentJson.snapshot === null` in the
- * `_meta.manifest_pointer` cursor emitted on read responses. The
- * wire format is `"<snapshot>@<tail_hint>"`, and `null` snapshots
- * serialise as this literal so the cursor is never empty and stays
- * byte-stable when destructured by operators.
+ * Stable seed for `CurrentJson.snapshot === null` when building the
+ * opaque `_meta.manifest_pointer` cursor emitted on read responses.
+ * The literal no longer appears by itself on the wire; it is folded
+ * into the server-side digest so the cursor never exposes physical
+ * snapshot keys.
  *
  * @see packages/server/src/contract.ts (HttpOkMeta)
  */

--- a/packages/protocol/src/spec/ir-schema.json
+++ b/packages/protocol/src/spec/ir-schema.json
@@ -26,11 +26,15 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["code", "httpStatus", "retriable", "summary"],
+        "required": ["code", "httpStatus", "retriable", "messagePolicy", "summary"],
         "properties": {
           "code": { "type": "string" },
           "httpStatus": { "type": ["integer", "null"] },
           "retriable": { "type": "boolean" },
+          "messagePolicy": {
+            "type": "string",
+            "enum": ["public", "scrubbed", "contextual", "not-on-http"]
+          },
           "summary": { "type": "string" }
         }
       }

--- a/packages/server/API.md
+++ b/packages/server/API.md
@@ -381,10 +381,16 @@ app.post("/notes", async (c) => {
 });
 ```
 
-`mapError` accepts any thrown value — non-`BaerlyError` throws fall
-through to `500 Internal` with the message redacted, and the
-underlying error is logged via the observability channel. The HTTP
-status / envelope shape is locked.
+`mapError` accepts any thrown value. Caller-facing errors such as
+`SchemaError`, `NotFound`, `PayloadTooLarge`, predicate `InvalidConfig`,
+and non-retriable caller `Conflict`s keep their actionable message.
+Storage/server diagnostics such as `Internal`, `NetworkError`,
+`InvalidResponse`, storage `AccessDenied`, storage `InvalidConfig`, and
+retriable CAS/storage `Conflict`s keep their code/status/retriable shape
+but use a generic wire message; the full thrown error is logged via the
+observability channel. Non-`BaerlyError` throws fall through to
+`500 Internal` with the message redacted. The HTTP status / envelope shape
+is locked.
 
 ## `defineConfig({ app, tenant, target, collections })`
 

--- a/packages/server/spec/baerly.spec.json
+++ b/packages/server/spec/baerly.spec.json
@@ -7,84 +7,98 @@
       "code": "InvalidConfig",
       "httpStatus": 400,
       "retriable": false,
+      "messagePolicy": "contextual",
       "summary": "Caller config or input is invalid."
     },
     {
       "code": "NetworkError",
       "httpStatus": 502,
       "retriable": true,
+      "messagePolicy": "scrubbed",
       "summary": "S3/HTTP transport failure (5xx, retries exhausted)."
     },
     {
       "code": "AccessDenied",
       "httpStatus": 403,
       "retriable": false,
+      "messagePolicy": "scrubbed",
       "summary": "S3 returned 403 — credentials or bucket policy."
     },
     {
       "code": "InvalidResponse",
       "httpStatus": 502,
       "retriable": false,
+      "messagePolicy": "scrubbed",
       "summary": "Server returned unparseable data."
     },
     {
       "code": "Internal",
       "httpStatus": 500,
       "retriable": false,
+      "messagePolicy": "scrubbed",
       "summary": "Internal invariant violation — file a bug."
     },
     {
       "code": "SchemaError",
       "httpStatus": 400,
       "retriable": false,
+      "messagePolicy": "public",
       "summary": "Document body failed schema validation; carries .issues."
     },
     {
       "code": "Conflict",
       "httpStatus": 409,
       "retriable": true,
+      "messagePolicy": "contextual",
       "summary": "Write conflicted (CAS exhausted, duplicate _id, guarded key)."
     },
     {
       "code": "Unauthorized",
       "httpStatus": 401,
       "retriable": false,
+      "messagePolicy": "public",
       "summary": "Verifier returned no identity."
     },
     {
       "code": "NotFound",
       "httpStatus": 404,
       "retriable": false,
+      "messagePolicy": "public",
       "summary": "Addressed resource does not exist."
     },
     {
       "code": "PayloadTooLarge",
       "httpStatus": 413,
       "retriable": false,
+      "messagePolicy": "public",
       "summary": "Request body exceeded MAX_BODY_BYTES."
     },
     {
       "code": "UnsatisfiablePredicate",
       "httpStatus": 400,
       "retriable": false,
+      "messagePolicy": "public",
       "summary": "Predicate is well-formed but contradicts itself."
     },
     {
       "code": "UseQueryAwaitedRecorder",
       "httpStatus": null,
       "retriable": false,
+      "messagePolicy": "not-on-http",
       "summary": "A useQuery callback awaited a recorder terminal."
     },
     {
       "code": "UnexpectedWriteInQuery",
       "httpStatus": null,
       "retriable": false,
+      "messagePolicy": "not-on-http",
       "summary": "A write verb was called inside a useQuery callback."
     },
     {
       "code": "MutationFailed",
       "httpStatus": null,
       "retriable": false,
+      "messagePolicy": "not-on-http",
       "summary": "A useMutation callback rejected with a non-BaerlyError."
     }
   ],

--- a/packages/server/src/contract.ts
+++ b/packages/server/src/contract.ts
@@ -9,7 +9,11 @@ import {
  * Wire envelope for every error response. Mirrors `BaerlyError` so
  * the client SDK reconstructs the same class shape it would see
  * in-process. `code` is the discriminant; `cause` is never sent on
- * the wire.
+ * the wire. `message` follows the HTTP message policy: caller-facing
+ * errors carry actionable detail, predicate `InvalidConfig` keeps its
+ * request-fix guidance, and storage/server diagnostics use generic text
+ * so bucket keys, layout, ETags, and upstream response bodies stay
+ * server-side.
  */
 export interface HttpErrorEnvelope {
   readonly error: {
@@ -63,10 +67,8 @@ export const errorEnvelope = (
  *
  * - `manifest_pointer` is an opaque-to-the-consumer string cursor
  *   identifying the `current.json` generation this read folded over.
- *   Today's format is `"<snapshot>@<tail_hint>"` where `<snapshot>` is
- *   the literal `"none"` when `CurrentJson.snapshot` is `null`. Treat
- *   as opaque on the wire — the shape may change in a future minor
- *   without breaking destructuring consumers.
+ *   It is a digest of manifest state, not a bucket key; treat it as
+ *   opaque on the wire.
  * - `fresh` is `true` iff this read advanced the locally-cached
  *   pointer (cold path); `false` iff it served from the cached view
  *   (cached pointer was unchanged).
@@ -124,13 +126,13 @@ export type Routes =
  * | 201    | `POST` insert success — body `{ _id }`.                          |
  * | 204    | `DELETE` success — no body.                                      |
  * | 304    | Reserved. Long-poll idleness ships as 200 + empty events.        |
- * | 400    | Body parse failed → `HttpErrorEnvelope` `code:"SchemaError"`.    |
+ * | 400    | Caller request failed → `SchemaError` / `InvalidConfig` / `UnsatisfiablePredicate`. Predicate `InvalidConfig` guidance is public; server/storage config detail is scrubbed. |
  * | 401    | `Verifier` returned null → `code:"Unauthorized"`, `message: "Missing or invalid Authorization header"`. |
  * | 403    | Auth ok but tenant prefix denied → `code:"AccessDenied"`.        |
  * | 404    | Doc not found → `code:"NotFound"`. NOT used for "tenant unknown" (→ 401). |
- * | 409    | Write conflict → `code:"Conflict"` (`retriable` says whether to retry). |
+ * | 409    | Write conflict → `code:"Conflict"` (`retriable` says whether to retry). Non-retriable caller conflicts keep their message; retriable CAS/storage conflicts are scrubbed. |
  * | 413    | Request body exceeded `MAX_BODY_BYTES` → `code:"PayloadTooLarge"`. |
- * | 502    | Storage/network upstream failed → `code:"NetworkError"` / `code:"InvalidResponse"`. |
- * | 500    | Anything else → `code:"Internal"`.                               |
+ * | 502    | Storage/network upstream failed → `code:"NetworkError"` / `code:"InvalidResponse"` with a generic message. |
+ * | 500    | Anything else → `code:"Internal"` with a generic message.         |
  */
 export type HttpStatus = 200 | 201 | 204 | 304 | 400 | 401 | 403 | 404 | 409 | 413 | 500 | 502;

--- a/packages/server/src/http/router.test.ts
+++ b/packages/server/src/http/router.test.ts
@@ -55,17 +55,56 @@ describe("mapError", () => {
     });
   });
 
-  test("upstream storage errors map to 502 with their own message", () => {
-    const err = new BaerlyError("InvalidResponse", "GET k: missing ETag");
+  test("upstream storage errors map to 502 with scrubbed messages", () => {
+    const err = new BaerlyError(
+      "InvalidResponse",
+      "GET app/router-test/tenant/t1/manifests/notes/current.json: missing ETag",
+    );
     const { status, envelope } = mapError(err);
     expect(status).toBe(502);
     expect(envelope.error).toEqual({
       code: "InvalidResponse",
-      message: "GET k: missing ETag",
+      message: "upstream response error",
       retriable: false,
     });
+    expect(envelope.error.message).not.toContain("current.json");
+    expect(records).toHaveLength(1);
+    const serialized = records[0]!.properties["error"] as { code: string; message: string };
+    expect(serialized.code).toBe("InvalidResponse");
+    expect(serialized.message).toContain("current.json");
 
-    expect(mapError(new BaerlyError("NetworkError", "S3 timeout")).status).toBe(502);
+    const network = mapError(
+      new BaerlyError(
+        "NetworkError",
+        "LIST app/router-test/tenant/t1/manifests/notes: 503 upstream body",
+      ),
+    );
+    expect(network.status).toBe(502);
+    expect(network.envelope.error).toEqual({
+      code: "NetworkError",
+      message: "upstream network error",
+      retriable: true,
+    });
+  });
+
+  test("AccessDenied is scrubbed on the wire but logged in full", () => {
+    const err = new BaerlyError(
+      "AccessDenied",
+      "GET app/router-test/tenant/t1/manifests/notes/current.json: provider denied bucket policy",
+    );
+    const { status, envelope } = mapError(err);
+    expect(status).toBe(403);
+    expect(envelope.error).toEqual({
+      code: "AccessDenied",
+      message: "access denied",
+      retriable: false,
+      resolution: "These credentials are denied for this tenant prefix or bucket policy.",
+    });
+    expect(envelope.error.message).not.toContain("current.json");
+    expect(records).toHaveLength(1);
+    const serialized = records[0]!.properties["error"] as { code: string; message: string };
+    expect(serialized.code).toBe("AccessDenied");
+    expect(serialized.message).toContain("current.json");
   });
 
   test("unsatisfiable predicates are caller errors", () => {
@@ -94,6 +133,97 @@ describe("mapError", () => {
       retriable: false,
       resolution: "Choose a different `_id`.",
     });
+  });
+
+  test("retriable Conflict is scrubbed but non-retriable caller Conflict stays actionable", () => {
+    const storageConflict = new BaerlyError(
+      "Conflict",
+      "Writer: CAS conflict on app/router-test/tenant/t1/manifests/notes/current.json",
+      undefined,
+      undefined,
+      undefined,
+      "Re-read and re-apply your change.",
+      true,
+    );
+    expect(mapError(storageConflict).envelope.error).toEqual({
+      code: "Conflict",
+      message: "write conflict",
+      retriable: true,
+      resolution: "Re-read and re-apply your change.",
+    });
+
+    const callerConflict = new BaerlyError(
+      "Conflict",
+      "duplicate _id",
+      undefined,
+      undefined,
+      undefined,
+      "Choose a different `_id`.",
+      false,
+    );
+    expect(mapError(callerConflict).envelope.error).toEqual({
+      code: "Conflict",
+      message: "duplicate _id",
+      retriable: false,
+      resolution: "Choose a different `_id`.",
+    });
+  });
+
+  test("InvalidConfig scrubs storage config detail by default", () => {
+    const storageError = new BaerlyError(
+      "InvalidConfig",
+      "LocalFsStorage: resolved path escapes root: app/router-test/tenant/t1/manifests/notes/current.json",
+    );
+    expect(mapError(storageError).envelope.error).toEqual({
+      code: "InvalidConfig",
+      message: "invalid server configuration",
+      retriable: false,
+    });
+    const serialized = records[0]!.properties["error"] as { code: string; message: string };
+    expect(serialized.message).toContain("current.json");
+  });
+
+  test("Internal BaerlyError is scrubbed on the wire but logged in full", () => {
+    // Server-thrown protocol-invariant violations embed bucket-key /
+    // log-prefix layout in their message; that detail must never reach
+    // the client, only the server-side log.
+    const err = new BaerlyError(
+      "Internal",
+      "compact: snapshot pointer router-test/notes/t1/manifests/notes/snapshot/L0/0000-sha256.json resolves to no body; protocol violation",
+    );
+    const { status, envelope } = mapError(err);
+    expect(status).toBe(500);
+    // Wire envelope carries no internal layout detail.
+    expect(envelope.error).toEqual({
+      code: "Internal",
+      message: "internal error",
+      retriable: false,
+    });
+    // The full message reaches the structured server-side channel.
+    expect(records).toHaveLength(1);
+    expect(records[0]!.level).toBe("error");
+    expect(records[0]!.category).toEqual(["baerly", "http"]);
+    expect(records[0]!.message.join("")).toBe("scrubbed_error");
+    const serialized = records[0]!.properties["error"] as { code: string; message: string };
+    expect(serialized.code).toBe("Internal");
+    expect(serialized.message).toContain("snapshot/L0/0000-sha256.json");
+  });
+
+  test("client-runtime-only BaerlyError codes collapse to Internal on HTTP", () => {
+    const err = new BaerlyError(
+      "UseQueryAwaitedRecorder",
+      "useQuery recorder error should never reach the server",
+    );
+    const { status, envelope } = mapError(err);
+    expect(status).toBe(500);
+    expect(envelope.error).toEqual({
+      code: "Internal",
+      message: "internal error",
+      retriable: false,
+    });
+    expect(records).toHaveLength(1);
+    const serialized = records[0]!.properties["error"] as { code: string; message: string };
+    expect(serialized.code).toBe("UseQueryAwaitedRecorder");
   });
 
   test("unknown thrown value is sanitized and emitted via the observability channel", () => {
@@ -201,7 +331,7 @@ describe("observability middleware", () => {
     expect(p["outcome"]).toBe("conflict");
     const err = p["error"] as { code: string; message: string };
     expect(err.code).toBe("Conflict");
-    expect(err.message).toBe("CAS lost");
+    expect(err.message).toBe("write conflict");
   });
 
   test("x-request-id header is honoured", async () => {
@@ -232,9 +362,36 @@ describe("observability middleware", () => {
     const req = new Request("http://localhost/v1/throw-internal");
     const res = await withHttpObservability(req, (r) => app.fetch(r));
     expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error).toMatchObject({ code: "Internal", message: "internal error" });
     const lines = canonical();
     expect(lines).toHaveLength(1);
     expect(lines[0]!.level).toBe("error");
+  });
+
+  test("router scrubs storage key detail from malformed current.json errors", async () => {
+    const storage = new MemoryStorage();
+    await storage.put(
+      "app/router-test/tenant/t1/manifests/notes/current.json",
+      new TextEncoder().encode("{not json"),
+    );
+    const db = Db.create({
+      storage,
+      app: "router-test",
+      tenant: "t1",
+    });
+    const app = createRouter({ db });
+    const req = new Request("http://localhost/v1/c/notes");
+    const res = await withHttpObservability(req, (r) => app.fetch(r));
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error).toEqual({
+      code: "InvalidResponse",
+      message: "upstream response error",
+      retriable: false,
+    });
+    expect(JSON.stringify(body)).not.toContain("current.json");
+    expect(JSON.stringify(body)).not.toContain("router-test");
   });
 });
 
@@ -322,6 +479,20 @@ describe("request-path 400s carry a resolution hint", () => {
       readonly error: { readonly code: string; readonly resolution?: string };
     };
     expect(body.error.resolution).toBe(WHERE_ORDER_JSON_RESOLUTION);
+  });
+
+  test("predicate InvalidConfig from ?where= keeps caller-facing guidance", async () => {
+    const app = buildApp();
+    const where = encodeURIComponent(
+      JSON.stringify({ clauses: [{ op: "eq", field: "_id", value: "x" }] }),
+    );
+    const res = await app.request(`/v1/c/notes?where=${where}`);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      readonly error: { readonly code: string; readonly message: string };
+    };
+    expect(body.error.code).toBe("InvalidConfig");
+    expect(body.error.message).toContain('Predicates may not key on "_id"');
   });
 });
 

--- a/packages/server/src/http/router.ts
+++ b/packages/server/src/http/router.ts
@@ -43,7 +43,7 @@ import {
   type SinceResponse,
 } from "../contract.ts";
 import { serializeError } from "../observability/canonical.ts";
-import { CATEGORY, getLogger } from "../observability/index.ts";
+import { CATEGORY, getCurrentContext, getLogger } from "../observability/index.ts";
 import { runAllWithMeta, runByIdWithMeta } from "../query.ts";
 import { longPollSince } from "./since.ts";
 
@@ -352,7 +352,11 @@ const parseWhereParam = (c: Context): PredicateWire => {
       WHERE_ORDER_JSON_RESOLUTION,
     );
   }
-  return validateWire(parsed as PredicateWire);
+  try {
+    return validateWire(parsed as PredicateWire);
+  } catch (error) {
+    throw markCallerFacingInvalidConfig(error);
+  }
 };
 
 /**
@@ -438,6 +442,123 @@ export const ERROR_TO_STATUS: ReadonlyMap<BaerlyErrorCode, HttpStatus> = new Map
 ]);
 
 /**
+ * Machine-visible policy for whether an error code's thrown message is
+ * safe to copy into the HTTP envelope. This is code-level metadata;
+ * `Conflict` is instance-contextual because duplicate `_id` conflicts are
+ * caller-facing, while retriable CAS/storage conflicts may carry bucket keys.
+ * `InvalidConfig` is also contextual: predicate-wire validation errors are
+ * caller-facing, but storage/adapter config errors may carry internal layout.
+ *
+ * Deliberately NOT re-exported from the `@baerly/server/http` barrel.
+ */
+export type ErrorMessagePolicy = "public" | "scrubbed" | "contextual";
+
+type ErrorCodePolicy =
+  | { readonly messagePolicy: "public" }
+  | {
+      readonly messagePolicy: "scrubbed";
+      readonly scrubbedMessage: string;
+    }
+  | {
+      readonly messagePolicy: "contextual";
+      readonly scrubbedMessage: string;
+      readonly shouldExpose: (err: BaerlyError) => boolean;
+    };
+
+const CALLER_FACING_INVALID_CONFIG_ERRORS = new WeakSet<BaerlyError>();
+
+const ERROR_CODE_POLICY = {
+  AccessDenied: {
+    messagePolicy: "scrubbed",
+    scrubbedMessage: "access denied",
+  },
+  Conflict: {
+    messagePolicy: "contextual",
+    scrubbedMessage: "write conflict",
+    shouldExpose: (err) => !err.retriable,
+  },
+  Internal: {
+    messagePolicy: "scrubbed",
+    scrubbedMessage: "internal error",
+  },
+  InvalidConfig: {
+    messagePolicy: "contextual",
+    scrubbedMessage: "invalid server configuration",
+    shouldExpose: (err) => CALLER_FACING_INVALID_CONFIG_ERRORS.has(err),
+  },
+  InvalidResponse: {
+    messagePolicy: "scrubbed",
+    scrubbedMessage: "upstream response error",
+  },
+  MutationFailed: {
+    messagePolicy: "scrubbed",
+    scrubbedMessage: "internal error",
+  },
+  NetworkError: {
+    messagePolicy: "scrubbed",
+    scrubbedMessage: "upstream network error",
+  },
+  NotFound: {
+    messagePolicy: "public",
+  },
+  PayloadTooLarge: {
+    messagePolicy: "public",
+  },
+  SchemaError: {
+    messagePolicy: "public",
+  },
+  Unauthorized: {
+    messagePolicy: "public",
+  },
+  UnexpectedWriteInQuery: {
+    messagePolicy: "scrubbed",
+    scrubbedMessage: "internal error",
+  },
+  UnsatisfiablePredicate: {
+    messagePolicy: "public",
+  },
+  UseQueryAwaitedRecorder: {
+    messagePolicy: "scrubbed",
+    scrubbedMessage: "internal error",
+  },
+} as const satisfies Record<BaerlyErrorCode, ErrorCodePolicy>;
+
+export const errorMessagePolicyFor = (code: BaerlyErrorCode): ErrorMessagePolicy =>
+  ERROR_CODE_POLICY[code].messagePolicy;
+
+const markCallerFacingInvalidConfig = (err: unknown): unknown => {
+  if (err instanceof BaerlyError && err.code === "InvalidConfig") {
+    CALLER_FACING_INVALID_CONFIG_ERRORS.add(err);
+  }
+  return err;
+};
+
+const shouldExposeErrorMessage = (err: BaerlyError): boolean => {
+  const policy = ERROR_CODE_POLICY[err.code];
+  if (policy.messagePolicy === "public") {
+    return true;
+  }
+  if (policy.messagePolicy === "scrubbed") {
+    return false;
+  }
+  return policy.shouldExpose(err);
+};
+
+const scrubbedMessageFor = (code: BaerlyErrorCode): string => {
+  const policy = ERROR_CODE_POLICY[code];
+  return policy.messagePolicy === "public" ? "internal error" : policy.scrubbedMessage;
+};
+
+const logScrubbedError = (err: BaerlyError, status: HttpStatus): void => {
+  const ctx = getCurrentContext();
+  getLogger(CATEGORY.http).error("scrubbed_error", {
+    error: serializeError(err),
+    status,
+    ...(ctx !== undefined ? { request_id: ctx.request_id } : {}),
+  });
+};
+
+/**
  * Map an unknown thrown value onto the wire envelope plus an HTTP
  * status code. The mapping is keyed by `BaerlyError.code` so any future
  * code addition forces a re-check here. Unmapped server-side codes fall
@@ -449,7 +570,27 @@ export const ERROR_TO_STATUS: ReadonlyMap<BaerlyErrorCode, HttpStatus> = new Map
  */
 export function mapError(err: unknown): { status: HttpStatus; envelope: HttpErrorEnvelope } {
   if (err instanceof BaerlyError) {
-    const status = ERROR_TO_STATUS.get(err.code) ?? 500;
+    const mappedStatus = ERROR_TO_STATUS.get(err.code);
+    const status = mappedStatus ?? 500;
+    const wireCode: BaerlyErrorCode = mappedStatus === undefined ? "Internal" : err.code;
+    // Do not use HTTP status as the "safe to expose" signal: storage
+    // and protocol errors mapped to 4xx/502 often carry physical bucket
+    // keys, ETags, upstream response bodies, or provider binding text.
+    // Preserve caller-facing messages, scrub server/storage diagnostics,
+    // and keep the full detail in the server-side log.
+    if (wireCode !== err.code || !shouldExposeErrorMessage(err)) {
+      logScrubbedError(err, status);
+      return {
+        status,
+        envelope: errorEnvelope(
+          wireCode,
+          scrubbedMessageFor(wireCode),
+          undefined,
+          wireCode === "Conflict" ? err.resolution : undefined,
+          wireCode === err.code ? err.retriable : undefined,
+        ),
+      };
+    }
     return {
       status,
       envelope: errorEnvelope(err.code, err.message, err.issues, err.resolution, err.retriable),

--- a/packages/server/src/query.test.ts
+++ b/packages/server/src/query.test.ts
@@ -26,7 +26,7 @@ import { beforeEach, describe, expect, test } from "vitest";
 import { compact, type InternalCompactOptions } from "./compactor.ts";
 import { Db } from "./db.ts";
 import { planQuery } from "./query-planner.ts";
-import { runAllWithMeta, singleIdFromPredicate } from "./query.ts";
+import { runAllWithMeta, serializeManifestPointer, singleIdFromPredicate } from "./query.ts";
 
 const wireOf = (clauses: PredicateWire["clauses"]): PredicateWire => ({ clauses });
 import { Writer } from "./writer.ts";
@@ -480,7 +480,7 @@ describe("Db.collection read terminals", () => {
     // deliberately stale-low tail_hint=3. The strict walk covers
     // [log_seq_start=0, 3); the forward-probe must discover the true
     // tail=8 and fold [3, 8). All 8 docs must surface and the manifest
-    // pointer must reflect @8, not @3.
+    // pointer must reflect the discovered tail, not the stored hint.
     await createCurrentJson(storage, currentJsonKey(COLL), {
       schema_version: CURRENT_JSON_SCHEMA_VERSION,
       snapshot: null,
@@ -521,8 +521,47 @@ describe("Db.collection read terminals", () => {
       "doc-6",
       "doc-7",
     ]);
-    // Pointer reflects the discovered tail (8), not the stored hint (3).
-    expect(res.manifestPointer.endsWith("@8")).toBe(true);
+    // Pointer reflects the discovered tail (8), not the stored hint (3),
+    // while staying opaque enough not to expose bucket layout.
+    expect(res.manifestPointer).toMatch(/^m1:[0-9a-z]+$/);
+    expect(res.manifestPointer).not.toContain("current.json");
+    expect(res.manifestPointer).not.toContain("manifests");
+    const staleHead = {
+      schema_version: CURRENT_JSON_SCHEMA_VERSION,
+      snapshot: null,
+      tail_hint: 3,
+      writer_fence: { epoch: 0, owner: "test", claimed_at: "" },
+      log_seq_start: 0,
+      snapshot_bytes: 0,
+      snapshot_rows: 0,
+    } satisfies CurrentJson;
+    const staleHintPointer = serializeManifestPointer(staleHead, 3);
+    const discoveredTailPointer = serializeManifestPointer(staleHead, 8);
+    expect(res.manifestPointer).toBe(discoveredTailPointer);
+    expect(res.manifestPointer).not.toBe(staleHintPointer);
+  });
+});
+
+describe("serializeManifestPointer", () => {
+  test("emits a stable opaque digest of manifest state and discovered tail", () => {
+    const head = {
+      schema_version: CURRENT_JSON_SCHEMA_VERSION,
+      snapshot: "manifests/notes/snapshot/L0/0000-sha256.json",
+      tail_hint: 3,
+      writer_fence: { epoch: 0, owner: "test", claimed_at: "" },
+      log_seq_start: 0,
+      snapshot_bytes: 123,
+      snapshot_rows: 2,
+    } satisfies CurrentJson;
+
+    const discoveredTailPointer = serializeManifestPointer(head, 8);
+    expect(discoveredTailPointer).toBe("m1:0btxreq7patbd");
+    expect(serializeManifestPointer(head, 8)).toBe(discoveredTailPointer);
+    expect(serializeManifestPointer(head, 3)).toBe("m1:0btxtcvr9h3e0");
+    expect(serializeManifestPointer(head, 3)).not.toBe(discoveredTailPointer);
+    expect(discoveredTailPointer).not.toContain("manifests");
+    expect(discoveredTailPointer).not.toContain("snapshot");
+    expect(discoveredTailPointer).not.toContain("sha256");
   });
 });
 

--- a/packages/server/src/query.ts
+++ b/packages/server/src/query.ts
@@ -130,15 +130,33 @@ export interface ReadResult<T extends DocumentData> {
 }
 
 /**
- * Serialise a {@link CurrentJson} head into the wire cursor
- * `"<snapshot>@<tail>"`. `tail` is the DISCOVERED tail (defaults to
- * `json.tail_hint` when no probe has run). `null` snapshots stringify
- * as {@link MANIFEST_POINTER_EMPTY_SNAPSHOT}.
+ * Serialise a {@link CurrentJson} head into an opaque wire cursor.
+ * `tail` is the DISCOVERED tail (defaults to `json.tail_hint` when no
+ * probe has run). Physical snapshot keys feed the digest but never
+ * cross the HTTP boundary.
  *
  * @internal — exported for `query.test.ts`.
  */
+const manifestPointerDigest = (seed: string): string => {
+  let hash = 0xcbf29ce484222325n;
+  for (let i = 0; i < seed.length; i++) {
+    hash ^= BigInt(seed.charCodeAt(i));
+    hash = (hash * 0x100000001b3n) & 0xffffffffffffffffn;
+  }
+  return hash.toString(36).padStart(13, "0");
+};
+
 export const serializeManifestPointer = (json: CurrentJson, tail = json.tail_hint): string =>
-  `${json.snapshot ?? MANIFEST_POINTER_EMPTY_SNAPSHOT}@${tail}`;
+  `m1:${manifestPointerDigest(
+    [
+      json.snapshot ?? MANIFEST_POINTER_EMPTY_SNAPSHOT,
+      json.log_seq_start,
+      json.tail_hint,
+      json.snapshot_bytes,
+      json.snapshot_rows,
+      tail,
+    ].join("|"),
+  )}`;
 
 /**
  * Frozen state carried along a `Query<T>` chain. Every modifier
@@ -598,7 +616,7 @@ const runRead = async <T extends DocumentData>(
   // not-found head still emits a well-defined cursor so the wire shape
   // never carries `""`.
   if (head === null) {
-    return { rows: [], manifestPointer: `${MANIFEST_POINTER_EMPTY_SNAPSHOT}@0`, fresh };
+    return { rows: [], manifestPointer: "m1:0000000000000", fresh };
   }
 
   // ── Optional index-walk fast path. ──────────────────────────────

--- a/packages/server/src/spec/ir.test.ts
+++ b/packages/server/src/spec/ir.test.ts
@@ -16,10 +16,17 @@ describe("buildSpecIR", () => {
     const conflict = ir.errorCodes.find((e) => e.code === "Conflict");
     expect(conflict?.httpStatus).toBe(409);
     expect(conflict?.retriable).toBe(true);
+    expect(conflict?.messagePolicy).toBe("contextual");
     expect(ir.errorCodes.find((e) => e.code === "NetworkError")?.httpStatus).toBe(502);
     expect(ir.errorCodes.find((e) => e.code === "NetworkError")?.retriable).toBe(true);
+    expect(ir.errorCodes.find((e) => e.code === "NetworkError")?.messagePolicy).toBe("scrubbed");
+    expect(ir.errorCodes.find((e) => e.code === "InvalidConfig")?.messagePolicy).toBe("contextual");
     expect(ir.errorCodes.find((e) => e.code === "InvalidResponse")?.httpStatus).toBe(502);
+    expect(ir.errorCodes.find((e) => e.code === "InvalidResponse")?.messagePolicy).toBe("scrubbed");
     expect(ir.errorCodes.find((e) => e.code === "UnsatisfiablePredicate")?.httpStatus).toBe(400);
+    expect(ir.errorCodes.find((e) => e.code === "UnsatisfiablePredicate")?.messagePolicy).toBe(
+      "public",
+    );
 
     // Client-runtime-only codes never travel HTTP → null, not a fabricated 500.
     const nullHttpStatusCodes = ir.errorCodes
@@ -27,6 +34,19 @@ describe("buildSpecIR", () => {
       .map((e) => e.code)
       .toSorted();
     expect(nullHttpStatusCodes).toEqual([...CLIENT_RUNTIME_CODES].toSorted());
+    expect(
+      ir.errorCodes
+        .filter((e) => e.messagePolicy === "not-on-http")
+        .map((e) => e.code)
+        .toSorted(),
+    ).toEqual([...CLIENT_RUNTIME_CODES].toSorted());
+  });
+
+  test("Internal is the only code that resolves to HTTP 500", () => {
+    // `mapError` scrubs server/storage diagnostics by code policy; any
+    // new 500-class code needs an explicit status AND message policy.
+    const status500Codes = ir.errorCodes.filter((e) => e.httpStatus === 500).map((e) => e.code);
+    expect(status500Codes).toEqual(["Internal"]);
   });
 
   test("declares the full by-id CRUD surface, not just the collection routes", () => {

--- a/packages/server/src/spec/ir.ts
+++ b/packages/server/src/spec/ir.ts
@@ -12,7 +12,7 @@ import {
 // the path reach is contained; a moved/restructured root fails loudly at
 // `pnpm gen:spec` rather than silently emitting a wrong version.
 import pkg from "../../../../package.json" with { type: "json" };
-import { ERROR_TO_STATUS } from "../http/router.ts";
+import { ERROR_TO_STATUS, errorMessagePolicyFor, type ErrorMessagePolicy } from "../http/router.ts";
 
 /** Machine-readable contract IR. Validated against `protocol/src/spec/ir-schema.json`. */
 export interface SpecIR {
@@ -25,6 +25,7 @@ export interface SpecIR {
     // travel HTTP); a number for every code the HTTP layer can return.
     readonly httpStatus: number | null;
     readonly retriable: boolean;
+    readonly messagePolicy: ErrorMessagePolicy | "not-on-http";
     readonly summary: string;
   }>;
   readonly operators: ReadonlyArray<{
@@ -232,6 +233,7 @@ export function buildSpecIR(): SpecIR {
       // server-side codes that mapError falls through to a 500.
       httpStatus: ERROR_TO_STATUS.get(code) ?? (CLIENT_RUNTIME_CODES.has(code) ? null : 500),
       retriable: isRetriableCode(code),
+      messagePolicy: CLIENT_RUNTIME_CODES.has(code) ? "not-on-http" : errorMessagePolicyFor(code),
       summary: ERROR_SUMMARY[code],
     })),
     operators: PREDICATE_OPS.map((name) => ({

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -290,7 +290,10 @@ const BUDGETS: readonly Budget[] = [
   //     mangling locals that this unminified-gz axis still counts). Treat raw/gz as
   //     creep tripwires, NOT hard limits; do not trim explanatory comments or golf
   //     identifiers to satisfy them. min-gz here is 19104 / 19456 (−352, healthy).
-  { entry: "index.js", raw: 222 * 1024, gz: 70 * 1024, minGz: 19 * 1024 },
+  //   → raw +1 KiB (2026-06-25): opaque manifest_pointer digest replaces the
+  //     old snapshot/log-tail-shaped cursor. The FNV helper reaches the kernel
+  //     query closure (measured 227561 raw); gz/min-gz remain under.
+  { entry: "index.js", raw: 223 * 1024, gz: 70 * 1024, minGz: 19 * 1024 },
   // The three auth verifier factories (bearerJwt, sharedSecret,
   // cloudflareAccess) plus the transitive jose closure pulled in by
   // bearerJwt's createRemoteJWKSet + jwtVerify. Adding a fourth
@@ -429,7 +432,16 @@ const BUDGETS: readonly Budget[] = [
   //     reach http.js via the protocol barrel → errorEnvelope. Measured: 342699 raw.
   //   → raw +1 KiB (2026-06-24): WS4.1 T2 WHERE_ORDER/WRITE_BODY_SHAPE_RESOLUTION wired into
   //     router.ts throw sites (7 new resolution strings inline). Measured: 343596 raw.
-  { entry: "http.js", raw: 336 * 1024, gz: 100 * 1024, minGz: 34 * 1024 },
+  //   → raw +2 KiB / gz +1 KiB / min-gz +1 KiB (2026-06-25): HTTP error
+  //     message policy now scrubs storage/server diagnostics by code+origin,
+  //     logs the full original error server-side, and preserves predicate
+  //     InvalidConfig guidance for raw HTTP callers. Opaque manifest pointers
+  //     also reach the read path. Measured: 345775 raw / 102837 gz / 35038 min-gz.
+  //   → raw +1 KiB (2026-06-25): PR review follow-up replaces duplicated
+  //     defaulted switches and prefix-based InvalidConfig exposure with one
+  //     exhaustive policy table plus a typed request-boundary marker.
+  //     Measured: 346767 raw; gz/min-gz remain under.
+  { entry: "http.js", raw: 339 * 1024, gz: 101 * 1024, minGz: 35 * 1024 },
   // Observability primitives — ObservabilityContext, the
   // request-scoped MetricsRecorder, LogTape config + the
   // JSON sink only (the pretty sink + picocolors now live in
@@ -672,7 +684,14 @@ const BUDGETS: readonly Budget[] = [
   //     122866 gz / 42545 min-gz. Budgets carry the policy ~1 KiB headroom (the
   //     gz axis in particular: 121 KiB clears 122866 by ~1 KiB, vs 14 B if pinned
   //     to 120 KiB — too tight against this closure's known ambient drift).
-  { entry: "cloudflare.js", raw: 402 * 1024, gz: 121 * 1024, minGz: 43 * 1024 },
+  //   → raw +2 KiB (2026-06-25): same request-path error scrub/log policy and
+  //     opaque manifest_pointer digest as http.js, pulled through the Worker
+  //     adapter aggregator. Measured: 413601 raw; gz/min-gz remain under.
+  //   → raw +1 KiB / gz +1 KiB (2026-06-25): same exhaustive policy-table
+  //     follow-up as http.js. The gz axis crossed by 17 B; keep the clear
+  //     table rather than byte-golfing policy metadata.
+  //     Measured: 414593 raw / 123921 gz; min-gz remains under.
+  { entry: "cloudflare.js", raw: 405 * 1024, gz: 122 * 1024, minGz: 43 * 1024 },
   // Client surface — `BaerlyClient<TConfig>` + fetcher plumbing.
   // Browser/runtime-agnostic; no kernel modules in the closure.
   // Budget history:


### PR DESCRIPTION
## Summary
- scrub storage/server diagnostic messages from HTTP error envelopes while preserving caller-facing predicate `InvalidConfig` guidance and non-retriable caller conflicts
- log full original `BaerlyError` details server-side and publish `messagePolicy` in the generated spec
- make read `manifest_pointer` values opaque digests so response metadata does not expose bucket layout

## Verification
- `pnpm verify:agent`
- `pnpm test:agent`
- pre-commit hook: bundle-size, format, lint, typecheck, docs, spec drift
