### PR TITLE
feat: S3-compatible storage from a Cloudflare Worker

### DIFF
--- a/.changeset/s3-from-worker.md
+++ b/.changeset/s3-from-worker.md
@@ -1,0 +1,25 @@
+---
+"@gusto/baerly-storage": minor
+---
+
+Cloudflare Workers can now use S3-compatible storage over HTTP instead of
+a native R2 binding, as an opt-in path. New Worker-safe
+`@gusto/baerly-storage/s3` subpath exports `S3HttpStorage` + `sigV4Signer`
+(closure has no `node:` builtins), and `baerlyWorker` accepts an optional
+`storage` in its factory options (defaulting to the `env.BUCKET` R2
+binding). `BaerlyEnv.BUCKET` is now optional so an S3-only Worker need not
+declare an R2 binding. `sigV4Signer` fails fast with `InvalidConfig` when
+`accessKeyId`, `secretAccessKey`, or `region` is empty or whitespace-only
+(e.g. a blank or accidentally-spaced wrangler `var`) rather than signing
+with blank credentials — or a malformed empty-region SigV4 scope — and
+drawing an opaque 403.
+
+This path ships at the same support tier as AWS-via-`S3HttpStorage`:
+credential-gated, operator-owned production validation. CI guards the
+closure under workerd on two levels — a bundle probe that it stays
+`node:`-free (loads in a Worker) and an in-isolate wire test that
+`S3HttpStorage` + `sigV4Signer` actually run there (signing, XML parse,
+request/response plumbing) against an in-memory S3 stub. CI does not drive
+a real S3 endpoint from workerd; verify yours with `baerly doctor
+--bucket` before relying on it. Note `baerly deploy` / `doctor
+--target=cloudflare` still expect an R2 binding in `wrangler.jsonc`.

--- a/docs/spec/storage-compatibility.md
+++ b/docs/spec/storage-compatibility.md
@@ -253,6 +253,72 @@ doctor --bucket` probe races K concurrent creates of a fresh key and
 > asserting a single immediate snapshot over the wire. AWS S3, MinIO, and
 > the native R2 binding assert immediately.
 
+### S3 (over HTTP) from a Cloudflare Worker
+
+A Worker normally uses a native R2 binding (`r2BindingStorage`, wired by
+default in `baerlyWorker`). When the approved bucket is AWS S3 or a
+cross-account R2 — i.e. there is no in-account binding — inject
+`S3HttpStorage` instead. Import it from the Worker-safe
+`@gusto/baerly-storage/s3` subpath (its closure has no `node:` builtins;
+`@gusto/baerly-storage/node` does and will not bundle):
+
+```ts
+import { baerlyWorker } from "@gusto/baerly-storage/cloudflare";
+import { S3HttpStorage, sigV4Signer } from "@gusto/baerly-storage/s3";
+import config from "../../baerly.config.ts";
+
+export default baerlyWorker((env) => ({
+  config,
+  storage: new S3HttpStorage({
+    endpoint: env.S3_ENDPOINT, // e.g. https://s3.us-east-1.amazonaws.com
+    bucket: env.S3_BUCKET,
+    sign: sigV4Signer({
+      accessKeyId: env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+      region: env.AWS_REGION,
+    }),
+  }),
+}));
+```
+
+The commit protocol requires exactly-one-winner create-if-absent
+(`If-None-Match: "*"`) and `If-Match` CAS. Native R2 bindings guarantee
+this; over the S3 HTTP API you inherit the *endpoint's* conditional-write
+and consistency behavior, so this path is only as strong as the backend
+you point it at. Cost trade-off: the `/s3` closure carries `aws4fetch` +
+`fast-xml-parser`; a same-account binding avoids both.
+
+**Support tier.** This path is opt-in and sits at the same tier as
+AWS-via-`S3HttpStorage`: credential-gated, with production validation you
+own. Its wire behavior is verified under Node (against MinIO and, in
+credential-gated runs, real S3 / R2). Under workerd, CI covers it on two
+levels: `tests/integration/s3-worker-safe.test.ts` proves the
+`@gusto/baerly-storage/s3` closure *bundles* `node:`-free (it loads in a
+Worker), and `tests/integration/s3-worker-wire.test.ts` proves it *runs*
+in a real Workerd isolate — `S3HttpStorage` + `sigV4Signer` drive a
+put / get / CAS / list round-trip through an in-memory S3-shaped `fetch`
+stub, exercising aws4fetch's WebCrypto signing, `fast-xml-parser`, and the
+`Request`/`Response` plumbing in-isolate. What CI does **not** do is drive
+a *real* S3 endpoint from workerd (TLS + the endpoint's own
+conditional-write semantics); that is the manual e2e recipe in
+`manual-e2e/README.md`. Run `baerly doctor --bucket=<uri>` against your
+endpoint before relying on it.
+
+**Deploy tooling still assumes R2.** `baerly deploy` and
+`baerly doctor --target=cloudflare` walk `wrangler.jsonc`'s `r2_buckets[]`
+and will flag a missing binding — they do not yet understand an S3-only
+Worker. Keep (or intentionally omit) the R2 binding with that in mind, and
+validate the S3 endpoint with `baerly doctor --bucket=<uri>` rather than
+the target-scoped `doctor`.
+
+**Credentials posture.** A same-account R2 binding needs no secret. This
+path instead requires long-lived static cloud credentials
+(`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) stored as Worker secrets;
+scope them to the one bucket and treat them like any other deployed
+secret. `sigV4Signer` covers static credentials only — for rotating /
+temporary credentials, pass your own `(req) => Promise<Request>` signer to
+`S3HttpStorage`.
+
 ## Per-provider conditional-write matrix
 
 Dated because provider behaviour drifts — re-verify before relying on a

--- a/manual-e2e/README.md
+++ b/manual-e2e/README.md
@@ -107,6 +107,45 @@ curl -s "$CF_DEPLOY_URL/v1/c/some-table"
 # Expect: 401 with {"error":{"code":"Unauthorized",...}}
 ```
 
+### Worker-over-S3 (workerd wire check)
+
+The default deploy reads R2 through the in-cell binding, so it does **not**
+exercise the `@gusto/baerly-storage/s3` path inside workerd. To verify that
+path against a real S3-compatible endpoint from inside an isolate, deploy a
+variant whose Worker entry injects `S3HttpStorage` instead of relying on the
+`BUCKET` binding:
+
+```ts
+// src/index.ts of the deployed scaffold — S3 variant
+import { baerlyWorker } from "@gusto/baerly-storage/cloudflare";
+import { S3HttpStorage, sigV4Signer } from "@gusto/baerly-storage/s3";
+import config from "../baerly.config.ts";
+
+export default baerlyWorker((env) => ({
+  config,
+  storage: new S3HttpStorage({
+    endpoint: env.S3_ENDPOINT,
+    bucket: env.S3_BUCKET,
+    sign: sigV4Signer({
+      accessKeyId: env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+      region: env.AWS_REGION,
+    }),
+  }),
+}));
+```
+
+Set `S3_ENDPOINT` / `S3_BUCKET` / `AWS_REGION` as `vars` and
+`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` via `wrangler secret put`,
+then `pnpm baerly deploy`. Point `CF_DEPLOY_URL` at the deployed URL and
+run `pnpm test:manual-e2e`. The conformance cascade now runs end-to-end
+with `S3HttpStorage` executing **inside workerd against a real S3
+endpoint** — the one thing CI cannot cover. (CI already runs
+`S3HttpStorage` in a Workerd isolate via
+`tests/integration/s3-worker-wire.test.ts`, but against an in-memory
+`fetch` stub; only this manual run exercises real TLS + the endpoint's own
+conditional-write semantics from inside workerd.) Tear down when done.
+
 ## Section 2: Deploy the Node host
 
 ### Prerequisites

--- a/package.json
+++ b/package.json
@@ -60,6 +60,10 @@
       "types": "./packages/adapter-node/src/index.ts",
       "import": "./packages/adapter-node/src/index.ts"
     },
+    "./s3": {
+      "types": "./packages/adapter-node/src/s3.ts",
+      "import": "./packages/adapter-node/src/s3.ts"
+    },
     "./maintenance": {
       "types": "./packages/server/src/maintenance.ts",
       "import": "./packages/server/src/maintenance.ts"
@@ -110,6 +114,10 @@
       "./node": {
         "types": "./dist/node.d.ts",
         "import": "./dist/node.js"
+      },
+      "./s3": {
+        "types": "./dist/s3.d.ts",
+        "import": "./dist/s3.js"
       },
       "./maintenance": {
         "types": "./dist/maintenance.d.ts",

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -4,12 +4,15 @@
  * without SigV4 — the dominant path when your Worker and bucket
  * are in the same Cloudflare account.
  *
- * Cross-cloud or cross-account R2 from a Worker? Import
- * `S3HttpStorage` directly from `@gusto/baerly-storage/node`. That path
- * pulls `aws4fetch` and `fast-xml-parser`, which is why it is not
+ * Cross-cloud, cross-account, or S3-instead-of-R2 from a Worker? Import
+ * `S3HttpStorage` + `sigV4Signer` from the Worker-safe
+ * `@gusto/baerly-storage/s3` subpath and pass the instance as
+ * `baerlyWorker((env) => ({ config, storage }))`. That subpath pulls
+ * `aws4fetch` + `fast-xml-parser` (SigV4 + XML), which is why it is not
  * re-exported here: the closure of `@gusto/baerly-storage/cloudflare`
- * stays peer-free so R2-only consumers don't carry the SigV4 +
- * XML parser bytes.
+ * stays peer-free so same-account R2-binding consumers don't carry those
+ * bytes. Do NOT import from `@gusto/baerly-storage/node` in a Worker —
+ * that barrel drags `node:http` / `node:path`.
  *
  * The `fetch(req, env, ctx)` Worker mount lives at the `/worker`
  * subpath: `import { baerlyWorker } from "@baerly/adapter-cloudflare/worker"`.

--- a/packages/adapter-cloudflare/src/resolve-storage.ts
+++ b/packages/adapter-cloudflare/src/resolve-storage.ts
@@ -1,0 +1,29 @@
+import { BaerlyError, type Storage } from "@baerly/protocol";
+import { r2BindingStorage } from "./r2-binding-storage.ts";
+import type { BaerlyEnv, BaerlyWorkerOptions } from "./worker.ts";
+
+/**
+ * Resolve the request-time {@link Storage} for a Worker.
+ *
+ * Precedence: an explicitly injected `options.storage` (the S3-over-HTTP
+ * / cross-account path) wins; otherwise the same-account R2 binding
+ * `env.BUCKET`. With neither, fail closed with `InvalidConfig` rather
+ * than silently serving nothing.
+ */
+export function resolveWorkerStorage(
+  options: Pick<BaerlyWorkerOptions, "storage">,
+  env: Pick<BaerlyEnv, "BUCKET">,
+): Storage {
+  if (options.storage) {
+    return options.storage;
+  }
+  if (!env.BUCKET) {
+    throw new BaerlyError(
+      "InvalidConfig",
+      "baerlyWorker: no storage available. Bind an R2 bucket as `BUCKET`, " +
+        "or pass `storage` in the factory options — e.g. " +
+        'new S3HttpStorage(...) from "@gusto/baerly-storage/s3".',
+    );
+  }
+  return r2BindingStorage(env.BUCKET);
+}

--- a/packages/adapter-cloudflare/src/worker-storage.test.ts
+++ b/packages/adapter-cloudflare/src/worker-storage.test.ts
@@ -1,0 +1,35 @@
+import { BaerlyError, MemoryStorage } from "@baerly/protocol";
+import { describe, expect, test } from "vitest";
+import { resolveWorkerStorage } from "./resolve-storage.ts";
+
+describe("resolveWorkerStorage", () => {
+  test("returns the injected storage when options.storage is set", () => {
+    const injected = new MemoryStorage();
+    const resolved = resolveWorkerStorage({ storage: injected }, {});
+    expect(resolved).toBe(injected);
+  });
+
+  test("falls back to the R2 binding when no storage is injected", () => {
+    // Minimal R2Bucket stand-in — resolveWorkerStorage only forwards it
+    // to r2BindingStorage, which stores the handle without calling it.
+    const fakeBucket = {} as R2Bucket;
+    const injected = new MemoryStorage();
+    const resolved = resolveWorkerStorage({}, { BUCKET: fakeBucket });
+    // Took the R2 branch: a Storage-shaped handle that is NOT the
+    // injected instance. `toBeDefined()` alone passes for any truthy
+    // value and wouldn't prove the R2 path was taken.
+    expect(resolved).not.toBe(injected);
+    expect(typeof resolved.get).toBe("function");
+    expect(typeof resolved.put).toBe("function");
+    expect(typeof resolved.list).toBe("function");
+  });
+
+  test("throws InvalidConfig when neither storage nor BUCKET is present", () => {
+    expect(() => resolveWorkerStorage({}, {})).toThrowError(BaerlyError);
+    try {
+      resolveWorkerStorage({}, {});
+    } catch (error) {
+      expect((error as BaerlyError).code).toBe("InvalidConfig");
+    }
+  });
+});

--- a/packages/adapter-cloudflare/src/worker.ts
+++ b/packages/adapter-cloudflare/src/worker.ts
@@ -4,6 +4,7 @@ import {
   CF_FREE_MAX_SAFE_FOLD_BYTES,
   MAINTENANCE_PROFILE_CF_FREE,
   MAINTENANCE_PROFILE_CF_PAID,
+  type Storage,
   type Verifier,
 } from "@baerly/protocol";
 import { Db, resolveVerifier } from "@baerly/server";
@@ -23,7 +24,7 @@ import {
   runWithContext,
 } from "@baerly/server/observability";
 import { type CacheStatus, invalidateOnWrite, withReadCache } from "./cache.ts";
-import { r2BindingStorage } from "./r2-binding-storage.ts";
+import { resolveWorkerStorage } from "./resolve-storage.ts";
 
 /**
  * Cloudflare Workers have no TTY, so the default sink is always
@@ -84,7 +85,7 @@ const resolveCfSink = (config: ObservabilityConfig | undefined): ObservabilityCo
  *     {@link WorkerScheduledHandler}).
  */
 export interface BaerlyEnv {
-  BUCKET: R2Bucket;
+  BUCKET?: R2Bucket;
   APP: string;
   /**
    * Raise the snapshot-rebuild ceiling `C`. Parsed as a number;
@@ -218,6 +219,16 @@ export interface BaerlyWorkerOptions {
    */
   readonly config: BaerlyAppConfig;
   /**
+   * Request-time `Storage`. **Optional.** When unset, the Worker uses
+   * the same-account R2 binding `env.BUCKET` (the dominant path). Inject
+   * this to talk to S3 / cross-account R2 over the S3 REST API
+   * from a Worker — e.g. `new S3HttpStorage(...)` +
+   * `sigV4Signer(...)` from `@gusto/baerly-storage/s3`. Resolved once
+   * per isolate inside the factory (where `env` is in scope), same as
+   * the R2 binding.
+   */
+  readonly storage?: Storage;
+  /**
    * Cron Trigger handler. When unset, `scheduled()` is a no-op even
    * if `triggers.crons` is declared. See {@link WorkerScheduledHandler}.
    */
@@ -321,6 +332,12 @@ export function baerlyWorker<E extends BaerlyEnv = BaerlyEnv>(
   interface ResolvedState {
     readonly options: BaerlyWorkerOptions;
     readonly verifier: Verifier;
+    // Base Storage resolved once per isolate (injected `options.storage`
+    // or the `env.BUCKET` R2 binding), same lifetime as `verifier`. The
+    // per-request `observableStorage(...)` wrap still happens on every
+    // request — it binds to the request's observability bag — but the
+    // underlying handle is no longer reconstructed each time.
+    readonly storage: Storage;
   }
   let resolved: ResolvedState | undefined;
   // Cached so every subsequent fetch re-throws the same error rather
@@ -350,7 +367,7 @@ export function baerlyWorker<E extends BaerlyEnv = BaerlyEnv>(
             return typeof value === "string" ? value : undefined;
           },
         });
-        resolved = { options, verifier };
+        resolved = { options, verifier, storage: resolveWorkerStorage(options, env) };
       } catch (error) {
         resolutionError = error;
         throw error;
@@ -419,7 +436,7 @@ export function baerlyWorker<E extends BaerlyEnv = BaerlyEnv>(
         });
       }
 
-      const { options, verifier } = await ensureResolved(env);
+      const { options, verifier, storage: baseStorage } = await ensureResolved(env);
 
       // Opt-in dev landing page. Off in production (options.dev
       // unset); when set, GET / serves HTML and GET /favicon.ico
@@ -487,8 +504,10 @@ export function baerlyWorker<E extends BaerlyEnv = BaerlyEnv>(
         // per-call class A/B counts and per-op duration histograms
         // land in the active per-request bag. Writer / compactor / GC
         // emissions reach the same bag via `getCurrentContext()?.recorder`
-        // — the canonical-line flusher reads it at end-of-request.
-        const storage = observableStorage(r2BindingStorage(env.BUCKET));
+        // — the canonical-line flusher reads it at end-of-request. The
+        // base handle is resolved once per isolate (see `ResolvedState`);
+        // only the observability wrap is per-request.
+        const storage = observableStorage(baseStorage);
         const db = Db.create({
           storage,
           app: env.APP,

--- a/packages/adapter-node/src/s3-signer.test.ts
+++ b/packages/adapter-node/src/s3-signer.test.ts
@@ -1,0 +1,80 @@
+import { BaerlyError } from "@baerly/protocol";
+import { describe, expect, test } from "vitest";
+import { sigV4Signer, type SigV4SignerOptions } from "./s3-signer.ts";
+
+describe("sigV4Signer", () => {
+  test("returns a signer that stamps an AWS4-HMAC-SHA256 Authorization header", async () => {
+    const sign = sigV4Signer({
+      accessKeyId: "AKIAEXAMPLE",
+      secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      region: "us-east-1",
+    });
+    const signed = await sign(
+      new Request("https://s3.us-east-1.amazonaws.com/my-bucket/log/00000001", {
+        method: "PUT",
+        body: new Uint8Array([1, 2, 3]),
+      }),
+    );
+    expect(signed.headers.get("authorization")).toMatch(/^AWS4-HMAC-SHA256 /);
+    expect(signed.headers.get("x-amz-content-sha256")).toBeTruthy();
+  });
+
+  test.each([
+    ["empty accessKeyId", { accessKeyId: "", secretAccessKey: "secret", region: "auto" }],
+    ["empty secretAccessKey", { accessKeyId: "AKIA", secretAccessKey: "", region: "auto" }],
+    ["empty region", { accessKeyId: "AKIA", secretAccessKey: "secret", region: "" }],
+    // Whitespace-only wrangler vars are truthy in JS but signing-blank in
+    // effect — a `var` set to `" "` produces the same opaque 403 as one
+    // left empty, so the guard trims before the emptiness check.
+    ["whitespace accessKeyId", { accessKeyId: "  ", secretAccessKey: "secret", region: "auto" }],
+    [
+      "whitespace secretAccessKey",
+      { accessKeyId: "AKIA", secretAccessKey: "\t\n", region: "auto" },
+    ],
+    ["whitespace region", { accessKeyId: "AKIA", secretAccessKey: "secret", region: "   " }],
+    // A wrangler `var` (or process env key) that is declared *nowhere*
+    // resolves to `undefined` at runtime — the `string | undefined` field
+    // type mirrors the documented `env.AWS_ACCESS_KEY_ID` shape, so these
+    // rows need no cast. The guard must fail-close on this (the most common
+    // misconfig) with the same `InvalidConfig`, not let `.trim()` throw a raw
+    // `TypeError` that is more opaque than the 403 it prevents.
+    ["absent accessKeyId", { accessKeyId: undefined, secretAccessKey: "secret", region: "auto" }],
+    ["absent secretAccessKey", { accessKeyId: "AKIA", secretAccessKey: undefined, region: "auto" }],
+    ["absent region", { accessKeyId: "AKIA", secretAccessKey: "secret", region: undefined }],
+  ] satisfies [string, SigV4SignerOptions][])(
+    "throws InvalidConfig on %s rather than signing with blank credentials",
+    (_label, opts) => {
+      expect(() => sigV4Signer(opts)).toThrowError(BaerlyError);
+      try {
+        sigV4Signer(opts);
+      } catch (error) {
+        expect((error as BaerlyError).code).toBe("InvalidConfig");
+      }
+    },
+  );
+
+  test("trims whitespace-padded credentials before signing, not just for the guard", async () => {
+    // A stray leading/trailing space (copy-paste artifact) must not reach the
+    // signer: the Credential scope carries the trimmed access key id + region
+    // verbatim, so padded values here would sign wrong and draw an opaque 403.
+    const signed = await sigV4Signer({
+      accessKeyId: "  AKIAEXAMPLE  ",
+      secretAccessKey: "  secret  ",
+      region: "  us-east-1  ",
+    })(new Request("https://s3.us-east-1.amazonaws.com/b/k", { method: "GET" }));
+    expect(signed.headers.get("authorization")).toMatch(
+      /Credential=AKIAEXAMPLE\/\d{8}\/us-east-1\/s3\/aws4_request/,
+    );
+  });
+
+  test("threads a session token through for temporary credentials", async () => {
+    const sign = sigV4Signer({
+      accessKeyId: "ASIAEXAMPLE",
+      secretAccessKey: "secret",
+      region: "auto",
+      sessionToken: "FQoGZXIvYXdzEXANPLETOKEN",
+    });
+    const signed = await sign(new Request("https://s3.example.com/b/k", { method: "GET" }));
+    expect(signed.headers.get("x-amz-security-token")).toBe("FQoGZXIvYXdzEXANPLETOKEN");
+  });
+});

--- a/packages/adapter-node/src/s3-signer.ts
+++ b/packages/adapter-node/src/s3-signer.ts
@@ -1,0 +1,88 @@
+import { BaerlyError } from "@baerly/protocol";
+import { AwsClient } from "aws4fetch";
+
+/**
+ * Static-credential inputs for {@link sigV4Signer}.
+ */
+export interface SigV4SignerOptions {
+  // Typed `string | undefined`, not `string`: the documented usage feeds
+  // these straight from a Worker `env` / `process.env`, where an absent key
+  // is `undefined` at runtime even when the ambient env type claims `string`.
+  // The keys stay required (so a caller can't silently omit one), but the
+  // value may be absent — `sigV4Signer` fail-closes on absent/blank below.
+  /** AWS access key id (or R2 / Minio equivalent). */
+  accessKeyId: string | undefined;
+  /** AWS secret access key (or R2 / Minio equivalent). */
+  secretAccessKey: string | undefined;
+  /**
+   * Region, e.g. `"us-east-1"`. R2 ignores the value but `aws4fetch`
+   * requires one — use `"auto"` for R2's S3-compat endpoint.
+   */
+  region: string | undefined;
+  /** Optional STS session token for temporary credentials. */
+  sessionToken?: string;
+}
+
+/**
+ * Static-credential SigV4 signer for {@link S3HttpStorage}, safe inside
+ * a Cloudflare Worker: `aws4fetch` signs with WebCrypto, so there is no
+ * `node:crypto` in the closure. Returns the `(req) => Promise<Request>`
+ * seam `S3HttpStorageOptions.sign` expects.
+ *
+ * For rotating credentials, pass your own `(req) => Promise<Request>`
+ * to `S3HttpStorage` instead — this helper covers the static case.
+ *
+ * @example
+ * ```ts
+ * import { S3HttpStorage, sigV4Signer } from "@gusto/baerly-storage/s3";
+ *
+ * const storage = new S3HttpStorage({
+ *   endpoint: env.S3_ENDPOINT,
+ *   bucket: env.S3_BUCKET,
+ *   sign: sigV4Signer({
+ *     accessKeyId: env.AWS_ACCESS_KEY_ID,
+ *     secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+ *     region: env.AWS_REGION,
+ *   }),
+ * });
+ * ```
+ */
+export function sigV4Signer(opts: SigV4SignerOptions): (req: Request) => Promise<Request> {
+  // Fail fast on blank credentials. A wrangler `var` declared but left
+  // empty resolves to "" — without this guard aws4fetch signs with empty
+  // creds and the endpoint answers an opaque 403 on the first request,
+  // far from the misconfig. Mirrors the fail-closed contract on
+  // `resolveWorkerStorage` and `sharedSecret` (empty `SHARED_SECRET`).
+  //
+  // Coalesce-then-trim once, then both validate AND sign with the trimmed
+  // values. A `var`/env key declared *nowhere* resolves to `undefined` at
+  // runtime — the most common misconfig — and a bare `.trim()` on it throws
+  // a raw `TypeError` more opaque than the 403 this guard exists to prevent;
+  // `?? ""` routes absent and blank alike into the fail-closed check.
+  // Trimming catches a whitespace-only value (`" "`, `"\t\n"`), truthy in JS
+  // but signing-blank in effect, and — critically — feeds the *trimmed*
+  // value to `AwsClient`: a stray leading/trailing space on an otherwise
+  // valid credential (a copy-paste artifact) would otherwise pass the guard
+  // yet sign with the padded value, producing an invalid signature and the
+  // same opaque 403. `region` gets the same treatment — an empty region
+  // yields a malformed SigV4 scope (`YYYYMMDD//s3/aws4_request`).
+  const accessKeyId = (opts.accessKeyId ?? "").trim();
+  const secretAccessKey = (opts.secretAccessKey ?? "").trim();
+  const region = (opts.region ?? "").trim();
+  if (!accessKeyId || !secretAccessKey || !region) {
+    throw new BaerlyError(
+      "InvalidConfig",
+      "sigV4Signer: `accessKeyId`, `secretAccessKey`, and `region` must be " +
+        "non-empty. Check the credentials passed from your Worker `env` / " +
+        "process env.",
+    );
+  }
+  const client = new AwsClient({
+    accessKeyId,
+    secretAccessKey,
+    sessionToken: opts.sessionToken,
+    region,
+    service: "s3",
+  });
+  return (req: Request) => client.sign(req);
+}

--- a/packages/adapter-node/src/s3.ts
+++ b/packages/adapter-node/src/s3.ts
@@ -1,0 +1,21 @@
+/**
+ * Runtime-neutral S3-over-HTTP storage entry
+ * (`@gusto/baerly-storage/s3`).
+ *
+ * Unlike `@gusto/baerly-storage/node`, this subpath's import closure
+ * contains **no** `node:` builtins, so it bundles into a Cloudflare
+ * Worker. Reach for it when a Worker must talk to S3 / cross-account
+ * R2 over the S3 REST API instead of a native R2 binding.
+ *
+ * Bundle cost: pulls `aws4fetch` (SigV4) + `fast-xml-parser`. Workers
+ * that use a same-account R2 binding should stay on
+ * `@gusto/baerly-storage/cloudflare`, whose closure carries neither.
+ *
+ * The Worker-safety of this closure is enforced by the esbuild probe in
+ * `tests/integration/s3-worker-safe.test.ts` — the layer linter does not
+ * cover it (adapter-node is Node-only by design).
+ */
+export { S3HttpStorage } from "./s3-http.ts";
+export type { S3HttpStorageOptions } from "./s3-http.ts";
+export { sigV4Signer } from "./s3-signer.ts";
+export type { SigV4SignerOptions } from "./s3-signer.ts";

--- a/rolldown.config.ts
+++ b/rolldown.config.ts
@@ -49,13 +49,14 @@ export default defineConfig({
     "app-config": "packages/protocol/src/app-config.ts",
     cloudflare: "packages/adapter-cloudflare/src/index.ts",
     node: "packages/adapter-node/src/index.ts",
+    s3: "packages/adapter-node/src/s3.ts",
     client: "packages/client/src/index.ts",
     "client-react": "packages/client/src/react/index.ts",
     dev: "packages/dev/src/index.ts",
     "dev-vite": "packages/dev/src/vite-plugin.ts",
   },
   // `fast-xml-parser` and `aws4fetch` are bundled into the library
-  // entries that use them (`dist/node.js` + `dist/dev-vite.js`).
+  // entries that use them (`dist/node.js` + `dist/s3.js` + `dist/dev-vite.js`).
   // They used to be optional peer deps, but pnpm skips optional peers
   // on install, so a fresh `create-baerly-storage` scaffold's
   // `node_modules` had no copy on disk and `vite.config.ts` died on

--- a/tests/fixtures/s3-memory-stub.ts
+++ b/tests/fixtures/s3-memory-stub.ts
@@ -1,0 +1,108 @@
+/**
+ * A minimal in-memory S3-over-`fetch` stub — only the verbs
+ * `S3HttpStorage` emits: `PUT` (with `If-None-Match: "*"` create-if-absent
+ * and `If-Match` CAS), object `GET`, `GET list-type=2` (→ `ListObjectsV2`
+ * XML), and `DELETE`. Every inbound request is recorded so a test can
+ * assert the real SigV4 `Authorization` header rode along — i.e. the
+ * signer ran in the chain and was not silently bypassed.
+ *
+ * Import-free so it loads inside Workerd (the `cloudflare-pool` project),
+ * the same constraint as `tests/fixtures/randomized-cascade.ts`. Shared by
+ * the S3-from-a-Worker tests: `tests/integration/s3-worker-wire.test.ts`
+ * (storage in isolation) and `tests/integration/s3-worker-e2e.test.ts`
+ * (a full `baerlyWorker` routing HTTP through injected `S3HttpStorage`).
+ */
+
+import { expect } from "vitest";
+
+export interface SeenRequest {
+  method: string;
+  url: string;
+  authorization: string | null;
+}
+
+/**
+ * Assert every recorded request carried a real SigV4 `Authorization`
+ * header — i.e. the signer ran in the chain and nothing was silently
+ * bypassed. Shared by the wire test (storage in isolation) and the e2e
+ * test (full `baerlyWorker`), which both need the same proof. Imports
+ * `expect` from `vitest`, available under both the default and
+ * `cloudflare-pool` (Workerd) projects.
+ */
+export function assertAllRequestsSigned(seen: readonly SeenRequest[]): void {
+  expect(seen.length).toBeGreaterThan(0);
+  for (const r of seen) {
+    expect(r.authorization).toMatch(/^AWS4-HMAC-SHA256 /);
+  }
+}
+
+interface Stored {
+  body: Uint8Array;
+  etag: string;
+}
+
+export function makeS3Stub(bucket: string): { fetchImpl: typeof fetch; seen: SeenRequest[] } {
+  const store = new Map<string, Stored>();
+  const seen: SeenRequest[] = [];
+  let seq = 0;
+
+  const fetchImpl = (async (input: RequestInfo | URL): Promise<Response> => {
+    const req = input as Request;
+    const url = new URL(req.url);
+    seen.push({
+      method: req.method,
+      url: req.url,
+      authorization: req.headers.get("authorization"),
+    });
+    const key = decodeURIComponent(url.pathname.replace(new RegExp(`^/${bucket}/?`), ""));
+
+    if (req.method === "GET" && url.searchParams.get("list-type") === "2") {
+      const prefix = url.searchParams.get("prefix") ?? "";
+      const keys = [...store.keys()].filter((k) => k.startsWith(prefix)).toSorted();
+      const xml =
+        `<?xml version="1.0" encoding="UTF-8"?><ListBucketResult>` +
+        keys
+          .map(
+            (k) =>
+              `<Contents><Key>${encodeURIComponent(k)}</Key><ETag>${store.get(k)!.etag}</ETag></Contents>`,
+          )
+          .join("") +
+        `</ListBucketResult>`;
+      return new Response(xml, { status: 200, headers: { "content-type": "application/xml" } });
+    }
+
+    if (req.method === "GET") {
+      const hit = store.get(key);
+      return hit === undefined
+        ? new Response(null, { status: 404 })
+        : // `Uint8Array<ArrayBufferLike>` isn't assignable to the narrowed
+          // lib.dom `BodyInit`, though the runtime accepts it — same cast
+          // `S3HttpStorage#put` makes.
+          new Response(hit.body as BodyInit, { status: 200, headers: { ETag: hit.etag } });
+    }
+
+    if (req.method === "PUT") {
+      const exists = store.has(key);
+      if (req.headers.get("If-None-Match") === "*" && exists) {
+        return new Response(null, { status: 412 });
+      }
+      const ifMatch = req.headers.get("If-Match");
+      if (ifMatch !== null && (!exists || store.get(key)!.etag !== ifMatch)) {
+        return new Response(null, { status: 412 });
+      }
+      const body = new Uint8Array(await req.arrayBuffer());
+      const etag = `"etag-${seq++}"`;
+      store.set(key, { body, etag });
+      return new Response(null, { status: 200, headers: { ETag: etag } });
+    }
+
+    if (req.method === "DELETE") {
+      store.delete(key);
+      return new Response(null, { status: 204 });
+    }
+
+    return new Response(null, { status: 405 });
+  }) as unknown as typeof fetch;
+
+  return { fetchImpl, seen };
+}

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -742,7 +742,12 @@ const BUDGETS: readonly Budget[] = [
   //     shipped code reshuffled across chunk boundaries by a new entry point, not
   //     golf-able waste, so per the POLICY (cf. the index.js fail-closed bump)
   //     min-gz rebaselines. raw/gz stay under main's bounds (419336 / 125799).
-  { entry: "cloudflare.js", raw: 410 * 1024, gz: 123 * 1024, minGz: 44 * 1024 },
+  //   → raw +1 KiB / gz +1 KiB (2026-07-01): the injected-storage feature adds
+  //     the resolveWorkerStorage helper + the ResolvedState resolve-once plumbing
+  //     in worker.ts — genuinely new code in the Worker aggregator. raw crosses
+  //     the 410 KiB bound and gz the 123 KiB bound (measured 420142 raw /
+  //     126038 gz); min-gz is 44325, still under the 44 KiB set above.
+  { entry: "cloudflare.js", raw: 411 * 1024, gz: 124 * 1024, minGz: 44 * 1024 },
   // Client surface — `BaerlyClient<TConfig>` + fetcher plumbing.
   // Browser/runtime-agnostic; no kernel modules in the closure.
   // Budget history:

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -314,9 +314,12 @@ const BUDGETS: readonly Budget[] = [
   //     rather than golf the doc/error.
   //   NOTE (2026-07-01): the gz 71 KiB bump above also absorbs CI's cross-
   //     environment gz nondeterminism (~18 B observed) that flaked the axis
-  //     near the old 70 KiB ceiling. The IRSA credential work on this branch
-  //     ships under the separate `node`/adapter-node entry, not the kernel
-  //     barrel, so it does not move this closure.
+  //     near the old 70 KiB ceiling. The IRSA credential work ships under the
+  //     separate `node`/adapter-node entry, not the kernel barrel, so it does
+  //     not move this closure.
+  //   NOTE (2026-07-01): adding the ./s3 rolldown input re-chunks shared modules
+  //     and nudges the index.js gz closure up (measured 72639 vs 72704 budget,
+  //     65 B of headroom) — still under the 71 KiB bound, left un-bumped.
   { entry: "index.js", raw: 227 * 1024, gz: 71 * 1024, minGz: 20 * 1024 },
   // The three auth verifier factories (bearerJwt, sharedSecret,
   // cloudflareAccess) plus the transitive jose closure pulled in by
@@ -465,7 +468,10 @@ const BUDGETS: readonly Budget[] = [
   //     defaulted switches and prefix-based InvalidConfig exposure with one
   //     exhaustive policy table plus a typed request-boundary marker.
   //     Measured: 346767 raw; gz/min-gz remain under.
-  { entry: "http.js", raw: 339 * 1024, gz: 101 * 1024, minGz: 35 * 1024 },
+  //   → raw +2 KiB (2026-06-30): adding the ./s3 rolldown input re-chunks
+  //     shared modules, nudging this closure over the prior 339 KiB budget.
+  //     Measured: 347346 raw.
+  { entry: "http.js", raw: 341 * 1024, gz: 101 * 1024, minGz: 35 * 1024 },
   // Observability primitives — ObservabilityContext, the
   // request-scoped MetricsRecorder, LogTape config + the
   // JSON sink only (the pretty sink + picocolors now live in
@@ -595,7 +601,10 @@ const BUDGETS: readonly Budget[] = [
   //   → raw −2 KiB / gz −1 KiB (2026-06-24): W4-5 bundle hygiene — constants chunk no
   //     longer in maintenance closure (moved RESOLUTION constants to leaf; JSDoc trim).
   //     Measured: 124579 raw / 38165 gz / 11113 min-gz.
-  { entry: "maintenance.js", raw: 122 * 1024, gz: 38 * 1024, minGz: 11 * 1024 },
+  //   → raw +2 KiB (2026-06-30): adding the ./s3 rolldown input re-chunks
+  //     shared modules, nudging this closure over the prior 122 KiB budget.
+  //     Measured: 125023 raw.
+  { entry: "maintenance.js", raw: 124 * 1024, gz: 38 * 1024, minGz: 11 * 1024 },
   // Cloudflare Workers adapter — re-exports the kernel barrel
   // (Db, Writer, etc.) plus the R2-binding `Storage` impl
   // and the `baerlyCloudflare` helper. Aggregator: closure
@@ -727,7 +736,13 @@ const BUDGETS: readonly Budget[] = [
   //     closure rather than raise the ceiling. Post-trim measured 418893 raw /
   //     125590 gz / 44028 min-gz; min-gz clears 43 KiB by 4 B. Only the raw/gz
   //     creep tripwires are rebaselined.
-  { entry: "cloudflare.js", raw: 410 * 1024, gz: 123 * 1024, minGz: 43 * 1024 },
+  //   → min-gz +1 KiB (2026-07-01): adding the ./s3 rolldown input re-chunks
+  //     shared modules, and this closure's min-gz — already only 4 B under the
+  //     43 KiB ceiling on main — crosses it (measured 44194). The bytes are real
+  //     shipped code reshuffled across chunk boundaries by a new entry point, not
+  //     golf-able waste, so per the POLICY (cf. the index.js fail-closed bump)
+  //     min-gz rebaselines. raw/gz stay under main's bounds (419336 / 125799).
+  { entry: "cloudflare.js", raw: 410 * 1024, gz: 123 * 1024, minGz: 44 * 1024 },
   // Client surface — `BaerlyClient<TConfig>` + fetcher plumbing.
   // Browser/runtime-agnostic; no kernel modules in the closure.
   // Budget history:
@@ -865,6 +880,21 @@ const BUDGETS: readonly Budget[] = [
   //     bundle has no min-gz axis, so gz is its tightest tripwire; rebaselined
   //     gz 14→15 KiB rather than golf the doc/error (see the POLICY on index.js).
   { entry: "dev.js", raw: 40 * 1024, gz: 15 * 1024 },
+  // Worker-safe S3 entry — `S3HttpStorage` + `sigV4Signer` + the
+  // `aws4fetch` SigV4 client + `fast-xml-parser` XML parser.
+  // Intended for cross-account R2 / non-R2 S3 from a Cloudflare
+  // Worker; the `./cloudflare` subpath excludes this closure so
+  // R2-binding consumers don't pay for it.
+  // Budget history:
+  //   → 160 KiB raw / 47 KiB gz / 25 KiB min-gz (2026-07-01): initial
+  //     baseline. Closure: S3HttpStorage + sigV4Signer + the aws4fetch SigV4
+  //     client (emitted as its own shared chunk) + fast-xml-parser, plus the
+  //     assertValidStorageKey key-namespace guard from main (the key-* chunk
+  //     reaches the s3-http closure). Measured: 163298 raw / 47023 gz /
+  //     25100 min-gz. raw/gz are sized with headroom over the chunk-boundary
+  //     overhead that the separate aws4fetch chunk carries; min-gz (the hard
+  //     ceiling, the real shipped-to-browser cost) clears 25 KiB.
+  { entry: "s3.js", raw: 160 * 1024, gz: 47 * 1024, minGz: 25 * 1024 },
 ];
 
 // Static-import specifiers only. Dynamic `import(...)` is intentionally

--- a/tests/integration/s3-worker-e2e.test.ts
+++ b/tests/integration/s3-worker-e2e.test.ts
@@ -1,0 +1,135 @@
+/**
+ * S3-from-a-Worker, end to end — the *composition* proof.
+ *
+ * `s3-worker-wire.test.ts` proves `S3HttpStorage` runs inside Workerd;
+ * `packages/adapter-cloudflare/src/worker-storage.test.ts` proves
+ * `resolveWorkerStorage` picks the injected instance. This test wires the
+ * two together: it builds a real `baerlyWorker` with an injected
+ * `S3HttpStorage` (and **no** `env.BUCKET`), drives an HTTP insert + read
+ * through the Worker's `fetch`, and asserts the round-trip flowed through
+ * the injected storage — i.e. the factory `storage` option reaches the
+ * per-request `Db` and the traffic hit S3, not an R2 binding.
+ *
+ * This is the seam a Worker author actually uses:
+ *
+ *   baerlyWorker((env) => ({ config, storage: new S3HttpStorage(...) }))
+ *
+ * Runs under the `cloudflare-pool` vitest project (Workerd/miniflare) via
+ * `pnpm test:adapter-cloudflare` — the stub is the terminal `fetch`, so
+ * no MinIO, no docker, no network. It lives under `tests/` (not the CF
+ * package `src`) because it imports the node-free `/s3` barrel and the
+ * package-layer linter forbids `adapter-cloudflare → adapter-node`.
+ */
+import { BaerlyError, type BaerlyAppConfig } from "@baerly/protocol";
+import { describe, expect, test } from "vitest";
+import { S3HttpStorage, sigV4Signer } from "../../packages/adapter-node/src/s3.ts";
+import { baerlyWorker, type BaerlyEnv } from "../../packages/adapter-cloudflare/src/worker.ts";
+import { assertAllRequestsSigned, makeS3Stub } from "../fixtures/s3-memory-stub.ts";
+
+const ENDPOINT = "https://s3.us-east-1.amazonaws.com";
+const BUCKET = "e2e-test";
+
+const config: BaerlyAppConfig = {
+  app: "s3-e2e",
+  tenant: "s3-e2e-tenant",
+  target: "cloudflare",
+  // `auth: "none"` pins every request to `config.tenant` — no header
+  // wrangling needed to exercise the storage path.
+  auth: "none",
+  collections: {},
+};
+
+const makeExec = (): ExecutionContext => ({
+  waitUntil(): void {},
+  passThroughOnException(): void {},
+  props: {},
+});
+
+const asCfRequest = (req: Request): Request<unknown, IncomingRequestCfProperties> =>
+  req as Request<unknown, IncomingRequestCfProperties>;
+
+describe("baerlyWorker routes HTTP through injected S3HttpStorage", () => {
+  test("insert then read round-trips through the injected S3 storage, no R2 binding", async () => {
+    const { fetchImpl, seen } = makeS3Stub(BUCKET);
+    const storage = new S3HttpStorage({
+      endpoint: ENDPOINT,
+      bucket: BUCKET,
+      fetch: fetchImpl,
+      sign: sigV4Signer({
+        accessKeyId: "AKIAE2ETEST",
+        secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        region: "us-east-1",
+      }),
+      retries: 0,
+    });
+
+    const handler = baerlyWorker(() => ({ config, storage }));
+    // Deliberately NO `BUCKET` — an S3-only Worker declares no R2 binding.
+    // `BaerlyEnv.BUCKET` is optional; if the injected storage weren't
+    // wired through, `resolveWorkerStorage` would throw `InvalidConfig`.
+    const env: BaerlyEnv = { APP: "s3-e2e-app" };
+
+    const postRes = await handler.fetch!(
+      asCfRequest(
+        new Request("https://x/v1/c/notes", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ doc: { title: "hello from s3" } }),
+        }),
+      ),
+      env,
+      makeExec(),
+    );
+    expect(postRes.status).toBe(201);
+    const { _id } = (await postRes.json()) as { readonly _id: string };
+    expect(typeof _id).toBe("string");
+
+    const getRes = await handler.fetch!(
+      asCfRequest(new Request(`https://x/v1/c/notes/${_id}`, { method: "GET" })),
+      env,
+      makeExec(),
+    );
+    expect(getRes.status).toBe(200);
+    const { data } = (await getRes.json()) as { readonly data: { title: string } };
+    expect(data.title).toBe("hello from s3");
+
+    // The traffic actually went to the injected S3 endpoint, signed —
+    // proof it routed through `storage`, not an R2 binding (there is none).
+    // The endpoint + PUT assertions are the composition-specific proof; the
+    // generic "everything was signed" check is the shared helper.
+    expect(seen.every((r) => r.url.startsWith(`${ENDPOINT}/${BUCKET}/`))).toBe(true);
+    expect(seen.some((r) => r.method === "PUT")).toBe(true);
+    assertAllRequestsSigned(seen);
+  });
+
+  test("fails closed at the baerlyWorker level when neither storage nor BUCKET is present", async () => {
+    // The composition counterpart to `resolveWorkerStorage`'s unit test:
+    // a Worker built with no injected `storage` AND no `env.BUCKET` must
+    // reject the request rather than serve it, and the resolution error is
+    // cached so every subsequent request re-throws the *same* instance
+    // (worker.ts `resolutionError`) rather than re-running resolution.
+    const handler = baerlyWorker(() => ({ config }));
+    const env: BaerlyEnv = { APP: "s3-e2e-app" }; // no BUCKET, no injected storage
+
+    const req = (): Request<unknown, IncomingRequestCfProperties> =>
+      asCfRequest(new Request("https://x/v1/c/notes/anything", { method: "GET" }));
+
+    const attempt = async (): Promise<unknown> => {
+      try {
+        await handler.fetch!(req(), env, makeExec());
+        return undefined;
+      } catch (error) {
+        return error;
+      }
+    };
+
+    const first = await attempt();
+    expect(first).toBeInstanceOf(BaerlyError);
+    expect((first as BaerlyError).code).toBe("InvalidConfig");
+
+    const second = await attempt();
+    // Same instance → served from the `resolutionError` cache, proving the
+    // fail-closed state is sticky and not silently re-resolved per request.
+    expect(second).toBe(first);
+  });
+});

--- a/tests/integration/s3-worker-safe.test.ts
+++ b/tests/integration/s3-worker-safe.test.ts
@@ -1,0 +1,33 @@
+// tests/integration/s3-worker-safe.test.ts
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+import { describe, expect, test } from "vitest";
+
+const distDir = resolve(dirname(fileURLToPath(import.meta.url)), "../../dist");
+const s3Entry = resolve(distDir, "s3.js");
+
+describe("@gusto/baerly-storage/s3 is Worker-safe", () => {
+  test("dist/s3.js exists (built by pretest)", () => {
+    expect(existsSync(s3Entry)).toBe(true);
+  });
+
+  test("bundles for the browser/worker platform with no node: builtin", async () => {
+    // platform:"browser" does NOT auto-externalize node: builtins — if
+    // the closure imports one, esbuild fails to resolve it. A clean build
+    // proves the closure is Workerd-loadable.
+    const result = await build({
+      entryPoints: [s3Entry],
+      bundle: true,
+      platform: "browser",
+      format: "esm",
+      write: false,
+      logLevel: "silent",
+    });
+    expect(result.errors).toEqual([]);
+    const code = result.outputFiles.map((f) => f.text).join("\n");
+    // Belt-and-suspenders: no literal node: specifier survived inlining.
+    expect(code).not.toMatch(/["']node:/);
+  });
+});

--- a/tests/integration/s3-worker-wire.test.ts
+++ b/tests/integration/s3-worker-wire.test.ts
@@ -28,94 +28,10 @@
 import { BaerlyError } from "@baerly/protocol";
 import { describe, expect, test } from "vitest";
 import { S3HttpStorage, sigV4Signer } from "../../packages/adapter-node/src/s3.ts";
+import { assertAllRequestsSigned, makeS3Stub } from "../fixtures/s3-memory-stub.ts";
 
 const ENDPOINT = "https://s3.us-east-1.amazonaws.com";
 const BUCKET = "wire-test";
-
-interface Stored {
-  body: Uint8Array;
-  etag: string;
-}
-
-interface SeenRequest {
-  method: string;
-  url: string;
-  authorization: string | null;
-}
-
-/**
- * A minimal in-memory S3 over `fetch` — only the verbs `S3HttpStorage`
- * emits: `PUT` (with `If-None-Match: "*"` create-if-absent and `If-Match`
- * CAS), object `GET`, `GET list-type=2` (→ `ListObjectsV2` XML), and
- * `DELETE`. Every inbound request is recorded so a test can assert the
- * real SigV4 `Authorization` header rode along — i.e. the signer ran in
- * the chain and was not silently bypassed.
- */
-function makeS3Stub(): { fetchImpl: typeof fetch; seen: SeenRequest[] } {
-  const store = new Map<string, Stored>();
-  const seen: SeenRequest[] = [];
-  let seq = 0;
-
-  const fetchImpl = (async (input: RequestInfo | URL): Promise<Response> => {
-    const req = input as Request;
-    const url = new URL(req.url);
-    seen.push({
-      method: req.method,
-      url: req.url,
-      authorization: req.headers.get("authorization"),
-    });
-    const key = decodeURIComponent(url.pathname.replace(new RegExp(`^/${BUCKET}/?`), ""));
-
-    if (req.method === "GET" && url.searchParams.get("list-type") === "2") {
-      const prefix = url.searchParams.get("prefix") ?? "";
-      const keys = [...store.keys()].filter((k) => k.startsWith(prefix)).toSorted();
-      const xml =
-        `<?xml version="1.0" encoding="UTF-8"?><ListBucketResult>` +
-        keys
-          .map(
-            (k) =>
-              `<Contents><Key>${encodeURIComponent(k)}</Key><ETag>${store.get(k)!.etag}</ETag></Contents>`,
-          )
-          .join("") +
-        `</ListBucketResult>`;
-      return new Response(xml, { status: 200, headers: { "content-type": "application/xml" } });
-    }
-
-    if (req.method === "GET") {
-      const hit = store.get(key);
-      return hit === undefined
-        ? new Response(null, { status: 404 })
-        : // `Uint8Array<ArrayBufferLike>` isn't assignable to the narrowed
-          // lib.dom `BodyInit`, though the runtime accepts it — same cast
-          // `S3HttpStorage#put` makes.
-          new Response(hit.body as BodyInit, { status: 200, headers: { ETag: hit.etag } });
-    }
-
-    if (req.method === "PUT") {
-      const exists = store.has(key);
-      if (req.headers.get("If-None-Match") === "*" && exists) {
-        return new Response(null, { status: 412 });
-      }
-      const ifMatch = req.headers.get("If-Match");
-      if (ifMatch !== null && (!exists || store.get(key)!.etag !== ifMatch)) {
-        return new Response(null, { status: 412 });
-      }
-      const body = new Uint8Array(await req.arrayBuffer());
-      const etag = `"etag-${seq++}"`;
-      store.set(key, { body, etag });
-      return new Response(null, { status: 200, headers: { ETag: etag } });
-    }
-
-    if (req.method === "DELETE") {
-      store.delete(key);
-      return new Response(null, { status: 204 });
-    }
-
-    return new Response(null, { status: 405 });
-  }) as unknown as typeof fetch;
-
-  return { fetchImpl, seen };
-}
 
 const mkStorage = (fetchImpl: typeof fetch): S3HttpStorage =>
   new S3HttpStorage({
@@ -146,7 +62,7 @@ describe("@gusto/baerly-storage/s3 executes inside Workerd", () => {
   });
 
   test("put → get round-trips bytes through real signed requests", async () => {
-    const { fetchImpl, seen } = makeS3Stub();
+    const { fetchImpl, seen } = makeS3Stub(BUCKET);
     const s = mkStorage(fetchImpl);
 
     const put = await s.put("docs/greeting", new TextEncoder().encode("hello from workerd"), {
@@ -160,14 +76,11 @@ describe("@gusto/baerly-storage/s3 executes inside Workerd", () => {
 
     // Every request that reached the wire carried a SigV4 header — proof
     // the real aws4fetch signer ran in the chain in-isolate.
-    expect(seen.length).toBeGreaterThan(0);
-    for (const r of seen) {
-      expect(r.authorization).toMatch(/^AWS4-HMAC-SHA256 /);
-    }
+    assertAllRequestsSigned(seen);
   });
 
   test("If-None-Match:'*' create-if-absent conflict maps to Conflict", async () => {
-    const { fetchImpl } = makeS3Stub();
+    const { fetchImpl } = makeS3Stub(BUCKET);
     const s = mkStorage(fetchImpl);
 
     await s.put("log/00000001", new Uint8Array([1]), { ifNoneMatch: "*" });
@@ -179,7 +92,7 @@ describe("@gusto/baerly-storage/s3 executes inside Workerd", () => {
   });
 
   test("list parses ListObjectsV2 XML with fast-xml-parser in-isolate", async () => {
-    const { fetchImpl } = makeS3Stub();
+    const { fetchImpl } = makeS3Stub(BUCKET);
     const s = mkStorage(fetchImpl);
 
     await s.put("p/a", new Uint8Array([1]), { ifNoneMatch: "*" });

--- a/tests/integration/s3-worker-wire.test.ts
+++ b/tests/integration/s3-worker-wire.test.ts
@@ -1,0 +1,195 @@
+/**
+ * S3-over-HTTP executes *inside Workerd* — the wire-execution proof.
+ *
+ * `tests/integration/s3-worker-safe.test.ts` proves the
+ * `@gusto/baerly-storage/s3` closure *bundles* for the browser/worker
+ * platform (no `node:` builtin survives). That is a load check, not a
+ * run check. This test proves the closure actually *runs* inside a real
+ * Workerd isolate: it instantiates `S3HttpStorage` with the real
+ * `sigV4Signer` (aws4fetch → WebCrypto) and drives a
+ * put → get → conditional-create → list round-trip through an in-memory
+ * S3-shaped `fetch` stub.
+ *
+ * That exercises the exact seams the Node-side S3 tests cannot reach from
+ * Workerd, and which the docs flag as otherwise only covered by the
+ * manual e2e (see `manual-e2e/README.md`):
+ *   - aws4fetch SigV4 signing under Workerd's WebCrypto (not `node:crypto`),
+ *   - `fast-xml-parser` parsing a `ListObjectsV2` body in-isolate,
+ *   - the `Request` body / `Response.arrayBuffer` plumbing under Workerd.
+ *
+ * Runs under the `cloudflare-pool` vitest project (Workerd/miniflare) via
+ * `pnpm test:adapter-cloudflare` — no MinIO, no docker, no network: the
+ * stub is the terminal `fetch`. It lives under `tests/` (not
+ * `packages/adapter-cloudflare/src/`) because the package-layer linter
+ * forbids `adapter-cloudflare → adapter-node`, and it imports the
+ * node-free `/s3` barrel by relative path — NOT `@baerly/adapter-node`,
+ * whose index barrel drags `node:http` and would fail to bundle here.
+ */
+import { BaerlyError } from "@baerly/protocol";
+import { describe, expect, test } from "vitest";
+import { S3HttpStorage, sigV4Signer } from "../../packages/adapter-node/src/s3.ts";
+
+const ENDPOINT = "https://s3.us-east-1.amazonaws.com";
+const BUCKET = "wire-test";
+
+interface Stored {
+  body: Uint8Array;
+  etag: string;
+}
+
+interface SeenRequest {
+  method: string;
+  url: string;
+  authorization: string | null;
+}
+
+/**
+ * A minimal in-memory S3 over `fetch` — only the verbs `S3HttpStorage`
+ * emits: `PUT` (with `If-None-Match: "*"` create-if-absent and `If-Match`
+ * CAS), object `GET`, `GET list-type=2` (→ `ListObjectsV2` XML), and
+ * `DELETE`. Every inbound request is recorded so a test can assert the
+ * real SigV4 `Authorization` header rode along — i.e. the signer ran in
+ * the chain and was not silently bypassed.
+ */
+function makeS3Stub(): { fetchImpl: typeof fetch; seen: SeenRequest[] } {
+  const store = new Map<string, Stored>();
+  const seen: SeenRequest[] = [];
+  let seq = 0;
+
+  const fetchImpl = (async (input: RequestInfo | URL): Promise<Response> => {
+    const req = input as Request;
+    const url = new URL(req.url);
+    seen.push({
+      method: req.method,
+      url: req.url,
+      authorization: req.headers.get("authorization"),
+    });
+    const key = decodeURIComponent(url.pathname.replace(new RegExp(`^/${BUCKET}/?`), ""));
+
+    if (req.method === "GET" && url.searchParams.get("list-type") === "2") {
+      const prefix = url.searchParams.get("prefix") ?? "";
+      const keys = [...store.keys()].filter((k) => k.startsWith(prefix)).toSorted();
+      const xml =
+        `<?xml version="1.0" encoding="UTF-8"?><ListBucketResult>` +
+        keys
+          .map(
+            (k) =>
+              `<Contents><Key>${encodeURIComponent(k)}</Key><ETag>${store.get(k)!.etag}</ETag></Contents>`,
+          )
+          .join("") +
+        `</ListBucketResult>`;
+      return new Response(xml, { status: 200, headers: { "content-type": "application/xml" } });
+    }
+
+    if (req.method === "GET") {
+      const hit = store.get(key);
+      return hit === undefined
+        ? new Response(null, { status: 404 })
+        : // `Uint8Array<ArrayBufferLike>` isn't assignable to the narrowed
+          // lib.dom `BodyInit`, though the runtime accepts it — same cast
+          // `S3HttpStorage#put` makes.
+          new Response(hit.body as BodyInit, { status: 200, headers: { ETag: hit.etag } });
+    }
+
+    if (req.method === "PUT") {
+      const exists = store.has(key);
+      if (req.headers.get("If-None-Match") === "*" && exists) {
+        return new Response(null, { status: 412 });
+      }
+      const ifMatch = req.headers.get("If-Match");
+      if (ifMatch !== null && (!exists || store.get(key)!.etag !== ifMatch)) {
+        return new Response(null, { status: 412 });
+      }
+      const body = new Uint8Array(await req.arrayBuffer());
+      const etag = `"etag-${seq++}"`;
+      store.set(key, { body, etag });
+      return new Response(null, { status: 200, headers: { ETag: etag } });
+    }
+
+    if (req.method === "DELETE") {
+      store.delete(key);
+      return new Response(null, { status: 204 });
+    }
+
+    return new Response(null, { status: 405 });
+  }) as unknown as typeof fetch;
+
+  return { fetchImpl, seen };
+}
+
+const mkStorage = (fetchImpl: typeof fetch): S3HttpStorage =>
+  new S3HttpStorage({
+    endpoint: ENDPOINT,
+    bucket: BUCKET,
+    fetch: fetchImpl,
+    sign: sigV4Signer({
+      accessKeyId: "AKIAWIRETEST",
+      secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      region: "us-east-1",
+    }),
+    retries: 0,
+  });
+
+describe("@gusto/baerly-storage/s3 executes inside Workerd", () => {
+  test("sigV4Signer signs a Request with Workerd's WebCrypto", async () => {
+    const sign = sigV4Signer({ accessKeyId: "AKIA", secretAccessKey: "secret", region: "auto" });
+    const signed = await sign(
+      new Request(`${ENDPOINT}/${BUCKET}/log/00000001`, {
+        method: "PUT",
+        body: new Uint8Array([1, 2, 3]),
+      }),
+    );
+    // AWS4-HMAC-SHA256 + a content hash — computed via `crypto.subtle`,
+    // which is the whole point of running this in-isolate.
+    expect(signed.headers.get("authorization")).toMatch(/^AWS4-HMAC-SHA256 /);
+    expect(signed.headers.get("x-amz-content-sha256")).toBeTruthy();
+  });
+
+  test("put → get round-trips bytes through real signed requests", async () => {
+    const { fetchImpl, seen } = makeS3Stub();
+    const s = mkStorage(fetchImpl);
+
+    const put = await s.put("docs/greeting", new TextEncoder().encode("hello from workerd"), {
+      ifNoneMatch: "*",
+    });
+    expect(put.etag).toBeTruthy();
+
+    const got = await s.get("docs/greeting");
+    expect(got).not.toBeNull();
+    expect(new TextDecoder().decode(got!.body)).toBe("hello from workerd");
+
+    // Every request that reached the wire carried a SigV4 header — proof
+    // the real aws4fetch signer ran in the chain in-isolate.
+    expect(seen.length).toBeGreaterThan(0);
+    for (const r of seen) {
+      expect(r.authorization).toMatch(/^AWS4-HMAC-SHA256 /);
+    }
+  });
+
+  test("If-None-Match:'*' create-if-absent conflict maps to Conflict", async () => {
+    const { fetchImpl } = makeS3Stub();
+    const s = mkStorage(fetchImpl);
+
+    await s.put("log/00000001", new Uint8Array([1]), { ifNoneMatch: "*" });
+    const conflict = await s
+      .put("log/00000001", new Uint8Array([2]), { ifNoneMatch: "*" })
+      .catch((error: unknown) => error);
+    expect(conflict).toBeInstanceOf(BaerlyError);
+    expect((conflict as BaerlyError).code).toBe("Conflict");
+  });
+
+  test("list parses ListObjectsV2 XML with fast-xml-parser in-isolate", async () => {
+    const { fetchImpl } = makeS3Stub();
+    const s = mkStorage(fetchImpl);
+
+    await s.put("p/a", new Uint8Array([1]), { ifNoneMatch: "*" });
+    await s.put("p/b", new Uint8Array([2]), { ifNoneMatch: "*" });
+    await s.put("other/c", new Uint8Array([3]), { ifNoneMatch: "*" });
+
+    const keys: string[] = [];
+    for await (const entry of s.list("p/")) {
+      keys.push(entry.key);
+    }
+    expect(keys.toSorted()).toEqual(["p/a", "p/b"]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -152,6 +152,13 @@ const cfHttpConformanceGlob = "packages/adapter-cloudflare/src/http-conformance.
 // `cloudflare-pool`.
 const cfS3WireGlob = "tests/integration/s3-worker-wire.test.ts";
 
+// S3-from-a-Worker end-to-end (Workerd variant). Builds a real
+// `baerlyWorker` with an injected `S3HttpStorage` (no R2 binding) and
+// drives an HTTP insert/read through its `fetch`, proving the factory
+// `storage` option routes traffic to S3 in-isolate. Same placement +
+// project-membership rationale as `cfS3WireGlob` above.
+const cfS3E2eGlob = "tests/integration/s3-worker-e2e.test.ts";
+
 export default defineConfig({
   test: {
     projects: [
@@ -191,6 +198,7 @@ export default defineConfig({
             cfCacheTestGlob,
             cfHttpConformanceGlob,
             cfS3WireGlob,
+            cfS3E2eGlob,
             // The check-acceptance fixtures vendor `*.test.ts` files
             // that exist purely so the harness's co-occurrence grep
             // can find `insert` + `<table>` heuristics — they aren't
@@ -260,6 +268,7 @@ export default defineConfig({
             cfCacheTestGlob,
             cfHttpConformanceGlob,
             cfS3WireGlob,
+            cfS3E2eGlob,
           ],
           // `tests/setup/r2-binding.ts` runs inside Workerd, imports
           // from `cloudflare:test`, and re-publishes `env.BUCKET` on

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -140,6 +140,18 @@ const cfCacheTestGlob = "packages/adapter-cloudflare/src/cache*.test.ts";
 // default project. Membership rules match the four globs above.
 const cfHttpConformanceGlob = "packages/adapter-cloudflare/src/http-conformance.test.ts";
 
+// S3-over-HTTP wire-execution proof (Workerd variant). Instantiates
+// `S3HttpStorage` + the real `sigV4Signer` and runs a put/get/CAS/list
+// round-trip through an in-memory S3-shaped `fetch` stub INSIDE Workerd,
+// closing the gap the `s3-worker-safe.test.ts` bundle probe can't (load
+// vs. run). Unlike the globs above it lives under `tests/` rather than
+// `packages/adapter-cloudflare/src/`: the package-layer linter forbids
+// `adapter-cloudflare → adapter-node`, so a file that imports
+// `S3HttpStorage` cannot live in the CF package's `src`. Same project
+// membership rules — excluded from the default (Node) project, run under
+// `cloudflare-pool`.
+const cfS3WireGlob = "tests/integration/s3-worker-wire.test.ts";
+
 export default defineConfig({
   test: {
     projects: [
@@ -178,6 +190,7 @@ export default defineConfig({
             cfWorkerTestGlob,
             cfCacheTestGlob,
             cfHttpConformanceGlob,
+            cfS3WireGlob,
             // The check-acceptance fixtures vendor `*.test.ts` files
             // that exist purely so the harness's co-occurrence grep
             // can find `insert` + `<table>` heuristics — they aren't
@@ -246,6 +259,7 @@ export default defineConfig({
             cfWorkerTestGlob,
             cfCacheTestGlob,
             cfHttpConformanceGlob,
+            cfS3WireGlob,
           ],
           // `tests/setup/r2-binding.ts` runs inside Workerd, imports
           // from `cloudflare:test`, and re-publishes `env.BUCKET` on


### PR DESCRIPTION
Cloudflare Workers can talk to S3-compatible storage over HTTP instead of a native R2 binding — an opt-in path for cross-account R2 or AWS S3 from a Worker.

## What's new
- `@gusto/baerly-storage/s3` subpath exports `S3HttpStorage` + `sigV4Signer`, closure guaranteed `node:`-free so it bundles for workerd.
- `baerlyWorker` accepts an optional `storage` in its factory (defaults to the `env.BUCKET` R2 binding); `BaerlyEnv.BUCKET` is now optional so an S3-only Worker needs no R2 binding.

## Coverage
- Bundle probe: `/s3` closure stays `node:`-free (loads in a Worker).
- Wire test: `S3HttpStorage` + `sigV4Signer` run in a real Workerd isolate — signing, XML parse, request/response plumbing against an in-memory S3 stub.
- CI does not drive a real S3 endpoint from workerd; that's the manual e2e recipe. Verify your endpoint with `baerly doctor --bucket`.

## Caveats
- Same support tier as AWS-via-`S3HttpStorage`: credential-gated, operator-owned validation.
- `baerly deploy` / `doctor --target=cloudflare` still assume an R2 binding in `wrangler.jsonc`.

Ships as a minor (changeset included).