### PR TITLE
docs: trim package-layers diagram to the portability core

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 title: Architecture overview
 audience: coder
 summary: Module dependency graph and lifecycle of db.collection(...).insert().
-last-reviewed: 2026-06-28
+last-reviewed: 2026-06-30
 tags: [architecture, lifecycle, module-map]
 related: ["spec/sync-protocol.md", "contributing/extending.md", "contributing/features.md"]
 ---
@@ -222,25 +222,12 @@ import; anything not listed is forbidden, and self-imports are allowed:
 
 ```mermaid
 flowchart TD
-    create["create-baerly-storage"]
-    cli["cli"]
     client["client"]
     adapterCf["adapter-cloudflare"]
     adapterNode["adapter-node"]
     dev["dev"]
     server["server"]
     protocol["protocol"]
-
-    create --> cli
-    create --> server
-    create --> protocol
-
-    cli --> client
-    cli --> adapterCf
-    cli --> adapterNode
-    cli --> dev
-    cli --> server
-    cli --> protocol
 
     client --> server
     client --> protocol
@@ -260,8 +247,14 @@ flowchart TD
     dev -->|vite-plugin| adapterNode
     adapterNode -->|dev-landing| dev
 
-    linkStyle 19,20 stroke:#d33,stroke-width:2px
+    linkStyle 10,11 stroke:#d33,stroke-width:2px
 ```
+
+The diagram shows the portability core — the layering down to the pure
+`protocol` leaf and the cordoned `dev ↔ adapter-node` cycle. The two
+top-of-stack consumers, `cli` and `create-baerly-storage`, are omitted:
+they import broadly almost by definition and add edges without changing
+the shape. The table above remains the complete, enforced edge set.
 
 The two red edges are an accepted Node-only `dev ↔ adapter-node` cycle:
 `@baerly/dev`'s Vite plugin imports `baerlyNode` as the in-process dev


### PR DESCRIPTION
## What

Trims the mermaid diagram in `docs/architecture.md` §Package layers down to the 6-node portability core, dropping the `cli` and `create-baerly-storage` nodes.

## Why

The diagram restated all 21 import edges the table directly above it already enumerates — and that table is the **declared source of truth** (and the executable mirror of `lint-package-layers.mjs`'s `RULES`). `cli` and `create-baerly-storage` are top-of-stack consumers that import broadly almost by definition; they contributed 9 of the 21 edges without adding anything to the architectural picture.

What's left is the part the diagram uniquely earns over the table:
- the layering down to the pure `protocol` leaf, and
- the cordoned `dev ↔ adapter-node` cycle, which a table can't show *as* a cycle.

## Notes

- Fixed the `linkStyle` indices (`19,20` → `10,11`) so the red highlight still lands on the cycle edges after the edge count dropped — `verify:mermaid` parses syntax but wouldn't catch a mis-targeted highlight.
- Added a caption noting the omission and pointing at the table as the complete, enforced edge set.
- Bumped `last-reviewed`.
- `pnpm verify:docs` passes (mermaid parses clean, 4 blocks).

No overlap with the other open docs PRs (#20, #21) — neither touches `architecture.md`.