### PR TITLE
chore(infra): scrub inherited Minio dev credential from the tree

### DIFF
--- a/bench/load-harness/cli.ts
+++ b/bench/load-harness/cli.ts
@@ -213,7 +213,7 @@ async function buildVariant(v: Variant): Promise<VariantBuild> {
       }
       const signer = new AwsClient({
         accessKeyId: "baerly",
-        secretAccessKey: "ZOAmumEzdsUUcVlQ",
+        secretAccessKey: "baerly-local-dev",
         region: "us-east-1",
         service: "s3",
       });

--- a/bench/storage.ts
+++ b/bench/storage.ts
@@ -334,11 +334,12 @@ function endpointFor(via: BenchStorageOpts["via"]): string {
 }
 
 function makeSigner(): AwsClient {
-  // Credentials match `docker-compose.yml`'s Minio service. Local
-  // only; never published.
+  // Credentials match `docker-compose.yml`'s Minio service defaults
+  // (BAERLY_MINIO_ROOT_USER / BAERLY_MINIO_ROOT_PASSWORD). Local only;
+  // never published.
   return new AwsClient({
     accessKeyId: "baerly",
-    secretAccessKey: "ZOAmumEzdsUUcVlQ",
+    secretAccessKey: "baerly-local-dev",
     region: "us-east-1",
     service: "s3",
   });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       - ${BAERLY_MINIO_HOST_PORT:-9102}:9000
       - 9103:9090
     environment:
-      MINIO_ROOT_USER: baerly
-      MINIO_ROOT_PASSWORD: ZOAmumEzdsUUcVlQ
+      MINIO_ROOT_USER: ${BAERLY_MINIO_ROOT_USER:-baerly}
+      MINIO_ROOT_PASSWORD: ${BAERLY_MINIO_ROOT_PASSWORD:-baerly-local-dev}
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/minio/health/live"]
       interval: 2s

--- a/packages/adapter-node/src/s3-http.conformance.test.ts
+++ b/packages/adapter-node/src/s3-http.conformance.test.ts
@@ -4,17 +4,20 @@ import { beforeAll, describe, expect, test } from "vitest";
 import { defineStorageConformanceSuite } from "@baerly/protocol/conformance";
 import { S3HttpStorage } from "./s3-http.ts";
 import { createBucket } from "../../../tests/fixtures/s3-fixtures.ts";
-import { MINIO_ENDPOINT, MINIO_HOST_PORT } from "../../../tests/setup/ports.ts";
+import {
+  MINIO_ACCESS_KEY,
+  MINIO_ENDPOINT,
+  MINIO_HOST_PORT,
+  MINIO_SECRET_KEY,
+} from "../../../tests/setup/ports.ts";
 import { minioStorage } from "./storage-factories.ts";
 
 // Same Minio that `pnpm dev:storage` provisions. Endpoint and creds
 // are pinned across the existing Minio-touching tests
 // (`tests/integration/randomized.test.ts`,
 //  `tests/integration/conformance.test.ts`,
-//  `docker-compose.yml`). Re-use; do not invent. The endpoint comes
-// from `tests/setup/ports.ts` so per-worktree port overrides flow through.
-const MINIO_ACCESS_KEY = "baerly";
-const MINIO_SECRET_KEY = "ZOAmumEzdsUUcVlQ";
+//  `docker-compose.yml`). Re-use; do not invent. Endpoint and creds come
+// from `tests/setup/ports.ts` so per-worktree overrides flow through.
 const MINIO_REGION = "us-east-1";
 const BUCKET = "baerly-conformance-adapter-node";
 

--- a/tests/integration/collection-api.test.ts
+++ b/tests/integration/collection-api.test.ts
@@ -30,12 +30,12 @@ import { S3HttpStorage } from "@baerly/adapter-node";
 import { LocalFsStorage } from "@baerly/dev";
 import { createBucket } from "../fixtures/s3-fixtures.ts";
 import { runCollectionApiCascade } from "../fixtures/collection-api-cascade.ts";
-import { MINIO_ENDPOINT } from "../setup/ports.ts";
+import { MINIO_ACCESS_KEY, MINIO_ENDPOINT, MINIO_SECRET_KEY } from "../setup/ports.ts";
 
 const stableConfig = {
   endpoint: MINIO_ENDPOINT,
   region: "eu-central-1",
-  credentials: { accessKeyId: "baerly", secretAccessKey: "ZOAmumEzdsUUcVlQ" },
+  credentials: { accessKeyId: MINIO_ACCESS_KEY, secretAccessKey: MINIO_SECRET_KEY },
 };
 
 const minioEnabled = process.env["MINIO"] === "1";

--- a/tests/integration/conformance.test.ts
+++ b/tests/integration/conformance.test.ts
@@ -27,7 +27,7 @@ import { S3HttpStorage } from "@baerly/adapter-node";
 import { defineStorageConformanceSuite } from "@baerly/protocol/conformance";
 
 import { createBucket } from "../fixtures/s3-fixtures.ts";
-import { MINIO_ENDPOINT } from "../setup/ports.ts";
+import { MINIO_ACCESS_KEY, MINIO_ENDPOINT, MINIO_SECRET_KEY } from "../setup/ports.ts";
 
 // Minio's REST gateway rejects request paths whose resource component
 // is `.` or `..` (it validates URL paths as POSIX paths on the backing
@@ -83,8 +83,8 @@ const endpoints: Endpoint[] = [
           region: "us-east-1",
           bucket: "baerly-conformance-multi",
           credentials: {
-            accessKeyId: "baerly",
-            secretAccessKey: "ZOAmumEzdsUUcVlQ",
+            accessKeyId: MINIO_ACCESS_KEY,
+            secretAccessKey: MINIO_SECRET_KEY,
           },
         }
       : undefined,

--- a/tests/integration/create-if-absent.test.ts
+++ b/tests/integration/create-if-absent.test.ts
@@ -36,7 +36,7 @@ import { S3HttpStorage } from "@baerly/adapter-node";
 import { uuid } from "@baerly/protocol";
 
 import { createBucket } from "../fixtures/s3-fixtures.ts";
-import { MINIO_ENDPOINT } from "../setup/ports.ts";
+import { MINIO_ACCESS_KEY, MINIO_ENDPOINT, MINIO_SECRET_KEY } from "../setup/ports.ts";
 
 const MINIO = process.env["MINIO"] === "1";
 
@@ -44,7 +44,7 @@ const MINIO = process.env["MINIO"] === "1";
 // and `randomized.test.ts` (and `docker-compose.yml`).
 const ENDPOINT = MINIO_ENDPOINT;
 const BUCKET = "baerly-create-if-absent";
-const CREDS = { accessKeyId: "baerly", secretAccessKey: "ZOAmumEzdsUUcVlQ" };
+const CREDS = { accessKeyId: MINIO_ACCESS_KEY, secretAccessKey: MINIO_SECRET_KEY };
 
 describe.runIf(MINIO)("create-if-absent (bare-* against MinIO)", () => {
   const signer = new AwsClient({

--- a/tests/integration/http-conformance.test.ts
+++ b/tests/integration/http-conformance.test.ts
@@ -50,14 +50,14 @@ import { withHttpObservability } from "@baerly/server/observability";
 import { createBucket } from "../fixtures/s3-fixtures.ts";
 import { runHttpConformanceCascade, type HttpFetch } from "../fixtures/http-conformance-cascade.ts";
 import { CONFORMANCE_TENANT, testVerifier } from "../fixtures/test-verifier.ts";
-import { MINIO_ENDPOINT } from "../setup/ports.ts";
+import { MINIO_ACCESS_KEY, MINIO_ENDPOINT, MINIO_SECRET_KEY } from "../setup/ports.ts";
 
 const APP = "http-conf";
 
 const stableConfig = {
   endpoint: MINIO_ENDPOINT,
   region: "eu-central-1",
-  credentials: { accessKeyId: "baerly", secretAccessKey: "ZOAmumEzdsUUcVlQ" },
+  credentials: { accessKeyId: MINIO_ACCESS_KEY, secretAccessKey: MINIO_SECRET_KEY },
 };
 
 const minioEnabled = process.env["MINIO"] === "1";

--- a/tests/integration/randomized.test.ts
+++ b/tests/integration/randomized.test.ts
@@ -32,7 +32,13 @@ import {
   runMultiDocCascade,
   runRangeWalkParityCascade,
 } from "../fixtures/randomized-cascade.ts";
-import { MINIO_ENDPOINT, TOXIPROXY_ADMIN_ENDPOINT, TOXIPROXY_ENDPOINT } from "../setup/ports.ts";
+import {
+  MINIO_ACCESS_KEY,
+  MINIO_ENDPOINT,
+  MINIO_SECRET_KEY,
+  TOXIPROXY_ADMIN_ENDPOINT,
+  TOXIPROXY_ENDPOINT,
+} from "../setup/ports.ts";
 
 /**
  * (a) Per-doc consistency: `observed` must be a subsequence of `written`
@@ -58,7 +64,7 @@ const isSubsequence = (observed: readonly string[], written: readonly string[]):
 const stableConfig = {
   endpoint: MINIO_ENDPOINT,
   region: "eu-central-1",
-  credentials: { accessKeyId: "baerly", secretAccessKey: "ZOAmumEzdsUUcVlQ" },
+  credentials: { accessKeyId: MINIO_ACCESS_KEY, secretAccessKey: MINIO_SECRET_KEY },
 };
 const unstableConfig = { ...stableConfig, endpoint: TOXIPROXY_ENDPOINT };
 

--- a/tests/setup/ports.ts
+++ b/tests/setup/ports.ts
@@ -1,7 +1,8 @@
 /**
- * Test-side mirror of the host ports docker-compose.yml binds. Default values
- * match the compose defaults; override per-worktree with environment variables
- * to run two stacks on one machine.
+ * Test-side mirror of the host ports and Minio root credentials
+ * docker-compose.yml binds. Default values match the compose defaults;
+ * override per-worktree with environment variables to run two stacks on one
+ * machine.
  *
  *   BAERLY_MINIO_HOST_PORT=9202 \
  *   BAERLY_TOXIPROXY_HOST_PORT=9204 \
@@ -9,8 +10,14 @@
  *   BAERLY_POSTGRES_HOST_PORT=5434 \
  *     pnpm dev:storage
  *
- * Consumers should import these and never write the literal port. The point
- * is exactly to make "what port is Minio on?" answerable in one place.
+ * Consumers should import these and never write the literal port or
+ * credential. The point is exactly to make "what port is Minio on?" and
+ * "what's the Minio key?" answerable in one place.
+ *
+ * The credentials are local-dev only — they authenticate the throwaway Minio
+ * container `pnpm dev:storage` spins up on localhost and grant nothing in
+ * production. Override the defaults with `BAERLY_MINIO_ROOT_USER` /
+ * `BAERLY_MINIO_ROOT_PASSWORD` (the same vars docker-compose.yml reads).
  */
 const num = (env: string, fallback: number): number => {
   const v = process.env[env];
@@ -23,6 +30,14 @@ const num = (env: string, fallback: number): number => {
   }
   return parsed;
 };
+
+const str = (env: string, fallback: string): string => {
+  const v = process.env[env];
+  return v === undefined || v === "" ? fallback : v;
+};
+
+export const MINIO_ACCESS_KEY = str("BAERLY_MINIO_ROOT_USER", "baerly");
+export const MINIO_SECRET_KEY = str("BAERLY_MINIO_ROOT_PASSWORD", "baerly-local-dev");
 
 export const MINIO_HOST_PORT = num("BAERLY_MINIO_HOST_PORT", 9102);
 export const TOXIPROXY_HOST_PORT = num("BAERLY_TOXIPROXY_HOST_PORT", 9104);


### PR DESCRIPTION
## What

The Minio root password `ZOAmumEzdsUUcVlQ` was hardcoded across eight files. It was **inherited from the mps3 upstream** ([endpointservices/mps3@e65c9af](https://github.com/endpointservices/mps3/commit/e65c9afc0a5feeb59e870352325eecddd278544d), 2023) and squashed into this repo's `Initial Commit`. A `git blame` on `docker-compose.yml` points at a later reformat commit, but that only carried the value forward.

It only ever authenticated the localhost Minio container `pnpm dev:storage` spins up — it grants nothing in production. But its opaque shape trips secret scanners, and the same literal was copy-pasted into eight files.

## Change

Route the dev credential through one source of truth and replace the opaque value with a clearly-local placeholder:

- **`tests/setup/ports.ts`** — add env-overridable `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` (backed by `BAERLY_MINIO_ROOT_USER` / `BAERLY_MINIO_ROOT_PASSWORD`), defaults `baerly` / `baerly-local-dev`, mirroring the existing port-override pattern.
- **`docker-compose.yml`** — read the same env vars with matching defaults.
- **7 importing test suites** now pull the creds from `ports.ts` instead of hardcoding.
- **`bench/`** (self-contained, doesn't import test setup) swaps the literal to the local placeholder.

## Notes

- **History is not rewritten.** The value was localhost-only and already public upstream since 2023, so a rewrite seemed like overkill — happy to do a `git filter-repo` pass if reviewers prefer.
- `pnpm verify` and the no-infra test suite (2263 passed, 75 Minio-gated skips) stay green.