### PR TITLE
ci: SHA-pin GitHub Actions and provision pnpm via Corepack

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Code owners. GitHub requests review from the matching owner on PRs that
+# touch these paths. Ownership here is ADVISORY — `main` does not enable
+# "require review from Code Owners" branch protection, so these lines
+# auto-request a reviewer but never block a merge. (Enforcement is
+# deliberately off: with a single owner, GitHub forbids self-approval, so
+# requiring code-owner review would block the maintainer's own PRs.)
+#
+# Later, more specific rules win, so the catch-all is listed first.
+
+# Default owner for everything — routes every PR, including external
+# contributions, to the maintainer for a review request.
+* @baer
+
+# CI / supply-chain surface, called out explicitly. CODEOWNERS is also the
+# supported replacement for the `reviewers:` key Dependabot removed in
+# Aug 2025: the github-actions Dependabot config bumps `.github/workflows/*`
+# (and the trailing `# vX.Y.Z` comments there), so owning `.github/` is what
+# puts a human in front of every new pinned SHA.
+/.github/ @baer

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,58 @@
+# Dependabot version updates.
+#
+# Scope: the GitHub Actions used by our workflows. Those `uses:` refs are
+# pinned to full commit SHAs (see .github/workflows/ci.yml) for supply-chain
+# safety, which means they can't drift on their own — Dependabot is how they
+# stay current. It understands the `owner/repo@<sha> # vX.Y.Z` format and
+# opens a PR that bumps BOTH the SHA and the trailing version comment, with
+# the upstream release notes attached for review.
+#
+# npm dependency *security* updates are handled by the org-level Dependabot
+# alert config and don't need an entry here. We deliberately do NOT enable
+# npm *version* updates: the runtime footprint is curated by hand (see the
+# anti-patterns section of CLAUDE.md), so automated npm bump PRs would be noise.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # "/" scans .github/workflows for github-actions; it is not a filesystem path.
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Let a freshly-published action ref "bake" before we propose it. The
+    # whole point of SHA-pinning is to resist a compromised or freshly
+    # force-pushed release; a cooldown closes the just-published-malicious-
+    # release window that a same-day bump would otherwise walk straight into.
+    cooldown:
+      default-days: 7
+    # Group bumps into as few PRs as possible, but keep MAJOR bumps separate:
+    # a major (e.g. checkout v7 -> v8) can carry runner-minimum or behavior
+    # breaks that deserve their own reviewable PR, while minor/patch flow
+    # together as low-risk noise. Dependabot places an update in the first
+    # group it matches, so the major group is listed first.
+    groups:
+      github-actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    # Two groups (major, minor+patch) → at most two grouped PRs in flight.
+    # The limit only bites if a group ever fails to group and fans out into
+    # per-action PRs; 2 keeps that capped to the intended one-PR-per-group.
+    open-pull-requests-limit: 2
+    # Review routing is via .github/CODEOWNERS (`/.github/ @baer`), not a
+    # `reviewers:` key here — Dependabot removed that option in Aug 2025,
+    # replacing it with code owners. CODEOWNERS is what puts a human in
+    # front of each new SHA against the upstream release notes.
+    commit-message:
+      # Conventional Commits, matching the repo style: `ci(deps): bump ...`.
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,18 @@ jobs:
       - name: Verify
         run: pnpm verify
 
+      # create-baerly-storage's "real git" integration test scaffolds a
+      # project and asserts `git init` + an initial commit happened. The
+      # scaffolder gracefully SKIPS git-init when no `user.name`/`user.email`
+      # is configured (intended product behavior), so on a bare runner —
+      # which has git but no identity — it would skip and the test would see
+      # no .git/. Configure a CI identity so the happy path is exercised.
+      # (Locally the test passes off the developer's ambient global config.)
+      - name: Configure git identity (for create-baerly-storage git-init test)
+        run: |
+          git config --global user.name "baerly-ci"
+          git config --global user.email "ci@baerly.invalid"
+
       # Default vitest project: memory + local-fs suites under pool: forks.
       # Zero infra, no credentials. The pretest hook rebuilds dist/ here.
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,22 +33,44 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      # Actions are pinned to a full commit SHA (not a moving tag) so a
+      # compromised or force-pushed tag can't silently change what runs in
+      # CI (cf. the tj-actions/changed-files compromise); the trailing
+      # comment records the human-readable version — bump both together.
+      # Only first-party actions/* are used here (covered by the org's
+      # `github_owned_allowed` policy); pnpm is provisioned via Corepack
+      # below rather than a third-party setup action, so nothing in this
+      # workflow needs an org Actions allow-list entry.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # pnpm/action-setup auto-detects the version from `packageManager`
-      # in package.json (currently pnpm@11.1.2) — no version pin here so
-      # upgrades to the packageManager field flow through automatically.
-      - uses: pnpm/action-setup@v4
+      # Provision pnpm with Corepack (bundled with Node) from the version
+      # pinned in package.json's `packageManager` field (pnpm@11.1.2) — the
+      # canonical, zero-third-party-action way to manage the package manager.
+      # Must run BEFORE setup-node: the `pnpm` shim has to exist on PATH when
+      # setup-node's `cache: pnpm` step shells `pnpm store path` to resolve
+      # the store dir to cache. (This enable targets the runner's
+      # pre-installed Node; it is re-run after setup-node below so the shim
+      # also resolves against the Node 24 that setup-node installs.)
+      # NOTE: Node 25 stops bundling Corepack — a future Node bump will need
+      # `npm i -g corepack` before this step.
+      - run: corepack enable
 
       # Node 24 is required, not optional: the default vitest project sets
       # `execArgv: ["--js-base-64"]` — a V8 flag that enables
       # Uint8Array.{toBase64,fromBase64}, which are TC39 Stage 4 but still
       # behind a flag in V8 13.6 / Node 24. The engines field in package.json
       # is `>=24`. cache: pnpm uses the pnpm store for node_modules caching.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm
+
+      # Re-enable Corepack against the Node 24 that setup-node just installed
+      # (it prepends its own toolcache bin to PATH over the pre-installed
+      # Node the first enable targeted). Cheap, idempotent insurance that the
+      # `pnpm` shim the install/test steps below invoke resolves against the
+      # pinned Node — not the runner's default.
+      - run: corepack enable
 
       # `pnpm install` triggers the `prepare` lifecycle hook
       # (scripts/prepare.mjs), which runs `pnpm run build` — so dist/ is

--- a/scripts/lint-format-coverage.mjs
+++ b/scripts/lint-format-coverage.mjs
@@ -60,6 +60,7 @@ const UNFORMATTED_EXT = new Set([
 const ALLOWED_BASENAMES = new Set([
   "LICENSE",
   "NOTICE",
+  "CODEOWNERS", // GitHub review-routing config; no formatter
   "Dockerfile",
   "_gitignore", // scaffold-template rename sentinel
   ".gitignore",

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { gzipSync } from "node:zlib";
 // min+gz numbers are esbuild-version-sensitive: a minifier version bump
 // rebaselines every entry's `minGz` ceiling at once.
-import { transformSync } from "esbuild";
+import { transform } from "esbuild";
 import { describe, expect, test } from "vitest";
 import { formatBundleSizeLine } from "../helpers/bundle-size-report.ts";
 
@@ -846,12 +846,9 @@ function collectClosure(entryAbs: string, seen: Set<string>): void {
   }
 }
 
-function measureClosure(entry: string): {
-  raw: number;
-  gz: number;
-  minGz: number;
-  files: string[];
-} {
+// Absolute paths of every chunk in `entry`'s static-import closure,
+// sorted for deterministic concatenation order.
+function closureFiles(entry: string): string[] {
   const distDir = resolve(__dirname, "../../dist");
   const entryAbs = resolve(distDir, entry);
   if (!existsSync(entryAbs)) {
@@ -859,29 +856,94 @@ function measureClosure(entry: string): {
   }
   const seen = new Set<string>();
   collectClosure(entryAbs, seen);
-  const files = [...seen].toSorted();
+  return [...seen].toSorted();
+}
+
+// Raw + gzipped closure size. Pure fs + zlib, NO esbuild — so the
+// raw-only callers (the inline-dep-creep raw ceiling + the import
+// allowlist guard) never invoke the minifier. The consumer-cost
+// `min+gz` axis is the only one that needs esbuild; it lives in the
+// separate async `measureMinGz` below so a minifier flake can't sink a
+// test that only reads `.raw`. Both take a pre-resolved `files` list so
+// a test that needs both axes walks the closure once.
+function measureClosure(files: string[]): {
+  raw: number;
+  gz: number;
+  files: string[];
+} {
+  const distDir = resolve(__dirname, "../../dist");
   const raw = files.reduce((sum, f) => sum + statSync(f).size, 0);
   const gz = gzipSync(Buffer.concat(files.map((f) => readFileSync(f)))).length;
-  // `min+gz` minifies each chunk with esbuild (the minifier most
-  // consumer bundlers — Vite/esbuild — actually run), concatenates,
-  // then gzips. This is the consumer-facing artifact proxy: the lib
-  // ships UNMINIFIED, so neither `raw` nor unminified-`gz` is what a
-  // consumer pays once their bundler re-minifies. CONSERVATIVE UPPER
-  // BOUND: per-file `transformSync` does syntax minification per chunk
-  // but NOT the cross-module tree-shaking / scope-hoisting a real
-  // consumer bundler does, so the real shipped cost is ≤ this number.
-  // It is not the exact shipped artifact.
-  const minified = files.map(
-    (f) => transformSync(readFileSync(f, "utf8"), { loader: "js", minify: true }).code,
-  );
-  const minGz = gzipSync(Buffer.concat(minified.map((c) => Buffer.from(c)))).length;
-  return { raw, gz, minGz, files: files.map((f) => f.replace(`${distDir}/`, "")) };
+  return { raw, gz, files: files.map((f) => f.replace(`${distDir}/`, "")) };
+}
+
+// `min+gz` minifies each chunk with esbuild (the minifier most consumer
+// bundlers — Vite/esbuild — actually run), concatenates, then gzips.
+// This is the consumer-facing artifact proxy: the lib ships UNMINIFIED,
+// so neither `raw` nor unminified-`gz` is what a consumer pays once
+// their bundler re-minifies. CONSERVATIVE UPPER BOUND: per-file syntax
+// minify only, NOT the cross-module tree-shaking / scope-hoisting a real
+// consumer bundler does, so the real shipped cost is ≤ this number.
+async function measureMinGz(files: string[]): Promise<number> {
+  const minified: string[] = [];
+  for (const file of files) {
+    minified.push(await minifyChunk(readFileSync(file, "utf8"), file));
+  }
+  return gzipSync(Buffer.concat(minified.map((c) => Buffer.from(c)))).length;
+}
+
+// Use esbuild's ASYNC `transform`, NOT `transformSync`. The sync API
+// routes every call through a single persistent worker-thread service
+// (SharedArrayBuffer + Atomics.wait). On a contended 2-vCPU CI runner
+// (many parallel forks, each with its own esbuild worker thread) that
+// channel desyncs — a response gets matched to the wrong request — and
+// once desynced EVERY subsequent sync transform in the fork returns the
+// wrong chunk's result, surfacing as a bogus "<stdin>:N: ERROR: X is not
+// declared in this file" on perfectly valid input. That desync is
+// PERSISTENT, which is why retrying the sync call never recovered it.
+// The async `transform` instead uses esbuild's long-lived child-process
+// service with a length-prefixed, request-ID-matched protocol — the
+// multiplexed path every bundler runs under load — which does not
+// desync this way.
+//
+// The retry below is belt-and-suspenders around a one-off service
+// restart, scoped to the esbuild call ONLY (not the whole suite): budget
+// assertions are deterministic functions of the committed dist/ bytes,
+// so a real over-budget or closure-leak regression still fails on the
+// first and every attempt. Nothing here can mask a genuine regression.
+//
+// Each intermediate failure is logged (not swallowed) so a retry that
+// only succeeds on attempt 2/3 still leaves a breadcrumb in CI output —
+// the signal that the underlying esbuild service is flaking. The final
+// throw is wrapped with the offending file so an exhausted-retry failure
+// names the chunk instead of surfacing a bare esbuild error.
+async function minifyChunk(source: string, file: string, attempts = 3): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const { code } = await transform(source, { loader: "js", minify: true });
+      return code;
+    } catch (error) {
+      lastError = error;
+      console.warn(
+        `minifyChunk: esbuild attempt ${attempt}/${attempts} failed for ${file}: ${error}`,
+      );
+    }
+  }
+  throw new Error(`minifyChunk: esbuild failed for ${file} after ${attempts} attempts`, {
+    cause: lastError,
+  });
 }
 
 describe("bundle size", () => {
   for (const { entry, raw, gz, minGz, skip } of BUDGETS) {
-    test.skipIf(skip)(`dist/${entry} closure stays within budget`, () => {
-      const measured = measureClosure(entry);
+    test.skipIf(skip)(`dist/${entry} closure stays within budget`, async () => {
+      // Walk the static-import closure once; both axes read the same list.
+      const files = closureFiles(entry);
+      const measured = measureClosure(files);
+      // Only the consumer-cost axis needs esbuild; compute it on the
+      // robust async path, and only for entries that declare a ceiling.
+      const minGzMeasured = minGz !== undefined ? await measureMinGz(files) : 0;
       // Show closure composition in failure output so a regression
       // points straight at the chunk that grew.
       const rawLine = formatBundleSizeLine({
@@ -901,7 +963,7 @@ describe("bundle size", () => {
       const minGzLine = formatBundleSizeLine({
         entry,
         kind: "min-gz",
-        measured: measured.minGz,
+        measured: minGzMeasured,
         budget: minGz ?? 0,
         chunks: measured.files,
       });
@@ -930,7 +992,7 @@ describe("bundle size", () => {
         { kind: "gz", measured: measured.gz, budget: gz, line: gzLine },
       ];
       if (minGz !== undefined) {
-        axes.push({ kind: "min-gz", measured: measured.minGz, budget: minGz, line: minGzLine });
+        axes.push({ kind: "min-gz", measured: minGzMeasured, budget: minGz, line: minGzLine });
       }
       const over = axes.filter((a) => a.measured > a.budget);
       const report = over
@@ -953,7 +1015,7 @@ describe("bundle size", () => {
   // `observability-*.js` subgraph (logtape + canonical-line render +
   // pretty sink) into the barrel.
   test("dist/index.js closure excludes the observability subgraph", () => {
-    const measured = measureClosure("index.js");
+    const measured = measureClosure(closureFiles("index.js"));
     const observabilityChunks = measured.files.filter((f) => f.startsWith("observability-"));
     expect(
       observabilityChunks,
@@ -1026,7 +1088,7 @@ describe("bundle size", () => {
     { entry: "dev-vite.js", raw: 710 * 1024 },
   ]) {
     test(`dist/${entry} closure stays under the inline-dep-creep raw ceiling`, () => {
-      const measured = measureClosure(entry).raw;
+      const measured = measureClosure(closureFiles(entry)).raw;
       expect(
         measured,
         `${entry} raw closure ${measured} B exceeds inline-dep-creep ceiling ${raw} B`,

--- a/tests/integration/maintenance-profile-equivalence.test.ts
+++ b/tests/integration/maintenance-profile-equivalence.test.ts
@@ -62,6 +62,7 @@ import {
   type Ticket as BaseTicket,
   TENANT,
 } from "../fixtures/maintenance-harness.ts";
+import { ciTimeout } from "../setup/ci.ts";
 
 // This suite's row carries an extra `rev` revision counter its op stream
 // churns; the shared `Ticket` is the three-field common core (which
@@ -197,12 +198,15 @@ describe("MaintenanceProfile cross-profile correctness", () => {
 
       test(
         "(A) materialized state is byte-for-byte identical across every profile (and the no-maintenance reference)",
-        // 120s: under single-write commit each commit forward-probes the
-        // log tail (galloping, O(log gap) GETs). The no-maintenance
+        // 120s locally: under single-write commit each commit forward-probes
+        // the log tail (galloping, O(log gap) GETs). The no-maintenance
         // reference seed never advances tail_hint, so its gap grows to the
         // full stream length — over LocalFs (real file I/O) under
         // full-suite CPU contention the three replays exceed the old 60s.
-        { timeout: 120_000 },
+        // ciTimeout gives the 2-vCPU CI core extra headroom (the higher
+        // ceiling only bites if the replay is genuinely that slow; locally
+        // the tighter bound stands).
+        { timeout: ciTimeout(120_000) },
         async () => {
           const ops = buildOps();
 
@@ -267,7 +271,7 @@ describe("MaintenanceProfile cross-profile correctness", () => {
 
       test(
         "(B) profiles genuinely differ in maintenance RATE: ONE fold pass advances log_seq_start by exactly maxFoldEntriesPerPass",
-        { timeout: 60_000 },
+        { timeout: ciTimeout(60_000) },
         // Deliberately PAIRWISE (cf-free vs node), not a loop over
         // PROFILE_CASES — a future 3rd profile touches this by hand.
         async () => {

--- a/tests/integration/phase5-end-to-end.test.ts
+++ b/tests/integration/phase5-end-to-end.test.ts
@@ -54,6 +54,7 @@ import {
   Writer,
 } from "@baerly/server/_internal/testing";
 import { wrapCountingStorage } from "../fixtures/counting-storage.ts";
+import { ciTimeout } from "../setup/ci.ts";
 import {
   APP,
   bootstrap as bootstrapCurrentJson,
@@ -102,8 +103,9 @@ describe("Synthetic 5000-entry end-to-end gate", () => {
         // per-commit file PUTs under macOS ulimit). The seed is O(N) —
         // no per-commit integrity walk, and the in-band maintenance tick
         // is explicitly DISABLED during the seed (see (1)) so it can't
-        // re-fold the growing tail. 90s gives headroom on local-fs.
-        { timeout: 90_000 },
+        // re-fold the growing tail. 90s gives headroom on local-fs;
+        // ciTimeout widens it on the slower, contended CI core.
+        { timeout: ciTimeout(90_000) },
         async () => {
           const made = await variant.build();
           cleanup = made.cleanup;
@@ -237,7 +239,7 @@ describe("Synthetic 5000-entry end-to-end gate", () => {
 
       test(
         "idle reader uses < 1 Class A op / writer / hour (cost-model gate)",
-        { timeout: 30_000 },
+        { timeout: ciTimeout(30_000) },
         async () => {
           const made = await variant.build();
           cleanup = made.cleanup;
@@ -378,7 +380,7 @@ const countOrphanSnapshots = async (storage: Storage, currentJsonKey: string): P
 describe("write-tick in-band maintenance (no runScheduledMaintenance)", () => {
   test(
     "writes alone maintain the bucket: snapshot lands + log_seq_start advances",
-    { timeout: 30_000 },
+    { timeout: ciTimeout(30_000) },
     async () => {
       // NOTE: `runScheduledMaintenance` is NOT imported nor called inside
       // this test body. The ONLY maintenance trigger is the writer's
@@ -441,7 +443,7 @@ describe("write-tick in-band maintenance (no runScheduledMaintenance)", () => {
     // pace only "once" (the weak old "count dropped" gate), the count
     // would still climb here; the plateau assertion is what confronts
     // the §7.1 rate. Memory-only (see block comment).
-    { timeout: 60_000 },
+    { timeout: ciTimeout(60_000) },
     async () => {
       const storage = new MemoryStorage();
       await bootstrap(storage);
@@ -507,7 +509,7 @@ describe("write-tick in-band maintenance (no runScheduledMaintenance)", () => {
 
   test(
     "ceiling honored: a low maxFoldBytes DEFERS the fold; the default ceiling FOLDS",
-    { timeout: 30_000 },
+    { timeout: ciTimeout(30_000) },
     async () => {
       // Two arms over the same seed on a fresh memory bucket. On a FRESH
       // bucket the runner's `foldViable = snapshot_bytes <= C` gate
@@ -601,7 +603,7 @@ describe("write-tick in-band maintenance (no runScheduledMaintenance)", () => {
     // is the §7.1 RATE in its sharpest form: the post-drain orphan count
     // must be BOUNDED and INVARIANT under the write count — a 2× longer
     // run must NOT leave ~2× the orphans. Memory-only (see block comment).
-    { timeout: 60_000 },
+    { timeout: ciTimeout(60_000) },
     async () => {
       const blob = "x".repeat(BODY_BYTES);
       const FOLDERS = 6; // concurrent fold attempts per round — models N isolates racing one fold; the round's superseded prior snapshot (~1/round, NOT FOLDERS-proportional) is what strands

--- a/tests/integration/write-amp.test.ts
+++ b/tests/integration/write-amp.test.ts
@@ -21,6 +21,7 @@ import { createObservabilityContext, runWithContext } from "@baerly/server/obser
 import { Writer } from "@baerly/server/_internal/testing";
 import { wrapCountingStorage } from "../fixtures/counting-storage.ts";
 import { bootstrap, COLLECTION, CURRENT_JSON_KEY } from "../fixtures/maintenance-harness.ts";
+import { ciTimeout } from "../setup/ci.ts";
 
 const WRITES = 800;
 const BODY = 2000;
@@ -48,7 +49,7 @@ const measure = async (opts: BoundedMaintenanceOptions): Promise<number> => {
 };
 
 describe("amortized billable Class A per write (cost-model gate)", () => {
-  test("cf-free profile stays in the ~3x band", { timeout: 30_000 }, async () => {
+  test("cf-free profile stays in the ~3x band", { timeout: ciTimeout(30_000) }, async () => {
     const amperWrite = await measure({
       profile: MAINTENANCE_PROFILE_CF_FREE,
       minEntriesToCompact: 50,
@@ -62,7 +63,7 @@ describe("amortized billable Class A per write (cost-model gate)", () => {
     expect(amperWrite).toBeLessThan(4);
   });
 
-  test("node profile stays in the ~4x band", { timeout: 30_000 }, async () => {
+  test("node profile stays in the ~4x band", { timeout: ciTimeout(30_000) }, async () => {
     const amperWrite = await measure({
       profile: MAINTENANCE_PROFILE_NODE,
       minEntriesToCompact: 50,

--- a/tests/setup/ci.ts
+++ b/tests/setup/ci.ts
@@ -1,0 +1,41 @@
+/**
+ * CI-environment test helpers.
+ *
+ * GitHub-hosted `ubuntu-latest` runners are 2-vCPU with a markedly slower
+ * single core than a typical dev machine, and under `pool: "forks"` the
+ * heavy CPU/LocalFs-bound integration tests also contend for those two
+ * cores. Both effects are wall-clock, not correctness: the same assertions
+ * run and pass, they just need headroom. Per-test timeouts authored against
+ * dev-core speed are too tight there — which is why CI has flaked on a
+ * rotating cast of heavy tests (phase5 / maintenance-profile) as each one
+ * crossed its individual ceiling under contention.
+ *
+ * `ciTimeout` widens a per-test timeout on CI only, so the tighter local
+ * bound stays the day-to-day signal (a contributor still sees a test that
+ * has grown slow). Apply it uniformly to the heavy maintenance/compaction
+ * suites rather than bumping individual timeouts reactively.
+ *
+ * `CI=true` is set by GitHub Actions and most other CI providers.
+ */
+
+/** True when running under CI (GitHub Actions sets `CI=true`). */
+export const IS_CI = !!process.env["CI"];
+
+/**
+ * Widen a per-test timeout when running on CI; return it unchanged locally.
+ *
+ * The factor (default 3×) is empirical headroom for the slower, contended
+ * CI core. A timeout is a ceiling, so green runs never pay it — only a
+ * genuinely hung test burns the full budget, and the job-level
+ * `timeout-minutes` still backstops that.
+ *
+ * Note this is a different multiplier from the global default-timeout
+ * widening in `vitest.config.ts` (4×: 5s → 20s). That widens the 5s base
+ * every default test inherits; `ciTimeout` is applied per-test on the
+ * heavy maintenance/compaction suites, which already carry much larger
+ * bases (30s–120s). Two independent tunings against two different bases,
+ * not one shared constant — keep them separate.
+ */
+export function ciTimeout(baseMs: number, factor = 3): number {
+  return IS_CI ? baseMs * factor : baseMs;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,7 @@
 
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
 import { configDefaults, defineConfig } from "vitest/config";
+import { IS_CI } from "./tests/setup/ci.ts";
 
 // `pnpm test:randomize` sets `FC_NUM_RUNS=10000`. At that volume the
 // disk-bound property tests in `packages/dev/src/local-fs.test.ts`,
@@ -42,6 +43,13 @@ import { configDefaults, defineConfig } from "vitest/config";
 const isRandomize =
   process.env["FC_NUM_RUNS"] !== undefined && Number(process.env["FC_NUM_RUNS"]) > 1_000;
 const isMinio = process.env["MINIO"] === "1";
+// CI runners (GitHub-hosted `ubuntu-latest` is 2 vCPUs) are markedly slower
+// than dev machines, and under `pool: forks` the full suite contends hard for
+// those two cores — heavy but correct CPU/LocalFs-bound tests (dataset
+// determinism, maintenance-profile equivalence) overrun the 5s default that
+// is comfortable locally. Give the default budget headroom in CI.
+// `IS_CI` (`CI=true`, set by GitHub Actions and most CI providers) is the
+// shared detector — the same one `ciTimeout` uses for per-test widening.
 const vitestTestTimeoutMs = ((): number => {
   if (isRandomize) {
     return 600_000;
@@ -49,7 +57,12 @@ const vitestTestTimeoutMs = ((): number => {
   if (isMinio) {
     return 30_000;
   }
-  return 5_000;
+  // 4× the local 5s default — empirical headroom for the contended
+  // 2-vCPU CI core under `pool: forks`. This is the floor every default
+  // test gets; the heavy maintenance/compaction suites layer `ciTimeout`
+  // (a separate 3× factor) on top of their own already-large bases, so
+  // the two multipliers are independent tunings, not a single constant.
+  return IS_CI ? 20_000 : 5_000;
 })();
 
 // `conformance.test.ts` requires gitignored credentials files


### PR DESCRIPTION
## What

Hardens the CI workflow now that GitHub Actions is enabled on the repo, and wires up automated maintenance of the action pins.

- **SHA-pin the actions.** `actions/checkout` and `actions/setup-node` move from moving `@v4` tags to full commit SHAs at the current latest majors (**v7.0.0**, **v6.4.0**), each annotated with its version. A moving tag can be force-pushed or repointed by a compromised maintainer to run arbitrary code in CI (cf. the `tj-actions/changed-files` compromise); a SHA freezes exactly what runs.
- **Provision pnpm via Corepack** (`corepack enable`, reading the `pnpm@11.1.2` pin in `package.json`'s `packageManager` field) instead of the third-party `pnpm/action-setup`. Corepack runs **before** `setup-node` so the `pnpm` shim is on PATH when `cache: pnpm` resolves the store path.
- **Add `.github/dependabot.yml`** (github-actions ecosystem) so the SHA pins don't silently rot: grouped PRs (majors separated, 7-day cooldown, routed to the maintainer) that bump both the SHA and the version comment with release notes attached.
- **Add `.github/CODEOWNERS`** so the Dependabot bump PRs (and every other PR) auto-request the maintainer — CODEOWNERS is the supported replacement for the `reviewers:` key Dependabot removed in Aug 2025. Advisory only; `main` does not require code-owner review.

## Why Corepack over `pnpm/action-setup` + allowlist

The repo's Actions policy is `selected` (curated allowlist). `pnpm/action-setup` is a third-party action not on that list, so it would fail before install and require a platform-team allowlist entry. We considered SHA-pinning it and requesting the allowlist entry, but chose Corepack because:

- **Smaller supply-chain surface** — zero third-party actions; trust stays at Node + the pinned pnpm + the registry, with no extra maintainer's code to vet. This aligns with the *intent* of the allowlist rather than routing around it.
- **No external dependency** — nothing here needs an allowlist entry, so the workflow is self-contained and CI can go green without waiting on org policy.
- pnpm version stays sourced from the existing `packageManager` pin — single source of truth.

Trade-off accepted: Corepack is still flagged experimental and has had occasional wobbles. The interaction we can't verify until this PR's first run is `corepack enable` → `setup-node cache: pnpm`. It's the documented pattern, and the fallback is trivial (drop `cache: pnpm`, or let setup-node v6 auto-detect) if the runner ever can't find pnpm.

## Scope

Mostly CI-config, plus the test-infra changes needed to make CI go green on a 2-vCPU runner:

- **CI workflow + Dependabot + CODEOWNERS** (above) — the core of this PR.
- **Bundle-size flake fix** (`tests/integration/bundle-size.test.ts`) — the `min+gz` axis moves from esbuild's `transformSync` to the async `transform` API. The sync API routes every call through one persistent worker-thread service that desyncs permanently under 2-vCPU contention, surfacing as bogus "X is not declared in this file" errors on valid input (retrying the sync call never recovered it). The async path uses esbuild's request-ID-matched child-process protocol and doesn't desync. Raw/gz checks no longer invoke the minifier at all. A scoped retry (with logged attempts) wraps the esbuild call only — budget assertions stay deterministic functions of the committed `dist/` bytes, so no real regression can be masked.
- **CI timeout headroom** (`tests/setup/ci.ts`, `vitest.config.ts`, heavy suites) — the global default test timeout widens 5s→20s on CI, and heavy maintenance/compaction suites wrap per-test timeouts in `ciTimeout()`. Wall-clock headroom only; the same assertions run and pass, just with room for the slower contended core.

`pnpm verify` / `pnpm test` / `test:adapter-cloudflare` pass; the bundle-size and CI-timeout changes were validated by running the affected suites locally.

## FYI for whoever owns Actions policy

This repo is public with CI now running on `pull_request`. Current posture (unchanged here) is sensible: fork-PR approval = first-time-contributors, default `GITHUB_TOKEN` perms = read-only. Flagging for a conscious confirmation, not a fix.
