### PR TITLE
fail closed on ephemeral storage in production

### DIFF
--- a/.changeset/fail-closed-ephemeral-storage.md
+++ b/.changeset/fail-closed-ephemeral-storage.md
@@ -1,0 +1,54 @@
+---
+"@gusto/baerly-storage": minor
+---
+
+Fail closed on ephemeral storage in production
+
+`MemoryStorage` now refuses to construct in a detected deployment
+(`NODE_ENV=production` or a known PaaS marker) unless ephemerality is
+explicitly acknowledged. This prevents the silent-data-loss failure mode where
+an app falls back to in-memory storage in production — writes "succeed" into
+process RAM and vanish on every restart, with no loud signal.
+
+**What changed**
+
+- `new MemoryStorage()` throws `BaerlyError("InvalidConfig")` in a detected
+  deployment. Tests and local dev are unaffected (neither sets those signals).
+- New `resolveStorageFromEnv(env?)` export on `@gusto/baerly-storage/node`: the
+  safe, tested storage selector the Node example scaffolds now use, so apps
+  don't hand-roll one with a silent fallback.
+- New `assertStorageReachable(storage)` export on `@gusto/baerly-storage/node`:
+  an opt-in boot/readiness check that fails closed on an unreachable or
+  CAS-broken bucket (the wrong-bucket-name gap a missing-bucket guard can't
+  catch).
+- New pure `isDeployedEnv(env)` predicate on `@gusto/baerly-storage`.
+
+**Migration**
+
+- If you intentionally run in-memory storage in a deployed environment (e.g. a
+  throwaway demo), opt in explicitly — either in code:
+
+  ```ts
+  new MemoryStorage({ ephemeral: true })
+  ```
+
+  or via the environment:
+
+  ```sh
+  BAERLY_ALLOW_EPHEMERAL_STORAGE=true
+  ```
+
+- No action needed for tests, local dev, or apps already using a real S3/R2
+  bucket.
+
+**Platform note**
+
+- The guard is effectively Node-only. A Cloudflare Worker requires an R2
+  binding and has no silent in-memory fallback path, and the deploy-detection
+  predicate reads `process.env`, which is empty on Workerd — so the guard never
+  fires (and never needs to) on Cloudflare.
+- CI environments are never treated as deployed. When `CI` is set (to a
+  non-empty, non-`false` value) the PaaS-marker detection is suppressed, so
+  `MemoryStorage` still constructs in CI — including Kubernetes-hosted CI agents
+  that set `KUBERNETES_SERVICE_HOST`. An explicit `NODE_ENV=production` still
+  trips the guard.

--- a/docs/guide/operations.md
+++ b/docs/guide/operations.md
@@ -2,7 +2,7 @@
 title: Operations runbook
 audience: operator
 summary: Production preflight, auth, backup, observability, capacity, and route checks.
-last-reviewed: 2026-06-28
+last-reviewed: 2026-06-30
 tags: [operations, runbook, production]
 related: [auth.md, backups.md, observability.md, "../about/graduation.md", "../about/cost-model.md"]
 ---
@@ -54,6 +54,34 @@ dumped under the old build and restored/reseeded under the current schema
 
 There is no `baerly doctor --target=node` backend today; the bucket
 probe is the Node safety check.
+
+### Readiness check
+
+`GET /v1/healthz` is an anonymous *liveness* probe — it answers "is the
+process up?" without touching storage. `assertStorageReachable` from
+`@gusto/baerly-storage/node` is the application-level *readiness* check:
+it proves the configured bucket is reachable and honors the conditional
+writes (CAS) the protocol depends on. It throws `BaerlyError` —
+`NetworkError` if the bucket is unreachable, `InvalidConfig` if CAS is
+broken — so the process fails closed before serving traffic.
+
+```ts
+import { resolveStorageFromEnv, assertStorageReachable } from "@gusto/baerly-storage/node";
+const { storage, label } = resolveStorageFromEnv();
+await assertStorageReachable(storage); // throws before we serve traffic
+console.log(`[baerly] storage=${label} (reachable)`);
+```
+
+It is opt-in by design: it performs a handful of live round-trips
+(writing and deleting throwaway sentinels), so do not run it on every
+request or wire it into a hot path. Run it once at startup, or behind a
+`/readyz` handler your platform polls. On serverless or edge runtimes
+with frequent cold starts (e.g. Cloudflare isolates) you would not want
+it on every cold start.
+
+It catches an unreachable, access-denied, or non-existent bucket and a
+CAS-broken store, but not a wrong-but-writable bucket — a typo that
+points at another bucket you own boots clean.
 
 ### Auth
 

--- a/examples/minimal-node/src/server/resolve-storage.ts
+++ b/examples/minimal-node/src/server/resolve-storage.ts
@@ -1,105 +1,18 @@
 /**
- * Storage resolution for the Node server entry, in priority order:
+ * Storage selection is your app's policy, surfaced here as an editable
+ * seam. The default is the library's `resolveStorageFromEnv`, in priority
+ * order:
  *   1. R2_ACCOUNT_ID set → Cloudflare R2 (S3-compat endpoint)
  *   2. BUCKET set        → AWS S3
  *   3. neither, local dev → LocalFsStorage (zero credentials)
- *   4. neither, deployed  → throw. local-fs is a local-dev convenience
- *      only — single-process, no cross-process CAS, no crash-fsync — so
- *      it is never a production store (there is no opt-in).
+ *   4. neither, deployed  → throw. It never silently falls back to a
+ *      non-durable store (local-fs or in-memory) in a deployment — that
+ *      is the failure mode that loses data in production.
  *
- * Extracted from the server entry so the deployment safety guard is one
- * tested unit instead of fragile copy-paste — see
- * `tests/integration/node-storage-resolution.test.ts`. Kept byte-identical
- * across the Node example scaffolds and fenced by a drift test in that file.
- * Edit it freely in your own app: this is your storage policy, not the
- * kernel's.
+ * Replace this re-export with your own `(env) => ResolvedStorage` if your
+ * policy differs (a custom endpoint, MinIO, GCS, …). The resolver is
+ * exported and tested in `@gusto/baerly-storage/node` so every app shares
+ * one safe default instead of hand-rolling one.
  */
-import { localFsStorage, r2Storage, s3Storage } from "@gusto/baerly-storage/node";
-import type { Storage } from "@gusto/baerly-storage";
-
-export interface ResolvedStorage {
-  readonly storage: Storage;
-  /** Human-readable backend label for the startup log line. */
-  readonly label: string;
-}
-
-// Heuristic for "this is a real deployment, not a laptop." Any one
-// marker is enough; it decides whether a missing bucket should fail
-// loud (deployment) or fall back to local-fs (local dev).
-const PAAS_MARKERS = [
-  "RAILWAY_ENVIRONMENT",
-  "RENDER",
-  "FLY_APP_NAME",
-  "K_SERVICE", // Google Cloud Run
-  "DYNO", // Heroku
-  "KUBERNETES_SERVICE_HOST", // Kubernetes
-  "ECS_CONTAINER_METADATA_URI_V4", // AWS ECS
-];
-
-/**
- * Choose the storage backend from environment variables. `env` is
- * injectable so the decision can be unit-tested; it defaults to
- * `process.env`.
- *
- * @throws when a deployment is detected with no bucket configured —
- * local-fs is never a production store, and there is no opt-in.
- */
-export const resolveStorage = (
-  env: Record<string, string | undefined> = process.env,
-): ResolvedStorage => {
-  const reqEnv = (name: string): string => {
-    const v = env[name];
-    if (v === undefined || v === "") {
-      throw new Error(`Missing required env var: ${name}`);
-    }
-    return v;
-  };
-
-  const looksDeployed =
-    env["NODE_ENV"] === "production" || PAAS_MARKERS.some((m) => (env[m] ?? "") !== "");
-
-  if (env["R2_ACCOUNT_ID"] !== undefined) {
-    return {
-      storage: r2Storage({
-        accountId: reqEnv("R2_ACCOUNT_ID"),
-        bucket: reqEnv("BUCKET"),
-        credentials: {
-          accessKeyId: reqEnv("AWS_ACCESS_KEY_ID"),
-          secretAccessKey: reqEnv("AWS_SECRET_ACCESS_KEY"),
-        },
-      }),
-      label: `r2 (bucket=${env["BUCKET"]})`,
-    };
-  }
-  if (env["BUCKET"] !== undefined) {
-    return {
-      storage: s3Storage({
-        region: env["AWS_REGION"] ?? "us-east-1",
-        bucket: reqEnv("BUCKET"),
-        credentials: {
-          accessKeyId: reqEnv("AWS_ACCESS_KEY_ID"),
-          secretAccessKey: reqEnv("AWS_SECRET_ACCESS_KEY"),
-        },
-      }),
-      label: `s3 (bucket=${env["BUCKET"]})`,
-    };
-  }
-  if (!looksDeployed) {
-    return {
-      storage: localFsStorage(),
-      label: `local-fs (${env["BAERLY_DATA_DIR"] ?? "./.baerly-data"}) — local dev only, not a production store`,
-    };
-  }
-  throw new Error(
-    [
-      "[baerly] Refusing to start: no durable storage configured in a deployed environment.",
-      "Local filesystem storage is a local-dev convenience only — single-process, with no",
-      "cross-process CAS and no crash durability — so it is never used in production.",
-      "Configure a real bucket:",
-      "  • AWS S3:        BUCKET + AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY (+ optional AWS_REGION)",
-      "  • Cloudflare R2: R2_ACCOUNT_ID + BUCKET + AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY",
-      "Self-hosting without a cloud bucket? Run MinIO on the box for real S3 semantics, or",
-      "use SQLite + Litestream for a single-instance app.",
-    ].join("\n"),
-  );
-};
+export { resolveStorageFromEnv as resolveStorage } from "@gusto/baerly-storage/node";
+export type { ResolvedStorage } from "@gusto/baerly-storage/node";

--- a/examples/react-node/src/server/resolve-storage.ts
+++ b/examples/react-node/src/server/resolve-storage.ts
@@ -1,105 +1,18 @@
 /**
- * Storage resolution for the Node server entry, in priority order:
+ * Storage selection is your app's policy, surfaced here as an editable
+ * seam. The default is the library's `resolveStorageFromEnv`, in priority
+ * order:
  *   1. R2_ACCOUNT_ID set → Cloudflare R2 (S3-compat endpoint)
  *   2. BUCKET set        → AWS S3
  *   3. neither, local dev → LocalFsStorage (zero credentials)
- *   4. neither, deployed  → throw. local-fs is a local-dev convenience
- *      only — single-process, no cross-process CAS, no crash-fsync — so
- *      it is never a production store (there is no opt-in).
+ *   4. neither, deployed  → throw. It never silently falls back to a
+ *      non-durable store (local-fs or in-memory) in a deployment — that
+ *      is the failure mode that loses data in production.
  *
- * Extracted from the server entry so the deployment safety guard is one
- * tested unit instead of fragile copy-paste — see
- * `tests/integration/node-storage-resolution.test.ts`. Kept byte-identical
- * across the Node example scaffolds and fenced by a drift test in that file.
- * Edit it freely in your own app: this is your storage policy, not the
- * kernel's.
+ * Replace this re-export with your own `(env) => ResolvedStorage` if your
+ * policy differs (a custom endpoint, MinIO, GCS, …). The resolver is
+ * exported and tested in `@gusto/baerly-storage/node` so every app shares
+ * one safe default instead of hand-rolling one.
  */
-import { localFsStorage, r2Storage, s3Storage } from "@gusto/baerly-storage/node";
-import type { Storage } from "@gusto/baerly-storage";
-
-export interface ResolvedStorage {
-  readonly storage: Storage;
-  /** Human-readable backend label for the startup log line. */
-  readonly label: string;
-}
-
-// Heuristic for "this is a real deployment, not a laptop." Any one
-// marker is enough; it decides whether a missing bucket should fail
-// loud (deployment) or fall back to local-fs (local dev).
-const PAAS_MARKERS = [
-  "RAILWAY_ENVIRONMENT",
-  "RENDER",
-  "FLY_APP_NAME",
-  "K_SERVICE", // Google Cloud Run
-  "DYNO", // Heroku
-  "KUBERNETES_SERVICE_HOST", // Kubernetes
-  "ECS_CONTAINER_METADATA_URI_V4", // AWS ECS
-];
-
-/**
- * Choose the storage backend from environment variables. `env` is
- * injectable so the decision can be unit-tested; it defaults to
- * `process.env`.
- *
- * @throws when a deployment is detected with no bucket configured —
- * local-fs is never a production store, and there is no opt-in.
- */
-export const resolveStorage = (
-  env: Record<string, string | undefined> = process.env,
-): ResolvedStorage => {
-  const reqEnv = (name: string): string => {
-    const v = env[name];
-    if (v === undefined || v === "") {
-      throw new Error(`Missing required env var: ${name}`);
-    }
-    return v;
-  };
-
-  const looksDeployed =
-    env["NODE_ENV"] === "production" || PAAS_MARKERS.some((m) => (env[m] ?? "") !== "");
-
-  if (env["R2_ACCOUNT_ID"] !== undefined) {
-    return {
-      storage: r2Storage({
-        accountId: reqEnv("R2_ACCOUNT_ID"),
-        bucket: reqEnv("BUCKET"),
-        credentials: {
-          accessKeyId: reqEnv("AWS_ACCESS_KEY_ID"),
-          secretAccessKey: reqEnv("AWS_SECRET_ACCESS_KEY"),
-        },
-      }),
-      label: `r2 (bucket=${env["BUCKET"]})`,
-    };
-  }
-  if (env["BUCKET"] !== undefined) {
-    return {
-      storage: s3Storage({
-        region: env["AWS_REGION"] ?? "us-east-1",
-        bucket: reqEnv("BUCKET"),
-        credentials: {
-          accessKeyId: reqEnv("AWS_ACCESS_KEY_ID"),
-          secretAccessKey: reqEnv("AWS_SECRET_ACCESS_KEY"),
-        },
-      }),
-      label: `s3 (bucket=${env["BUCKET"]})`,
-    };
-  }
-  if (!looksDeployed) {
-    return {
-      storage: localFsStorage(),
-      label: `local-fs (${env["BAERLY_DATA_DIR"] ?? "./.baerly-data"}) — local dev only, not a production store`,
-    };
-  }
-  throw new Error(
-    [
-      "[baerly] Refusing to start: no durable storage configured in a deployed environment.",
-      "Local filesystem storage is a local-dev convenience only — single-process, with no",
-      "cross-process CAS and no crash durability — so it is never used in production.",
-      "Configure a real bucket:",
-      "  • AWS S3:        BUCKET + AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY (+ optional AWS_REGION)",
-      "  • Cloudflare R2: R2_ACCOUNT_ID + BUCKET + AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY",
-      "Self-hosting without a cloud bucket? Run MinIO on the box for real S3 semantics, or",
-      "use SQLite + Litestream for a single-instance app.",
-    ].join("\n"),
-  );
-};
+export { resolveStorageFromEnv as resolveStorage } from "@gusto/baerly-storage/node";
+export type { ResolvedStorage } from "@gusto/baerly-storage/node";

--- a/packages/adapter-node/src/assert-storage-reachable.test.ts
+++ b/packages/adapter-node/src/assert-storage-reachable.test.ts
@@ -1,0 +1,67 @@
+import {
+  BaerlyError,
+  MemoryStorage,
+  type Storage,
+  type StorageGetResult,
+  type StorageListEntry,
+  type StoragePutResult,
+} from "@baerly/protocol";
+import { describe, expect, test } from "vitest";
+import { assertStorageReachable } from "./assert-storage-reachable.ts";
+
+// A backend that ACCEPTS every write regardless of If-Match / If-None-Match
+// — i.e. silently ignores the conditionals the protocol depends on. probeCas
+// must catch this; assertStorageReachable must turn it into a thrown error.
+const conditionalsIgnoredStorage = (): Storage => ({
+  async get(): Promise<StorageGetResult | null> {
+    return null;
+  },
+  async put(): Promise<StoragePutResult> {
+    return { etag: '"ignored"' };
+  },
+  async delete(): Promise<void> {},
+  async *list(): AsyncIterable<StorageListEntry> {},
+});
+
+// A backend whose every operation throws — stands in for a wrong/unreachable
+// bucket or denied credentials.
+const unreachableStorage = (): Storage => ({
+  async get(): Promise<StorageGetResult | null> {
+    throw new Error("getaddrinfo ENOTFOUND wrong-bucket.example");
+  },
+  async put(): Promise<StoragePutResult> {
+    throw new Error("getaddrinfo ENOTFOUND wrong-bucket.example");
+  },
+  async delete(): Promise<void> {
+    throw new Error("getaddrinfo ENOTFOUND wrong-bucket.example");
+  },
+  list(): AsyncIterable<StorageListEntry> {
+    throw new Error("getaddrinfo ENOTFOUND wrong-bucket.example");
+  },
+});
+
+describe("assertStorageReachable", () => {
+  test("resolves for a CAS-correct, reachable backend", async () => {
+    await expect(assertStorageReachable(new MemoryStorage())).resolves.toBeUndefined();
+  });
+
+  test("throws InvalidConfig when the backend ignores conditional writes", async () => {
+    const err = await assertStorageReachable(conditionalsIgnoredStorage()).catch(
+      (error: unknown) => error,
+    );
+    expect(err).toBeInstanceOf(BaerlyError);
+    expect((err as BaerlyError).code).toBe("InvalidConfig");
+    // The thrown message names the failing CAS checks so an operator can act.
+    expect((err as BaerlyError).message).toContain("conditional writes");
+    expect((err as BaerlyError).message).toMatch(/ifMatch-stale|ifNoneMatch-exists/);
+  });
+
+  test("throws NetworkError when the backend is unreachable", async () => {
+    const err = await assertStorageReachable(unreachableStorage()).catch((error: unknown) => error);
+    expect(err).toBeInstanceOf(BaerlyError);
+    expect((err as BaerlyError).code).toBe("NetworkError");
+    expect((err as BaerlyError).message).toContain("could not be reached");
+    // Original cause is preserved for diagnostics.
+    expect((err as BaerlyError).cause).toBeInstanceOf(Error);
+  });
+});

--- a/packages/adapter-node/src/assert-storage-reachable.ts
+++ b/packages/adapter-node/src/assert-storage-reachable.ts
@@ -1,0 +1,68 @@
+import { BaerlyError, probeCas, type Storage } from "@baerly/protocol";
+
+/** Options for {@link assertStorageReachable}. */
+export interface AssertStorageReachableOptions {
+  /** Key prefix for the throwaway probe sentinels. Default `""`. */
+  keyPrefix?: string;
+  signal?: AbortSignal;
+}
+
+/**
+ * Boot-time readiness check: confirm a live `Storage` backend is both
+ * reachable and honours the conditional writes the protocol depends on.
+ * `await` it at startup (or from a `/readyz` handler wired to your
+ * platform's readiness probe) to fail closed on a misconfigured backend —
+ * an unreachable or non-existent bucket, denied/missing credentials (wrong
+ * endpoint/region), or an S3-compatible store that silently ignores
+ * `If-Match`/`If-None-Match` (the CAS the protocol depends on) — instead
+ * of discovering it on the first user write. It cannot detect a
+ * wrong-but-writable bucket: a typo to another reachable bucket you own
+ * boots clean, because the probe can only tell that *a* bucket is reachable
+ * and CAS-correct, not that it is the *intended* one. This complements
+ * `resolveStorageFromEnv`, which catches a *missing* configuration:
+ * `assertStorageReachable` additionally catches an
+ * unreachable/access-denied/CAS-broken backend at boot instead of on the
+ * first write.
+ *
+ * Opt-in by design: it performs a handful of live round-trips (writes and
+ * deletes throwaway sentinels under `keyPrefix`), so it is never run
+ * automatically on every boot. Reuses the same `probeCas` machinery as
+ * `baerly doctor --bucket`.
+ *
+ * @throws BaerlyError `NetworkError` if the backend is unreachable, or
+ * `InvalidConfig` if it is reachable but fails a required CAS check.
+ *
+ * @example
+ * ```ts
+ * const { storage, label } = resolveStorageFromEnv();
+ * await assertStorageReachable(storage); // throws before we serve traffic
+ * console.log(`[baerly] storage=${label} (reachable)`);
+ * ```
+ */
+export const assertStorageReachable = async (
+  storage: Storage,
+  opts?: AssertStorageReachableOptions,
+): Promise<void> => {
+  let result;
+  try {
+    result = await probeCas(storage, opts);
+  } catch (error) {
+    throw new BaerlyError(
+      "NetworkError",
+      "Storage readiness check failed: the backend could not be reached. Verify the bucket name, " +
+        `region/endpoint, and credentials. Cause: ${error instanceof Error ? error.message : String(error)}`,
+      error,
+    );
+  }
+  if (!result.ok) {
+    const failed = result.checks
+      .filter((c) => !c.ok)
+      .map((c) => `  - ${c.name}: ${c.detail}`)
+      .join("\n");
+    throw new BaerlyError(
+      "InvalidConfig",
+      "Storage readiness check failed — the backend does not honour the conditional writes baerly " +
+        `requires (data corruption risk). Use a fully S3-conditional-compatible store:\n${failed}`,
+    );
+  }
+};

--- a/packages/adapter-node/src/index.ts
+++ b/packages/adapter-node/src/index.ts
@@ -51,6 +51,8 @@ export { localFsStorage } from "./local-fs-storage.ts";
 export type { LocalFsStorageFactoryOptions } from "./local-fs-storage.ts";
 export { resolveStorageFromEnv } from "./resolve-storage.ts";
 export type { ResolvedStorage } from "./resolve-storage.ts";
+export { assertStorageReachable } from "./assert-storage-reachable.ts";
+export type { AssertStorageReachableOptions } from "./assert-storage-reachable.ts";
 export {
   type Credentials,
   type CredentialsProvider,

--- a/packages/adapter-node/src/index.ts
+++ b/packages/adapter-node/src/index.ts
@@ -49,6 +49,8 @@ export type { S3HttpStorageOptions } from "./s3-http.ts";
 export { s3Storage, r2Storage, minioStorage, gcsStorage } from "./storage-factories.ts";
 export { localFsStorage } from "./local-fs-storage.ts";
 export type { LocalFsStorageFactoryOptions } from "./local-fs-storage.ts";
+export { resolveStorageFromEnv } from "./resolve-storage.ts";
+export type { ResolvedStorage } from "./resolve-storage.ts";
 export {
   type Credentials,
   type CredentialsProvider,

--- a/packages/adapter-node/src/resolve-storage.test.ts
+++ b/packages/adapter-node/src/resolve-storage.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "vitest";
+import { resolveStorageFromEnv } from "./resolve-storage.ts";
+
+// Canonical coverage for the exported storage resolver. The Node example
+// scaffolds re-export this, so an app that uses the safe default cannot
+// reintroduce the silent non-durable fallback that lost data in
+// production (Gusto/web#24499). The example re-export is drift-fenced in
+// tests/integration/node-storage-resolution.test.ts.
+
+const FULL_AWS_CREDS = {
+  AWS_ACCESS_KEY_ID: "ak",
+  AWS_SECRET_ACCESS_KEY: "sk",
+} as const;
+
+describe("resolveStorageFromEnv — local dev fallback", () => {
+  test("falls back to local-fs when no bucket and not deployed", () => {
+    const { storage, label } = resolveStorageFromEnv({});
+    expect(storage).toBeDefined();
+    expect(label).toContain("local-fs");
+    expect(label).toContain("not a production store");
+  });
+
+  test("local-fs label reflects BAERLY_DATA_DIR when set", () => {
+    const { label } = resolveStorageFromEnv({ BAERLY_DATA_DIR: "/data/here" });
+    expect(label).toContain("/data/here");
+  });
+});
+
+describe("resolveStorageFromEnv — bucket selection", () => {
+  test("BUCKET → s3, even in a deployment", () => {
+    const { storage, label } = resolveStorageFromEnv({
+      NODE_ENV: "production",
+      BUCKET: "my-bucket",
+      ...FULL_AWS_CREDS,
+    });
+    expect(storage).toBeDefined();
+    expect(label).toBe("s3 (bucket=my-bucket)");
+  });
+
+  test("R2_ACCOUNT_ID → r2 (takes priority over plain BUCKET)", () => {
+    const { label } = resolveStorageFromEnv({
+      R2_ACCOUNT_ID: "acct",
+      BUCKET: "my-bucket",
+      ...FULL_AWS_CREDS,
+    });
+    expect(label).toBe("r2 (bucket=my-bucket)");
+  });
+
+  test("a configured bucket missing its credentials fails loud", () => {
+    expect(() => resolveStorageFromEnv({ BUCKET: "my-bucket" })).toThrow(
+      /Missing required env var/,
+    );
+  });
+
+  test("an empty-string BUCKET is treated as unset (local dev falls back, not a confusing throw)", () => {
+    const { label } = resolveStorageFromEnv({ BUCKET: "" });
+    expect(label).toContain("local-fs");
+  });
+
+  test("an empty-string R2_ACCOUNT_ID is ignored; a real BUCKET still selects s3", () => {
+    const { label } = resolveStorageFromEnv({
+      R2_ACCOUNT_ID: "",
+      BUCKET: "my-bucket",
+      ...FULL_AWS_CREDS,
+    });
+    expect(label).toBe("s3 (bucket=my-bucket)");
+  });
+});
+
+describe("resolveStorageFromEnv — production fail-loud guard", () => {
+  test("NODE_ENV=production with no bucket refuses to start", () => {
+    expect(() => resolveStorageFromEnv({ NODE_ENV: "production" })).toThrow(/Refusing to start/);
+  });
+
+  test("the throw names a real bucket so the operator knows the fix", () => {
+    let message = "";
+    try {
+      resolveStorageFromEnv({ NODE_ENV: "production" });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain("AWS S3");
+    expect(message).toContain("Cloudflare R2");
+    expect(message).toContain("BUCKET");
+  });
+
+  // Per-marker coverage of the deploy-detection predicate lives in
+  // packages/protocol/src/env.test.ts; here we only confirm the resolver
+  // fails closed when isDeployedEnv is true via one representative marker.
+  test("a PaaS marker (NODE_ENV unset) refuses to start", () => {
+    expect(() => resolveStorageFromEnv({ KUBERNETES_SERVICE_HOST: "1" })).toThrow(
+      /Refusing to start/,
+    );
+  });
+
+  test("polarity: local dev falls back, deployment throws", () => {
+    expect(() => resolveStorageFromEnv({})).not.toThrow();
+    expect(() => resolveStorageFromEnv({ NODE_ENV: "production" })).toThrow(/Refusing to start/);
+  });
+});

--- a/packages/adapter-node/src/resolve-storage.ts
+++ b/packages/adapter-node/src/resolve-storage.ts
@@ -1,0 +1,106 @@
+import { BaerlyError, isDeployedEnv, type Storage } from "@baerly/protocol";
+import { localFsStorage } from "./local-fs-storage.ts";
+import { r2Storage, s3Storage } from "./storage-factories.ts";
+
+/** Result of {@link resolveStorageFromEnv}. */
+export interface ResolvedStorage {
+  readonly storage: Storage;
+  /** Human-readable backend label for a startup log line. */
+  readonly label: string;
+}
+
+/**
+ * Choose a Node `Storage` backend from environment variables, in priority
+ * order:
+ *   1. `R2_ACCOUNT_ID` set → Cloudflare R2 (S3-compat endpoint)
+ *   2. `BUCKET` set        → AWS S3
+ *   3. neither, local dev  → `localFsStorage` (zero credentials)
+ *   4. neither, deployed   → throw
+ *
+ * This is the safe default the example scaffolds use, exported so apps
+ * don't hand-roll their own selector and reintroduce the silent
+ * in-memory / local-fs fallback this library exists to prevent. There is
+ * deliberately **no** fallback to a non-durable store in a deployment:
+ * local-fs is single-process with no cross-process CAS and no crash
+ * durability, and in-memory storage loses all data on restart, so a
+ * deployed environment with no bucket fails loud instead.
+ *
+ * `env` is injectable for testing; it defaults to `process.env`.
+ *
+ * @throws BaerlyError `InvalidConfig` when {@link isDeployedEnv} is true
+ * and no bucket is configured, or when a configured bucket is missing its
+ * credentials.
+ *
+ * @example
+ * ```ts
+ * import { baerlyNode, resolveStorageFromEnv } from "@gusto/baerly-storage/node";
+ * import config from "./baerly.config.ts";
+ *
+ * const { storage, label } = resolveStorageFromEnv();
+ * console.log(`[baerly] storage=${label}`);
+ * await baerlyNode({ config, storage }).listen(Number(process.env["PORT"] ?? 8080));
+ * ```
+ */
+export const resolveStorageFromEnv = (
+  env: Record<string, string | undefined> = process.env,
+): ResolvedStorage => {
+  // An env var set to "" is treated as unset for backend selection, so an
+  // exported-but-empty BUCKET / R2_ACCOUNT_ID falls through to the local-dev
+  // fallback (or the deployment fail-closed) rather than entering a branch
+  // and then throwing a confusing "missing required env var" for a var that
+  // is, technically, set.
+  const isSet = (name: string): boolean => (env[name] ?? "") !== "";
+  const reqEnv = (name: string): string => {
+    const v = env[name];
+    if (v === undefined || v === "") {
+      throw new BaerlyError("InvalidConfig", `Missing required env var: ${name}`);
+    }
+    return v;
+  };
+
+  if (isSet("R2_ACCOUNT_ID")) {
+    return {
+      storage: r2Storage({
+        accountId: reqEnv("R2_ACCOUNT_ID"),
+        bucket: reqEnv("BUCKET"),
+        credentials: {
+          accessKeyId: reqEnv("AWS_ACCESS_KEY_ID"),
+          secretAccessKey: reqEnv("AWS_SECRET_ACCESS_KEY"),
+        },
+      }),
+      label: `r2 (bucket=${env["BUCKET"]})`,
+    };
+  }
+  if (isSet("BUCKET")) {
+    return {
+      storage: s3Storage({
+        region: env["AWS_REGION"] ?? "us-east-1",
+        bucket: reqEnv("BUCKET"),
+        credentials: {
+          accessKeyId: reqEnv("AWS_ACCESS_KEY_ID"),
+          secretAccessKey: reqEnv("AWS_SECRET_ACCESS_KEY"),
+        },
+      }),
+      label: `s3 (bucket=${env["BUCKET"]})`,
+    };
+  }
+  if (!isDeployedEnv(env)) {
+    return {
+      storage: localFsStorage(),
+      label: `local-fs (${env["BAERLY_DATA_DIR"] ?? "./.baerly-data"}) — local dev only, not a production store`,
+    };
+  }
+  throw new BaerlyError(
+    "InvalidConfig",
+    [
+      "[baerly] Refusing to start: no durable storage configured in a deployed environment.",
+      "Local filesystem storage is a local-dev convenience only — single-process, with no",
+      "cross-process CAS and no crash durability — so it is never used in production.",
+      "Configure a real bucket:",
+      "  • AWS S3:        BUCKET + AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY (+ optional AWS_REGION)",
+      "  • Cloudflare R2: R2_ACCOUNT_ID + BUCKET + AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY",
+      "Self-hosting without a cloud bucket? Run MinIO on the box for real S3 semantics, or",
+      "use SQLite + Litestream for a single-instance app.",
+    ].join("\n"),
+  );
+};

--- a/packages/protocol/src/env.test.ts
+++ b/packages/protocol/src/env.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import { PAAS_MARKERS, isDeployedEnv } from "./env.ts";
+
+describe("isDeployedEnv", () => {
+  test("empty env is not deployed (local dev / test default)", () => {
+    expect(isDeployedEnv({})).toBe(false);
+  });
+
+  test("NODE_ENV=production is deployed", () => {
+    expect(isDeployedEnv({ NODE_ENV: "production" })).toBe(true);
+  });
+
+  test("NODE_ENV=test / development is not deployed", () => {
+    expect(isDeployedEnv({ NODE_ENV: "test" })).toBe(false);
+    expect(isDeployedEnv({ NODE_ENV: "development" })).toBe(false);
+  });
+
+  test("CI=true alone is not deployed (plain GitHub Actions)", () => {
+    expect(isDeployedEnv({ CI: "true" })).toBe(false);
+  });
+
+  test("each PaaS marker independently trips the signal", () => {
+    for (const marker of PAAS_MARKERS) {
+      expect(isDeployedEnv({ [marker]: "1" })).toBe(true);
+    }
+  });
+
+  test("a PaaS marker set to empty string does not trip the signal", () => {
+    for (const marker of PAAS_MARKERS) {
+      expect(isDeployedEnv({ [marker]: "" })).toBe(false);
+    }
+  });
+
+  test("CI suppresses PaaS markers (k8s-hosted CI agent)", () => {
+    for (const marker of PAAS_MARKERS) {
+      expect(isDeployedEnv({ [marker]: "1", CI: "true" })).toBe(false);
+    }
+  });
+
+  test("CI does not suppress an explicit NODE_ENV=production", () => {
+    expect(isDeployedEnv({ NODE_ENV: "production", CI: "true" })).toBe(true);
+  });
+
+  test("CI=false does not suppress (a literal non-CI value)", () => {
+    expect(isDeployedEnv({ KUBERNETES_SERVICE_HOST: "1", CI: "false" })).toBe(true);
+  });
+});

--- a/packages/protocol/src/env.ts
+++ b/packages/protocol/src/env.ts
@@ -1,0 +1,39 @@
+// Deployment detection shared by the in-memory storage guard and the
+// Node resolveStorageFromEnv resolver. Pure (env passed in) so it stays
+// Workerd-loadable. Markers are vars each platform sets unconditionally:
+// Cloud Run, Heroku, Kubernetes, ECS, Railway, Render, Fly.
+//
+// The list is deliberately conservative: every marker here is set ONLY by
+// the platform at runtime, never by that platform's local dev emulator, so
+// detection cannot false-positive a developer's machine. Serverless markers
+// like VERCEL / NETLIFY / AWS_LAMBDA_FUNCTION_NAME are intentionally omitted
+// — their local emulators (`vercel dev`, `netlify dev`, SAM local) set the
+// same vars, so adding them would break local development. Before adding a
+// marker, confirm it is never set by that platform's dev tooling. An
+// unmarked host should set NODE_ENV=production to opt into the guard.
+export const PAAS_MARKERS = [
+  "RAILWAY_ENVIRONMENT",
+  "RENDER",
+  "FLY_APP_NAME",
+  "K_SERVICE",
+  "DYNO",
+  "KUBERNETES_SERVICE_HOST",
+  "ECS_CONTAINER_METADATA_URI_V4",
+] as const;
+
+/**
+ * True when `env` looks like a deployed environment: `NODE_ENV=production`
+ * or any {@link PAAS_MARKERS} set to a non-empty value. Decides whether a
+ * non-durable store (in-memory, local-fs) should fail loud instead of
+ * silently serving a production workload. A CI runner (`CI` set to a
+ * non-empty, non-`false` value) is never treated as deployed, so PaaS
+ * markers from an in-cluster CI agent do not trip it.
+ */
+export const isDeployedEnv = (env: Record<string, string | undefined>): boolean => {
+  // A CI runner is never a deployment — even in a k8s pod that sets a PaaS
+  // marker (e.g. KUBERNETES_SERVICE_HOST) — so it must not trip the markers.
+  const inCi = (env["CI"] ?? "") !== "" && env["CI"] !== "false";
+  return (
+    env["NODE_ENV"] === "production" || (!inCi && PAAS_MARKERS.some((m) => (env[m] ?? "") !== ""))
+  );
+};

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -14,6 +14,7 @@ export {
 } from "./coordination/current-json.ts";
 export * from "./coordination/gc-pending.ts";
 export * from "./collection-api.ts";
+export { isDeployedEnv, PAAS_MARKERS } from "./env.ts";
 export * from "./errors.ts";
 export * from "./indexes.ts";
 export * from "./json.ts";

--- a/packages/protocol/src/storage/memory.test.ts
+++ b/packages/protocol/src/storage/memory.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { PAAS_MARKERS } from "../env.ts";
 import { BaerlyError } from "../errors.ts";
 import { defineStorageConformanceSuite } from "./conformance.ts";
 import { MemoryStorage, getOrCreateMemoryStorageForBucket, resetMemoryStorage } from "./memory.ts";
@@ -267,5 +268,94 @@ describe("getOrCreateMemoryStorageForBucket() and resetMemoryStorage()", () => {
     const after = getOrCreateMemoryStorageForBucket("create-bucket");
     // After reset the shared map is cleared; a new instance is created.
     expect(before).not.toBe(after);
+  });
+});
+
+// --------------------------------------------------------------------
+// MemoryStorage production guard — fail closed in a deployed environment
+// Regression scope: a deployed app silently ran on MemoryStorage because
+// its storage selector fell back to in-memory; writes "succeeded" into
+// RAM and vanished on restart (Gusto/web#24499). The guard makes that
+// fail loud at construction. `vi.stubEnv` simulates a deployment — plain
+// CI (CI=true only) never trips it.
+// --------------------------------------------------------------------
+describe("MemoryStorage production guard", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("constructs without opt-in in a non-deployed env (dev/test default)", () => {
+    expect(() => new MemoryStorage()).not.toThrow();
+  });
+
+  test("throws InvalidConfig with no opt-in when NODE_ENV=production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const construct = (): MemoryStorage => new MemoryStorage();
+    let err: unknown;
+    try {
+      construct();
+    } catch (error) {
+      err = error;
+    }
+    expect(err).toBeInstanceOf(BaerlyError);
+    expect((err as BaerlyError).code).toBe("InvalidConfig");
+    const msg = (err as BaerlyError).message;
+    expect(msg).toContain("in-memory storage");
+    expect(msg).toContain("lost on restart");
+    // Message must name both opt-in mechanisms so the fix is discoverable.
+    expect(msg).toContain("ephemeral: true");
+    expect(msg).toContain("BAERLY_ALLOW_EPHEMERAL_STORAGE=true");
+  });
+
+  test("each PaaS marker alone trips the guard with no opt-in", () => {
+    for (const marker of PAAS_MARKERS) {
+      // Neutralize the ambient CI var (GitHub Actions sets CI=true), which
+      // would otherwise suppress the PaaS-marker branch — see the
+      // "PaaS marker inside CI" case below.
+      vi.stubEnv("CI", "");
+      vi.stubEnv(marker, "1");
+      expect(() => new MemoryStorage()).toThrow(BaerlyError);
+      vi.unstubAllEnvs();
+    }
+  });
+
+  test("a PaaS marker inside CI does not trip the guard", () => {
+    vi.stubEnv("KUBERNETES_SERVICE_HOST", "1");
+    vi.stubEnv("CI", "true");
+    expect(() => new MemoryStorage()).not.toThrow();
+  });
+
+  test("ephemeral:true opt-in allows construction in a deployment", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    expect(() => new MemoryStorage({ ephemeral: true })).not.toThrow();
+  });
+
+  test("BAERLY_ALLOW_EPHEMERAL_STORAGE=true opt-in allows construction in a deployment", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("BAERLY_ALLOW_EPHEMERAL_STORAGE", "true");
+    expect(() => new MemoryStorage()).not.toThrow();
+  });
+
+  test("a non-'true' value for the env opt-in does not satisfy the guard", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("BAERLY_ALLOW_EPHEMERAL_STORAGE", "1");
+    expect(() => new MemoryStorage()).toThrow(BaerlyError);
+  });
+
+  test("opt-in in a deployment logs a one-time data-loss warning", async () => {
+    // Reset the module so the process-level once-flag starts fresh, then
+    // drive a fresh MemoryStorage through the opt-in path twice.
+    vi.resetModules();
+    vi.stubEnv("NODE_ENV", "production");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const { MemoryStorage: FreshMemoryStorage } = await import("./memory.ts");
+      expect(new FreshMemoryStorage({ ephemeral: true })).toBeInstanceOf(FreshMemoryStorage);
+      expect(new FreshMemoryStorage({ ephemeral: true })).toBeInstanceOf(FreshMemoryStorage);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0]?.[0]).toContain("ALL DATA IS LOST ON RESTART");
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/packages/protocol/src/storage/memory.ts
+++ b/packages/protocol/src/storage/memory.ts
@@ -1,3 +1,4 @@
+import { isDeployedEnv } from "../env.ts";
 import { BaerlyError } from "../errors.ts";
 import type {
   Storage,
@@ -15,6 +16,49 @@ interface StoredObject {
 }
 
 const utf8Encoder = new TextEncoder();
+
+const EPHEMERAL_ENV_OPT_IN = "BAERLY_ALLOW_EPHEMERAL_STORAGE";
+
+// Read process env without a `node:` import so protocol stays Workerd-
+// loadable (on Workerd `process` is absent → env is `{}` → not deployed).
+const readProcessEnv = (): Record<string, string | undefined> =>
+  (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {};
+
+let warnedEphemeralInDeployment = false;
+
+// Fail closed when in-memory storage would silently back a deployed
+// workload (writes "succeed" into RAM, vanish on restart). No-op in
+// dev/test; bypass in a deployment only via an explicit acknowledgement.
+const assertEphemeralAllowed = (explicitOptIn: boolean): void => {
+  const env = readProcessEnv();
+  if (!isDeployedEnv(env)) {
+    return;
+  }
+  if (!explicitOptIn && env[EPHEMERAL_ENV_OPT_IN] !== "true") {
+    throw new BaerlyError(
+      "InvalidConfig",
+      "Refusing to use in-memory storage in a deployed environment — all data is lost on restart. " +
+        "MemoryStorage is for tests/local dev only; configure a durable bucket (AWS S3 / Cloudflare R2). " +
+        `To intentionally opt in: new MemoryStorage({ ephemeral: true }) or ${EPHEMERAL_ENV_OPT_IN}=true.`,
+    );
+  }
+  if (!warnedEphemeralInDeployment) {
+    warnedEphemeralInDeployment = true;
+    console.warn(
+      "[baerly] in-memory storage in a deployed environment — ALL DATA IS LOST ON RESTART.",
+    );
+  }
+};
+
+/** Options for {@link MemoryStorage}. */
+export interface MemoryStorageOptions {
+  /**
+   * Acknowledge the store is intentionally ephemeral — required to
+   * construct in a detected deployment ({@link isDeployedEnv}); ignored in
+   * dev/test. Env equivalent: `BAERLY_ALLOW_EPHEMERAL_STORAGE=true`.
+   */
+  ephemeral?: boolean;
+}
 
 /**
  * Compare two keys by their UTF-8 byte sequences — the order S3 and
@@ -61,6 +105,10 @@ const compareKeysUtf8 = (a: string, b: string): number => {
 export class MemoryStorage implements Storage {
   readonly #objects = new Map<string, StoredObject>();
   #etagCounter = 0;
+
+  constructor(opts?: MemoryStorageOptions) {
+    assertEphemeralAllowed(opts?.ephemeral === true);
+  }
 
   #nextEtag(): string {
     this.#etagCounter += 1;

--- a/packages/server/API.md
+++ b/packages/server/API.md
@@ -682,16 +682,18 @@ export default baerlyWorker((env) => ({
   // scheduled?: (controller, env, ctx) => …    // opt-in cron handler
 }));
 
-// Node listener entry (any host that runs `node server.js`)
-// localFsStorage() is the zero-credential default for local/single-node;
-// promote to s3Storage / r2Storage for production.
-import { baerlyNode, localFsStorage, s3Storage } from "@gusto/baerly-storage/node";
-baerlyNode({
-  storage: localFsStorage(),
-  webRoot: "dist/client",                         // optional SPA static-serve
-}).listen(PORT);
+// Node listener entry (any host that runs `node server.js`).
+// resolveStorageFromEnv() is the safe default selector: R2_ACCOUNT_ID → R2,
+// BUCKET → S3, else local-fs (dev only). It REFUSES to start in a detected
+// deployment with no bucket — never a silent in-memory/local-fs fallback,
+// which is how hand-rolled selectors ship data loss to production.
+// (assertStorageReachable(storage) adds an opt-in boot-time CAS probe.)
+import { baerlyNode, resolveStorageFromEnv } from "@gusto/baerly-storage/node";
+const { storage, label } = resolveStorageFromEnv();
+baerlyNode({ storage, webRoot: "dist/client" }).listen(PORT); // webRoot optional
 
-// Production S3 / R2 stores use bucket credentials instead.
+// Or select the store yourself (custom endpoint, MinIO, GCS, …):
+import { s3Storage } from "@gusto/baerly-storage/node";
 baerlyNode({
   storage: s3Storage({ bucket: "…", credentials: { … } }),
   verifier: bearerJwt({ jwks, issuer, audience }),

--- a/packages/server/RECIPES.md
+++ b/packages/server/RECIPES.md
@@ -64,6 +64,23 @@ environment variable is missing or empty at startup.
 **Fix:** set the `SHARED_SECRET` env (`wrangler secret put SHARED_SECRET`
 on Cloudflare, `.dev.vars` for local dev, process env on Node).
 
+### `BaerlyError code="InvalidConfig"` — `Refusing to start: no durable storage configured` / `Refusing to use in-memory storage`
+
+**Cause:** a deployed process (`NODE_ENV=production` or a known PaaS marker)
+reached storage selection with no real bucket configured — or constructed
+`MemoryStorage` there. In-memory "succeeds" into RAM and vanishes on every
+restart; local-fs is single-process with no cross-process CAS. Both are
+refused in a deployment so the failure is loud at boot, not silent data loss
+in production.
+**Fix:** don't hand-roll storage selection — call `resolveStorageFromEnv()`
+from `@gusto/baerly-storage/node` (`R2_ACCOUNT_ID` → R2, `BUCKET` → S3, else
+local-fs in dev) and configure a bucket: `BUCKET` + `AWS_ACCESS_KEY_ID` +
+`AWS_SECRET_ACCESS_KEY` (add `R2_ACCOUNT_ID` for R2). To catch an
+unreachable or CAS-broken bucket at boot rather than on the first write,
+`await assertStorageReachable(storage)`. Intentionally ephemeral (a throwaway
+demo)? Opt in explicitly: `new MemoryStorage({ ephemeral: true })` or
+`BAERLY_ALLOW_EPHEMERAL_STORAGE=true`.
+
 ### `BaerlyError code="UseQueryAwaitedRecorder"`
 
 **Cause:** awaited a terminal (`.get`/`.first`/`.all`/`.count`) inside a

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -294,7 +294,22 @@ const BUDGETS: readonly Budget[] = [
   //   → raw +1 KiB (2026-06-25): opaque manifest_pointer digest replaces the
   //     old snapshot/log-tail-shaped cursor. The FNV helper reaches the kernel
   //     query closure (measured 227561 raw); gz/min-gz remain under.
-  { entry: "index.js", raw: 223 * 1024, gz: 70 * 1024, minGz: 19 * 1024 },
+  //   → raw +1 KiB / min-gz +1 KiB (2026-06-30): MemoryStorage fail-closed
+  //     guard — `isDeployedEnv` predicate + the actionable error string ship in
+  //     the kernel closure (measured 229129 raw / 19688 min-gz). Genuinely new
+  //     safety logic (prevents silent in-memory-in-prod data loss); the error
+  //     string survives minification, so min-gz climbs too. Justified.
+  //   → raw +1 KiB (2026-06-30): `isDeployedEnv` now suppresses the PaaS-marker
+  //     branch under CI (so MemoryStorage stays usable in k8s-hosted CI, which
+  //     sets KUBERNETES_SERVICE_HOST). +22 raw over the prior bound (measured
+  //     229398); min-gz is 19724 / 20480 (−756, healthy) — per the POLICY above,
+  //     raw is a creep tripwire, so rebaseline rather than golf the predicate.
+  //   NOTE (2026-06-30): the gz axis is now near-ceiling — measured ~71667 vs
+  //     71680 (70 KiB), ~13 B of headroom. Left un-bumped on purpose (measure-
+  //     then-rebaseline discipline; it passes today). The next kernel change
+  //     that adds gz bytes should expect to trip this and rebaseline gz with a
+  //     measured value, not treat it as a regression.
+  { entry: "index.js", raw: 225 * 1024, gz: 70 * 1024, minGz: 20 * 1024 },
   // The three auth verifier factories (bearerJwt, sharedSecret,
   // cloudflareAccess) plus the transitive jose closure pulled in by
   // bearerJwt's createRemoteJWKSet + jwtVerify. Adding a fourth
@@ -692,7 +707,10 @@ const BUDGETS: readonly Budget[] = [
   //     follow-up as http.js. The gz axis crossed by 17 B; keep the clear
   //     table rather than byte-golfing policy metadata.
   //     Measured: 414593 raw / 123921 gz; min-gz remains under.
-  { entry: "cloudflare.js", raw: 405 * 1024, gz: 122 * 1024, minGz: 43 * 1024 },
+  //   → raw +2 KiB (2026-06-30): MemoryStorage fail-closed guard pulled through
+  //     the protocol barrel into the Worker aggregator (measured 416161 raw);
+  //     gz/min-gz remain under. Same safety logic as the index.js bump above.
+  { entry: "cloudflare.js", raw: 407 * 1024, gz: 122 * 1024, minGz: 43 * 1024 },
   // Client surface — `BaerlyClient<TConfig>` + fetcher plumbing.
   // Browser/runtime-agnostic; no kernel modules in the closure.
   // Budget history:

--- a/tests/integration/node-storage-resolution.test.ts
+++ b/tests/integration/node-storage-resolution.test.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import { PAAS_MARKERS } from "@baerly/protocol";
 import { describe, expect, test } from "vitest";
 import { resolveStorage } from "../../examples/minimal-node/src/server/resolve-storage.ts";
 
@@ -15,16 +16,6 @@ const FULL_AWS_CREDS = {
   AWS_ACCESS_KEY_ID: "ak",
   AWS_SECRET_ACCESS_KEY: "sk",
 } as const;
-
-const PAAS_MARKERS = [
-  "RAILWAY_ENVIRONMENT",
-  "RENDER",
-  "FLY_APP_NAME",
-  "K_SERVICE",
-  "DYNO",
-  "KUBERNETES_SERVICE_HOST",
-  "ECS_CONTAINER_METADATA_URI_V4",
-];
 
 describe("resolveStorage — local dev fallback", () => {
   test("falls back to local-fs when no bucket and not deployed", () => {
@@ -80,6 +71,12 @@ describe("resolveStorage — production fail-loud guard", () => {
     expect(message).toContain("AWS S3");
     expect(message).toContain("Cloudflare R2");
     expect(message).toContain("BUCKET");
+  });
+
+  // Guard against a vacuous pass: if the canonical list were ever emptied,
+  // the marker loop below would iterate zero times and assert nothing.
+  test("the canonical PaaS marker list is non-empty", () => {
+    expect(PAAS_MARKERS.length).toBeGreaterThan(0);
   });
 
   // Every PaaS marker independently trips the guard — a regression that


### PR DESCRIPTION
An app can fall back to `MemoryStorage` in production and lose every write on
restart, silently (Gusto/web#24499). This makes that fail loud.

- `new MemoryStorage()` throws `InvalidConfig` in a detected deployment
  (`NODE_ENV=production` or a known PaaS marker). Tests, local dev, and CI are
  unaffected. Opt in with `new MemoryStorage({ ephemeral: true })` or
  `BAERLY_ALLOW_EPHEMERAL_STORAGE=true`.
- `resolveStorageFromEnv()` (`@gusto/baerly-storage/node`): the tested storage
  selector the Node scaffolds now re-export instead of hand-rolling one. No
  silent non-durable fallback in a deployment.
- `assertStorageReachable()` (`@gusto/baerly-storage/node`): opt-in boot probe
  that fails closed on an unreachable or CAS-broken bucket.
- `isDeployedEnv(env)` predicate on `@gusto/baerly-storage`.

Minor bump. Behavior change for anyone intentionally running in-memory in a
deployment — opt in as above.