### PR TITLE
docs: reposition from maturity-tier to workload-envelope framing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -410,7 +410,7 @@ auto-load on matching edits and point at the same files.
   _operator-installed_ scheduling (`wrangler.jsonc` `triggers.crons`,
   `node-cron`, k8s `CronJob`, systemd timer, DO Alarms). The kernel must
   work on a bare bucket with zero operator infrastructure — the pitch is
-  "Just a Bucket" (thesis criterion #6, [thesis.md](docs/about/thesis.md#what-prototype-tier-storage-needs)).
+  "Just a Bucket" (thesis criterion #6, [thesis.md](docs/about/thesis.md#what-apps-within-the-envelope-need)).
   Scheduled cron is a _user-opt-in_ acceleration via the exported
   `runScheduledMaintenance` SDK, never a default and never a requirement.
   **In-band write-tick maintenance is the sanctioned default and it

--- a/docs/about/cost-model.md
+++ b/docs/about/cost-model.md
@@ -417,7 +417,7 @@ Read this as positioning, not a provider quote:
   a bucket-native data layer or live CDC handoff. Off Workers, managed
   Postgres at $25+/mo behind a vendor catalog is the relevant
   comparison. If Cloudflare lock-in and SQL are acceptable, switch to
-  D1; [that move is the success path, not churn](thesis.md#what-prototype-tier-storage-needs).
+  D1; [that move is the success path, not churn](thesis.md#what-apps-within-the-envelope-need).
   Firebase Blaze also undercuts baerly-storage on raw per-op at M
   (~$5 vs. ~$19). That is expected: M is past the design center.
 - **L:** baerly-storage's R2 Class B alone (~$1 500) costs more than a

--- a/docs/about/graduation.md
+++ b/docs/about/graduation.md
@@ -9,9 +9,13 @@ related: [cost-model.md, workload-fit.md, thesis.md, "../adr/002-ephemeral-coord
 
 # Graduation thresholds
 
-baerly-storage is sized for the prototype tier: internal tools, side
-projects, and small product experiments. Graduation is what you do when
-one collection outgrows that tier.
+baerly-storage is built for production apps that live within a defined
+workload envelope: internal tools, admin panels, dashboards, and
+low-to-moderate-traffic line-of-business apps, up to roughly
+~30 writes/min/collection, ~10 GB/tenant stored, and ~100
+collections/tenant. Graduation is what you do when a collection or
+workload crosses one of those documented bounds — a scale event, not a
+maturity one.
 
 The threshold concept is **the fold**: the moment maintenance turns many
 small committed writes into one refreshed snapshot. That makes reads

--- a/docs/about/thesis.md
+++ b/docs/about/thesis.md
@@ -41,8 +41,9 @@ Agent-Built Software_; the technical detail lives across `docs/`.
 It is now cheap to try a software idea. That creates many small apps
 with uncertain lifespans and mixed criticality: dashboards, internal
 trackers, personal apps, workflow sidecars. Some run for a week. Some
-run every Tuesday for five years. Some become important. Most live
-between toy and production.
+run every Tuesday for five years. Some become important. Most are
+production apps — real data, real users — that simply live inside a
+defined workload envelope.
 
 You need three primitives to build software in 2026: compute, tokens,
 and storage. Compute has an answer: FaaS, pay per request, scale to
@@ -53,30 +54,34 @@ The gap shows up as ordinary failures: `localStorage` does not survive a
 share link; LLM-generated Postgres + RLS can return empty arrays when a
 policy is wrong, which looks like "no data" instead of broken
 authorization; a real database invites service ceremony the operator
-never sees. baerly-storage is sized for the territory between toy and
-production.
+never sees. baerly-storage is built for production apps that live
+within a defined workload envelope — internal tools, admin panels,
+dashboards, and low-to-moderate-traffic line-of-business apps. The
+ceiling is scale and shape, not seriousness.
 
 Better models do not remove that need. Stronger agents do better when
 the surface is small, tools are boring, and invalid states are
 unrepresentable.
 
-## What prototype-tier storage needs
+## What apps within the envelope need
 
-Prototype-tier does not mean fake data. It means live data while the
-operator is still learning whether the app deserves standing
-infrastructure. Sandboxes and review bots reduce blast radius after a
-tool has chosen a storage shape; baerly-storage supplies the safer
-default.
+Apps within the envelope run real data and real users. What they share
+is that they have not yet crossed — or do not need to cross — the
+cost-and-commitment threshold of standing infrastructure: a managed
+database service, a migration workflow, a DBA on-call. Sandboxes and
+review bots reduce blast radius after a tool has chosen a storage
+shape; baerly-storage supplies the safer default before that investment
+is warranted.
 
 The criteria:
 
 1. **Idle rounds to zero.** No $5/mo floors multiplied across forty
-   abandoned internal tools. A prototype should not accumulate rent for
+   abandoned internal tools. An app should not accumulate rent for
    merely existing.
 2. **Low operational overhead.** No CVE rotation, no kernel patches, no
    on-call for an app with fifteen users.
-3. **Graduation path with no hostage situation.** Prototype-tier
-   storage without an exit is deferred migration pain. _Graduation is
+3. **Graduation path with no hostage situation.** Storage within a
+   scale envelope without an exit is deferred migration pain. _Graduation is
    the success path, not a failure mode._ When an app crosses the
    envelope and moves to Cloudflare D1 or Postgres, that is a
    baerly-storage **win**, not a churn event. Snapshot export ships
@@ -152,8 +157,8 @@ Criteria #2 and #5 rule out Postgres directly:
    deserves it or not.
 
 Postgres and D1 are graduation targets, not villains. baerly-storage's
-job is to keep the experiment cheap and exit-controlled until the
-operator knows the app deserves that tier.
+job is to keep production apps cheap and exit-controlled until they
+cross the scale envelope where a database service is the right tool.
 
 ## Why object storage
 
@@ -240,8 +245,8 @@ bucket layout and read/write algorithms are explained in
   where it is available; that is the graduation signal, not a
   competitive position. See [cost-model.md](cost-model.md).
 - **Not a D1 / Postgres replacement.** D1 and Postgres are graduation
-  targets. baerly-storage keeps the experiment cheap until the user
-  knows whether it is worth graduating.
+  targets. baerly-storage keeps production apps cheap and exit-ready
+  until they cross the scale envelope where graduating makes sense.
 
 ## Workload ceiling
 

--- a/docs/contributing/conventions/change-discipline.md
+++ b/docs/contributing/conventions/change-discipline.md
@@ -182,7 +182,7 @@ Before proposing a mechanism that involves scheduling, cleanup,
 coordination, or cross-request state, run the three checks below. A
 failing answer means the mechanism needs redesign before it becomes a
 configuration option. The principle this enforces is thesis criterion #6
-([Zero operator burden](../../about/thesis.md#what-prototype-tier-storage-needs)):
+([Zero operator burden](../../about/thesis.md#what-apps-within-the-envelope-need)):
 "create a bucket; run the kernel inside an HTTP handler" is the entire
 operator action set.
 

--- a/examples/minimal-cloudflare/AGENTS.md
+++ b/examples/minimal-cloudflare/AGENTS.md
@@ -549,7 +549,7 @@ The cost model puts the soft ceiling at:
 
 At M-size (~30 writes/min) the projected cost is ~$18/mo on R2. Past
 those, per-class op pricing and fan-out scan cost start to dominate;
-you're better off on a real database.
+you've outgrown the workload envelope — move to a database service (D1 / Postgres) suited to higher scale.
 Pick your graduation target:
 
 - **Cloudflare Workers + lock-in OK:** [D1](https://developers.cloudflare.com/d1/) — cheaper per-write at M-size.

--- a/examples/minimal-cloudflare/README.md
+++ b/examples/minimal-cloudflare/README.md
@@ -123,14 +123,14 @@ needs no secrets. If you adopt a "Going to production" recipe:
 
 baerly-storage is designed for the small-to-medium operating point.
 Past these thresholds, S3 list-prefix latency and per-class operation
-pricing start to dominate, and you're better off on a real database:
+pricing starts to dominate, and you've outgrown the workload envelope — move to a database service:
 
 - **~30 writes / minute / collection** — per-collection throughput estimate (CAS-livelock model)
 - **>10 GB / tenant** — R2 free-tier storage cost line (a billing signal, not a protocol ceiling)
 - **~100 collections / tenant** — soft fan-out guideline (linear cost, bench-grounded; nothing enforces it)
 
 When you cross these signals, graduation is mechanical:
-`baerly export --target=postgres` walks your log entries (already Debezium-style CDC change events) into a real DB. If your
+`baerly export --target=postgres` walks your log entries (already Debezium-style CDC change events) into a database service. If your
 deploy target is Cloudflare Workers and you'll accept Cloudflare
 lock-in, [D1](https://developers.cloudflare.com/d1/) is cheaper
 per-write at M-size and is a natural next step. If you're on
@@ -138,7 +138,7 @@ AWS, on-prem, or want your data portable, managed Postgres is
 the typical destination. Either way — graduation is a Baerly win,
 not a churn event.
 
-**Export to a real database** (swap `--target=` for `sqlite`,
+**Export to a database service** (swap `--target=` for `sqlite`,
 `postgres`, or `d1`):
 
 ```sh

--- a/examples/minimal-node/AGENTS.md
+++ b/examples/minimal-node/AGENTS.md
@@ -453,7 +453,7 @@ The cost model puts the soft ceiling at:
 
 At M-size (~30 writes/min) the projected cost is ~$26/mo on S3 (~$18/mo on R2). Past
 those, per-class op pricing and fan-out scan cost start to dominate;
-you're better off on a real database.
+you've outgrown the workload envelope — move to a database service (D1 / Postgres) suited to higher scale.
 Pick your graduation target:
 
 - **Cloudflare Workers + lock-in OK:** [D1](https://developers.cloudflare.com/d1/) — cheaper per-write at M-size.

--- a/examples/minimal-node/README.md
+++ b/examples/minimal-node/README.md
@@ -161,14 +161,14 @@ Verify: `curl https://<your-service>/v1/healthz`.
 
 baerly-storage is designed for the small-to-medium operating point.
 Past these thresholds, S3 list-prefix latency and per-class operation
-pricing start to dominate, and you're better off on a real database:
+pricing starts to dominate, and you've outgrown the workload envelope — move to a database service:
 
 - **~30 writes / minute / collection** — per-collection throughput estimate (CAS-livelock model)
 - **>10 GB / tenant** — R2 free-tier storage cost line (a billing signal, not a protocol ceiling)
 - **~100 collections / tenant** — soft fan-out guideline (linear cost, bench-grounded; nothing enforces it)
 
 When you cross these signals, graduation is mechanical:
-`baerly export --target=postgres` walks your log entries (already Debezium-style CDC change events) into a real DB. If your
+`baerly export --target=postgres` walks your log entries (already Debezium-style CDC change events) into a database service. If your
 deploy target is Cloudflare Workers and you'll accept Cloudflare
 lock-in, [D1](https://developers.cloudflare.com/d1/) is cheaper
 per-write at M-size and is a natural next step. If you're on
@@ -176,7 +176,7 @@ AWS, on-prem, or want your data portable, managed Postgres is
 the typical destination. Either way — graduation is a Baerly win,
 not a churn event.
 
-**Export to a real database** (swap `--target=` for `sqlite`,
+**Export to a database service** (swap `--target=` for `sqlite`,
 `postgres`, or `d1`):
 
 ```sh

--- a/examples/react-cloudflare/AGENTS.md
+++ b/examples/react-cloudflare/AGENTS.md
@@ -553,7 +553,7 @@ The cost model puts the soft ceiling at:
 
 At M-size (~30 writes/min) the projected cost is ~$18/mo on R2. Past
 those, per-class op pricing and fan-out scan cost start to dominate;
-you're better off on a real database.
+you've outgrown the workload envelope — move to a database service (D1 / Postgres) suited to higher scale.
 Pick your graduation target:
 - **Cloudflare Workers + lock-in OK:** [D1](https://developers.cloudflare.com/d1/) — cheaper per-write at M-size.
 - **Off-Workers or portability matters:** managed Postgres.

--- a/examples/react-node/AGENTS.md
+++ b/examples/react-node/AGENTS.md
@@ -495,7 +495,7 @@ The cost model puts the soft ceiling at:
 
 At M-size (~30 writes/min) the projected cost is ~$26/mo on S3 (~$18/mo on R2). Past
 those, per-class op pricing and fan-out scan cost start to dominate;
-you're better off on a real database.
+you've outgrown the workload envelope — move to a database service (D1 / Postgres) suited to higher scale.
 Pick your graduation target:
 - **Cloudflare Workers + lock-in OK:** [D1](https://developers.cloudflare.com/d1/) — cheaper per-write at M-size.
 - **Off-Workers or portability matters:** managed Postgres.

--- a/examples/react-node/README.md
+++ b/examples/react-node/README.md
@@ -182,14 +182,14 @@ follow `AGENTS.md` → "Going to production":
 
 baerly-storage is designed for the small-to-medium operating point.
 Past these thresholds, S3 list-prefix latency and per-class operation
-pricing start to dominate, and you're better off on a real database:
+pricing starts to dominate, and you've outgrown the workload envelope — move to a database service:
 
 - **~30 writes / minute / collection** — per-collection throughput estimate (CAS-livelock model)
 - **>10 GB / tenant** — R2 free-tier storage cost line (a billing signal, not a protocol ceiling)
 - **~100 collections / tenant** — soft fan-out guideline (linear cost, bench-grounded; nothing enforces it)
 
 When you cross these signals, graduation is mechanical:
-`baerly export --target=postgres` walks your log entries (already Debezium-style CDC change events) into a real DB. If your
+`baerly export --target=postgres` walks your log entries (already Debezium-style CDC change events) into a database service. If your
 deploy target is Cloudflare Workers and you'll accept Cloudflare
 lock-in, [D1](https://developers.cloudflare.com/d1/) is cheaper
 per-write at M-size and is a natural next step. If you're on
@@ -197,7 +197,7 @@ AWS, on-prem, or want your data portable, managed Postgres is
 the typical destination. Either way — graduation is a Baerly win,
 not a churn event.
 
-**Export to a real database** (swap `--target=` for `sqlite`,
+**Export to a database service** (swap `--target=` for `sqlite`,
 `postgres`, or `d1`):
 
 ```sh

--- a/packages/server/src/maintenance.ts
+++ b/packages/server/src/maintenance.ts
@@ -505,14 +505,13 @@ export const runBoundedMaintenance = async (
         if (nextSeq - (current.last_warned_seq ?? 0) >= MAINTENANCE_WARN_INTERVAL_WRITES) {
           console.warn(
             `baerly-storage: collection "${collection}" is deferring compaction — its ` +
-              `snapshot exceeds the fold ceiling (${snapshotBytes > C ? "bytes" : "rows"}), ` +
-              `so the tail keeps growing and read amplification will climb. This is ` +
-              `graduation-pending: the dataset has outgrown prototype-tier maintenance. ` +
-              `On paid Cloudflare / Node you can raise BAERLY_MAINTENANCE_MAX_FOLD_BYTES — ` +
-              `but on Cloudflare a cap above what a single isolate can fold makes folds get ` +
-              `CPU-killed mid-flight and silently not land (no clean metric — watch snapshot ` +
-              `age / object count); see docs/about/graduation.md. Otherwise, graduate to a ` +
-              `server-backed database.`,
+              `snapshot exceeds the fold ceiling (${snapshotBytes > C ? `${C} bytes` : `${E} rows`}), ` +
+              `so the tail keeps growing and read amplification will climb. The dataset has ` +
+              `outgrown the maintenance envelope. On paid Cloudflare / Node you can raise ` +
+              `BAERLY_MAINTENANCE_MAX_FOLD_BYTES — but on Cloudflare a cap above what a single ` +
+              `isolate can fold makes folds get CPU-killed mid-flight and silently not land ` +
+              `(no clean metric — watch snapshot age / object count); see docs/about/graduation.md. ` +
+              `Otherwise, move to a database service (D1 / Postgres).`,
           );
           // SEPARATE best-effort CAS — explicitly NOT folded into any
           // commit CAS. A lost stamp just means another isolate warns


### PR DESCRIPTION
## What

Corrects a positioning error that runs through the docs, an operator warning, and the example templates: the project repeatedly implied baerly-storage is **not for production** — "between toy and production", "prototype-tier", "you're better off on a real database". That conflates two different axes:

- **Workload scale / shape** — baerly has a real, documented ceiling here (~30 writes/min per collection, cross-collection queries, etc.).
- **Production-readiness** — baerly *is* production-grade. Internal tools, admin panels, and low-to-moderate-traffic line-of-business apps are first-class production use cases that live inside the envelope indefinitely.

This branch reframes everything so the only ceiling is scale/shape, and "graduation" is a scale event, not a maturity one.

### Commits
1. **`thesis.md` + `graduation.md`** — purge "between toy and production" / "prototype-tier" positioning; retitle the section `## What prototype-tier storage needs` → `## What apps within the envelope need` (with the three inbound anchor links in `CLAUDE.md`, `cost-model.md`, `change-discipline.md` updated for the slug rename); graduation.md now front-loads the concrete scale bounds.
2. **`maintenance.ts`** — reword the graduation-pending `console.warn` from "outgrown prototype-tier maintenance … graduate to a server-backed database" to "outgrown the maintenance envelope … move to a database service (D1 / Postgres)", and name the concrete fold ceiling (`${C} bytes` / `${E} rows`). String text only — no logic/threshold/control-flow change.
3. **Example templates (7 files)** — replace "you're better off on a real database" / "Export to a real database" with workload-envelope framing. The four `AGENTS.md` replacements are byte-identical to satisfy the `agents-md-drift` test.

## What's preserved (deliberately)

All threshold numbers, cost figures, the "outgrown a browser tab but has not earned a database service" framing, "crossing the envelope is the graduation signal", "graduation is the success path, not a failure", and the shape-fit / cross-collection reasoning. These were already honest and scale-based.

## Relationship to PR #20

Independent (branched off `main`, disjoint files). PR #20 reframed `docs/about/alternatives.md` with the same corrected framing; this branch handles the rest. Both can merge in any order.

## Verification

`pnpm verify` (typecheck, examples, lint, format, docs + taxonomy + link/anchor validation, spec-drift), `pnpm bundle-sizes` (all entries under budget — the reworded warn is slightly smaller), and `pnpm test:agent` (2278 passed, incl. `agents-md-drift`) all green.

## Known minor (non-blocking)

The three example READMEs say "move to a database service:" while the AGENTS.md add "(D1 / Postgres) suited to higher scale" — cosmetic; the READMEs name the targets in the following sentences. Can tighten to strict parity if desired.