### PR TITLE
docs: benefits-first front door — add Why baerly-storage + Alternatives pages, correct lineage framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # baerly-storage
 
-**A database with no server. No daemon. No database runtime. Just your app and a bucket.**
+**A document database that lives in a bucket you already own — no new vendor to clear, no server to keep running, and an API small enough for an LLM (or a non-engineer) to use zero-shot.**
 
 ```text
 before: client → app handler → database server  (a server)
@@ -23,14 +23,19 @@ log object commits a write. When the request ends, baerly-storage is
 gone.
 
 - **A tiny API humans and agents can hold in context.** No DDL, no raw
-  SQL — 8 verbs and a ~12k-token API surface.
+  SQL — 8 verbs and a ~12k-token API surface small enough to hand to an
+  LLM or a non-engineer and walk away.
 - **Idle rounds to zero.** No database process to keep warm, and no
   per-app database floor across a fleet of small internal tools.
 - **No data hostage.** `baerly export --target=postgres` gives you a
   per-collection SQL snapshot. Crossing the envelope is the graduation
   signal; the data exit is mechanical.
-- **Built like git.** Content-addressed documents, immutable numbered log
-  entries, and one conditional log create as the commit, per collection.
+- **No new vendor.** Your S3/R2 bucket cleared security review years
+  ago; every hosted alternative means a fresh vendor review and an IT
+  ticket for a new managed-DB SKU.
+- **Nothing to go down.** No resident service in your critical path —
+  one fewer failure domain and one fewer vendor in your dependency tree.
+  Servers that don't exist can't go down.
 
 <!-- Hero demo: render `docs/assets/demo.gif` from `docs/assets/demo.tape`
      (`vhs docs/assets/demo.tape`) against a real bucket, then uncomment:
@@ -101,47 +106,6 @@ support Cloudflare Access and JWKS bearer verification; shared-secret
 auth is for service-to-service calls and dev. See
 [`client-auth.md`](./docs/guide/client-auth.md).
 
-## How it works
-
-**Built like git: content-addressed documents, immutable numbered log
-entries, and one conditional log create as the commit, per collection.**
-
-A bucket can store objects; it cannot run a transaction coordinator. The
-hard part is the commit: one writer must win, and every reader must be
-able to tell what won. [S3's strong consistency][s3-strong] makes object
-storage usable as shared state; conditional writes supply the
-one-writer-wins operation.
-
-Concretely, a write drops new immutable objects in the bucket and then
-creates the next numbered log entry for that collection with
-create-if-absent (`If-None-Match: "*"`). Two writers racing the same slot
-cannot both win; the loser reads the winner and retries at the next slot.
-That create _is_ the commit. There is no resident coordinator: each
-request reads bucket state, tries that create, and leaves no required
-process behind. A read follows `current.json` to the snapshot and folds
-the committed log tail into rows.
-
-baerly-storage shares the immutable-artifact foundation of table formats
-like Apache Iceberg and Delta Lake, but commits with a narrower step: one
-conditional create-if-absent log entry per collection, with no
-metadata-pointer swap and no separate coordinator. S3's strong
-read-after-write consistency and conditional writes (`If-None-Match`) make
-that single create safe. See
-[prior art and lineage](docs/spec/prior-art.md) for how it relates to
-Iceberg, Delta Lake, Litestream, and Turbopuffer.
-
-Each collection has its own ordered log, so **writes are per-collection
-linearizable** — the `If-None-Match` log create linearizes every commit.
-Cross-collection writes are unordered and non-atomic; that boundary is
-part of the contract (see [When (not) to use it](#when-not-to-use-it)).
-
-The durable contract is the bucket layout plus the conditional-write
-rules. Another language could speak it by writing the same layout and
-honoring the same rules. See
-[`storage-compatibility.md`](./docs/spec/storage-compatibility.md).
-
-[s3-strong]: https://aws.amazon.com/blogs/aws/amazon-s3-update-strong-read-after-write-consistency/
-
 ## Cheat sheet
 
 ```ts
@@ -196,22 +160,53 @@ It is **deliberately not** a few things:
 - **Realtime is long-poll first.** Polling is always correct; a WebSocket
   tier would be a future opt-in.
 
-### Scale at a glance
+None of these are apologies — baerly-storage names its envelope so
+graduation is a feature, not a surprise: `baerly export
+--target=postgres` makes the exit mechanical.
+The shape test lives in
+[workload-fit.md](./docs/about/workload-fit.md); the numeric envelope in
+[graduation.md](./docs/about/graduation.md).
 
-| Dimension           | Number                                                                                                                  | Notes                                                                                                                              |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| Shape               | 1 important screen = 1 collection                                                                                       | The fit test above; fails before size matters                                                                                     |
-| Throughput          | ~30 writes/min/collection sustained                                                                                     | M-size operating point — model/estimate, pending real-infra measurement on Cloudflare R2                                          |
-| Per-collection size | ~100–500 docs (~512 KB snapshot) before compaction defers on CF free                                                    | A fold fits the free-tier CPU budget at ~512 KB; erosion, not a cliff — model/estimate, pending real CF-isolate measurement       |
-| Fan-out             | ~100 collections/tenant (soft guideline)                                                                                | Bench-grounded linear cost (`pnpm bench:collection-fanout`); nothing in the protocol enforces a cap — cost grows linearly with N   |
-| Storage             | >10 GB/tenant stored = R2 free-tier boundary                                                                            | A cost line, not a protocol ceiling; billing begins above 10 GB-mo on R2                                                          |
-| Cost                | ~$18/mo all-in on R2 (~$13 object-storage ops + $5 Workers Paid floor), ~$26/mo on S3 at M-size                         | At ~30 writes/min account-wide aggregate; `baerly cost` projects the object-storage-ops portion only (no platform floor)           |
+## How it works
 
-**Graduation is the success path, not a failure mode.** Crossing any of
-these is the signal to graduate the workload — `baerly export
---target=postgres` makes the data exit mechanical. See
-[workload-fit.md](./docs/about/workload-fit.md) for the shape test and
-[graduation.md](./docs/about/graduation.md) for the full envelope.
+**Built like git: content-addressed documents, immutable numbered log
+entries, and one conditional log create as the commit, per collection.**
+
+A bucket can store objects; it cannot run a transaction coordinator. The
+hard part is the commit: one writer must win, and every reader must be
+able to tell what won. [S3's strong consistency][s3-strong] makes object
+storage usable as shared state; conditional writes supply the
+one-writer-wins operation.
+
+Concretely, a write drops new immutable objects in the bucket and then
+creates the next numbered log entry for that collection with
+create-if-absent (`If-None-Match: "*"`). Two writers racing the same slot
+cannot both win; the loser reads the winner and retries at the next slot.
+That create _is_ the commit. There is no resident coordinator: each
+request reads bucket state, tries that create, and leaves no required
+process behind. A read follows `current.json` to the snapshot and folds
+the committed log tail into rows.
+
+baerly-storage shares the immutable-artifact foundation of table formats
+like Apache Iceberg and Delta Lake, but commits with a narrower step: one
+conditional create-if-absent log entry per collection, with no
+metadata-pointer swap and no separate coordinator. S3's strong
+read-after-write consistency and conditional writes (`If-None-Match`) make
+that single create safe. See
+[prior art and lineage](docs/spec/prior-art.md) for how it relates to
+Iceberg, Delta Lake, Litestream, and Turbopuffer.
+
+Each collection has its own ordered log, so **writes are per-collection
+linearizable** — the `If-None-Match` log create linearizes every commit.
+Cross-collection writes are unordered and non-atomic; that boundary is
+part of the contract (see [When (not) to use it](#when-not-to-use-it)).
+
+The durable contract is the bucket layout plus the conditional-write
+rules. Another language could speak it by writing the same layout and
+honoring the same rules. See
+[`storage-compatibility.md`](./docs/spec/storage-compatibility.md).
+
+[s3-strong]: https://aws.amazon.com/blogs/aws/amazon-s3-update-strong-read-after-write-consistency/
 
 ## Go deeper
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ these is the signal to graduate the workload — `baerly export
 - 🔧 **Embed by hand** —
   [`packages/server/API.md`](./packages/server/API.md) (embed-by-hand +
   custom-routes recipes; ships as `dist/API.md` in the package)
+- 📊 **Alternatives** —
+  [`docs/about/alternatives.md`](./docs/about/alternatives.md) (how
+  baerly-storage compares to Firebase, Supabase, Convex, and Cloudflare
+  D1)
 
 ## Where things live
 

--- a/README.md
+++ b/README.md
@@ -121,11 +121,12 @@ request reads bucket state, tries that create, and leaves no required
 process behind. A read follows `current.json` to the snapshot and folds
 the committed log tail into rows.
 
-This is the write-immutable-data-then-publish-an-atomic-pointer pattern
-that table formats like Apache Iceberg use, narrowed to a document
-database: the commit is a single conditional create of the next numbered
-log object (`If-None-Match`), made safe by S3's strong read-after-write
-consistency and conditional writes — no separate coordinator. See
+baerly-storage shares the immutable-artifact foundation of table formats
+like Apache Iceberg and Delta Lake, but commits with a narrower step: one
+conditional create-if-absent log entry per collection, with no
+metadata-pointer swap and no separate coordinator. S3's strong
+read-after-write consistency and conditional writes (`If-None-Match`) make
+that single create safe. See
 [prior art and lineage](docs/spec/prior-art.md) for how it relates to
 Iceberg, Delta Lake, Litestream, and Turbopuffer.
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ these is the signal to graduate the workload — `baerly export
 
 ## Go deeper
 
+- ✨ **Why baerly-storage** —
+  [`docs/about/why-baerly.md`](./docs/about/why-baerly.md)
 - 🧭 **How it works** —
   [`docs/about/how-it-works.md`](./docs/about/how-it-works.md) (bucket +
   conditional log create)

--- a/README.md
+++ b/README.md
@@ -1,30 +1,25 @@
 # baerly-storage
 
-**A document database that lives in a bucket you already own — no new vendor to clear, no server to keep running, and an API small enough for an LLM (or a non-engineer) to use zero-shot.**
+**A database with no server. No daemon. No database runtime. Just your app and a bucket.**
+
+A document database that lives _in_ an S3/R2 bucket you already own. No new vendor to clear, nothing resident to keep running, and an API small enough for an open-weights LLM to zero-shot.
 
 ```text
 before: client → app handler → database server  (a server)
 after:  client → app handler → S3/R2 bucket     (just storage)
 ```
 
-baerly-storage is a **document database whose execution layer fits inside
-an HTTP request**.
+The trick is to cram the entire database execution layer inside an HTTP
+request. There is no server, daemon, or coordinator: each read or
+write runs as library code inside your request handler, the bucket
+holds the data, and the protocol supplies the commit rules.
 
-It stores durable state in S3-compatible object storage, including AWS S3
-and Cloudflare R2, and ships as a TypeScript implementation for Workers
-and Node.
+The load-bearing operation is narrow — one conditional create of the next
+log object commits a write. When the request ends, baerly-storage is gone. Poof!
 
-There is no database server, daemon, or coordinator. Each read or write
-runs as library code inside your Worker or Node handler; the bucket holds
-the data, and the protocol supplies the commit rules.
-
-The load-bearing operation is narrow: one conditional create of the next
-log object commits a write. When the request ends, baerly-storage is
-gone.
-
-- **A tiny API humans and agents can hold in context.** No DDL, no raw
-  SQL — 8 verbs and a ~12k-token API surface small enough to hand to an
-  LLM or a non-engineer and walk away.
+- **An API small enough to hold in your context.** No DDL, no raw SQL —
+  8 verbs and a ~12k-token surface you can hand to an LLM or a
+  non-engineer and walk away.
 - **Idle rounds to zero.** No database process to keep warm, and no
   per-app database floor across a fleet of small internal tools.
 - **No data hostage.** `baerly export --target=postgres` gives you a
@@ -33,9 +28,10 @@ gone.
 - **No new vendor.** Your S3/R2 bucket cleared security review years
   ago; every hosted alternative means a fresh vendor review and an IT
   ticket for a new managed-DB SKU.
-- **Nothing to go down.** No resident service in your critical path —
-  one fewer failure domain and one fewer vendor in your dependency tree.
-  Servers that don't exist can't go down.
+- **Nothing to go down.** No resident service in your critical path, one
+  fewer failure domain. Servers that don't exist can't go down.
+- **Built like git.** Content-addressed documents, immutable numbered log
+  entries, and one conditional log create as the commit, per collection.
 
 <!-- Hero demo: render `docs/assets/demo.gif` from `docs/assets/demo.tape`
      (`vhs docs/assets/demo.tape`) against a real bucket, then uncomment:
@@ -97,15 +93,6 @@ disappears is the database service and its surrounding machinery:
 Ordinary schema shape changes are TypeScript or config edits — no DDL, no
 SQL strings, no generated migration ceremony.
 
-### Security model
-
-Bucket credentials never leave the server. Browsers talk only to your
-trusted handler, which authenticates the caller, chooses the tenant
-prefix, and applies the protocol against the bucket. Production recipes
-support Cloudflare Access and JWKS bearer verification; shared-secret
-auth is for service-to-service calls and dev. See
-[`client-auth.md`](./docs/guide/client-auth.md).
-
 ## Cheat sheet
 
 ```ts
@@ -133,11 +120,55 @@ Full reference: [`docs/guide/cheatsheet.md`](./docs/guide/cheatsheet.md),
 or `cat node_modules/@gusto/baerly-storage/dist/API.md` in an installed
 app.
 
+## How it works
+
+**The hard part of a database-in-a-bucket is the commit.** A bucket can
+store objects; it cannot run a transaction coordinator. So one writer must
+win each race, and every reader must be able to tell what won. [S3's strong consistency][s3-strong] makes object
+storage usable as shared state; conditional writes supply the
+one-writer-wins operation.
+
+Concretely, a write drops new immutable objects in the bucket and then
+creates the next numbered log entry for that collection with
+create-if-absent (`If-None-Match: "*"`). Two writers racing the same slot
+cannot both win; the loser reads the winner and retries at the next slot.
+That create _is_ the commit. There is no resident coordinator: each
+request reads bucket state, tries that create, and leaves no required
+process behind. A read follows `current.json` to the snapshot and folds
+the committed log tail into rows.
+
+baerly-storage shares the immutable-artifact foundation of table formats
+like Apache Iceberg and Delta Lake, but commits with a narrower step: no
+metadata-pointer swap and no separate coordinator — just that one log
+create. See [prior art and lineage](docs/spec/prior-art.md) for how it
+relates to Iceberg, Delta Lake, Litestream, and Turbopuffer.
+
+Each collection has its own ordered log, so **writes are per-collection
+linearizable** — the `If-None-Match` log create linearizes every commit.
+Cross-collection writes are unordered and non-atomic; that boundary is
+part of the contract (see [When (not) to use it](#when-not-to-use-it)).
+
+The durable contract is the bucket layout plus the conditional-write
+rules. Another language could speak it by writing the same layout and
+honoring the same rules. See
+[`storage-compatibility.md`](./docs/spec/storage-compatibility.md).
+
+[s3-strong]: https://aws.amazon.com/blogs/aws/amazon-s3-update-strong-read-after-write-consistency/
+
+### Security model
+
+Bucket credentials never leave the server. Browsers talk only to your
+trusted handler, which authenticates the caller, chooses the tenant
+prefix, and applies the protocol against the bucket. Production recipes
+support Cloudflare Access and JWKS bearer verification; shared-secret
+auth is for service-to-service calls and dev. See
+[`client-auth.md`](./docs/guide/client-auth.md).
+
 ## When (not) to use it
 
 Before you count rows or price reads, ask one question:
 
-> Can the app's most important screen be answered from one collection?
+> Can the app's most important work be done from one collection?
 
 If yes, baerly-storage may fit; then check query shape, atomicity, size,
 and cost. A todo list, a single board's kanban, an event's RSVPs, one
@@ -166,47 +197,6 @@ graduation is a feature, not a surprise: `baerly export
 The shape test lives in
 [workload-fit.md](./docs/about/workload-fit.md); the numeric envelope in
 [graduation.md](./docs/about/graduation.md).
-
-## How it works
-
-**Built like git: content-addressed documents, immutable numbered log
-entries, and one conditional log create as the commit, per collection.**
-
-A bucket can store objects; it cannot run a transaction coordinator. The
-hard part is the commit: one writer must win, and every reader must be
-able to tell what won. [S3's strong consistency][s3-strong] makes object
-storage usable as shared state; conditional writes supply the
-one-writer-wins operation.
-
-Concretely, a write drops new immutable objects in the bucket and then
-creates the next numbered log entry for that collection with
-create-if-absent (`If-None-Match: "*"`). Two writers racing the same slot
-cannot both win; the loser reads the winner and retries at the next slot.
-That create _is_ the commit. There is no resident coordinator: each
-request reads bucket state, tries that create, and leaves no required
-process behind. A read follows `current.json` to the snapshot and folds
-the committed log tail into rows.
-
-baerly-storage shares the immutable-artifact foundation of table formats
-like Apache Iceberg and Delta Lake, but commits with a narrower step: one
-conditional create-if-absent log entry per collection, with no
-metadata-pointer swap and no separate coordinator. S3's strong
-read-after-write consistency and conditional writes (`If-None-Match`) make
-that single create safe. See
-[prior art and lineage](docs/spec/prior-art.md) for how it relates to
-Iceberg, Delta Lake, Litestream, and Turbopuffer.
-
-Each collection has its own ordered log, so **writes are per-collection
-linearizable** — the `If-None-Match` log create linearizes every commit.
-Cross-collection writes are unordered and non-atomic; that boundary is
-part of the contract (see [When (not) to use it](#when-not-to-use-it)).
-
-The durable contract is the bucket layout plus the conditional-write
-rules. Another language could speak it by writing the same layout and
-honoring the same rules. See
-[`storage-compatibility.md`](./docs/spec/storage-compatibility.md).
-
-[s3-strong]: https://aws.amazon.com/blogs/aws/amazon-s3-update-strong-read-after-write-consistency/
 
 ## Go deeper
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,9 @@ backend support in the storage compatibility spec.
   what to do about it.
 - [`about/pricing-log.md`](about/pricing-log.md) — append-only audit of
   cost commitments.
+- [`about/alternatives.md`](about/alternatives.md) — how baerly-storage
+  compares to Firebase, Supabase, Convex, and Cloudflare D1 on ceremony,
+  vendor commitment, availability surface, and exit path.
 
 ## Build an app
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,9 @@ Limits are split by the decision they support: shape in workload fit,
 runtime and graduation in graduation thresholds, cost in cost model, and
 backend support in the storage compatibility spec.
 
+- [`about/why-baerly.md`](about/why-baerly.md) — the six things
+  baerly-storage is built to be: LLM-legible API, no ceremony, data in
+  your bucket, no new vendor, no resident service, and a mechanical exit.
 - [`about/thesis.md`](about/thesis.md) — the positioning on-ramp: what
   baerly-storage is, who it fits, and what boundaries it deliberately
   keeps — the _why_.

--- a/docs/about/alternatives.md
+++ b/docs/about/alternatives.md
@@ -1,0 +1,103 @@
+---
+title: Alternatives
+audience: product
+summary: How baerly-storage compares to Firebase, Supabase, Convex, and Cloudflare D1 — on ceremony, vendor commitment, availability surface, and exit path.
+last-reviewed: 2026-07-01
+tags: [positioning, product, comparison]
+related: [thesis.md, workload-fit.md, cost-model.md, graduation.md]
+---
+
+# Alternatives
+
+baerly-storage is the database built for the software LLMs write — and
+the builders they hand it to. The whole thing is a small, typed
+TypeScript library that runs in your own request handler over a bucket
+you already own: no schema migrations to author, no row-level-security
+policies to generate, no service to stand up or keep online. It is small
+enough to give a non-engineer building an internal tool and let them go.
+
+It fits a specific niche: live application data for apps that have
+outgrown a browser tab but haven't yet earned a database service —
+internal tools, admin panels, dashboards, and low-to-moderate-traffic
+line-of-business apps. This page compares it to the four alternatives
+most often reached for at that tier.
+
+Firebase, Supabase, Convex, and D1 are all capable backends. The
+question here is what it costs — in ceremony, in vendor commitment, and
+in exit risk — to reach for one instead. The lens is positioning, not
+dollars; cost modeling lives in [cost-model.md](cost-model.md).
+Competitor facts were web-verified 2026-07-01 ([sources](#sources)).
+
+## At a glance
+
+|                         | baerly-storage                        | Firebase (Firestore)       | Supabase                       | Convex                     | Cloudflare D1              |
+| ----------------------- | ------------------------------------- | -------------------------- | ------------------------------ | -------------------------- | -------------------------- |
+| **Schema / migrations** | none (optional validators)            | schemaless                 | Postgres DDL + migrations      | optional TS schema         | SQL DDL + migrations       |
+| **Tenancy / auth**      | prefix-scoped in code                 | Security Rules DSL         | RLS policies                   | app code                   | app code                   |
+| **Query model**         | document DB, no joins                 | NoSQL doc queries          | full SQL (joins, FTS)          | reactive TS queries        | full SQL (SQLite)          |
+| **Real-time**           | long-poll                             | ✅ native push             | via Postgres                   | ✅ native                  | ❌                         |
+| **Runtime & data**      | your S3 bucket; nothing resident      | Google's managed service   | managed PG service (or self-host) | Convex's managed service | Cloudflare's managed service |
+| **To adopt**            | use a bucket you already have         | new vendor (legal + procurement) | new vendor (legal + procurement) | new vendor (legal + procurement) | new vendor (legal + procurement) |
+| **Exit path**           | `baerly export` → SQL                 | proprietary, paid plan     | `pg_dump` → SQL                | JSON (+ script for SQL)    | `.sql` export              |
+
+On availability and supply chain: baerly-storage adds no service beyond
+the bucket and compute you already run — one fewer vendor in your
+critical path and your dependency tree. Servers that don't exist can't
+go down. Your bucket (S3/R2) and your handler's host keep their own
+SLAs; baerly-storage just doesn't add a third to depend on.
+
+## Cost & limits
+
+|                | baerly-storage                     | Firebase           | Supabase                        | Convex                        | Cloudflare D1                |
+| -------------- | ---------------------------------- | ------------------ | ------------------------------- | ----------------------------- | ---------------------------- |
+| **Idle cost**  | $0 on S3; ~$5/mo CF floor, amortized | $0 (Spark)       | auto-pauses idle; Pro always-on | $0 (free tier)                | $0, scale-to-zero            |
+| **Free tier**  | your storage bill only             | 50k reads/day, 20k writes/day, 1 GiB stored | project-based (see pricing) | 0.5 GB, 1M calls/mo, 20 GB-hr | 5M rows read/day, 100k rows written/day, 5 GB |
+
+Idle cost is a portfolio story: one amortized floor across a fleet of
+mostly-idle apps, not a per-project bill multiplied by forty. The fleet
+math lives in [cost-model.md](cost-model.md).
+
+## Reach for…
+
+- **baerly-storage** — you want a database small and safe enough to hand
+  to an LLM or a non-engineer and walk away: no migrations, no
+  security-policy DSL, no service to operate. The data lives in a bucket
+  you already own, nothing new joins your uptime path or your vendor
+  list, and the exit is `baerly export` → standard SQL. Best when each
+  screen maps to one collection.
+- **Firebase** — consumer and mobile apps needing real-time sync at
+  scale with mature native SDKs.
+- **Supabase** — you need relational queries (joins, full-text search,
+  PostGIS); its `pg_dump` exit is every bit as clean as baerly's, into
+  the entire Postgres ecosystem.
+- **Convex** — real-time collaborative apps built on reactive
+  TypeScript. Like baerly-storage it is TypeScript-first and
+  low-ceremony; unlike it, Convex is a managed service that holds your
+  data and sits in your uptime path, and onboarding it is a new-vendor
+  decision.
+- **Cloudflare D1** — Workers apps that want SQL and are content to stay
+  on Cloudflare.
+
+## When baerly-storage is the wrong fit
+
+Two axes disqualify it, each with its own page:
+
+- **Shape doesn't fit** — core screens need cross-collection joins,
+  aggregations, or full-text search. See [workload-fit.md](workload-fit.md).
+- **Scale exceeds the envelope** — sustained single-collection write
+  contention (roughly above ~30 writes/min, an estimate pending
+  real-infra measurement) or high-throughput workloads. See
+  [graduation.md](graduation.md).
+
+For real-time push to many clients, Firebase or Convex have better
+primitives — baerly-storage offers per-collection long-poll, not a
+managed subscription graph.
+
+## Sources
+
+All verified 2026-07-01.
+
+- Firebase: [export/import](https://firebase.google.com/docs/firestore/manage-data/export-import), [pricing](https://firebase.google.com/pricing)
+- Supabase: [backups](https://supabase.com/docs/guides/platform/backups), [pricing](https://supabase.com/pricing)
+- Convex: [export](https://docs.convex.dev/database/import-export/export), [pricing](https://www.convex.dev/pricing)
+- Cloudflare D1: [import/export](https://developers.cloudflare.com/d1/best-practices/import-export-data/), [pricing](https://developers.cloudflare.com/d1/platform/pricing/)

--- a/docs/about/cost-model.md
+++ b/docs/about/cost-model.md
@@ -2,7 +2,7 @@
 title: Cost model
 audience: product
 summary: Per-line-item rates, write-amp meter, compression posture.
-last-reviewed: 2026-06-28
+last-reviewed: 2026-07-01
 tags: [cost, pricing, operations]
 related: [pricing-log.md, thesis.md, workload-fit.md, graduation.md]
 ---
@@ -34,6 +34,12 @@ and
 pages. Re-check before quoting any figure externally; price and cap
 changes land in [pricing-log.md](pricing-log.md), the
 one-line-per-change history, on the day they ship.
+
+> **Portfolio number:** at N≈30 mostly-idle apps, baerly-storage costs
+> ~$5/mo on Cloudflare (one Workers Paid floor, amortized — not ×30) or
+> $0/mo on self-hosted Node. See the
+> [idle × N portfolio comparison](#at-the-audience-operating-point-idle--n-portfolio)
+> further down.
 
 ## Per-line-item rates (Cloudflare R2 + Workers)
 
@@ -363,7 +369,7 @@ floors before quoting totals externally.
 | **baerly-storage (self-hosted Node)** | **$0/mo** (your hardware)                | No platform floor; idle storage-op cost is $0 against an S3-API bucket. See the AWS free-tier caveat above.                                                                                                                                  |
 | Cloudflare D1                 | ~$5/mo                                   | Same single Workers Paid floor amortized across all N apps; ties baerly-storage here, **but only if all N apps are Workers-native**. `wrangler d1 export` gives a SQL dump, but leaving is a dump-and-reload migration, not a zero-cooperation exit. |
 | Supabase Free                 | $0                                       | Two free projects per org; not a fleet posture for N=30.                                                                                                                                                                                     |
-| Supabase Pro                  | ≈ $25/app × 30 ≈ **~$750/mo** _(est.)_   | Paid plans bill per project (each carries its own always-on Postgres compute), so a 30-app fleet pays ~30 per-project floors. Derived from the documented ~$25/project Pro floor; usage on top varies.                                       |
+| Supabase Pro                  | ≈ $25 org + 29 × ~$10 ≈ **~$315/mo** _(est.)_ | Pro bills **per organization**, not per project: one ~$25/mo org fee (includes ~$10 compute credit, ≈ one always-on project), and each additional project adds its own compute from ~$10/mo. A 30-project fleet is the org fee plus 29 more compute instances, not 30 × $25. Compute tier and usage on top vary.                                       |
 | Neon Launch                   | ≈ $5/app × 30 ≈ **~$150/mo** _(est.)_    | Usage-based with no monthly minimum and scale-to-zero, but each intermittently-awake app still meters CU-hours; ~$5/app is a typical small-app monthly figure, so a 30-app fleet lands near ~$150/mo. Varies with how often each app wakes.  |
 | Firebase Spark                | $0 while inside no-cost Firestore quotas | Official quota is 1 GiB stored, 20k writes/day, 50k reads/day, 20k deletes/day, **per project** — a 30-app fleet can stay $0 only while every app stays inside quota.                                                                        |
 

--- a/docs/about/how-it-works.md
+++ b/docs/about/how-it-works.md
@@ -136,18 +136,17 @@ adversarial fencing model in
 
 ## The same playbook as Apache Iceberg
 
-This is not a new trick. Table formats like Apache Iceberg commit by
-writing immutable data and then publishing an atomic pointer to it.
-baerly-storage uses the same write-immutable-then-publish pattern,
-applied to a document database instead of analytics tables — but the
-commit point is narrower. Iceberg-style writers prepare new metadata and
-atomically swap the table's current-metadata pointer; baerly-storage
-commits by creating one numbered log object with create-if-absent, and
-there is no metadata pointer to swap (`current.json` is only a
-compaction bookmark, not the authority on state). S3's strong
-read-after-write consistency and conditional writes (`If-None-Match`
-create-if-absent, `If-Match` compare-and-swap) make that publish safe
-without a separate coordinator.
+This is not a new trick. Table formats like Apache Iceberg and Delta
+Lake share the same foundation: write immutable artifacts into object
+storage, then commit. baerly-storage sits in that lineage — but the
+commit step is narrower. Iceberg-style writers prepare new metadata and
+atomically swap a table's current-metadata pointer via a coordinator or
+catalog service; baerly-storage commits by creating one numbered log
+entry with create-if-absent (`If-None-Match: "*"`). There is no
+metadata-pointer swap and no separate coordinator: `current.json` is a
+compactor-owned hint that advances outside the commit path, not the
+authority on committed state. S3's strong read-after-write consistency
+and conditional writes make that single create safe.
 
 Systems like Litestream and Turbopuffer also lean on object storage, but
 they ship long-lived replication or query fleets; baerly-storage keeps

--- a/docs/about/thesis.md
+++ b/docs/about/thesis.md
@@ -127,6 +127,7 @@ The criteria split across two audiences:
 | --- | --- | --- | --- |
 | Agents and authors writing code | #4, LLM-legible API | _Closed vocabulary, types as contract, zero-shot from .d.ts alone_ | The public surface |
 | Platform teams deploying it | #6, zero operator burden | _No cron, no sidecar, no scheduler, no on-call_ | The deployment story and runtime model |
+| Non-engineer builders | #1, #5, no DDL, idle-to-zero | _Ship a shareable app before you know whether it deserves standing infrastructure_ | The scaffold quickstart and cost model |
 
 A design choice that improves one audience without harming the other is
 a win. A choice that improves authoring DX by adding operator chores, or
@@ -143,46 +144,28 @@ bounded. Public API ownership lives in
 lock lives in
 [change-discipline.md](../contributing/conventions/change-discipline.md#api-surface-lock).
 
-## Why not Postgres
+## No new vendor
 
-Criteria #2 and #5 rule out Postgres directly:
+Almost every team already has S3 / R2 / GCS / Azure Blob for exports,
+backups, documents, archives, or analytics drops. That is not
+database-protocol support, but the security review for "give me a
+bucket" happened years ago. Hosted database alternatives (D1, Neon,
+Convex, Supabase, Firebase) are excellent, but each triggers a fresh
+vendor procurement review, secrets-manager integration, and an IT ticket
+to add a new managed-DB SKU to the catalog. The bucket already exists.
 
-1. **Real DBs entail real obligations.** Provisioning, secrets, backups,
-   CVE rotation, migrations, alarms when the disk fills, alarms when the
-   pool is exhausted — none of that becomes free because the app has four
-   users.
-2. **A DB-shaped tool invites DB-shaped ceremony in the codebase.**
-   Schemas to invent and preserve across edits, migrations to author and
-   order, RLS to write — the ceremony stack arrives whether the workload
-   deserves it or not.
-
-Postgres and D1 are graduation targets, not villains. baerly-storage's
-job is to keep production apps cheap and exit-controlled until they
-cross the scale envelope where a database service is the right tool.
-
-## Why object storage
-
-Object storage is chosen for two product reasons: the bucket is usually
-already approved, and the commit path needs exactly one coordination
-primitive from the store. Under concurrent create-if-absent writes to
-the next numbered log object, one writer must win and the rest must get
-a conflict. The precise storage contract, supported backends, and live
-probe rules live in
-[storage-compatibility.md](../spec/storage-compatibility.md).
-
-**Politically pre-cleared.** Almost every team already has S3 / R2 /
-GCS / Azure Blob for exports, backups, documents, archives, or analytics
-drops. That is not database-protocol support, but the security review
-for "give me a bucket" happened years ago. Hosted alternatives (D1,
-Neon, Convex, Supabase, Firebase) are excellent, but each triggers a
-fresh vendor procurement review, secrets-manager integration, and an IT
-ticket to add a new managed-DB SKU to the catalog. The bucket already
-exists.
+That friction is low in a two-person team. In an organisation past
+roughly one hundred people, a new vendor relationship requires a legal
+review, a security questionnaire, and often an IT change request. The
+cost is weeks, not days — for an app with fifteen users. baerly-storage
+skips that entirely: the storage vendor review is already closed.
 
 **Vendor-independent where the contract holds.** Object storage is the
 rare primitive with a common dialect — the S3 API. Your bytes stay in
 your bucket; protocol support belongs to adapters and backends that pass
-the storage contract.
+the storage contract. The precise contract, supported backends, and live
+probe rules live in
+[storage-compatibility.md](../spec/storage-compatibility.md).
 
 ## Runtime model: nothing resident between requests
 
@@ -191,6 +174,11 @@ ends: a server, catalog, lock table, compactor, scheduler, or queue.
 baerly-storage avoids that shape. Each request reads bucket state, tries
 the conditional log create that commits the write, and leaves no
 required process behind.
+
+Servers that don't exist can't go down — nothing resident means a
+smaller availability and supply-chain surface. There is no database
+process to patch, no connection pool to exhaust, and no managed service
+dependency in your critical path.
 
 The kernel holds no in-memory state needed for correctness; a cold start
 reads correctly the same as a warm one. The only persistent data
@@ -203,6 +191,17 @@ convenience rather than a deployment requirement. The mechanism lives in
 [how-it-works.md](how-it-works.md#what-about-the-ever-growing-log), the
 operator limits in [graduation.md](graduation.md), and the rationale in
 [ADR-002](../adr/002-ephemeral-coordination.md).
+
+## Why object storage
+
+The commit path needs exactly one coordination primitive from the store:
+under concurrent create-if-absent writes to the next numbered log
+object, one writer must win and the rest must get a conflict. Object
+storage supplies that primitive and nothing more. (The procurement
+angle — why the bucket is usually pre-cleared — is covered in
+[§ No new vendor](#no-new-vendor) above.) The precise storage contract,
+supported backends, and live probe rules live in
+[storage-compatibility.md](../spec/storage-compatibility.md).
 
 ## Requirements → architecture
 
@@ -272,6 +271,23 @@ ships today; the log shape is intended to keep future incremental exit
 straightforward. The export and exit details live in
 [graduation.md](graduation.md) and
 [log-entry-shape.md](../spec/log-entry-shape.md).
+
+## Why not Postgres
+
+Criteria #2 and #5 rule out Postgres directly:
+
+1. **Real DBs entail real obligations.** Provisioning, secrets, backups,
+   CVE rotation, migrations, alarms when the disk fills, alarms when the
+   pool is exhausted — none of that becomes free because the app has four
+   users.
+2. **A DB-shaped tool invites DB-shaped ceremony in the codebase.**
+   Schemas to invent and preserve across edits, migrations to author and
+   order, RLS to write — the ceremony stack arrives whether the workload
+   deserves it or not.
+
+Postgres and D1 are graduation targets, not villains. baerly-storage's
+job is to keep production apps cheap and exit-controlled until they
+cross the scale envelope where a database service is the right tool.
 
 ## Audience in practice
 

--- a/docs/about/why-baerly.md
+++ b/docs/about/why-baerly.md
@@ -53,8 +53,9 @@ for "give me an S3 bucket" happened years ago. Adding a managed database
 service triggers a fresh vendor procurement review, a secrets-manager
 integration, and an IT ticket to add a new managed-DB SKU to the catalog —
 and that barrier only grows past roughly 100 people, where the approval
-chain lengthens. As [thesis.md](thesis.md) puts it: the bucket is
-"politically pre-cleared." baerly-storage plugs into what is already cleared.
+chain lengthens. The bucket is already cleared; baerly-storage plugs into
+what your security review closed years ago. See
+[thesis.md](thesis.md#no-new-vendor) for the full argument.
 
 ## Servers that don't exist can't go down
 

--- a/docs/about/why-baerly.md
+++ b/docs/about/why-baerly.md
@@ -1,0 +1,98 @@
+---
+title: Why baerly-storage
+audience: product
+summary: >
+  The six things baerly-storage is built to be — LLM-legible, no-ceremony,
+  safe to hand off, data in your bucket, no new vendor, no resident service,
+  idle-to-zero cost, and a mechanical exit.
+last-reviewed: 2026-07-01
+tags: [positioning, product]
+related: [thesis.md, alternatives.md, workload-fit.md, cost-model.md]
+---
+
+# Why baerly-storage
+
+baerly-storage is the database built for the software LLMs write — and the
+builders they hand it to. These are the six things it is built to be.
+
+## Built for the software LLMs write — and the people they hand it to
+
+The whole public surface is a small, typed, closed-vocabulary document API:
+eight verbs, a handful of modifiers, one error type discriminated by
+`.code`. An agent can reach the correct call zero-shot from the `.d.ts`
+files and `dist/API.md` without inventing ceremony. A human can hold it all
+in working context at the same time.
+
+There are no DDL migrations to author. Schema shape changes are TypeScript or
+config edits — no `CREATE TABLE`, no `ALTER TABLE`, no generated migration
+ceremony. A naming change four turns into a conversation does not cascade
+into a migration conflict.
+
+Tenant isolation is prefix-scoped at the `Db` layer in application code —
+not delegated to a row-level-security policy DSL. That matters because a
+wrong RLS policy returns empty arrays that look like "no data," not "broken
+authorization." baerly-storage removes that class of silent failure by
+keeping security-sensitive decisions where the LLM and the human can both
+read them.
+
+The result is a surface small and safe enough to hand to a non-engineer
+building an internal tool and let them go.
+
+## Your data, in a bucket you already own
+
+baerly-storage stores its durable state in an S3-compatible bucket — your
+AWS S3, your Cloudflare R2, your bucket. The bytes are not rented from a
+third party; they live where you already put your exports, backups, and
+documents. If the library stopped being maintained today, your data is in
+standard object storage. Nothing is held hostage.
+
+## No new vendor to clear
+
+Almost every team already has a bucket approved by IT. The security review
+for "give me an S3 bucket" happened years ago. Adding a managed database
+service triggers a fresh vendor procurement review, a secrets-manager
+integration, and an IT ticket to add a new managed-DB SKU to the catalog —
+and that barrier only grows past roughly 100 people, where the approval
+chain lengthens. As [thesis.md](thesis.md) puts it: the bucket is
+"politically pre-cleared." baerly-storage plugs into what is already cleared.
+
+## Servers that don't exist can't go down
+
+There is no resident database service in your critical path — no daemon to
+page about, no connection pool to exhaust, no additional uptime SLA to
+monitor. Your bucket and your handler's host keep their own SLAs.
+baerly-storage just does not add a third service to depend on, page on,
+or include in your supply chain.
+
+One fewer failure domain. One fewer entry in your dependency tree.
+
+Honest hedge: your bucket and handler still have their own failure modes;
+baerly-storage removes the database service failure mode, not all failure
+modes.
+
+## Idle rounds to zero
+
+A managed database floor multiplied across a fleet of mostly-idle internal
+tools accumulates fast. baerly-storage charges no floor of its own: at
+idle, storage-op cost is effectively zero (`< 1 Class A op / writer / hour`,
+CI-gated). On Cloudflare Workers, one $5/mo Workers Paid platform floor
+covers the entire fleet — amortized across all apps, not multiplied by N.
+On self-hosted Node, the idle cost is $0. See the N=30 portfolio comparison
+in
+[cost-model.md](cost-model.md#at-the-audience-operating-point-idle--n-portfolio).
+
+## The exit is mechanical
+
+`baerly export --target=postgres` produces a per-collection SQL snapshot.
+Crossing the workload envelope is the graduation signal — graduation is the
+success path, not a failure mode. The log shape is designed so that future
+incremental CDC exit stays straightforward rather than aspirational.
+
+When an app grows into Cloudflare D1 or Postgres, that is a
+baerly-storage win. The data exit requires no cooperation from a vendor.
+
+---
+
+Where this is the wrong tool →
+[workload-fit.md](workload-fit.md) (shape) and
+[graduation.md](graduation.md) (scale).

--- a/docs/contributing/conventions/docs.md
+++ b/docs/contributing/conventions/docs.md
@@ -66,11 +66,13 @@ These positioning lines are load-bearing brand copy and must stay
 recognizable and consistent wherever they appear. If you reword one,
 update every occurrence so they don't silently drift:
 
-- **"No database server. No daemon. No database runtime. Just your app
-  and a bucket."** — the punchy README lead. Explanatory docs may use
-  variants such as **"There is no separate database server."** or
-  **"There is no database server coordinating state."** where the
-  passage is teaching the runtime model.
+- **"A document database that lives in a bucket you already own — no
+  new vendor to clear, no server to keep running, and an API small
+  enough for an LLM (or a non-engineer) to use zero-shot."** — the
+  README tagline. Explanatory docs may use variants such as **"There
+  is no separate database server."** or **"There is no database server
+  coordinating state."** where the passage is teaching the runtime
+  model.
 - **"baerly-storage runs wherever the bucket credentials safely
   live."** — the shortest way to distinguish the TypeScript library
   from a hosted database service.


### PR DESCRIPTION
## What

Reworks the positioning front door — benefits-first ordering, a dedicated "why" page, and a search-intent competitor comparison — aligned to codebase reality rather than aspirational framing.

- **New `docs/about/why-baerly.md`** — six-section, gain-led benefits page (LLM-legible API, no ceremony, data in your bucket, no new vendor, no resident service, idle-to-zero, mechanical exit). No disqualifiers on the page; links out to `workload-fit.md` / `graduation.md` for boundaries. Wired in as the first bullet under "Go deeper" (README) and "Evaluate the bet" (`docs/README.md`).
- **New `docs/about/alternatives.md`** — search-intent comparison vs Firebase / Supabase / Convex / Cloudflare D1, laid out as tables across ceremony, vendor commitment, availability surface, and exit path. Every competitor fact is web-verified and dated (`verified 2026-07-01`) with a source link. No restated dollar figures — links out to `cost-model.md` as the single source of truth for cost.
- **`README.md` — benefits-first reorder.** Leads with the gains before mechanics; new tagline; softens the "deliberately not" section so the envelope reads as a feature, not an apology; relocates "How it works" below the cheat sheet. The old "Scale at a glance" table is dropped from the README — that numeric envelope already lives (and is owned) in `graduation.md`, so this removes a second copy rather than the data.
- **`docs/about/thesis.md` — gains-first restructure.** Promotes "No new vendor" to a first-class section, adds a non-engineer audience row to the two-audiences table, and leads "Why object storage" with the single coordination primitive (cross-linking the procurement angle to "No new vendor").
- **Corrected lineage framing** in `README.md` + `docs/about/how-it-works.md` — the old text implied baerly-storage "publishes an atomic pointer like Iceberg/Delta." The commit is actually one conditional `If-None-Match` create-if-absent log entry per collection; `current.json` is a compactor-owned hint off the commit path. New framing: shared immutable-artifact foundation with Iceberg / Delta / Litestream / Turbopuffer, but a narrower commit with no metadata-pointer swap and no coordinator (matches `writer.ts` + ADR).
- **`docs/about/cost-model.md`** — surfaces the N≈30 portfolio number (~$5/mo Cloudflare, $0 self-hosted Node) as a headline callout near the top, with a down-link to the full idle × N table.
- **`docs/contributing/conventions/docs.md`** — updates the tracked README tagline in the brand-copy list to match the new front door.

## Why

Comparison / "X alternative" content is high-intent for a public-launch audience, and a benefits-first front door serves the non-engineer and LLM-author personas the thesis targets. The repo already had the honesty section (`When (not) to use it`) and cost tables, so this surfaces and consolidates rather than duplicates. The lineage line is a credibility signal for skeptical senior engineers — so it had to be accurate to the code, not aspirational.

## Accuracy pass

Competitor facts were re-verified against official pricing/docs pages on 2026-07-01 (13/14 held). Corrections applied this round:

- **Firebase free tier** — was "1 GB / day"; corrected to "50k reads/day, 20k writes/day, 1 GiB stored" (the 1 GiB is a cumulative storage cap, not a daily limit). This also removes a self-contradiction with `cost-model.md`.
- **Cloudflare D1 free tier** — clarified units to "rows read/day" / "rows written/day" (D1 meters rows, not queries).
- **Supabase Pro at N=30** (`cost-model.md`) — was modeled as $25 × 30 ≈ $750/mo; corrected to per-**org** billing (~$25 org fee incl. one project's compute + ~$10/mo per additional project) ≈ ~$315/mo. This was the most overstated (and most self-serving) competitor cost claim.
- `why-baerly.md` — replaced a quotation attributed to `thesis.md` ("politically pre-cleared") that no longer existed there after the thesis reorder, with a paraphrase and a `#no-new-vendor` anchor link.

## Decisions baked in

- Dollars live only in `cost-model.md`; `alternatives.md` links out.
- baerly-storage's own claims use precise phrasings (idle = `$0` self-hosted / `~$5/mo` Cloudflare floor amortized; schema = optional validators; exit = `baerly export` shipped + CI-tested).
- Availability claims carry an honest hedge: the bucket and handler keep their own SLAs; baerly-storage removes the *database-service* failure mode, not all failure modes.

## Verification

`pnpm verify:docs` green (cross-link + heading-anchor validation, `audience` / `last-reviewed` frontmatter + 180-day staleness, doc_type taxonomy + index coverage, mermaid). Docs-only branch; no code paths touched.
