### PR TITLE
feat(adapter-node): IRSA web-identity credentials for EKS

### DIFF
--- a/.changeset/irsa-web-identity-credentials.md
+++ b/.changeset/irsa-web-identity-credentials.md
@@ -1,0 +1,30 @@
+---
+'@gusto/baerly-storage': minor
+---
+
+Add IRSA (web-identity) credential support for S3 on EKS. `fromEksPodIdentity()`
+only handled the EKS Pod Identity agent (`AWS_CONTAINER_CREDENTIALS_FULL_URI`);
+clusters that inject credentials via IRSA (`AWS_ROLE_ARN` +
+`AWS_WEB_IDENTITY_TOKEN_FILE`) threw `InvalidConfig` on first sign, so every S3
+call failed.
+
+Two new credential providers in `@gusto/baerly-storage/node`:
+
+- `fromWebIdentity()` — exchanges the projected service-account token for
+  short-lived credentials via STS `AssumeRoleWithWebIdentity` (an unsigned call;
+  the token is the auth). Returns `expiration`, so the signing layer rotates the
+  ~1h credentials automatically. No AWS SDK dependency — uses `fetch` plus the
+  existing hardened XML parser.
+- `fromEks()` — auto-detects the mechanism per resolve (Pod Identity when
+  `AWS_CONTAINER_CREDENTIALS_FULL_URI` is present, otherwise IRSA), with a clear
+  `InvalidConfig` error when neither is configured. Prefer this over the
+  mechanism-specific providers unless you have a reason to pin one.
+
+Both EKS providers now fail with actionable errors instead of a bare status: a
+missing/unreadable or empty projected token throws `InvalidConfig`, and a failed
+STS `AssumeRoleWithWebIdentity` call folds the STS error `Code`/`Message` (e.g.
+`InvalidIdentityToken`) into the thrown message so credential misconfigs are
+diagnosable at a glance.
+
+`fromEksPodIdentity()` keeps its behavior; it only gains the same
+`InvalidConfig` token-file guards.

--- a/examples/minimal-node/AGENTS.md
+++ b/examples/minimal-node/AGENTS.md
@@ -370,15 +370,17 @@ apps or tenancy enforced outside baerly-storage.
   is not supported for database use today. JSDoc `@example` blocks for
   the factories are visible in your editor's TS hover.
 
-- **Switching from static creds to EKS Pod Identity** — in
+- **Switching from static creds to EKS** — in
   `src/server/index.ts`, swap `credentials: { accessKeyId,
-secretAccessKey }` for `credentials: fromEksPodIdentity()` and add
-  `fromEksPodIdentity` to your import:
-  `import { s3Storage, fromEksPodIdentity } from "@gusto/baerly-storage/node"`.
-  The agent reads `AWS_CONTAINER_CREDENTIALS_FULL_URI` +
-  `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` (EKS injects both). For
-  IRSA / ECS / EC2 / other AWS contexts, see
-  `packages/adapter-node/AGENTS.md` — pass any
+  secretAccessKey }` for `credentials: fromEks()` and add `fromEks`
+  to your import:
+  `import { s3Storage, fromEks } from "@gusto/baerly-storage/node"`.
+  `fromEks()` auto-detects the cluster's mechanism — EKS Pod Identity
+  (`AWS_CONTAINER_CREDENTIALS_FULL_URI` +
+  `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`) or IRSA (`AWS_ROLE_ARN` +
+  `AWS_WEB_IDENTITY_TOKEN_FILE`), both EKS-injected; to pin one, use
+  `fromEksPodIdentity()` or `fromWebIdentity()`. For ECS / EC2 / other
+  AWS contexts, see `packages/adapter-node/AGENTS.md` — pass any
   `() => Promise<Credentials>` or an `@aws-sdk/credential-providers`
   factory through the seam.
 

--- a/examples/react-node/AGENTS.md
+++ b/examples/react-node/AGENTS.md
@@ -406,15 +406,17 @@ apps or tenancy enforced outside baerly-storage.
   `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (and optional
   `AWS_REGION`).
 
-- **Switching from static creds to EKS Pod Identity** — in
+- **Switching from static creds to EKS** — in
   `src/server/index.ts`, swap `credentials: { accessKeyId,
-  secretAccessKey }` for `credentials: fromEksPodIdentity()` and add
-  `fromEksPodIdentity` to your import:
-  `import { s3Storage, fromEksPodIdentity } from "@gusto/baerly-storage/node"`.
-  The agent reads `AWS_CONTAINER_CREDENTIALS_FULL_URI` +
-  `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` (EKS injects both). For
-  IRSA / ECS / EC2 / other AWS contexts, see
-  `packages/adapter-node/AGENTS.md` — pass any
+  secretAccessKey }` for `credentials: fromEks()` and add `fromEks`
+  to your import:
+  `import { s3Storage, fromEks } from "@gusto/baerly-storage/node"`.
+  `fromEks()` auto-detects the cluster's mechanism — EKS Pod Identity
+  (`AWS_CONTAINER_CREDENTIALS_FULL_URI` +
+  `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`) or IRSA (`AWS_ROLE_ARN` +
+  `AWS_WEB_IDENTITY_TOKEN_FILE`), both EKS-injected; to pin one, use
+  `fromEksPodIdentity()` or `fromWebIdentity()`. For ECS / EC2 / other
+  AWS contexts, see `packages/adapter-node/AGENTS.md` — pass any
   `() => Promise<Credentials>` or an `@aws-sdk/credential-providers`
   factory through the seam.
 

--- a/packages/adapter-node/AGENTS.md
+++ b/packages/adapter-node/AGENTS.md
@@ -27,36 +27,41 @@ const storage = s3Storage({
 });
 ```
 
-### EKS Pod Identity — `fromEksPodIdentity()`
+### EKS — `fromEks()` (recommended)
 
-For EKS deployments where the pod's service account is associated
-with an IAM role via the EKS Pod Identity agent (2023+, the
-successor to IRSA), use `fromEksPodIdentity()`. The provider reads
-`AWS_CONTAINER_CREDENTIALS_FULL_URI` + `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`
-(EKS injects both), GETs the node-local agent at
-`169.254.170.23`, and returns short-lived credentials with
-`expiration`.
+For EKS deployments, use `fromEks()`. It auto-detects which credential
+mechanism the cluster injects — **EKS Pod Identity** (2023+) or **IRSA**
+(web-identity token) — so you don't have to know which one is in play:
 
 ```ts
-import { s3Storage, fromEksPodIdentity } from "@gusto/baerly-storage/node";
+import { s3Storage, fromEks } from "@gusto/baerly-storage/node";
 
 const storage = s3Storage({
   region: process.env.AWS_REGION!,
   bucket: process.env.BUCKET!,
-  credentials: fromEksPodIdentity(),
+  credentials: fromEks(),
 });
 ```
 
-Refresh is automatic: the signer caches credentials until 5 minutes
-before `expiration`, then calls the provider again. Concurrent
-refreshes are single-flighted.
+Detection runs per resolve (Pod Identity preferred when both env sets are
+present); it throws `InvalidConfig` when neither is configured.
 
-> **IRSA vs. EKS Pod Identity:** if your cluster still uses IRSA
-> (pre-2023), env vars are `AWS_WEB_IDENTITY_TOKEN_FILE` +
-> `AWS_ROLE_ARN` instead, and the app does the STS dance directly.
-> baerly-storage doesn't ship a native IRSA provider yet — write a small
-> one against the seam, or import `fromTokenFile()` from
-> `@aws-sdk/credential-providers`.
+### Pinning a mechanism — `fromEksPodIdentity()` / `fromWebIdentity()`
+
+Use these directly only if you need to pin one mechanism:
+
+- **`fromEksPodIdentity()`** — EKS Pod Identity agent. Reads
+  `AWS_CONTAINER_CREDENTIALS_FULL_URI` + `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`,
+  GETs the node-local agent at `169.254.170.23`, returns short-lived creds.
+- **`fromWebIdentity()`** — IRSA. Reads `AWS_ROLE_ARN` +
+  `AWS_WEB_IDENTITY_TOKEN_FILE`, exchanges the projected SA token via STS
+  `AssumeRoleWithWebIdentity` (unsigned — the token is the auth), returns
+  short-lived creds. Honors `AWS_ROLE_SESSION_NAME` and `AWS_REGION` /
+  `AWS_DEFAULT_REGION` (regional STS endpoint; falls back to global).
+
+All three report `expiration`, so refresh is automatic: the signer caches
+credentials until 5 minutes before `expiration`, then calls the provider
+again. Concurrent refreshes are single-flighted.
 
 ### Bring your own provider
 

--- a/packages/adapter-node/src/credentials/from-eks-pod-identity.test.ts
+++ b/packages/adapter-node/src/credentials/from-eks-pod-identity.test.ts
@@ -107,17 +107,70 @@ describe("fromEksPodIdentity", () => {
     ).rejects.toMatchObject({ code: "InvalidResponse" });
   });
 
-  test("passes AbortSignal.timeout to the agent fetch", async () => {
-    let capturedSignal: AbortSignal | undefined;
+  test("wraps a token-file read failure in a BaerlyError (InvalidConfig)", async () => {
+    const fakeReadFile = vi.fn<(path: string, encoding: "utf8") => Promise<string>>(async () => {
+      throw Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+    });
+    await expect(
+      fromEksPodIdentity({ fetch: vi.fn<typeof fetch>(), readFile: fakeReadFile })(),
+    ).rejects.toMatchObject({ code: "InvalidConfig" });
+  });
+
+  test("throws InvalidConfig when the token file is empty or whitespace", async () => {
+    const fakeFetch = vi.fn<typeof fetch>();
+    await expect(
+      fromEksPodIdentity({ fetch: fakeFetch, readFile: async () => "  \n" })(),
+    ).rejects.toMatchObject({ code: "InvalidConfig" });
+    expect(fakeFetch).not.toHaveBeenCalled();
+  });
+
+  test("wraps a fetch exception (timeout / DNS / unreachable) as NetworkError", async () => {
+    const fakeFetch = vi.fn<typeof fetch>(async () => {
+      throw Object.assign(new Error("The operation was aborted due to timeout"), {
+        name: "TimeoutError",
+      });
+    });
+    const fakeReadFile = vi.fn<(path: string, encoding: "utf8") => Promise<string>>(
+      async () => "tok",
+    );
+    await expect(
+      fromEksPodIdentity({ fetch: fakeFetch, readFile: fakeReadFile })(),
+    ).rejects.toMatchObject({
+      code: "NetworkError",
+      message: expect.stringContaining("agent fetch failed"),
+    });
+  });
+
+  test("surfaces a malformed Expiration as InvalidResponse", async () => {
+    const badExpiry = JSON.stringify({
+      AccessKeyId: "ASIATESTFROMEKS",
+      SecretAccessKey: "secret-from-agent",
+      Token: "session-token-from-agent",
+      Expiration: "not-a-date",
+    });
+    const fakeFetch = vi.fn<typeof fetch>(async () => new Response(badExpiry, { status: 200 }));
+    const fakeReadFile = vi.fn<(path: string, encoding: "utf8") => Promise<string>>(
+      async () => "tok",
+    );
+    await expect(
+      fromEksPodIdentity({ fetch: fakeFetch, readFile: fakeReadFile })(),
+    ).rejects.toMatchObject({ code: "InvalidResponse" });
+  });
+
+  test("passes AbortSignal.timeout and refuses redirects on the agent fetch", async () => {
+    let capturedInit: RequestInit | undefined;
     const fakeFetch = vi.fn<typeof fetch>(async (_url, init) => {
-      capturedSignal = init?.signal as AbortSignal | undefined;
+      capturedInit = init;
       return new Response(AGENT_RESPONSE, { status: 200 });
     });
     const fakeReadFile = vi.fn<(path: string, encoding: "utf8") => Promise<string>>(
       async () => "tok",
     );
     await fromEksPodIdentity({ fetch: fakeFetch, readFile: fakeReadFile })();
-    expect(capturedSignal).toBeInstanceOf(AbortSignal);
-    expect(capturedSignal!.aborted).toBe(false);
+    const signal = capturedInit?.signal as AbortSignal | undefined;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal!.aborted).toBe(false);
+    // A redirect would resend the token (Authorization header) to the target.
+    expect(capturedInit?.redirect).toBe("error");
   });
 });

--- a/packages/adapter-node/src/credentials/from-eks-pod-identity.ts
+++ b/packages/adapter-node/src/credentials/from-eks-pod-identity.ts
@@ -1,6 +1,7 @@
 import { readFile as fsReadFile } from "node:fs/promises";
 import { BaerlyError } from "@baerly/protocol";
 import type { CredentialsProvider } from "./types.ts";
+import { readProjectedToken } from "./token-file.ts";
 
 const FETCH_TIMEOUT_MS = 2_000;
 
@@ -44,14 +45,20 @@ export function fromEksPodIdentity(
       );
     }
 
-    const rawToken = await doReadFile(tokenPath, "utf8");
-    const token = rawToken.trim();
+    const token = await readProjectedToken(doReadFile, tokenPath, {
+      provider: "fromEksPodIdentity",
+      envVar: "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+    });
 
     let res: Response;
     try {
       res = await doFetch(uri, {
         method: "GET",
         headers: { Authorization: token },
+        // The token rides in the Authorization header; a redirect would resend
+        // it to the 3xx target. The node-local agent never redirects — refuse
+        // rather than follow, so a redirect surfaces as a NetworkError.
+        redirect: "error",
         signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       });
     } catch (error) {
@@ -94,11 +101,20 @@ export function fromEksPodIdentity(
     ) {
       throw new BaerlyError("InvalidResponse", "fromEksPodIdentity: malformed agent response");
     }
+    // A present-but-unparseable Expiration is as malformed as a missing field:
+    // `new Date(bad)` yields an Invalid Date (getTime() → NaN) rather than
+    // throwing, and the signer's `expiresAt - buffer > now()` refresh check is
+    // false for NaN — so a bad timestamp would silently defeat credential
+    // caching/rotation. Reject it here instead.
+    const expiration = new Date(json.Expiration);
+    if (Number.isNaN(expiration.getTime())) {
+      throw new BaerlyError("InvalidResponse", "fromEksPodIdentity: malformed agent response");
+    }
     return {
       accessKeyId: json.AccessKeyId,
       secretAccessKey: json.SecretAccessKey,
       sessionToken: json.Token,
-      expiration: new Date(json.Expiration),
+      expiration,
     };
   };
 }

--- a/packages/adapter-node/src/credentials/from-eks.test.ts
+++ b/packages/adapter-node/src/credentials/from-eks.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { fromEks } from "./from-eks.ts";
+
+const POD_IDENTITY_RESPONSE = JSON.stringify({
+  AccessKeyId: "ASIAPODIDENTITY",
+  SecretAccessKey: "secret-pod",
+  Token: "token-pod",
+  Expiration: "2026-05-28T18:00:00Z",
+});
+
+const STS_RESPONSE = `<AssumeRoleWithWebIdentityResponse>
+  <AssumeRoleWithWebIdentityResult><Credentials>
+    <AccessKeyId>ASIAWEBIDENTITY</AccessKeyId>
+    <SecretAccessKey>secret-web</SecretAccessKey>
+    <SessionToken>token-web</SessionToken>
+    <Expiration>2026-05-28T18:00:00Z</Expiration>
+  </Credentials></AssumeRoleWithWebIdentityResult>
+</AssumeRoleWithWebIdentityResponse>`;
+
+describe("fromEks", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("routes to EKS Pod Identity when AWS_CONTAINER_CREDENTIALS_FULL_URI is set", async () => {
+    vi.stubEnv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "http://169.254.170.23/v1/credentials");
+    vi.stubEnv("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", "/var/run/secrets/token");
+    const fakeFetch = vi.fn<typeof fetch>(
+      async () => new Response(POD_IDENTITY_RESPONSE, { status: 200 }),
+    );
+
+    const creds = await fromEks({ fetch: fakeFetch, readFile: async () => "tok" })();
+
+    // The Pod Identity mock's distinct key proves the router delegated there;
+    // fromEksPodIdentity's own test owns the GET/endpoint wire assertions.
+    expect(creds.accessKeyId).toBe("ASIAPODIDENTITY");
+  });
+
+  test("falls back to IRSA web-identity when only AWS_WEB_IDENTITY_TOKEN_FILE is set", async () => {
+    vi.stubEnv("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/holler");
+    vi.stubEnv("AWS_WEB_IDENTITY_TOKEN_FILE", "/var/run/secrets/token");
+    vi.stubEnv("AWS_REGION", "us-west-2");
+    const fakeFetch = vi.fn<typeof fetch>(async () => new Response(STS_RESPONSE, { status: 200 }));
+
+    const creds = await fromEks({ fetch: fakeFetch, readFile: async () => "tok" })();
+
+    // The web-identity mock's distinct key proves the router delegated there;
+    // fromWebIdentity's own test owns the POST/STS-endpoint wire assertions.
+    expect(creds.accessKeyId).toBe("ASIAWEBIDENTITY");
+  });
+
+  test("prefers Pod Identity when both mechanisms' env vars are present", async () => {
+    vi.stubEnv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "http://169.254.170.23/v1/credentials");
+    vi.stubEnv("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", "/var/run/secrets/token");
+    vi.stubEnv("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/holler");
+    vi.stubEnv("AWS_WEB_IDENTITY_TOKEN_FILE", "/var/run/secrets/token");
+    const fakeFetch = vi.fn<typeof fetch>(
+      async () => new Response(POD_IDENTITY_RESPONSE, { status: 200 }),
+    );
+
+    const creds = await fromEks({ fetch: fakeFetch, readFile: async () => "tok" })();
+    // Pod Identity wins the tie — its distinct key confirms which branch ran.
+    expect(creds.accessKeyId).toBe("ASIAPODIDENTITY");
+  });
+
+  test("throws InvalidConfig when neither mechanism's env vars are present", async () => {
+    vi.stubEnv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "");
+    vi.stubEnv("AWS_WEB_IDENTITY_TOKEN_FILE", "");
+    await expect(fromEks()()).rejects.toMatchObject({ code: "InvalidConfig" });
+  });
+});

--- a/packages/adapter-node/src/credentials/from-eks.ts
+++ b/packages/adapter-node/src/credentials/from-eks.ts
@@ -1,0 +1,45 @@
+import { BaerlyError } from "@baerly/protocol";
+import { fromEksPodIdentity } from "./from-eks-pod-identity.ts";
+import { fromWebIdentity } from "./from-web-identity.ts";
+import type { CredentialsProvider } from "./types.ts";
+
+/**
+ * Resolve AWS credentials on EKS regardless of which identity mechanism the
+ * cluster uses, so callers don't have to know. EKS injects credentials one of
+ * two ways:
+ *
+ * - **Pod Identity** (2023+): `AWS_CONTAINER_CREDENTIALS_FULL_URI` +
+ *   `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` → {@link fromEksPodIdentity}.
+ * - **IRSA** (web-identity token): `AWS_ROLE_ARN` +
+ *   `AWS_WEB_IDENTITY_TOKEN_FILE` → {@link fromWebIdentity}.
+ *
+ * Detection runs on every resolve (Pod Identity preferred when both are
+ * present), so the right mechanism is picked even if the env is populated late
+ * and re-checked on each refresh. Use this instead of the mechanism-specific
+ * providers unless you have a reason to pin one.
+ */
+export function fromEks(
+  opts: {
+    fetch?: typeof fetch;
+    readFile?: (path: string, encoding: "utf8") => Promise<string>;
+  } = {},
+): CredentialsProvider {
+  const podIdentity = fromEksPodIdentity(opts);
+  const webIdentity = fromWebIdentity(opts);
+
+  return async () => {
+    const uri = process.env["AWS_CONTAINER_CREDENTIALS_FULL_URI"];
+    const tokenFile = process.env["AWS_WEB_IDENTITY_TOKEN_FILE"];
+    if (uri !== undefined && uri !== "") {
+      return podIdentity();
+    }
+    if (tokenFile !== undefined && tokenFile !== "") {
+      return webIdentity();
+    }
+    throw new BaerlyError(
+      "InvalidConfig",
+      "fromEks: no EKS credentials in env — set AWS_CONTAINER_CREDENTIALS_FULL_URI " +
+        "(Pod Identity) or AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN (IRSA)",
+    );
+  };
+}

--- a/packages/adapter-node/src/credentials/from-web-identity.test.ts
+++ b/packages/adapter-node/src/credentials/from-web-identity.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { fromWebIdentity } from "./from-web-identity.ts";
+
+// A realistic STS AssumeRoleWithWebIdentity success body (namespace attr is
+// dropped by the parser's ignoreAttributes; extra result fields are ignored).
+const STS_RESPONSE = `<?xml version="1.0" encoding="UTF-8"?>
+<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleWithWebIdentityResult>
+    <AssumedRoleUser>
+      <Arn>arn:aws:sts::123456789012:assumed-role/holler/baerly-storage</Arn>
+      <AssumedRoleId>AROAEXAMPLE:baerly-storage</AssumedRoleId>
+    </AssumedRoleUser>
+    <Credentials>
+      <AccessKeyId>ASIATESTWEBID</AccessKeyId>
+      <SecretAccessKey>secret-from-sts</SecretAccessKey>
+      <SessionToken>session-token-from-sts</SessionToken>
+      <Expiration>2026-05-28T18:00:00Z</Expiration>
+    </Credentials>
+  </AssumeRoleWithWebIdentityResult>
+</AssumeRoleWithWebIdentityResponse>`;
+
+describe("fromWebIdentity", () => {
+  beforeEach(() => {
+    vi.stubEnv("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/holler");
+    vi.stubEnv(
+      "AWS_WEB_IDENTITY_TOKEN_FILE",
+      "/var/run/secrets/eks.amazonaws.com/serviceaccount/token",
+    );
+    vi.stubEnv("AWS_REGION", "us-west-2");
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("reads token file, POSTs AssumeRoleWithWebIdentity to regional STS, returns parsed creds with expiration", async () => {
+    const fakeFetch = vi.fn<typeof fetch>(async () => new Response(STS_RESPONSE, { status: 200 }));
+    const fakeReadFile = vi.fn<(path: string, encoding: "utf8") => Promise<string>>(
+      async () => "WEB-IDENTITY-JWT\n",
+    );
+
+    const creds = await fromWebIdentity({ fetch: fakeFetch, readFile: fakeReadFile })();
+
+    expect(fakeReadFile).toHaveBeenCalledWith(
+      "/var/run/secrets/eks.amazonaws.com/serviceaccount/token",
+      "utf8",
+    );
+    expect(fakeFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = fakeFetch.mock.calls[0]!;
+    expect(url).toBe("https://sts.us-west-2.amazonaws.com/");
+    expect(init?.method).toBe("POST");
+    const body = String(init?.body);
+    expect(body).toContain("Action=AssumeRoleWithWebIdentity");
+    expect(body).toContain("Version=2011-06-15");
+    expect(body).toContain("RoleArn=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2Fholler");
+    // Token is trimmed of the trailing newline before signing.
+    expect(body).toContain("WebIdentityToken=WEB-IDENTITY-JWT");
+
+    expect(creds).toEqual({
+      accessKeyId: "ASIATESTWEBID",
+      secretAccessKey: "secret-from-sts",
+      sessionToken: "session-token-from-sts",
+      expiration: new Date("2026-05-28T18:00:00Z"),
+    });
+  });
+
+  test("falls back to the global STS endpoint when no region is set", async () => {
+    vi.stubEnv("AWS_REGION", "");
+    vi.stubEnv("AWS_DEFAULT_REGION", "");
+    const fakeFetch = vi.fn<typeof fetch>(async () => new Response(STS_RESPONSE, { status: 200 }));
+    await fromWebIdentity({ fetch: fakeFetch, readFile: async () => "tok" })();
+    expect(fakeFetch.mock.calls[0]![0]).toBe("https://sts.amazonaws.com/");
+  });
+
+  test("throws InvalidConfig when AWS_ROLE_ARN is missing", async () => {
+    vi.stubEnv("AWS_ROLE_ARN", "");
+    await expect(fromWebIdentity()()).rejects.toMatchObject({ code: "InvalidConfig" });
+  });
+
+  test("throws InvalidConfig when AWS_WEB_IDENTITY_TOKEN_FILE is missing", async () => {
+    vi.stubEnv("AWS_WEB_IDENTITY_TOKEN_FILE", "");
+    await expect(fromWebIdentity()()).rejects.toMatchObject({ code: "InvalidConfig" });
+  });
+
+  test("surfaces STS 403 as AccessDenied (permanent)", async () => {
+    const fakeFetch = vi.fn<typeof fetch>(
+      async () => new Response("<ErrorResponse/>", { status: 403 }),
+    );
+    await expect(
+      fromWebIdentity({ fetch: fakeFetch, readFile: async () => "tok" })(),
+    ).rejects.toMatchObject({ code: "AccessDenied" });
+  });
+
+  test("includes the STS error Code and Message in the thrown error", async () => {
+    const stsError = `<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+      <Error>
+        <Type>Sender</Type>
+        <Code>InvalidIdentityToken</Code>
+        <Message>The ID Token provided is not a valid JWT.</Message>
+      </Error>
+    </ErrorResponse>`;
+    const fakeFetch = vi.fn<typeof fetch>(async () => new Response(stsError, { status: 400 }));
+    await expect(
+      fromWebIdentity({ fetch: fakeFetch, readFile: async () => "tok" })(),
+    ).rejects.toMatchObject({
+      code: "AccessDenied",
+      message: expect.stringContaining("InvalidIdentityToken"),
+    });
+    await expect(
+      fromWebIdentity({ fetch: fakeFetch, readFile: async () => "tok" })(),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining("The ID Token provided is not a valid JWT."),
+    });
+  });
+
+  test("wraps a token-file read failure in a BaerlyError (InvalidConfig)", async () => {
+    const fakeReadFile = vi.fn<(path: string, encoding: "utf8") => Promise<string>>(async () => {
+      throw Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" });
+    });
+    await expect(
+      fromWebIdentity({ fetch: vi.fn<typeof fetch>(), readFile: fakeReadFile })(),
+    ).rejects.toMatchObject({ code: "InvalidConfig" });
+  });
+
+  test("throws InvalidConfig when the token file is empty or whitespace", async () => {
+    const fakeFetch = vi.fn<typeof fetch>();
+    await expect(
+      fromWebIdentity({ fetch: fakeFetch, readFile: async () => "   \n" })(),
+    ).rejects.toMatchObject({ code: "InvalidConfig" });
+    // Never reached STS — the empty token is caught before the fetch.
+    expect(fakeFetch).not.toHaveBeenCalled();
+  });
+
+  test("surfaces STS 5xx as NetworkError (transient)", async () => {
+    const fakeFetch = vi.fn<typeof fetch>(async () => new Response("busy", { status: 503 }));
+    await expect(
+      fromWebIdentity({ fetch: fakeFetch, readFile: async () => "tok" })(),
+    ).rejects.toMatchObject({ code: "NetworkError" });
+  });
+
+  test("surfaces STS 429 (throttling) as NetworkError (transient)", async () => {
+    const fakeFetch = vi.fn<typeof fetch>(
+      async () => new Response("<ErrorResponse/>", { status: 429 }),
+    );
+    await expect(
+      fromWebIdentity({ fetch: fakeFetch, readFile: async () => "tok" })(),
+    ).rejects.toMatchObject({ code: "NetworkError" });
+  });
+
+  test("passes AWS_ROLE_SESSION_NAME through to STS as RoleSessionName", async () => {
+    vi.stubEnv("AWS_ROLE_SESSION_NAME", "holler-prod-42");
+    const fakeFetch = vi.fn<typeof fetch>(async () => new Response(STS_RESPONSE, { status: 200 }));
+    await fromWebIdentity({ fetch: fakeFetch, readFile: async () => "tok" })();
+    expect(String(fakeFetch.mock.calls[0]![1]?.body)).toContain("RoleSessionName=holler-prod-42");
+  });
+
+  test("defaults RoleSessionName to baerly-storage when AWS_ROLE_SESSION_NAME is unset", async () => {
+    vi.stubEnv("AWS_ROLE_SESSION_NAME", "");
+    const fakeFetch = vi.fn<typeof fetch>(async () => new Response(STS_RESPONSE, { status: 200 }));
+    await fromWebIdentity({ fetch: fakeFetch, readFile: async () => "tok" })();
+    expect(String(fakeFetch.mock.calls[0]![1]?.body)).toContain("RoleSessionName=baerly-storage");
+  });
+
+  test("surfaces a malformed 200 body as InvalidResponse", async () => {
+    const fakeFetch = vi.fn<typeof fetch>(async () => new Response("<nope/>", { status: 200 }));
+    await expect(
+      fromWebIdentity({ fetch: fakeFetch, readFile: async () => "tok" })(),
+    ).rejects.toMatchObject({ code: "InvalidResponse" });
+  });
+
+  test("wraps a fetch exception (timeout / DNS / unreachable) as NetworkError", async () => {
+    const fakeFetch = vi.fn<typeof fetch>(async () => {
+      // AbortSignal.timeout rejects with a TimeoutError-shaped DOMException; a
+      // DNS/connreset failure rejects with a TypeError. Either lands here.
+      throw Object.assign(new Error("The operation was aborted due to timeout"), {
+        name: "TimeoutError",
+      });
+    });
+    await expect(
+      fromWebIdentity({ fetch: fakeFetch, readFile: async () => "tok" })(),
+    ).rejects.toMatchObject({
+      code: "NetworkError",
+      message: expect.stringContaining("STS fetch failed"),
+    });
+  });
+
+  test("surfaces a non-ok STS response with an unparseable body as a bare-status error", async () => {
+    // No <Error> element → parseStsError returns undefined → no (Code: …) detail.
+    const fakeFetch = vi.fn<typeof fetch>(
+      async () => new Response("upstream proxy timeout, not xml", { status: 400 }),
+    );
+    await expect(
+      fromWebIdentity({ fetch: fakeFetch, readFile: async () => "tok" })(),
+    ).rejects.toMatchObject({
+      code: "AccessDenied",
+      message: "fromWebIdentity: STS responded 400",
+    });
+  });
+
+  test("surfaces a malformed Expiration as InvalidResponse", async () => {
+    // A present-but-unparseable Expiration is as malformed as a missing one:
+    // an Invalid Date would silently defeat the signer's refresh check.
+    const badExpiry = STS_RESPONSE.replace("2026-05-28T18:00:00Z", "not-a-date");
+    const fakeFetch = vi.fn<typeof fetch>(async () => new Response(badExpiry, { status: 200 }));
+    await expect(
+      fromWebIdentity({ fetch: fakeFetch, readFile: async () => "tok" })(),
+    ).rejects.toMatchObject({ code: "InvalidResponse" });
+  });
+
+  test("passes AbortSignal.timeout and refuses redirects on the STS fetch", async () => {
+    let capturedInit: RequestInit | undefined;
+    const fakeFetch = vi.fn<typeof fetch>(async (_url, init) => {
+      capturedInit = init;
+      return new Response(STS_RESPONSE, { status: 200 });
+    });
+    await fromWebIdentity({ fetch: fakeFetch, readFile: async () => "tok" })();
+    const signal = capturedInit?.signal as AbortSignal | undefined;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal!.aborted).toBe(false);
+    // A redirect would resend the unsigned token body to the 3xx target.
+    expect(capturedInit?.redirect).toBe("error");
+  });
+});

--- a/packages/adapter-node/src/credentials/from-web-identity.ts
+++ b/packages/adapter-node/src/credentials/from-web-identity.ts
@@ -1,0 +1,146 @@
+import { BaerlyError } from "@baerly/protocol";
+import { readFile as fsReadFile } from "node:fs/promises";
+import type { CredentialsProvider } from "./types.ts";
+import { readProjectedToken } from "./token-file.ts";
+import { parseAssumeRoleWithWebIdentity, parseStsError } from "../xml.ts";
+
+// STS is a regional (not node-local) service, so allow more headroom than the
+// 2 s Pod Identity agent budget — but still bound it against hangs.
+const FETCH_TIMEOUT_MS = 5_000;
+const DEFAULT_SESSION_NAME = "baerly-storage";
+
+/**
+ * Resolve AWS credentials via IRSA (IAM Roles for Service Accounts) — the
+ * web-identity-token flow, distinct from the EKS Pod Identity agent that
+ * {@link fromEksPodIdentity} handles. EKS projects a signed service-account
+ * token into the pod and the app exchanges it for short-lived credentials by
+ * calling STS `AssumeRoleWithWebIdentity` directly (the token *is* the auth, so
+ * the call is unsigned — no chicken-and-egg credential bootstrap).
+ *
+ * Env vars (set by EKS when the pod's service account is annotated with a role):
+ * - `AWS_ROLE_ARN` — the role to assume.
+ * - `AWS_WEB_IDENTITY_TOKEN_FILE` — path to the projected SA token.
+ * - `AWS_ROLE_SESSION_NAME` — optional session name (defaults to `baerly-storage`).
+ * - `AWS_REGION` / `AWS_DEFAULT_REGION` — optional; selects the regional STS
+ *   endpoint (falls back to the global endpoint).
+ *
+ * STS credentials expire (~1 h); the returned provider reports `expiration`, so
+ * the signing layer re-resolves before they lapse.
+ */
+export function fromWebIdentity(
+  opts: {
+    fetch?: typeof fetch;
+    readFile?: (path: string, encoding: "utf8") => Promise<string>;
+  } = {},
+): CredentialsProvider {
+  const doFetch = opts.fetch ?? fetch;
+  const doReadFile = opts.readFile ?? fsReadFile;
+
+  return async () => {
+    const roleArn = process.env["AWS_ROLE_ARN"];
+    const tokenPath = process.env["AWS_WEB_IDENTITY_TOKEN_FILE"];
+    const sessionName = process.env["AWS_ROLE_SESSION_NAME"] || DEFAULT_SESSION_NAME;
+    const region = process.env["AWS_REGION"] || process.env["AWS_DEFAULT_REGION"];
+    if (roleArn === undefined || roleArn === "") {
+      throw new BaerlyError("InvalidConfig", "fromWebIdentity: AWS_ROLE_ARN not set");
+    }
+    if (tokenPath === undefined || tokenPath === "") {
+      throw new BaerlyError(
+        "InvalidConfig",
+        "fromWebIdentity: AWS_WEB_IDENTITY_TOKEN_FILE not set",
+      );
+    }
+
+    const token = await readProjectedToken(doReadFile, tokenPath, {
+      provider: "fromWebIdentity",
+      envVar: "AWS_WEB_IDENTITY_TOKEN_FILE",
+    });
+
+    // Regional endpoint when a region is known (lower latency, and required in
+    // non-default partitions); otherwise the global endpoint.
+    const endpoint =
+      region !== undefined && region !== ""
+        ? `https://sts.${region}.amazonaws.com/`
+        : "https://sts.amazonaws.com/";
+    const body = new URLSearchParams({
+      Action: "AssumeRoleWithWebIdentity",
+      Version: "2011-06-15",
+      RoleArn: roleArn,
+      RoleSessionName: sessionName,
+      WebIdentityToken: token,
+    }).toString();
+
+    let res: Response;
+    try {
+      res = await doFetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/xml",
+        },
+        body,
+        // The POST carries the web-identity token as its only auth and is
+        // unsigned, so a redirect would resend the token to the 3xx target.
+        // STS never legitimately redirects this call — refuse rather than
+        // follow, so a redirect surfaces as a NetworkError instead of leaking.
+        redirect: "error",
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+    } catch (error) {
+      throw new BaerlyError(
+        "NetworkError",
+        `fromWebIdentity: STS fetch failed (${(error as Error).message})`,
+      );
+    }
+
+    // 5xx + 429 are transient — NetworkError so callers / chained providers can
+    // retry. Other 4xx (expired/invalid token, role trust mismatch) are
+    // permanent — AccessDenied so retry loops short-circuit (see
+    // PERMANENT_ERROR_CODES in s3-http.ts). Either way, fold the STS
+    // <ErrorResponse> Code/Message into the message — a bare status turns the
+    // exact misconfig this provider exists to debug (bad role trust policy,
+    // token audience mismatch, clock skew, expired token) into a guessing game.
+    if (!res.ok) {
+      const stsErr = parseStsError(await res.text());
+      const detail =
+        stsErr?.Code !== undefined
+          ? ` (${stsErr.Code}${stsErr.Message !== undefined ? `: ${stsErr.Message}` : ""})`
+          : "";
+      if (res.status >= 500 || res.status === 429) {
+        throw new BaerlyError(
+          "NetworkError",
+          `fromWebIdentity: STS responded ${res.status}${detail}`,
+        );
+      }
+      throw new BaerlyError(
+        "AccessDenied",
+        `fromWebIdentity: STS responded ${res.status}${detail}`,
+      );
+    }
+
+    const parsed = parseAssumeRoleWithWebIdentity(await res.text());
+    if (
+      parsed.AccessKeyId === undefined ||
+      parsed.SecretAccessKey === undefined ||
+      parsed.SessionToken === undefined ||
+      parsed.Expiration === undefined
+    ) {
+      throw new BaerlyError("InvalidResponse", "fromWebIdentity: malformed STS response");
+    }
+    // A present-but-unparseable Expiration is as malformed as a missing field:
+    // `new Date(bad)` yields an Invalid Date (getTime() → NaN) rather than
+    // throwing, and the signer's `expiresAt - buffer > now()` refresh check is
+    // false for NaN — so a bad timestamp would silently defeat credential
+    // caching/rotation. Reject it here instead.
+    const expiration = new Date(parsed.Expiration);
+    if (Number.isNaN(expiration.getTime())) {
+      throw new BaerlyError("InvalidResponse", "fromWebIdentity: malformed STS response");
+    }
+    return {
+      accessKeyId: parsed.AccessKeyId,
+      secretAccessKey: parsed.SecretAccessKey,
+      sessionToken: parsed.SessionToken,
+      expiration,
+    };
+  };
+}

--- a/packages/adapter-node/src/credentials/index.ts
+++ b/packages/adapter-node/src/credentials/index.ts
@@ -1,2 +1,4 @@
 export type { Credentials, CredentialsProvider } from "./types.ts";
+export { fromEks } from "./from-eks.ts";
 export { fromEksPodIdentity } from "./from-eks-pod-identity.ts";
+export { fromWebIdentity } from "./from-web-identity.ts";

--- a/packages/adapter-node/src/credentials/token-file.ts
+++ b/packages/adapter-node/src/credentials/token-file.ts
@@ -1,0 +1,37 @@
+import { BaerlyError } from "@baerly/protocol";
+
+/**
+ * Read and validate an EKS-projected service-account token file, shared by
+ * {@link fromWebIdentity} and {@link fromEksPodIdentity}. Reads the file,
+ * trims surrounding whitespace (the projected token has a trailing newline),
+ * and rejects an empty result.
+ *
+ * A missing / unreadable / empty projected token is a deploy misconfig, not a
+ * transient fault — so every failure is `InvalidConfig`, which short-circuits
+ * the retry loop (see `PERMANENT_ERROR_CODES` in `s3-http.ts`) instead of
+ * hammering the credential source. Error messages name the specific env var
+ * so the misconfig is debuggable.
+ */
+export async function readProjectedToken(
+  doReadFile: (path: string, encoding: "utf8") => Promise<string>,
+  tokenPath: string,
+  ctx: { provider: string; envVar: string },
+): Promise<string> {
+  let rawToken: string;
+  try {
+    rawToken = await doReadFile(tokenPath, "utf8");
+  } catch (error) {
+    throw new BaerlyError(
+      "InvalidConfig",
+      `${ctx.provider}: cannot read ${ctx.envVar} (${tokenPath}): ${(error as Error).message}`,
+    );
+  }
+  const token = rawToken.trim();
+  if (token === "") {
+    throw new BaerlyError(
+      "InvalidConfig",
+      `${ctx.provider}: ${ctx.envVar} (${tokenPath}) is empty`,
+    );
+  }
+  return token;
+}

--- a/packages/adapter-node/src/index.ts
+++ b/packages/adapter-node/src/index.ts
@@ -56,7 +56,9 @@ export type { AssertStorageReachableOptions } from "./assert-storage-reachable.t
 export {
   type Credentials,
   type CredentialsProvider,
+  fromEks,
   fromEksPodIdentity,
+  fromWebIdentity,
 } from "./credentials/index.ts";
 export { baerlyNode } from "./baerly-node.ts";
 export type { BaerlyNodeHandle, BaerlyNodeOptions } from "./baerly-node.ts";

--- a/packages/adapter-node/src/storage-factories.ts
+++ b/packages/adapter-node/src/storage-factories.ts
@@ -32,14 +32,14 @@ function buildS3Storage(opts: {
  * });
  * ```
  *
- * @example EKS Pod Identity (refreshing)
+ * @example EKS (refreshing) — auto-detects Pod Identity or IRSA
  * ```ts
- * import { s3Storage, fromEksPodIdentity } from "@gusto/baerly-storage/node";
+ * import { s3Storage, fromEks } from "@gusto/baerly-storage/node";
  *
  * const storage = s3Storage({
  *   region: process.env["AWS_REGION"] ?? "us-east-1",
  *   bucket: process.env["BUCKET"]!,
- *   credentials: fromEksPodIdentity(),
+ *   credentials: fromEks(),
  * });
  * ```
  */

--- a/packages/adapter-node/src/xml.test.ts
+++ b/packages/adapter-node/src/xml.test.ts
@@ -1,5 +1,10 @@
 import { expect, test, describe } from "vitest";
-import { parseListObjectsV2CommandOutput, parseS3Error } from "./xml.ts";
+import {
+  parseAssumeRoleWithWebIdentity,
+  parseListObjectsV2CommandOutput,
+  parseS3Error,
+  parseStsError,
+} from "./xml.ts";
 describe("XML parser", () => {
   test("parseListObjectsV2CommandOutput example", () => {
     const xml: string = `<?xml version="1.0" encoding="UTF-8"?>
@@ -300,6 +305,98 @@ describe("parseS3Error", () => {
     // runs, so the entity is never expanded. Locks the behavior.
     expect(
       parseS3Error(`<!DOCTYPE Error [<!ENTITY l. "x">]><Error><Code>&lt;</Code></Error>`),
+    ).toBeUndefined();
+  });
+});
+
+describe("parseAssumeRoleWithWebIdentity", () => {
+  test("extracts the <Credentials> block from an STS success body", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+        <AssumeRoleWithWebIdentityResult><Credentials>
+          <AccessKeyId>ASIAEXAMPLE</AccessKeyId>
+          <SecretAccessKey>secret</SecretAccessKey>
+          <SessionToken>token</SessionToken>
+          <Expiration>2026-05-28T18:00:00Z</Expiration>
+        </Credentials></AssumeRoleWithWebIdentityResult>
+      </AssumeRoleWithWebIdentityResponse>`;
+    expect(parseAssumeRoleWithWebIdentity(xml)).toEqual({
+      AccessKeyId: "ASIAEXAMPLE",
+      SecretAccessKey: "secret",
+      SessionToken: "token",
+      Expiration: "2026-05-28T18:00:00Z",
+    });
+  });
+
+  test("returns all-undefined fields for a body without <Credentials>", () => {
+    expect(parseAssumeRoleWithWebIdentity("<AssumeRoleWithWebIdentityResponse/>")).toEqual({
+      AccessKeyId: undefined,
+      SecretAccessKey: undefined,
+      SessionToken: undefined,
+      Expiration: undefined,
+    });
+  });
+
+  test("refuses a DTD (XXE guard) by throwing InvalidResponse", () => {
+    expect(() =>
+      parseAssumeRoleWithWebIdentity(
+        `<!DOCTYPE AssumeRoleWithWebIdentityResponse [<!ENTITY l. "x">]><AssumeRoleWithWebIdentityResponse/>`,
+      ),
+    ).toThrow(/DTD/);
+  });
+
+  test("does not echo the response body on unparseable XML (would leak live creds)", () => {
+    // A success-shaped-but-malformed 200 body carries plaintext credentials;
+    // the thrown error must not fold them in (it gets logged).
+    const secret = "SECRET-ACCESS-KEY-DO-NOT-LEAK";
+    // Truncated trailing tag makes fast-xml-parser throw mid-parse; the secret
+    // sits in the (unparseable) body the old code echoed into the error.
+    const malformed = `<AssumeRoleWithWebIdentityResponse><AssumeRoleWithWebIdentityResult><Credentials><SecretAccessKey>${secret}</SecretAccessKey><trunc`;
+    let thrown: unknown;
+    try {
+      parseAssumeRoleWithWebIdentity(malformed);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toMatchObject({ code: "InvalidResponse" });
+    expect((thrown as Error).message).not.toContain(secret);
+  });
+});
+
+describe("parseStsError", () => {
+  test("extracts Code and Message from an STS <ErrorResponse> body", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+        <Error>
+          <Type>Sender</Type>
+          <Code>InvalidIdentityToken</Code>
+          <Message>The ID Token provided is not a valid JWT.</Message>
+        </Error>
+        <RequestId>abc-123</RequestId>
+      </ErrorResponse>`;
+    expect(parseStsError(xml)).toEqual({
+      Code: "InvalidIdentityToken",
+      Message: "The ID Token provided is not a valid JWT.",
+    });
+  });
+
+  test("extracts Code alone when the STS <Error> carries no <Message>", () => {
+    const xml = `<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+        <Error><Type>Sender</Type><Code>InvalidIdentityToken</Code></Error>
+      </ErrorResponse>`;
+    expect(parseStsError(xml)).toEqual({ Code: "InvalidIdentityToken" });
+  });
+
+  test("returns undefined for a non-error body so callers fall back to the raw status", () => {
+    expect(parseStsError("<AssumeRoleWithWebIdentityResponse/>")).toBeUndefined();
+    expect(parseStsError("")).toBeUndefined();
+  });
+
+  test("refuses a DTD (XXE guard) and returns undefined", () => {
+    expect(
+      parseStsError(
+        `<!DOCTYPE ErrorResponse [<!ENTITY x "y">]><ErrorResponse><Error/></ErrorResponse>`,
+      ),
     ).toBeUndefined();
   });
 });

--- a/packages/adapter-node/src/xml.ts
+++ b/packages/adapter-node/src/xml.ts
@@ -1,5 +1,5 @@
-import { XMLParser } from "fast-xml-parser";
 import { BaerlyError } from "@baerly/protocol";
+import { XMLParser } from "fast-xml-parser";
 
 /**
  * Subset of S3's `ListObjectsV2CommandOutput` produced by
@@ -99,6 +99,91 @@ export const parseS3Error = (xml: string): ParsedS3Error | undefined => {
   return {
     ...(code !== undefined && { Code: code }),
     ...(message !== undefined && { Message: message }),
+  };
+};
+
+/**
+ * Parse an STS `<ErrorResponse><Error><Code>…</Code><Message>…</Message>
+ * </Error></ErrorResponse>` body (the shape STS returns on a failed
+ * `AssumeRoleWithWebIdentity` — e.g. `InvalidIdentityToken`,
+ * `ExpiredTokenException`, `AccessDenied`). Returns `undefined` when the body
+ * is not a recognizable STS error document (empty, HTML, a success payload, or
+ * a DTD), so callers can fall back to the bare status. Like {@link parseS3Error}
+ * this never throws — it runs on a path that is already reporting an error.
+ *
+ * Note the nesting differs from S3: STS wraps `<Error>` inside `<ErrorResponse>`.
+ */
+export const parseStsError = (xml: string): ParsedS3Error | undefined => {
+  if (!/<Error\b/i.test(xml) || /<!DOCTYPE\b/i.test(xml)) {
+    return undefined;
+  }
+  let result: { ErrorResponse?: { Error?: Record<string, unknown> } };
+  try {
+    result = xmlParser.parse(xml) as typeof result;
+  } catch {
+    return undefined;
+  }
+  const root = result.ErrorResponse?.Error;
+  if (root === undefined) {
+    return undefined;
+  }
+  const code = rawXmlVal(root, "Code");
+  const message = rawXmlVal(root, "Message");
+  if (code === undefined && message === undefined) {
+    return undefined;
+  }
+  return {
+    ...(code !== undefined && { Code: code }),
+    ...(message !== undefined && { Message: message }),
+  };
+};
+
+/**
+ * `<Credentials>` extracted from an STS
+ * `<AssumeRoleWithWebIdentityResponse>` body by
+ * {@link parseAssumeRoleWithWebIdentity}. Field names mirror the STS REST
+ * API (PascalCase), matching the convention of {@link ParsedS3Error}.
+ */
+export interface ParsedWebIdentityCredentials {
+  AccessKeyId?: string;
+  SecretAccessKey?: string;
+  SessionToken?: string;
+  Expiration?: string;
+}
+
+/**
+ * Parse an STS `AssumeRoleWithWebIdentity` success body, returning the
+ * `<Credentials>` block. Reuses the hardened, DTD-guarded {@link xmlParser};
+ * throws `InvalidResponse` on a DTD or unparseable XML. Missing fields come
+ * back `undefined` so the caller can map them to its own `InvalidResponse`.
+ *
+ * Unlike {@link parseListObjectsV2CommandOutput}, the error on unparseable
+ * XML must NOT echo the body: a success-shaped STS body carries the plaintext
+ * `SecretAccessKey`/`SessionToken`, so folding it into a thrown-then-logged
+ * error would leak live credentials.
+ */
+export const parseAssumeRoleWithWebIdentity = (xml: string): ParsedWebIdentityCredentials => {
+  if (/<!DOCTYPE\b/i.test(xml)) {
+    throw new BaerlyError("InvalidResponse", "DTD not allowed in STS XML responses");
+  }
+  let result: {
+    AssumeRoleWithWebIdentityResponse?: {
+      AssumeRoleWithWebIdentityResult?: { Credentials?: Record<string, unknown> };
+    };
+  };
+  try {
+    result = xmlParser.parse(xml) as typeof result;
+  } catch {
+    // No body in the message — see the note above; it may contain live creds.
+    throw new BaerlyError("InvalidResponse", "unparseable STS credentials response");
+  }
+  const creds =
+    result.AssumeRoleWithWebIdentityResponse?.AssumeRoleWithWebIdentityResult?.Credentials ?? {};
+  return {
+    AccessKeyId: rawXmlVal(creds, "AccessKeyId"),
+    SecretAccessKey: rawXmlVal(creds, "SecretAccessKey"),
+    SessionToken: rawXmlVal(creds, "SessionToken"),
+    Expiration: rawXmlVal(creds, "Expiration"),
   };
 };
 

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -312,6 +312,11 @@ const BUDGETS: readonly Budget[] = [
   //     predicted. Measured 231593 raw / 72425 gz / 19885 min-gz; min-gz stays
   //     under 20 KiB (−595). Per the POLICY, rebaselined the raw/gz tripwires
   //     rather than golf the doc/error.
+  //   NOTE (2026-07-01): the gz 71 KiB bump above also absorbs CI's cross-
+  //     environment gz nondeterminism (~18 B observed) that flaked the axis
+  //     near the old 70 KiB ceiling. The IRSA credential work on this branch
+  //     ships under the separate `node`/adapter-node entry, not the kernel
+  //     barrel, so it does not move this closure.
   { entry: "index.js", raw: 227 * 1024, gz: 71 * 1024, minGz: 20 * 1024 },
   // The three auth verifier factories (bearerJwt, sharedSecret,
   // cloudflareAccess) plus the transitive jose closure pulled in by


### PR DESCRIPTION
Adds native IRSA credential support for S3 on EKS. Previously `fromEksPodIdentity()` only handled the Pod Identity agent; IRSA clusters (`AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`) threw `InvalidConfig` and every S3 call failed.

Two new providers exported from `@gusto/baerly-storage/node`:

- **`fromWebIdentity()`** — exchanges the projected SA token for short-lived credentials via STS `AssumeRoleWithWebIdentity` (unsigned; the token is the auth). Returns `expiration` so the signer rotates automatically. No AWS SDK dep — `fetch` + the existing hardened XML parser.
- **`fromEks()`** — auto-detects Pod Identity vs IRSA per resolve, `InvalidConfig` when neither is configured. Recommended entry point.

Also: actionable errors on credential failures (missing/empty token → `InvalidConfig`; STS `Code`/`Message` folded into the thrown error), and `redirect: "error"` on both providers so a redirect can't leak the token. `fromEks()` is now the recommended EKS path in the scaffold docs.

`pnpm verify:agent` + `pnpm test:agent` green; no new runtime dependency.