### PR TITLE
Harden Storage conformance for remote backends + enforce the key namespace

### DIFF
--- a/.changeset/storage-key-namespace.md
+++ b/.changeset/storage-key-namespace.md
@@ -1,0 +1,30 @@
+---
+"@gusto/baerly-storage": patch
+---
+
+Reject `.` / `..` / empty object keys at the Storage boundary
+
+Every `Storage` adapter (`MemoryStorage`, `S3HttpStorage`, `r2BindingStorage`,
+`LocalFsStorage`) now validates each key on `get` / `put` / `delete` and throws
+`BaerlyError("InvalidConfig")` for an empty key or one whose `/`-delimited path
+has a `.` or `..` segment. Such a key is unaddressable over the S3/R2 HTTP API —
+RFC 3986 dot-segment removal rewrites `<bucket>/.` to the bucket root before the
+request is signed, so a naive PUT surfaces as a confusing bucket-root `403`
+rather than a clear error. The guard runs client-side, before any network call,
+so the rejection is identical across backends and portable to a language port.
+
+**What changed**
+
+- `get` / `put` / `delete` on all adapters reject `""`, `.`, `..`, and any key
+  containing a `.`/`..` path segment with `InvalidConfig`. `list(prefix)` is
+  unaffected — a prefix rides the `?prefix=` query component, where `.`/`..`
+  are harmless.
+- The full-key 1024-byte ceiling continues to be enforced on the write path
+  (`assertKeyWithinLimit`), where multi-segment keys are assembled.
+
+**Migration**
+
+- No action for normal use: the kernel never emits such keys, and
+  caller-controlled segments (`_id`, `collection`, `app`, `tenant`) are already
+  screened one layer up. If you call a `Storage` adapter directly with a bare
+  `.` / `..` / empty key, catch `BaerlyError` with `code === "InvalidConfig"`.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -18,6 +18,14 @@
     "no-underscore-dangle": ["error", { "allow": ["_id", "_raw", "_clear"] }],
     "eslint/curly": "error",
     "vitest/consistent-test-it": ["error", { "fn": "test" }],
+    // `expectEventuallyEqual` (packages/protocol/src/storage/conformance.ts)
+    // polls an eventually-consistent backend then asserts via `expect`
+    // internally; teach expect-expect to count it as an assertion so the
+    // shared conformance harness keeps the no-assertion safety net.
+    "vitest/expect-expect": [
+      "error",
+      { "assertFunctionNames": ["expect", "expectEventuallyEqual"] }
+    ],
     "unicorn/catch-error-name": "error",
     "vitest/prefer-expect-resolves": "error",
     "unicorn/switch-case-braces": "error",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,6 +402,15 @@ auto-load on matching edits and point at the same files.
 - ❌ Skipping or `.skip()`'ing a test to ship. If a test is wrong, fix it;
   if the code is wrong, fix the code.
 - ❌ Hard-coding new magic numbers. Add to `packages/protocol/src/constants.ts`.
+- ❌ Trimming JSDoc, comments, or error-message text to squeeze under the
+  **raw/gz bundle-size budget**. Those two axes are creep _tripwires_; `min-gz`
+  is the only hard ceiling (it's the real shipped-to-browser cost — see the
+  `POLICY` note in `tests/integration/bundle-size.test.ts`, which the failing
+  assertion now also prints). On an intentional change, rebaseline the KiB line
+  with a dated baseline note — don't golf docs/identifiers/messages. Comments
+  ship un-stripped, but doc + error quality outweigh a few raw bytes. (An axis
+  over on `min-gz` is different: that's a real regression — shrink the closure,
+  don't rebaseline.)
 - ❌ Reintroducing `bun:test`, Rome, or baseUrl imports — all replaced.
 - ❌ Extensionless relative imports (`from "./foo"`). Always write
   `from "./foo.ts"` or `from "./foo/index.ts"`. Node's

--- a/docs/spec/s3-xml-escaping-cases.md
+++ b/docs/spec/s3-xml-escaping-cases.md
@@ -134,8 +134,13 @@ S3/R2/MinIO/GCS never emit a DOCTYPE here. The runtime `fast-xml-parser`
 floor is pinned `^5.5.6` to cover the no-DOCTYPE numeric-character-reference
 expansion path (CVE-2026-33036) that the DTD guard cannot match.
 
-> Latent hardening (noted as invariants, not yet implemented): a malformed
-> percent-escape (a bare `%` or `%ZZ`) makes `decodeURIComponent` throw a
-> `URIError`; that should be caught and re-raised as
-> `BaerlyError("InvalidResponse")`, and `baerly doctor --bucket` should
-> probe that the backend honors `encoding-type=url`.
+A malformed percent-escape (a bare `%` or `%ZZ`) in a key field makes
+`decodeURIComponent` throw a raw `URIError`. `xmlVal`
+(`packages/adapter-node/src/xml.ts`) catches it and re-raises as
+`BaerlyError("InvalidResponse")` so the storage layer surfaces a typed,
+catchable error rather than an unhandled runtime exception (covered by
+`xml.test.ts`).
+
+> Latent hardening (noted as an invariant, not yet implemented):
+> `baerly doctor --bucket` should probe that the backend honors
+> `encoding-type=url`.

--- a/docs/spec/storage-compatibility.md
+++ b/docs/spec/storage-compatibility.md
@@ -138,6 +138,21 @@ doctor --bucket` probe races K concurrent creates of a fresh key and
 | **Unsupported**   | GCS (S3-interop), Azure Blob  | `gcsStorage` exists as an S3-interop factory, but GCS documents S3 `If-Match` / `If-None-Match` as read-scoped and baerly-storage does not emit native `x-goog-if-generation-match`, so GCS is unsupported for database use unless a live probe and conformance run prove otherwise. Azure Blob is not an S3 API and has no adapter. |
 | **Anything else** | other S3-compatible endpoints | Run `baerly doctor --bucket`. **Green ⇒ the conditional verbs are honoured — should work, you own production validation. Red ⇒ won't.**                                                                                                                                                                                      |
 
+> **R2's `list` is eventually consistent — and that's fine here.** Unlike
+> AWS S3 (strongly consistent for list since Dec 2020) and the local MinIO
+> dev stack, Cloudflare R2's S3 `ListObjectsV2` is *eventually* consistent:
+> list-after-write and list-after-delete can lag by a short window. This
+> does **not** weaken the protocol. The commit/read path never lists — a
+> commit is a conditional `log/<seq>` create, and readers discover the tail
+> by forward-probe `GET` ("first 404 = tail"), both strongly consistent on
+> R2; `list` is used only by idempotent maintenance enumeration (compaction
+> / GC), which re-runs to convergence. The practical consequence is in
+> testing: the credential-gated `pnpm test:conformance` run against real R2
+> exercises `list`/read-back assertions through a bounded poll
+> (`eventuallyConsistentList` in `defineStorageConformanceSuite`) instead of
+> asserting a single immediate snapshot over the wire. AWS S3, MinIO, and
+> the native R2 binding assert immediately.
+
 ## Per-provider conditional-write matrix
 
 Dated because provider behaviour drifts — re-verify before relying on a

--- a/docs/spec/storage-compatibility.md
+++ b/docs/spec/storage-compatibility.md
@@ -94,6 +94,106 @@ surfacing as an opaque provider 400/403.
 > `.`-free prefix arbitrary.) Only _keys_, which become path segments, are
 > constrained by the dot-segment rule.
 
+## Status → `BaerlyErrorCode` mapping
+
+A `Storage` port translates object-store HTTP status codes into the
+kernel's `BaerlyError` codes. The authoritative sources are the
+`errorCodes[]` table in `packages/server/spec/baerly.spec.json` (which
+carries each code's canonical `httpStatus` and `retriable` hint) and the
+S3-status → code mapping in `packages/adapter-node/src/s3-http.ts`. A
+language port MUST reproduce the mapping below to conform.
+
+Two subtleties are load-bearing:
+
+- **`404` on a plain `GET` is _not_ an error.** A missing key resolves to
+  `null` (`Storage.get` returns `Promise<StorageGetResult | null>`), never
+  a thrown `BaerlyError`. The kernel's forward-probe tail discovery ("first
+  `404` = tail") depends on this: a missing `log/<seq>` must surface as
+  `null`, not an exception. (`s3-http.ts` `get`: `case 404: return null`.)
+- **`409` vs `412` on a conditional create diverge by intent.** A `409
+  ConditionalRequestConflict` on an `If-None-Match: "*"` create means the
+  write was _contended_ and may not have landed, so it maps to a
+  **retryable** `NetworkError` — the single-write-commit writer re-probes
+  and either wins or sees `412`. A direct `Conflict` there would adopt-read
+  a possibly-absent entry. (`s3-http.ts` `put`: the `409 && ifNoneMatch ===
+  "*"` branch.)
+
+| Condition (over the wire / at the boundary)                    | `BaerlyError.code` | Nominal `httpStatus` | Retriable | Source                                                              |
+| -------------------------------------------------------------- | ------------------ | -------------------- | --------- | ------------------------------------------------------------------- |
+| `GET` / `HEAD` `404` (missing key)                             | _(none — `null`)_  | —                    | —         | `s3-http.ts` `get` `case 404: return null`                          |
+| `PUT` with `If-Match` sees `412`                               | `Conflict`         | 409                  | Yes       | `s3-http.ts` `put` `res.status === 412`; spec.json `Conflict`       |
+| `PUT` with `If-Match` sees `404` (MinIO's stale-CAS shape)     | `Conflict`         | 409                  | Yes       | `s3-http.ts` `put` `404 && ifMatch !== undefined`                   |
+| `PUT` `If-None-Match: "*"` sees `409` (contended create)       | `NetworkError`     | 502                  | Yes       | `s3-http.ts` `put` `409 && ifNoneMatch === "*"`                     |
+| Any verb sees `403`                                            | `AccessDenied`     | 403                  | No        | `s3-http.ts` `403` branches; spec.json `AccessDenied`               |
+| Any verb sees `429` or `5xx` (retries exhausted)               | `NetworkError`     | 502                  | Yes       | `s3-http.ts` `429 \|\| status >= 500` branches; spec.json           |
+| Unparseable / unexpected success body or missing `ETag`        | `InvalidResponse`  | 502                  | No        | `s3-http.ts` `InvalidResponse` branches; spec.json                  |
+| Empty key or a `.` / `..` path segment (rejected pre-request)  | `InvalidConfig`    | 400                  | No        | `assertValidStorageKey`; spec.json `InvalidConfig`; see [Key namespace](#key-namespace) |
+
+The `Conflict` code has a nominal `httpStatus` of `409` and is marked
+`retriable: true` in `baerly.spec.json` (CAS lost — the writer re-reads and
+retries). `NetworkError` is `retriable: true` (`httpStatus` `502`);
+`AccessDenied`, `InvalidResponse`, `NotFound`, and `InvalidConfig` are all
+`retriable: false`. A `DELETE` against a missing key throws nothing at all
+— see clause 1 below.
+
+## Storage behavioral contract
+
+These are the behaviors a `Storage` port MUST honour, as asserted by
+`defineStorageConformanceSuite` in
+`packages/protocol/src/storage/conformance.ts`. They are numbered so a
+porter can cite a specific clause.
+
+1. **`delete` MUST be idempotent.** Deleting a key that does not exist MUST
+   resolve successfully (return `undefined`), NOT throw. (`s3-http.ts`
+   treats `200` / `204` / `404` on `DELETE` as success; conformance:
+   _"delete is idempotent on a missing key"_.)
+2. **`get` of a missing key MUST return `null`.** It MUST NOT throw a
+   `NotFound` / `BaerlyError`. (Conformance: _"get of missing key returns
+   null"_.)
+3. **`list("")` MUST enumerate the entire namespace.** An empty prefix is a
+   whole-bucket scan; every stored key MUST be yielded. (Used by the
+   suite's own `deleteAllOnce` teardown and the _"returns the current etag
+   for each entry"_ case, both listing `""`.)
+4. **`startAfter` MUST be strict-exclusive.** When `list(prefix, {
+   startAfter })` is given, the `startAfter` key itself MUST NOT be
+   returned — only keys strictly greater than it. (Conformance: _"startAfter
+   is exclusive"_ and the _"startAfter:k yields strict suffix of lex-sorted
+   keys"_ property.)
+5. **`list` results MUST be sorted by UTF-8 byte order, NOT UTF-16.** For
+   BMP characters the two agree, but they diverge for supplementary-plane
+   characters (surrogate pairs): a UTF-16 code-unit sort orders an emoji
+   _before_ a high-BMP private-use character, while UTF-8 byte order — what
+   S3 / R2 use on the wire — orders it _after_. A port that sorts with its
+   native string comparator will pass the ASCII property tests yet be
+   silently wrong here. The fixed witness vector is the conformance case
+   _"keys sort by UTF-8 byte order, not UTF-16 (supplementary-plane
+   divergence)"_.
+6. **`maxKeys` MUST cap the yielded count** to the first `maxKeys` keys in
+   sort order. (Conformance: _"maxKeys caps the result"_.)
+7. **Body round-trip MUST be byte-exact at the size boundaries.** A `0`-byte
+   body and a 1 MiB (`1048576`-byte) body MUST `put` then `get` back
+   byte-for-byte. (Conformance: _"round-trip exactly 0 bytes"_ …
+   _"round-trip exactly 1048576 bytes"_, capped by `maxBodyBytes`.)
+
+### Out of scope for a `Storage` port
+
+Range-GET (partial-object reads via `Range:`) and delimiter-based listing
+(`?delimiter=` with `CommonPrefixes`) are intentionally OUT OF SCOPE — the
+kernel never issues them, so "unsupported" here means "deliberately not
+required," not "forgotten."
+
+### ETag opacity
+
+The `ETag` string is **opaque**. A port MUST compare it byte-for-byte —
+**including any surrounding quotes** — and round-trip it unchanged; it MUST
+NOT strip quotes, lowercase, or otherwise normalize the value. The
+`ifMatch` CAS contract (see [conditional writes](#s3-is-an-immutable-key-value-store-with-a-single-index))
+depends on this: the writer passes back the exact `etag` string returned by
+a prior `put`, and the store must match it verbatim. The conformance suite
+pins this by asserting `get(...).etag === put(...).etag` exactly, and by
+passing quoted literals such as `"deadbeef"` (with the quotes) straight
+through the `ifMatch` path.
+
 ## Support tiers
 
 baerly-storage's commit path creates-if-absent the numbered `log/<seq>`

--- a/docs/spec/storage-compatibility.md
+++ b/docs/spec/storage-compatibility.md
@@ -3,7 +3,7 @@ title: Storage compatibility
 audience: spec
 doc_type: current-contract
 summary: Which S3-compatible stores baerly-storage supports, and the conditional-write features it depends on.
-last-reviewed: 2026-06-14
+last-reviewed: 2026-06-30
 tags: [protocol, s3]
 related: [s3-xml-escaping-cases.md]
 ---
@@ -41,6 +41,58 @@ This is recent. Until **December 2020**, S3 was only eventually consistent for o
 S3 is an immutable key value store for (potentially very large) binary blobs. The keys are limited in size (1kb), but you can to range queries by prefix query in one direction only.
 
 You cannot update objects in-place — every object is immutable once written. Modern S3 _does_, however, support conditional writes (`If-None-Match: "*"` to create-if-absent, and `If-Match: <etag>` to compare-and-swap), and the protocol depends on them: a commit is a single `If-None-Match: "*"` create on the numbered `log/<seq>` object, and the compactor advances `current.json` with `If-Match` CAS (see [the protocol invariants in sync-protocol.md](sync-protocol.md#protocol-invariants)). So it's tricky getting multiplayer out of this system, but possible thanks to those conditional writes plus the strong consistency guarantees.
+
+## Key namespace
+
+baerly-storage addresses objects by string key over `PUT` / `GET` /
+`DELETE <endpoint>/<bucket>/<key>`. A **valid key** is:
+
+- **non-empty**;
+- at most **1024 bytes** of UTF-8 (`MAX_KEY_BYTES` — the S3/R2 hard limit); and
+- `/`-delimited, with **no path segment equal to `.` or `..`**.
+
+The dot-segment rule is a **portability invariant, not a vendor quirk.**
+RFC 3986 §5.2.4 ("remove dot segments") is mandatory for every conformant
+URL parser, so a key whose segment is `.` or `..` is rewritten _before the
+request is signed or sent_: `<endpoint>/<bucket>/.` normalizes to
+`<endpoint>/<bucket>/` (a bucket-root operation) and
+`<endpoint>/<bucket>/..` escapes the bucket entirely. This happens
+identically in TypeScript (`new URL` / `fetch`), Go (`net/url`), Rust
+(`url`), Python (`urllib`), and any other language a `Storage` port
+targets — over the wire it surfaces as a confusing bucket-root
+`403 AccessDenied`, never a clear error. So the contract is to reject such
+keys **at the boundary**, uniformly, rather than emit an unaddressable
+request.
+
+Enforcement is split by layer:
+
+- The **dot-segment / empty-key** rule (the unaddressable cases above) is
+  enforced at the **raw `Storage` boundary**: every adapter validates the
+  key on `get` / `put` / `delete` and rejects a violation with
+  `BaerlyError{code:"InvalidConfig"}` (`assertValidStorageKey` in
+  `@baerly/protocol`). This is the `Storage`-level counterpart to the
+  higher-level `assertPathSegment` guard, which already screens
+  caller-controlled key _segments_ (`_id`, `collection`, `app`, `tenant`).
+  The cross-adapter "key namespace" block in
+  `defineStorageConformanceSuite` asserts each backend rejects `.` and `..`
+  identically — **a language port MUST reproduce that rejection to
+  conform.**
+- The **1024-byte ceiling** is enforced on the **write path**, where
+  multi-segment keys are assembled (`assertKeyWithinLimit` at the writer's
+  PUT sites), rather than at the `Storage` boundary — per-segment caps
+  don't bound the assembled sum, and this keeps the boundary guard free of
+  a UTF-8 length pass on every call.
+
+The kernel itself never _emits_ a `.` / `..` or over-length key; both
+guards exist so a misuse fails fast and identically everywhere instead of
+surfacing as an opaque provider 400/403.
+
+> **A `list` _prefix_ is not a key.** The prefix passed to `Storage.list`
+> rides the `?prefix=` query component, where `.` / `..` are harmless on
+> AWS S3 and R2. (MinIO's gateway is stricter — it validates the prefix as
+> a POSIX path too — which is why the MinIO conformance run pins a
+> `.`-free prefix arbitrary.) Only _keys_, which become path segments, are
+> constrained by the dot-segment rule.
 
 ## Support tiers
 

--- a/packages/adapter-cloudflare/src/r2-binding-storage.ts
+++ b/packages/adapter-cloudflare/src/r2-binding-storage.ts
@@ -1,5 +1,6 @@
 import {
   BaerlyError,
+  assertValidStorageKey,
   type Storage,
   type StorageGetOptions,
   type StorageGetResult,
@@ -50,6 +51,7 @@ class R2BindingStorageImpl implements Storage {
   }
 
   async get(key: string, opts?: StorageGetOptions): Promise<StorageGetResult | null> {
+    assertValidStorageKey(key);
     opts?.signal?.throwIfAborted();
     const getOpts: R2GetOptions = {};
     if (opts?.ifNoneMatch !== undefined) {
@@ -70,6 +72,7 @@ class R2BindingStorageImpl implements Storage {
   }
 
   async put(key: string, body: Uint8Array, opts?: StoragePutOptions): Promise<StoragePutResult> {
+    assertValidStorageKey(key);
     opts?.signal?.throwIfAborted();
     const putOpts: R2PutOptions = {};
     if (opts?.contentType !== undefined) {
@@ -101,6 +104,7 @@ class R2BindingStorageImpl implements Storage {
   }
 
   async delete(key: string, opts?: { signal?: AbortSignal }): Promise<void> {
+    assertValidStorageKey(key);
     opts?.signal?.throwIfAborted();
     // R2.delete is idempotent — matches the `Storage.delete` contract.
     await this.#callBinding(() => this.#bucket.delete(key), `DELETE ${key}`);

--- a/packages/adapter-node/src/s3-http.conformance.test.ts
+++ b/packages/adapter-node/src/s3-http.conformance.test.ts
@@ -31,12 +31,17 @@ const signer = new AwsClient({
 });
 const sign = (req: Request): Promise<Request> => signer.sign(req);
 
-// Minio's REST gateway rejects request paths whose resource component
-// is `.` or `..` (it validates URL paths as POSIX paths on the backing
-// filesystem) — both `?prefix=.` listing and `PUT /bucket/.` (key=".")
-// surface as `XMinioInvalidResourceName` / `BucketAlreadyOwnedByYou`.
-// AWS S3 and R2 have no such restriction. Pin a `.`-free key + prefix
-// arbitrary for the Minio run only; everything else stays default.
+// A bare `.` / `..` *key* is unaddressable over the S3 HTTP API on every
+// backend (RFC 3986 dot-segment removal rewrites `<bucket>/.` before the
+// request is sent), so the shared `DEFAULT_KEY_ARB` already excludes it
+// and every adapter rejects it with `InvalidConfig` (see the "key
+// namespace" conformance block + docs/spec/storage-compatibility.md).
+// Minio adds a *stricter, Minio-specific* rule the others don't: its REST
+// gateway validates URL paths as POSIX paths on the backing filesystem, so
+// even a `?prefix=.` *listing* (where `.` rides a harmless query param on
+// AWS/R2) surfaces as `XMinioInvalidResourceName`. Pin a `.`-free key +
+// prefix arbitrary for the Minio run to dodge that gateway quirk;
+// everything else stays default.
 const MINIO_KEY_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
 const MINIO_KEY_ARB = fc.string({
   minLength: 1,

--- a/packages/adapter-node/src/s3-http.ts
+++ b/packages/adapter-node/src/s3-http.ts
@@ -4,6 +4,7 @@ import {
   RATE_LIMIT_BACKOFF_MILLIS,
   RETRY_AFTER_MAX_SECONDS,
   S3_REQUEST_MAX_RETRIES,
+  assertValidStorageKey,
   delay,
   type Storage,
   type StorageGetOptions,
@@ -194,6 +195,10 @@ export class S3HttpStorage implements Storage {
   }
 
   #objectUrl(key: string, versionId?: string): string {
+    // Choke point for every key-addressing verb — reject unaddressable
+    // `.`/`..`/empty keys before URL normalization turns them into a
+    // bucket-root 403. @see storage-compatibility.md "Key namespace".
+    assertValidStorageKey(key);
     const base = `${this.#endpoint}/${this.#bucket}/${encodeURIComponent(key)}`;
     return versionId !== undefined ? `${base}?versionId=${encodeURIComponent(versionId)}` : base;
   }

--- a/packages/adapter-node/src/xml.test.ts
+++ b/packages/adapter-node/src/xml.test.ts
@@ -164,6 +164,23 @@ describe("XML parser", () => {
     expect(parsed.Contents?.[0]?.Key).toBe("a\x01b\x1Fc\x7Fd");
   });
 
+  test("NUL byte (%00) in a key round-trips to a literal \\x00", () => {
+    // NUL (0x00) is illegal in XML 1.0 AND 1.1 — it cannot appear even as a
+    // numeric character reference, so encoding-type=url (%00) is the ONLY
+    // representation that can survive a valid ListObjectsV2 body. Pin the
+    // decode: decodeURIComponent("%00") === "\x00", so the parsed key
+    // contains the literal NUL character. Sibling of the ASCII 0–31 cases.
+    const xml: string = `<?xml version="1.0" encoding="UTF-8"?>
+      <ListBucketResult>
+        <Contents><Key>a%00b</Key></Contents>
+      </ListBucketResult>`;
+    const parsed = parseListObjectsV2CommandOutput(xml);
+    expect(parsed.Contents?.[0]?.Key).toBe("a\x00b");
+    // Non-tautology guard: the decoded key must differ from the raw wire form,
+    // proving the percent-escape was actually decoded (not passed through).
+    expect(parsed.Contents?.[0]?.Key).not.toBe("a%00b");
+  });
+
   test("space, %, and unicode in a key round-trip via url-decoding", () => {
     // With encoding-type=url S3 sends a space as `+`, a literal percent as
     // %25, and non-ASCII as percent-encoded UTF-8 (é = %C3%A9).
@@ -173,6 +190,29 @@ describe("XML parser", () => {
       </ListBucketResult>`;
     const parsed = parseListObjectsV2CommandOutput(xml);
     expect(parsed.Contents?.[0]?.Key).toBe("my 50% café");
+  });
+
+  test("malformed percent-escape in a key raises InvalidResponse, not an uncaught URIError", () => {
+    // With encoding-type=url a well-formed key is always valid percent-encoding.
+    // A bare `%` or an invalid pair (`%ZZ`) is a malformed or hostile response:
+    // decodeURIComponent throws a raw URIError. That must be caught and
+    // re-raised as BaerlyError("InvalidResponse") so the storage layer surfaces
+    // a typed, catchable error instead of an unhandled runtime exception.
+    // See docs/spec/s3-xml-escaping-cases.md ("Latent hardening").
+    const bareXml: string = `<?xml version="1.0" encoding="UTF-8"?>
+      <ListBucketResult>
+        <Contents><Key>bad%key</Key></Contents>
+      </ListBucketResult>`;
+    const invalidPairXml: string = `<?xml version="1.0" encoding="UTF-8"?>
+      <ListBucketResult>
+        <Contents><Key>bad%ZZkey</Key></Contents>
+      </ListBucketResult>`;
+    expect(() => parseListObjectsV2CommandOutput(bareXml)).toThrowError(
+      expect.objectContaining({ code: "InvalidResponse" }),
+    );
+    expect(() => parseListObjectsV2CommandOutput(invalidPairXml)).toThrowError(
+      expect.objectContaining({ code: "InvalidResponse" }),
+    );
   });
 
   test("NextContinuationToken is read verbatim — S3 does not url-encode it", () => {
@@ -222,6 +262,32 @@ describe("parseS3Error", () => {
     expect(parseS3Error("plain text 500")).toBeUndefined();
     // <Error> present but no Code/Message → nothing useful to surface.
     expect(parseS3Error("<Error><RequestId>abc</RequestId></Error>")).toBeUndefined();
+  });
+
+  test("decodes builtin XML entities and CDATA in the <Message> text", () => {
+    // DISTINCT from the DOCTYPE <!ENTITY> vector below (which is REJECTED as an
+    // entity-shadow attack): a normal builtin XML entity (&amp;) and a CDATA
+    // block in the Message TEXT are legitimate S3 error content and MUST be
+    // decoded/unwrapped into the plain Message string. fast-xml-parser handles
+    // both (processEntities default + htmlEntities) before rawXmlVal reads the
+    // field, so &amp; → & and <![CDATA[..]]> is unwrapped verbatim.
+    const entityXml: string = `<?xml version="1.0" encoding="UTF-8"?>
+      <Error><Code>InvalidArgument</Code><Message>bucket &amp; key are &lt;required&gt;</Message></Error>`;
+    const entityParsed = parseS3Error(entityXml);
+    expect(entityParsed).toEqual({
+      Code: "InvalidArgument",
+      Message: "bucket & key are <required>",
+    });
+    // Non-tautology guard: the decoded Message must differ from the raw
+    // entity-bearing form, proving the entities were actually expanded.
+    expect(entityParsed?.Message).not.toBe("bucket &amp; key are &lt;required&gt;");
+
+    const cdataXml: string = `<?xml version="1.0" encoding="UTF-8"?>
+      <Error><Code>InvalidArgument</Code><Message><![CDATA[a & b <c>]]></Message></Error>`;
+    expect(parseS3Error(cdataXml)).toEqual({
+      Code: "InvalidArgument",
+      Message: "a & b <c>",
+    });
   });
 
   test("refuses a DTD (XXE guard) and returns undefined", () => {

--- a/packages/adapter-node/src/xml.ts
+++ b/packages/adapter-node/src/xml.ts
@@ -47,7 +47,16 @@ const xmlVal = (obj: Record<string, unknown>, name: string): string | undefined 
   if (typeof v !== "string" || v === "") {
     return undefined;
   }
-  return decodeURIComponent(v.replace(/\+/g, " "));
+  // A well-formed encoding-type=url response only ever contains valid
+  // percent-escapes. A bare `%` or an invalid pair (`%ZZ`) makes
+  // decodeURIComponent throw a raw URIError — catch it and re-raise as a
+  // typed BaerlyError so the storage layer surfaces a catchable error rather
+  // than an unhandled runtime exception. See docs/spec/s3-xml-escaping-cases.md.
+  try {
+    return decodeURIComponent(v.replace(/\+/g, " "));
+  } catch {
+    throw new BaerlyError("InvalidResponse", `Malformed percent-escape in S3 <${name}>: ${v}`);
+  }
 };
 
 // Read a field verbatim. Used for everything S3 does NOT URL-encode:

--- a/packages/dev/src/local-fs.ts
+++ b/packages/dev/src/local-fs.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, posix, relative, resolve, sep } from "node:path";
 import {
   BaerlyError,
+  assertValidStorageKey,
   type Storage,
   type StorageGetOptions,
   type StorageGetResult,
@@ -236,9 +237,9 @@ export class LocalFsStorage implements Storage {
    * `BaerlyError("InvalidConfig", …)`.
    */
   #pathFor(key: string): string {
-    if (key.length === 0) {
-      throw new BaerlyError("InvalidConfig", "LocalFsStorage: empty key");
-    }
+    // Shared Storage key grammar (non-empty, no `.`/`..` segments); the
+    // FS-specific guards below add traversal/backslash/empty-segment checks.
+    assertValidStorageKey(key);
     if (key.startsWith("/")) {
       throw new BaerlyError("InvalidConfig", `LocalFsStorage: leading "/" in key: ${key}`);
     }

--- a/packages/protocol/src/json.test.ts
+++ b/packages/protocol/src/json.test.ts
@@ -219,4 +219,69 @@ describe("JSON Merge Patch (RFC 7386)", () => {
       expect(out).toEqual({ tags: [null, "b"] });
     });
   });
+
+  // Cross-language conformance vectors for the corners a port MUST reproduce.
+  // Some rows align with RFC 7396 Appendix A; two DELIBERATELY diverge from it,
+  // and those divergences are the load-bearing part for a port — get them wrong
+  // and patch coalescing (`fold(merge, undefined, patches)`) silently loses
+  // deletion intent. See docs/spec/json-merge-patch.md, "Log can be coalesced":
+  //   "The `undefined` accumulator is load-bearing. Folding {x:null} from {}
+  //    would produce {} and lose deletion intent. Folding it from `undefined`
+  //    preserves {x:null} as the summary patch."
+  describe("cross-language merge vectors (incl. deliberate RFC 7396 divergences)", () => {
+    // [id, target, patch, expected] — a portable input->output vector table.
+    // `patch` and `expected` are `unknown`: both legitimately carry `null`
+    // (deletion intent / preserved null), which is outside DocumentValue.
+    const rows: Array<[string, DocumentValue | undefined, unknown, unknown]> = [
+      // RFC-aligned (Appendix A row 9): an array patch replaces an array target
+      // wholesale — arrays are opaque, never element-merged.
+      ["array root replaced by array patch (RFC A9)", ["a", "b"], ["c", "d"], ["c", "d"]],
+
+      // RFC-aligned: null deletes an EXISTING key. Contrast with the two
+      // divergent rows below, where the target key is absent.
+      ["null deletes an existing key", { x: 1, y: 2 }, { x: null }, { y: 2 }],
+
+      // DIVERGENCE from RFC A14 ({"a":"b"} strictly): the object patch replaces
+      // the non-object (array) target, but because that target is not a plain
+      // object the patch is taken verbatim — so `c:null` is PRESERVED, not
+      // stripped. A port must preserve it to keep coalescing sound.
+      [
+        "object patch onto array target preserves null (diverges from RFC A14)",
+        [1, 2],
+        {
+          a: "b",
+          c: null,
+        },
+        { a: "b", c: null },
+      ],
+
+      // DIVERGENCE from RFC A15 ({"a":{"bb":{}}} strictly): merging a nested
+      // object into an ABSENT key recurses through `merge(undefined, patch)`,
+      // which returns the patch verbatim — so the deep `ccc:null` is PRESERVED.
+      [
+        "nested null under an absent key is preserved (diverges from RFC A15)",
+        {},
+        {
+          a: { bb: { ccc: null } },
+        },
+        { a: { bb: { ccc: null } } },
+      ],
+
+      // The load-bearing coalescing anchor stated in the spec verbatim:
+      // preserving the null when the accumulator is `undefined`.
+      [
+        "merge(undefined, {x:null}) preserves the delete (spec: undefined accumulator)",
+        undefined,
+        {
+          x: null,
+        },
+        { x: null },
+      ],
+    ];
+    for (const [id, target, patch, expected] of rows) {
+      test(id, () => {
+        expect(merge<DocumentValue>(target, patch as Partial<DocumentValue>)).toEqual(expected);
+      });
+    }
+  });
 });

--- a/packages/protocol/src/storage/conformance.ts
+++ b/packages/protocol/src/storage/conformance.ts
@@ -37,11 +37,10 @@ export interface ConformanceOptions {
   /**
    * Override the arbitrary used as the single-character `prefix`
    * passed to `list(prefix)`. Default: any char from the canonical
-   * `KEY_CHARS` set. Minio's REST gateway rejects URL paths whose
-   * resource component is `.` or `..` (those segments are reserved
-   * by POSIX path semantics on the backing filesystem); Minio-backed
-   * conformance runs pin this to a `.`-free set. AWS S3 and R2 have
-   * no such restriction.
+   * `KEY_CHARS` set (a `list` prefix rides in the `?prefix=` query
+   * component, so `.`/`..` are harmless there — unlike a *key*, which
+   * is a path segment; see {@link keyArb} and the "key namespace"
+   * block). Rarely needs overriding.
    */
   readonly prefixCharArb?: fc.Arbitrary<string>;
   /** Pinned size-boundary cap. Default: 1 MiB. */
@@ -57,11 +56,20 @@ export type ConformanceFactory = () => Promise<ConformanceFactoryResult>;
 
 const KEY_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.";
 
-const DEFAULT_KEY_ARB = fc.string({
-  minLength: 1,
-  maxLength: 32,
-  unit: fc.constantFrom(...KEY_CHARS.split("")),
-});
+// The generated key space is the portable baerly key grammar: a bare `.`
+// or `..` is excluded because it is *not a valid key on any HTTP-S3
+// backend* — RFC 3986 dot-segment removal (universal across every
+// language's URL parser) rewrites `<bucket>/.` → `<bucket>/` before the
+// request is sent, so it can never be addressed. The adapters reject it
+// with `InvalidConfig`; the "key namespace" block below asserts that.
+// @see docs/spec/storage-compatibility.md "Key namespace".
+const DEFAULT_KEY_ARB = fc
+  .string({
+    minLength: 1,
+    maxLength: 32,
+    unit: fc.constantFrom(...KEY_CHARS.split("")),
+  })
+  .filter((k) => k !== "." && k !== "..");
 
 const DEFAULT_BODY_ARB = fc.uint8Array({ minLength: 0, maxLength: 4096 });
 
@@ -191,6 +199,34 @@ export function defineStorageConformanceSuite(
           expect(got!.body.length).toBe(size);
           expect(bytesEqual(got!.body, body)).toBe(true);
           expect(got!.etag).toBe(etag);
+        });
+      }
+    });
+
+    describe("key namespace", () => {
+      // A bare "." or ".." is not a valid key on ANY backend and every
+      // adapter must reject it *identically* with `InvalidConfig`. On the
+      // HTTP-S3 adapters it is physically unaddressable — RFC 3986
+      // dot-segment removal (universal across every language's URL parser)
+      // rewrites `<bucket>/.` → `<bucket>/` before the request is signed,
+      // so a naïve PUT hits the bucket root and 403s. The binding / memory
+      // / local-fs adapters could technically store it, but reject it too
+      // so the portable contract is one rule, not per-backend. This is the
+      // cross-adapter equivalent of `assertPathSegment` one layer up.
+      // @see docs/spec/storage-compatibility.md "Key namespace".
+      const enc = new TextEncoder();
+      for (const badKey of [".", ".."]) {
+        const label = JSON.stringify(badKey);
+        test(`put(${label}) rejects with InvalidConfig`, async () => {
+          const p = s.put(badKey, enc.encode("v"));
+          await expect(p).rejects.toBeInstanceOf(BaerlyError);
+          await expect(p).rejects.toMatchObject({ code: "InvalidConfig" });
+        });
+        test(`get(${label}) rejects with InvalidConfig`, async () => {
+          await expect(s.get(badKey)).rejects.toMatchObject({ code: "InvalidConfig" });
+        });
+        test(`delete(${label}) rejects with InvalidConfig`, async () => {
+          await expect(s.delete(badKey)).rejects.toMatchObject({ code: "InvalidConfig" });
         });
       }
     });

--- a/packages/protocol/src/storage/conformance.ts
+++ b/packages/protocol/src/storage/conformance.ts
@@ -656,6 +656,38 @@ export function defineStorageConformanceSuite(
         );
       });
 
+      // Sort order is UTF-8 BYTE order, not the host language's default string
+      // sort. For BMP characters the two agree, but they DIVERGE for
+      // supplementary-plane characters (encoded as surrogate pairs in UTF-16):
+      // a UTF-16 code-unit sort (JS's default, and some languages' `char`
+      // comparator) orders an emoji BEFORE a high-BMP private-use character,
+      // while UTF-8 byte order — what S3/R2 use on the wire, and what
+      // MemoryStorage / LocalFsStorage implement via `compareKeysUtf8` — orders
+      // it AFTER. `keyArb` is ASCII-only, so the property tests below never
+      // exercise this; a port that sorts with its native string comparator will
+      // pass those yet be silently wrong here. This fixed vector is the witness.
+      // @see docs/spec/storage-compatibility.md "Key namespace".
+      test("keys sort by UTF-8 byte order, not UTF-16 (supplementary-plane divergence)", async () => {
+        const enc = new TextEncoder();
+        // Inserted unsorted. Expected UTF-8-byte order is
+        //   "a" (0x61) < "é" (0xC3 0xA9) < "\uE000" (0xEE..) < "🌍" (0xF0..).
+        // A UTF-16 sort would instead place "🌍" (lead surrogate 0xD83C =
+        // 55356) before "\uE000" (0xE000 = 57344).
+        const keys = ["🌍", "\uE000", "é", "a"];
+        const expected = ["a", "é", "\uE000", "🌍"];
+        for (const k of keys) {
+          await s.put(k, enc.encode("v"));
+        }
+        await expectEventuallyEqual(
+          () => collect(s.list("")).then((l) => l.map((e) => e.key)),
+          expected,
+          settle,
+        );
+        // Non-tautology guard: a naive UTF-16 sort of the same keys does NOT
+        // match the expected UTF-8 order, so the assertion above has teeth.
+        expect(keys.toSorted()).not.toEqual(expected);
+      });
+
       // Property: list(prefix) returns lex-sorted keys-with-prefix.
       // `keyArb` is constrained to non-slash characters, so prefixes
       // are simply a leading substring. Uniqueness is enforced by

--- a/packages/protocol/src/storage/conformance.ts
+++ b/packages/protocol/src/storage/conformance.ts
@@ -45,6 +45,36 @@ export interface ConformanceOptions {
   readonly prefixCharArb?: fc.Arbitrary<string>;
   /** Pinned size-boundary cap. Default: 1 MiB. */
   readonly maxBodyBytes?: number;
+  /**
+   * When true, the backend's `list` is eventually consistent —
+   * list-after-write and list-after-delete may lag, as real Cloudflare
+   * R2's S3 `ListObjectsV2` does (object read-after-write and the
+   * conditional-write verbs stay strong; only the bucket index lags).
+   * List/read-back assertions and the per-test `drain()` reset then poll
+   * until the store converges instead of asserting a single immediate
+   * snapshot. Defaults to false — Memory/LocalFs/Minio/native-R2-binding
+   * are strongly consistent for list and assert the first read.
+   *
+   * This flag is about *consistency* only. The *network-latency*
+   * accommodations (reduced property `numRuns`, raised per-test timeout)
+   * live on {@link remoteNetwork}, which this flag implies — an
+   * eventually-consistent backend is necessarily remote.
+   */
+  readonly eventuallyConsistentList?: boolean;
+  /**
+   * When true, the backend is a real remote HTTP endpoint (AWS S3, GCS,
+   * Cloudflare R2 over the S3 API) where every op is a network
+   * round-trip. Independent of the consistency model: AWS S3 is strongly
+   * consistent yet still remote. Property-test `numRuns` is reduced (the
+   * default 100 is hundreds of round-trips per property — infeasible in
+   * the test budget, and a resulting timeout orphan-bleeds writes into
+   * later tests via the shared handle, see `tests/setup/fast-check.ts`)
+   * and the per-test timeout is raised to absorb network latency.
+   * {@link eventuallyConsistentList} implies this. Defaults to false —
+   * Memory/LocalFs/native-R2-binding and the local Minio dev stack run
+   * the full local fuzz budget under the default timeout.
+   */
+  readonly remoteNetwork?: boolean;
 }
 
 export interface ConformanceFactoryResult {
@@ -73,6 +103,86 @@ const DEFAULT_KEY_ARB = fc
 
 const DEFAULT_BODY_ARB = fc.uint8Array({ minLength: 0, maxLength: 4096 });
 
+/**
+ * Convergence budget for a backend whose `list` is eventually consistent
+ * (`eventuallyConsistentList`). List/read-back assertions and the per-test
+ * `drain()` reset poll up to this long for the store to settle before
+ * asserting. Strongly-consistent backends use `settle === 0` and assert
+ * the first read, so this is never paid by Memory/LocalFs/Minio/R2-binding.
+ */
+const EVENTUAL_CONSISTENCY_SETTLE_MILLIS = 15_000;
+/** Poll interval while waiting for an eventually-consistent backend to settle. */
+const EVENTUAL_CONSISTENCY_POLL_MILLIS = 250;
+/**
+ * Per-test/hook timeout raised for a remote-network backend: each op is a
+ * real network round-trip (and, on an eventually-consistent backend,
+ * assertions poll), so the 5s default is too tight. Applied as the
+ * suite-level `timeout` (cascades to every inner test) and as the explicit
+ * `beforeEach` hook timeout.
+ */
+const REMOTE_NETWORK_TEST_TIMEOUT_MILLIS = 120_000;
+/**
+ * fast-check `numRuns` for property tests on a remote-network backend. The
+ * default 100 is hundreds of network round-trips per property — infeasible
+ * in the test budget, and a resulting timeout orphan-bleeds writes into
+ * later tests via the shared handle (see `tests/setup/fast-check.ts`). The
+ * heavy fuzzing runs on the in-memory / local-fs adapters; this only
+ * smoke-checks the property over the wire.
+ */
+const REMOTE_NETWORK_PROPERTY_RUNS = 10;
+/**
+ * fast-check `numRuns` for property tests on an eventually-consistent
+ * backend — fewer than {@link REMOTE_NETWORK_PROPERTY_RUNS}. Each iteration
+ * pays *two* convergence polls (the `drain()` reset and the settle-assert,
+ * up to {@link EVENTUAL_CONSISTENCY_SETTLE_MILLIS} each), so an
+ * eventually-consistent iteration costs ~2× a strongly-consistent remote
+ * one. At 10 runs a slow-convergence window can spill past the raised
+ * per-test timeout; halving the runs keeps the property comfortably inside
+ * it while still smoke-checking it over the wire.
+ */
+const EVENTUAL_CONSISTENCY_PROPERTY_RUNS = 5;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Read until `ok(value)` holds or the convergence deadline elapses, then
+ * return the last value read. With `settle === 0` (strongly-consistent
+ * backend) this is a single immediate read — behaviourally identical to a
+ * bare `await read()`. On non-convergence it returns the last value so the
+ * caller's assertion produces a meaningful diff rather than a timeout.
+ */
+async function pollUntil<T>(
+  read: () => Promise<T>,
+  ok: (value: T) => boolean,
+  settle: number,
+): Promise<T> {
+  let value = await read();
+  if (settle === 0 || ok(value)) {
+    return value;
+  }
+  const deadline = Date.now() + settle;
+  while (Date.now() < deadline) {
+    await sleep(EVENTUAL_CONSISTENCY_POLL_MILLIS);
+    value = await read();
+    if (ok(value)) {
+      return value;
+    }
+  }
+  return value;
+}
+
+const jsonEq = (a: unknown, b: unknown): boolean => JSON.stringify(a) === JSON.stringify(b);
+
+/** Poll `read` until it deep-equals `expected` (or the deadline), then assert. */
+async function expectEventuallyEqual<T>(
+  read: () => Promise<T>,
+  expected: T,
+  settle: number,
+): Promise<void> {
+  const actual = await pollUntil(read, (v) => jsonEq(v, expected), settle);
+  expect(actual).toEqual(expected);
+}
+
 const collect = async <T>(iter: AsyncIterable<T>): Promise<T[]> => {
   const out: T[] = [];
   for await (const x of iter) {
@@ -88,11 +198,33 @@ const collect = async <T>(iter: AsyncIterable<T>): Promise<T[]> => {
  * conformance suite already wires a per-test `factory()` for hard
  * isolation between vitest cases.
  */
-const drain = async (s: Storage): Promise<void> => {
-  const listed = await collect(s.list(""));
-  const keys = listed.map((e) => e.key);
-  for (const k of keys) {
-    await s.delete(k);
+const drain = async (s: Storage, settle = 0): Promise<void> => {
+  const deleteAllOnce = async (): Promise<number> => {
+    const listed = await collect(s.list(""));
+    const keys = listed.map((e) => e.key);
+    for (const k of keys) {
+      await s.delete(k);
+    }
+    return keys.length;
+  };
+  if (settle === 0) {
+    await deleteAllOnce();
+    return;
+  }
+  // Eventually-consistent backend: a just-written (or just-deleted) key
+  // may not yet be reflected in `list`, so a single sweep can leave
+  // residue that bleeds into the next test. Sweep until two consecutive
+  // lists come back empty, or the convergence deadline elapses.
+  const deadline = Date.now() + settle;
+  let consecutiveEmpty = 0;
+  while (Date.now() < deadline && consecutiveEmpty < 2) {
+    const removed = await deleteAllOnce();
+    if (removed === 0) {
+      consecutiveEmpty += 1;
+      await sleep(EVENTUAL_CONSISTENCY_POLL_MILLIS);
+    } else {
+      consecutiveEmpty = 0;
+    }
   }
 };
 
@@ -140,9 +272,36 @@ export function defineStorageConformanceSuite(
     bodyArb: options.bodyArb ?? DEFAULT_BODY_ARB,
     prefixCharArb: options.prefixCharArb ?? fc.constantFrom(...KEY_CHARS.split("")),
     maxBodyBytes: options.maxBodyBytes ?? 1 << 20,
+    eventuallyConsistentList: options.eventuallyConsistentList ?? false,
+    remoteNetwork: options.remoteNetwork ?? false,
   };
 
-  describe(`Storage conformance — ${name}`, () => {
+  // An eventually-consistent backend is necessarily remote, so it inherits
+  // the network-latency accommodations below even if the caller only set
+  // the consistency flag.
+  const isRemote = opts.remoteNetwork || opts.eventuallyConsistentList;
+  // Convergence budget (0 = strongly-consistent, assert the first read).
+  // Gated on the *consistency* flag only — a strongly-consistent remote
+  // backend (AWS S3) still asserts the first read.
+  const settle = opts.eventuallyConsistentList ? EVENTUAL_CONSISTENCY_SETTLE_MILLIS : 0;
+  // Reduced property-test fuzzing for a remote-network backend; `undefined`
+  // leaves the global `numRuns` (see fast-check.ts). An eventually-
+  // consistent backend polls twice per iteration (drain + settle-assert),
+  // so it runs fewer iterations still.
+  const propRuns = opts.eventuallyConsistentList
+    ? EVENTUAL_CONSISTENCY_PROPERTY_RUNS
+    : REMOTE_NETWORK_PROPERTY_RUNS;
+  const propParams = isRemote ? { numRuns: propRuns } : undefined;
+  // A remote backend does real network round-trips (and, when eventually
+  // consistent, polls), so the default 5s per-test/hook timeout is too
+  // tight. `undefined` leaves the runner default for local backends. The
+  // suite-level option cascades to every inner test (including the
+  // fast-check property tests); the per-hook timeout below covers the
+  // `drain()` in `beforeEach`. (`vi.setConfig` in a hook is too late —
+  // vitest binds timeouts at collection time.)
+  const testTimeoutMs = isRemote ? REMOTE_NETWORK_TEST_TIMEOUT_MILLIS : undefined;
+
+  describe(`Storage conformance — ${name}`, { timeout: testTimeoutMs }, () => {
     let s: Storage;
     let teardown: (() => Promise<void>) | undefined;
 
@@ -155,8 +314,8 @@ export function defineStorageConformanceSuite(
       // sees the residue of every prior test. Drain on entry so each
       // case starts from an empty namespace. No-op for fresh in-memory
       // / temp-dir factories.
-      await drain(s);
-    });
+      await drain(s, settle);
+    }, testTimeoutMs);
     afterEach(async () => {
       if (teardown) {
         await teardown();
@@ -165,12 +324,16 @@ export function defineStorageConformanceSuite(
     });
 
     describe("get/put round-trip", () => {
-      fcTest.prop({ k: opts.keyArb, body: opts.bodyArb })(
+      fcTest.prop({ k: opts.keyArb, body: opts.bodyArb }, propParams)(
         "get(put(k, body)).body === body and etag matches",
         async ({ k, body }) => {
-          await drain(s);
+          await drain(s, settle);
           const put = await s.put(k, body);
-          const got = await s.get(k);
+          const got = await pollUntil(
+            () => s.get(k),
+            (g) => g !== null && g.etag === put.etag && bytesEqual(g.body, body),
+            settle,
+          );
           expect(got).not.toBeNull();
           expect(bytesEqual(got!.body, body)).toBe(true);
           expect(got!.etag).toBe(put.etag);
@@ -194,7 +357,11 @@ export function defineStorageConformanceSuite(
             body[i] = i & 0xff;
           }
           const { etag } = await s.put("size", body);
-          const got = await s.get("size");
+          const got = await pollUntil(
+            () => s.get("size"),
+            (g) => g !== null && g.etag === etag && g.body.length === size,
+            settle,
+          );
           expect(got).not.toBeNull();
           expect(got!.body.length).toBe(size);
           expect(bytesEqual(got!.body, body)).toBe(true);
@@ -234,11 +401,23 @@ export function defineStorageConformanceSuite(
     describe("CAS — ifMatch", () => {
       test("succeeds and rotates etag on current etag", async () => {
         const first = await s.put("k", new TextEncoder().encode("v1"));
+        // On an eventually-consistent backend the `ifMatch` overwrite can
+        // hit a replica that hasn't seen `first` yet and spuriously 412 —
+        // wait until the first write is observable before the CAS.
+        await pollUntil(
+          () => s.get("k"),
+          (g) => g !== null && g.etag === first.etag,
+          settle,
+        );
         const second = await s.put("k", new TextEncoder().encode("v2"), {
           ifMatch: first.etag,
         });
         expect(second.etag).not.toBe(first.etag);
-        const got = await s.get("k");
+        const got = await pollUntil(
+          () => s.get("k"),
+          (g) => g !== null && g.etag === second.etag,
+          settle,
+        );
         expect(got).not.toBeNull();
         expect(got!.etag).toBe(second.etag);
       });
@@ -284,7 +463,11 @@ export function defineStorageConformanceSuite(
         await expect(
           s.put("k", new TextEncoder().encode("overwrite"), { ifNoneMatch: "*" }),
         ).rejects.toBeInstanceOf(BaerlyError);
-        const got = await s.get("k");
+        const got = await pollUntil(
+          () => s.get("k"),
+          (g) => g !== null && bytesEqual(g.body, original),
+          settle,
+        );
         expect(got).not.toBeNull();
         expect(bytesEqual(got!.body, original)).toBe(true);
       });
@@ -383,12 +566,21 @@ export function defineStorageConformanceSuite(
     describe("conditional get — ifNoneMatch", () => {
       test("returns null when current etag matches ifNoneMatch", async () => {
         const { etag } = await s.put("k", new TextEncoder().encode("v"));
-        await expect(s.get("k", { ifNoneMatch: etag })).resolves.toBeNull();
+        const got = await pollUntil(
+          () => s.get("k", { ifNoneMatch: etag }),
+          (g) => g === null,
+          settle,
+        );
+        expect(got).toBeNull();
       });
 
       test("returns the object when ifNoneMatch is stale", async () => {
         const { etag } = await s.put("k", new TextEncoder().encode("v"));
-        const got = await s.get("k", { ifNoneMatch: '"deadbeef"' });
+        const got = await pollUntil(
+          () => s.get("k", { ifNoneMatch: '"deadbeef"' }),
+          (g) => g !== null && g.etag === etag,
+          settle,
+        );
         expect(got).not.toBeNull();
         expect(got!.etag).toBe(etag);
       });
@@ -398,7 +590,12 @@ export function defineStorageConformanceSuite(
       test("removes a present key", async () => {
         await s.put("k", new TextEncoder().encode("v"));
         await s.delete("k");
-        await expect(s.get("k")).resolves.toBeNull();
+        const got = await pollUntil(
+          () => s.get("k"),
+          (g) => g === null,
+          settle,
+        );
+        expect(got).toBeNull();
       });
 
       test("is idempotent on a missing key", async () => {
@@ -413,40 +610,50 @@ export function defineStorageConformanceSuite(
         await s.put("a/3", new TextEncoder().encode("a3"));
         await s.put("a/2", new TextEncoder().encode("a2"));
         await s.put("c/0", new TextEncoder().encode("c0"));
-        const listed = await collect(s.list("a/"));
-        const all = listed.map((e) => e.key);
-        expect(all).toEqual(["a/1", "a/2", "a/3"]);
+        await expectEventuallyEqual(
+          () => collect(s.list("a/")).then((l) => l.map((e) => e.key)),
+          ["a/1", "a/2", "a/3"],
+          settle,
+        );
       });
 
       test("startAfter is exclusive", async () => {
         await s.put("a/1", new TextEncoder().encode("a1"));
         await s.put("a/2", new TextEncoder().encode("a2"));
         await s.put("a/3", new TextEncoder().encode("a3"));
-        const listed = await collect(s.list("a/", { startAfter: "a/1" }));
-        const after = listed.map((e) => e.key);
-        expect(after).toEqual(["a/2", "a/3"]);
+        await expectEventuallyEqual(
+          () => collect(s.list("a/", { startAfter: "a/1" })).then((l) => l.map((e) => e.key)),
+          ["a/2", "a/3"],
+          settle,
+        );
       });
 
       test("maxKeys caps the result", async () => {
         await s.put("a/1", new TextEncoder().encode("a1"));
         await s.put("a/2", new TextEncoder().encode("a2"));
         await s.put("a/3", new TextEncoder().encode("a3"));
-        const listed = await collect(s.list("a/", { maxKeys: 2 }));
-        const capped = listed.map((e) => e.key);
-        expect(capped).toEqual(["a/1", "a/2"]);
+        await expectEventuallyEqual(
+          () => collect(s.list("a/", { maxKeys: 2 })).then((l) => l.map((e) => e.key)),
+          ["a/1", "a/2"],
+          settle,
+        );
       });
 
       test("returns the current etag for each entry", async () => {
         const a = await s.put("a", new TextEncoder().encode("alpha"));
         const b = await s.put("b", new TextEncoder().encode("beta"));
-        const entries = await collect(s.list(""));
         // `StorageListEntry.lastModified` is optional per the type;
         // some adapters (R2 binding, S3) populate it from server-side
         // headers. Project to the load-bearing fields only.
-        expect(entries.map(({ key, etag }) => ({ key, etag }))).toEqual([
-          { key: "a", etag: a.etag },
-          { key: "b", etag: b.etag },
-        ]);
+        await expectEventuallyEqual(
+          () =>
+            collect(s.list("")).then((entries) => entries.map(({ key, etag }) => ({ key, etag }))),
+          [
+            { key: "a", etag: a.etag },
+            { key: "b", etag: b.etag },
+          ],
+          settle,
+        );
       });
 
       // Property: list(prefix) returns lex-sorted keys-with-prefix.
@@ -454,35 +661,43 @@ export function defineStorageConformanceSuite(
       // are simply a leading substring. Uniqueness is enforced by
       // `fc.uniqueArray`; gated on `caseSensitiveKeys` because some
       // stores collapse keys that differ only in case.
-      fcTest.prop({
-        entries: fc.uniqueArray(fc.tuple(opts.keyArb, opts.bodyArb), {
-          minLength: 0,
-          maxLength: 16,
-          selector: ([k]) => (opts.caseSensitiveKeys ? k : k.toLowerCase()),
-        }),
-        prefixChar: opts.prefixCharArb,
-      })("list(prefix) returns sorted keys-with-prefix", async ({ entries, prefixChar }) => {
-        await drain(s);
+      fcTest.prop(
+        {
+          entries: fc.uniqueArray(fc.tuple(opts.keyArb, opts.bodyArb), {
+            minLength: 0,
+            maxLength: 16,
+            selector: ([k]) => (opts.caseSensitiveKeys ? k : k.toLowerCase()),
+          }),
+          prefixChar: opts.prefixCharArb,
+        },
+        propParams,
+      )("list(prefix) returns sorted keys-with-prefix", async ({ entries, prefixChar }) => {
+        await drain(s, settle);
         for (const [k, body] of entries) {
           await s.put(k, body);
         }
-        const collected = await collect(s.list(prefixChar));
-        const listed = collected.map((e) => e.key);
         const expected = entries
           .map(([k]) => k)
           .filter((k) => k.startsWith(prefixChar))
           .toSorted();
-        expect(listed).toEqual(expected);
+        await expectEventuallyEqual(
+          () => collect(s.list(prefixChar)).then((c) => c.map((e) => e.key)),
+          expected,
+          settle,
+        );
       });
 
-      fcTest.prop({
-        entries: fc.uniqueArray(fc.tuple(opts.keyArb, opts.bodyArb), {
-          minLength: 1,
-          maxLength: 16,
-          selector: ([k]) => (opts.caseSensitiveKeys ? k : k.toLowerCase()),
-        }),
-      })("startAfter:k yields strict suffix of lex-sorted keys", async ({ entries }) => {
-        await drain(s);
+      fcTest.prop(
+        {
+          entries: fc.uniqueArray(fc.tuple(opts.keyArb, opts.bodyArb), {
+            minLength: 1,
+            maxLength: 16,
+            selector: ([k]) => (opts.caseSensitiveKeys ? k : k.toLowerCase()),
+          }),
+        },
+        propParams,
+      )("startAfter:k yields strict suffix of lex-sorted keys", async ({ entries }) => {
+        await drain(s, settle);
         for (const [k, body] of entries) {
           await s.put(k, body);
         }
@@ -490,16 +705,23 @@ export function defineStorageConformanceSuite(
         // Use the first key as the cursor — should yield everything
         // strictly greater than it.
         const cursor = sorted[0]!;
-        const collected = await collect(s.list("", { startAfter: cursor }));
-        const listed = collected.map((e) => e.key);
-        expect(listed).toEqual(sorted.filter((k) => k > cursor));
+        const expected = sorted.filter((k) => k > cursor);
+        await expectEventuallyEqual(
+          () => collect(s.list("", { startAfter: cursor })).then((c) => c.map((e) => e.key)),
+          expected,
+          settle,
+        );
       });
     });
 
     describe("binary fidelity", () => {
       test("PNG byte sequence round-trips byte-for-byte", async () => {
         await s.put("img", PNG_FIXTURE);
-        const got = await s.get("img");
+        const got = await pollUntil(
+          () => s.get("img"),
+          (g) => g !== null && bytesEqual(g.body, PNG_FIXTURE),
+          settle,
+        );
         expect(got).not.toBeNull();
         expect(bytesEqual(got!.body, PNG_FIXTURE)).toBe(true);
       });
@@ -508,7 +730,11 @@ export function defineStorageConformanceSuite(
         const original = "héllo🌍";
         const bytes = new TextEncoder().encode(original);
         await s.put("utf8", bytes);
-        const got = await s.get("utf8");
+        const got = await pollUntil(
+          () => s.get("utf8"),
+          (g) => g !== null && new TextDecoder().decode(g.body) === original,
+          settle,
+        );
         expect(got).not.toBeNull();
         expect(new TextDecoder().decode(got!.body)).toBe(original);
       });

--- a/packages/protocol/src/storage/index.ts
+++ b/packages/protocol/src/storage/index.ts
@@ -7,6 +7,7 @@ export type {
   StoragePutResult,
 } from "./types.ts";
 export { MemoryStorage, getOrCreateMemoryStorageForBucket, resetMemoryStorage } from "./memory.ts";
+export { assertValidStorageKey } from "./key.ts";
 export type {
   ConformanceFactory,
   ConformanceFactoryResult,

--- a/packages/protocol/src/storage/key.test.ts
+++ b/packages/protocol/src/storage/key.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import { BaerlyError } from "../errors.ts";
+import { assertValidStorageKey } from "./key.ts";
+
+describe("assertValidStorageKey", () => {
+  test("accepts ordinary keys, including dots that are not whole segments", () => {
+    for (const key of [
+      "a",
+      "log/0000000001",
+      "current.json",
+      "content/deadbeef",
+      "a.b",
+      ".hidden",
+      "trailing.",
+      "manifests/tickets/index/by_status/open",
+      "héllo🌍",
+    ]) {
+      expect(() => assertValidStorageKey(key)).not.toThrow();
+    }
+  });
+
+  test('rejects a key whose only segment is "." or ".." — RFC 3986 dot-segment removal makes it unaddressable over HTTP', () => {
+    for (const key of [".", ".."]) {
+      let err: unknown;
+      try {
+        assertValidStorageKey(key);
+      } catch (error) {
+        err = error;
+      }
+      expect(err, `${JSON.stringify(key)} must reject`).toBeInstanceOf(BaerlyError);
+      expect((err as BaerlyError).code).toBe("InvalidConfig");
+    }
+  });
+
+  test('rejects any interior "." / ".." path segment', () => {
+    for (const key of ["a/./b", "a/../b", "./a", "a/..", "../a", "a/."]) {
+      expect(() => assertValidStorageKey(key)).toThrow(BaerlyError);
+    }
+  });
+
+  test("rejects the empty key", () => {
+    expect(() => assertValidStorageKey("")).toThrow(BaerlyError);
+  });
+
+  test("does not enforce the byte ceiling — that lives on the write path (assertKeyWithinLimit)", () => {
+    expect(() => assertValidStorageKey("a".repeat(2048))).not.toThrow();
+  });
+});

--- a/packages/protocol/src/storage/key.ts
+++ b/packages/protocol/src/storage/key.ts
@@ -1,0 +1,41 @@
+import { BaerlyError } from "../errors.ts";
+
+/**
+ * Validate a raw {@link Storage} object key against the portable baerly key
+ * grammar before it is used to address an object. A key MUST be non-empty
+ * and `/`-delimited, with **no path segment equal to `.` or `..`**.
+ *
+ * The dot-segment rule is not a vendor quirk — it is a *client-side*
+ * universal: RFC 3986 §5.2.4 "remove dot segments" is mandatory for every
+ * conformant URL parser, so `<endpoint>/<bucket>/.` normalizes to
+ * `<endpoint>/<bucket>/` and `<endpoint>/<bucket>/..` escapes the bucket
+ * entirely — *before* the request is signed or sent, in TypeScript, Go,
+ * Rust, Python, or any language a `Storage` port is written in. Such a key
+ * cannot be addressed over the S3/R2 HTTP API regardless of backend; a bare
+ * `.` PUT surfaces as a confusing bucket-root 403 rather than a clear
+ * rejection. The kernel never emits such keys (caller-controlled segments
+ * are already screened by `assertPathSegment` one layer up), so this is the
+ * boundary guard that makes every adapter reject them *identically* and
+ * gives ports a single, testable contract.
+ *
+ * Thrown as `BaerlyError{code:"InvalidConfig"}` to match the sibling
+ * key/segment guards (`assertKeyWithinLimit`, `assertPathSegment`). The
+ * full-key 1024-byte ceiling is enforced separately on the write path
+ * (`assertKeyWithinLimit`), where multi-segment keys are assembled.
+ *
+ * @see docs/spec/storage-compatibility.md — "Key namespace"
+ */
+export function assertValidStorageKey(key: string): void {
+  if (key.length === 0) {
+    throw new BaerlyError("InvalidConfig", "storage key must be a non-empty string");
+  }
+  for (const segment of key.split("/")) {
+    if (segment === "." || segment === "..") {
+      throw new BaerlyError(
+        "InvalidConfig",
+        `storage key may not contain a "." or ".." path segment — RFC 3986 dot-segment ` +
+          `removal makes it unaddressable over the S3/R2 HTTP API: ${JSON.stringify(key)}`,
+      );
+    }
+  }
+}

--- a/packages/protocol/src/storage/memory.ts
+++ b/packages/protocol/src/storage/memory.ts
@@ -1,5 +1,6 @@
 import { isDeployedEnv } from "../env.ts";
 import { BaerlyError } from "../errors.ts";
+import { assertValidStorageKey } from "./key.ts";
 import type {
   Storage,
   StorageGetOptions,
@@ -116,6 +117,7 @@ export class MemoryStorage implements Storage {
   }
 
   async get(key: string, opts?: StorageGetOptions): Promise<StorageGetResult | null> {
+    assertValidStorageKey(key);
     opts?.signal?.throwIfAborted();
     const stored = this.#objects.get(key);
     if (stored === undefined) {
@@ -129,6 +131,7 @@ export class MemoryStorage implements Storage {
   }
 
   async put(key: string, body: Uint8Array, opts?: StoragePutOptions): Promise<StoragePutResult> {
+    assertValidStorageKey(key);
     opts?.signal?.throwIfAborted();
     const existing = this.#objects.get(key);
 
@@ -170,6 +173,7 @@ export class MemoryStorage implements Storage {
   }
 
   async delete(key: string, opts?: { signal?: AbortSignal }): Promise<void> {
+    assertValidStorageKey(key);
     opts?.signal?.throwIfAborted();
     this.#objects.delete(key);
   }

--- a/tests/fixtures/collection-api-cascade.ts
+++ b/tests/fixtures/collection-api-cascade.ts
@@ -866,6 +866,11 @@ const runLogEntryShape = async (
     expect(e.lsn).toMatch(LSN_RE);
     expect(typeof e.commit_ts).toBe("string");
     expect(Number.isFinite(new Date(e.commit_ts).getTime())).toBe(true);
+    // `commit_ts` is `Date#toISOString()` — strict UTC ISO-8601 with
+    // millisecond precision and a `Z` suffix. Pin the exact wire form so a
+    // language port emits the same shape (a mere Date.parse-able string is too
+    // loose: "2026" parses but is not the contract).
+    expect(e.commit_ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
     expect(typeof e.session).toBe("string");
     expect(e.session.length).toBeGreaterThan(0);
     expect(typeof e.seq).toBe("number");

--- a/tests/fixtures/http-conformance-cascade.ts
+++ b/tests/fixtures/http-conformance-cascade.ts
@@ -383,6 +383,38 @@ export const runHttpConformanceCascade = (opts: {
         expect(env.error?.code).toBe("NotFound");
       });
 
+      test("PATCH merge-patch returns 200 { modified: 1 } and preserves omitted keys", async () => {
+        // The success path was previously asserted ONLY inside the
+        // `describe.skipIf(!supportsCAS)` CAS block (which never runs —
+        // `supportsCAS` defaults false), so a merge-patch's 200
+        // `{ modified: 1 }` status/body and its JSON-merge semantics
+        // were never exercised over the HTTP wire. This UNGATED test
+        // pins both.
+        const table = await mintTable("patch-merge");
+        const ins = await postDoc(table, { title: "old", tag: "a", count: 1 });
+        expect(ins.status).toBe(201);
+        const id = ins.id!;
+        // Partial patch: touch only `title`. Merge semantics MUST leave
+        // `tag`/`count` intact — this is the merge-vs-replace
+        // distinction (contrast the "PUT replace" block, which drops
+        // omitted keys).
+        const patchRes = await doFetch(
+          authedRequest("PATCH", `/v1/c/${table}/${id}`, { patch: { title: "new" } }),
+        );
+        expect(patchRes.status).toBe(200);
+        const patchBody = (await patchRes.json()) as { readonly modified?: number };
+        expect(patchBody.modified).toBe(1);
+        const getRes = await doFetch(authedRequest("GET", `/v1/c/${table}/${id}`));
+        expect(getRes.status).toBe(200);
+        const { data } = (await getRes.json()) as { readonly data: Record<string, unknown> };
+        const { _id: _stripped, ...rest } = data;
+        void _stripped;
+        // Non-tautology guard: a whole-doc replace would have dropped
+        // `tag`/`count`. Merge-patch keeps them and only mutates
+        // `title`, so the preserved keys prove this wasn't a replace.
+        expect(rest).toEqual({ title: "new", tag: "a", count: 1 });
+      });
+
       test("POST > 1 MiB body returns 413 PayloadTooLarge", async () => {
         const table = await mintTable("rt-big");
         // 1 MiB + 1 bytes — exactly one byte over the cap so we
@@ -810,6 +842,118 @@ export const runHttpConformanceCascade = (opts: {
       });
     });
 
+    // ── Block 9c: routing fallthrough — unknown route + wrong method ─
+    //
+    // A porter re-implementing the wire must know what an unmatched
+    // request returns. DECISION (locked here): the kernel router
+    // (`packages/server/src/http/router.ts`) registers only the eight
+    // CRUD/query routes and an `app.onError` sink (router.ts:265); it
+    // installs NO custom `app.notFound(...)` and NO catch-all `.all()`.
+    // So an unmatched request falls through to Hono's DEFAULT
+    // notFoundHandler, which is `c.text("404 Not Found", 404)` (hono
+    // `hono-base.js`: `notFoundHandler = (c) => c.text("404 Not Found",
+    // 404)`). That is a BARE 404 — `text/plain` body `"404 Not
+    // Found"`, NOT the `HttpErrorEnvelope` JSON shape. The adapters
+    // return the router's Response verbatim (adapter-node
+    // `server.ts:209`; the fallthrough note at `server.ts:129-134`
+    // calls it "the kernel's 404"), so this is exactly what a client
+    // sees on the wire. `onError` fires only for THROWN errors, and no
+    // route throws when nothing matches — hence no envelope.
+    describe("routing fallthrough (unknown route + wrong method)", () => {
+      test("unknown path under /v1/ returns a bare hono 404 (NOT the error envelope)", async () => {
+        const res = await doFetch(authedRequest("GET", `/v1/does-not-exist`));
+        expect(res.status).toBe(404);
+        // Bare hono 404: text/plain "404 Not Found", not JSON.
+        const text = await res.text();
+        expect(text).toBe("404 Not Found");
+        // Non-tautology guard: prove it is NOT the ErrorEnvelope shape a
+        // matched-route 404 (e.g. GET of a missing _id) would carry.
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(text) as unknown;
+        } catch {
+          parsed = undefined;
+        }
+        const env = parsed as ErrorEnvelope | undefined;
+        expect(env?.error?.code).toBeUndefined();
+      });
+
+      test("wrong method on a known path returns a bare hono 404 (NOT 405, NOT the error envelope)", async () => {
+        // PATCH is registered on `/v1/c/:collection/:id`, not on the
+        // collection root `/v1/c/:collection` (POST-only). A PATCH to
+        // the collection root matches no route → same default 404
+        // fallthrough. Hono does not emit 405 Method Not Allowed here.
+        const table = freshTable("wrong-method");
+        const res = await doFetch(authedRequest("PATCH", `/v1/c/${table}`, { patch: { x: 1 } }));
+        expect(res.status).toBe(404);
+        const text = await res.text();
+        expect(text).toBe("404 Not Found");
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(text) as unknown;
+        } catch {
+          parsed = undefined;
+        }
+        const env = parsed as ErrorEnvelope | undefined;
+        expect(env?.error?.code).toBeUndefined();
+      });
+    });
+
+    // ── Block 9b: GET /v1/spec — the machine-readable contract ──────
+    // /v1/spec IS the porter's contract: a language re-implementation must
+    // serve a compatible document (specVersion, the errorCode→httpStatus map,
+    // httpRoutes, operators). It was previously untested over the wire. The
+    // route is anonymous (bypasses the verifier and stays up when auth/config
+    // is unhealthy); an authed caller additionally gets the declared
+    // collections. @see packages/server/src/spec/runtime-spec.ts.
+    describe("GET /v1/spec (machine-readable contract)", () => {
+      interface SpecErrorCode {
+        readonly code: string;
+        readonly httpStatus: number;
+        readonly retriable: boolean;
+      }
+      interface SpecBody {
+        readonly specVersion?: string;
+        readonly errorCodes?: ReadonlyArray<SpecErrorCode>;
+        readonly httpRoutes?: ReadonlyArray<unknown>;
+        readonly collections?: ReadonlyArray<unknown>;
+      }
+
+      test("anonymous request returns the static contract as JSON, without collections", async () => {
+        // No Authorization header — must still succeed (public infra).
+        const res = await doFetch(new Request(`${BASE}/v1/spec`, { method: "GET" }));
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type")).toContain("application/json");
+        const body = (await res.json()) as SpecBody;
+        expect(typeof body.specVersion).toBe("string");
+        expect(Array.isArray(body.errorCodes)).toBe(true);
+        expect(Array.isArray(body.httpRoutes)).toBe(true);
+        // Collections are gated behind a valid identity — an anonymous probe
+        // must not be able to enumerate tenant collection names.
+        expect(body.collections).toBeUndefined();
+      });
+
+      test("authed request appends the declared collections", async () => {
+        const res = await doFetch(authedRequest("GET", `/v1/spec`));
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as SpecBody;
+        expect(Array.isArray(body.collections)).toBe(true);
+      });
+
+      test("served errorCode→httpStatus/retriable map matches the wire behavior tested above", async () => {
+        // Drift gate: the contract a port reads MUST agree with the statuses
+        // the cascade actually observes. NotFound→404 (non-retriable) and
+        // Conflict→409 (retriable) are asserted on live responses elsewhere in
+        // this cascade; pin that the self-described map says the same.
+        const res = await doFetch(new Request(`${BASE}/v1/spec`, { method: "GET" }));
+        const body = (await res.json()) as SpecBody;
+        const byCode = new Map((body.errorCodes ?? []).map((e) => [e.code, e]));
+        expect(byCode.get("NotFound")).toMatchObject({ httpStatus: 404, retriable: false });
+        expect(byCode.get("Conflict")).toMatchObject({ httpStatus: 409, retriable: true });
+        expect(byCode.get("Unauthorized")).toMatchObject({ httpStatus: 401 });
+      });
+    });
+
     // ── Block 10: Long-poll /v1/since ───────────────────────────────
     describe.skipIf(!supportsLongPoll)("long-poll /v1/since", () => {
       test("GET /v1/since after an insert returns the event in the response (fast path)", async () => {
@@ -1048,6 +1192,62 @@ export const runHttpConformanceCascade = (opts: {
         const r2 = (await res2.json()) as MetaBody;
         expect(r2._meta.manifest_pointer).not.toBe(r1._meta.manifest_pointer);
         expect(r2._meta.fresh).toBe(true);
+      });
+    });
+
+    // ── Block 12: response Content-Type contract ────────────────────
+    //
+    // A porter must reproduce the media type across status classes. All
+    // body-bearing responses the router emits go through `c.json(...)`,
+    // which sets `Content-Type: application/json` (hono may append a
+    // `; charset=...` suffix, so match on the prefix). The bodiless
+    // 204 (DELETE success) carries no body. NOT re-tested here: the
+    // `/v1/spec` Content-Type, which Block 9b already pins on the
+    // anonymous probe.
+    describe("response Content-Type contract", () => {
+      const isJsonContentType = (res: Response): boolean =>
+        (res.headers.get("content-type") ?? "").startsWith("application/json");
+
+      test("201 (POST insert) and 200 (GET read) carry application/json", async () => {
+        const table = await mintTable("ct-2xx");
+        const postRes = await doFetch(authedRequest("POST", `/v1/c/${table}`, { doc: { a: 1 } }));
+        expect(postRes.status).toBe(201);
+        expect(isJsonContentType(postRes)).toBe(true);
+        const posted = (await postRes.json()) as { readonly _id: string };
+        const getRes = await doFetch(authedRequest("GET", `/v1/c/${table}/${posted._id}`));
+        expect(getRes.status).toBe(200);
+        expect(isJsonContentType(getRes)).toBe(true);
+      });
+
+      test("400 (malformed ?where=) carries application/json", async () => {
+        const table = freshTable("ct-400");
+        const res = await doFetch(authedRequest("GET", `/v1/c/${table}?where=notjson`));
+        expect(res.status).toBe(400);
+        expect(isJsonContentType(res)).toBe(true);
+      });
+
+      test("401 (missing Authorization) carries application/json", async () => {
+        const res = await doFetch(new Request(`${BASE}/v1/c/ct-401`, { method: "GET" }));
+        expect(res.status).toBe(401);
+        expect(isJsonContentType(res)).toBe(true);
+      });
+
+      test("404 (missing _id, matched route) carries application/json", async () => {
+        const table = await mintTable("ct-404");
+        await postDoc(table, { seed: 1 });
+        const res = await doFetch(authedRequest("GET", `/v1/c/${table}/never-existed`));
+        expect(res.status).toBe(404);
+        expect(isJsonContentType(res)).toBe(true);
+      });
+
+      test("204 (DELETE success) carries an empty body", async () => {
+        const table = await mintTable("ct-204");
+        const ins = await postDoc(table, { gone: true });
+        const del = await doFetch(authedRequest("DELETE", `/v1/c/${table}/${ins.id!}`));
+        expect(del.status).toBe(204);
+        // A 204 MUST NOT carry a body. `text()` yields the empty string.
+        const body = await del.text();
+        expect(body).toBe("");
       });
     });
   });

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -304,12 +304,15 @@ const BUDGETS: readonly Budget[] = [
   //     sets KUBERNETES_SERVICE_HOST). +22 raw over the prior bound (measured
   //     229398); min-gz is 19724 / 20480 (−756, healthy) — per the POLICY above,
   //     raw is a creep tripwire, so rebaseline rather than golf the predicate.
-  //   NOTE (2026-06-30): the gz axis is now near-ceiling — measured ~71667 vs
-  //     71680 (70 KiB), ~13 B of headroom. Left un-bumped on purpose (measure-
-  //     then-rebaseline discipline; it passes today). The next kernel change
-  //     that adds gz bytes should expect to trip this and rebaseline gz with a
-  //     measured value, not treat it as a regression.
-  { entry: "index.js", raw: 225 * 1024, gz: 70 * 1024, minGz: 20 * 1024 },
+  //   → raw +2 KiB / gz +1 KiB (2026-06-30): `assertValidStorageKey`
+  //     (storage/key.ts) reaches the MemoryStorage closure — the raw `Storage`
+  //     key-namespace guard, with its full explanatory JSDoc + a self-explaining
+  //     error message. Stacks on top of the fail-closed guard above, which is why
+  //     the gz axis (flagged near-ceiling on that bump) now crosses 70 KiB as
+  //     predicted. Measured 231593 raw / 72425 gz / 19885 min-gz; min-gz stays
+  //     under 20 KiB (−595). Per the POLICY, rebaselined the raw/gz tripwires
+  //     rather than golf the doc/error.
+  { entry: "index.js", raw: 227 * 1024, gz: 71 * 1024, minGz: 20 * 1024 },
   // The three auth verifier factories (bearerJwt, sharedSecret,
   // cloudflareAccess) plus the transitive jose closure pulled in by
   // bearerJwt's createRemoteJWKSet + jwtVerify. Adding a fourth
@@ -710,7 +713,16 @@ const BUDGETS: readonly Budget[] = [
   //   → raw +2 KiB (2026-06-30): MemoryStorage fail-closed guard pulled through
   //     the protocol barrel into the Worker aggregator (measured 416161 raw);
   //     gz/min-gz remain under. Same safety logic as the index.js bump above.
-  { entry: "cloudflare.js", raw: 407 * 1024, gz: 122 * 1024, minGz: 43 * 1024 },
+  //   → raw +3 KiB / gz +1 KiB (2026-06-30): `assertValidStorageKey` reaches the
+  //     r2-binding + s3-http closures (the raw `Storage` key-namespace guard).
+  //     Stacks on top of the fail-closed guard above; the two guards' minified
+  //     error strings together pushed min-gz +31 B past the 43 KiB HARD ceiling
+  //     (44063), so — per the POLICY, which forbids rebaselining min-gz — the
+  //     key-guard's (test-unasserted) error message was tightened to shrink the
+  //     closure rather than raise the ceiling. Post-trim measured 418893 raw /
+  //     125590 gz / 44028 min-gz; min-gz clears 43 KiB by 4 B. Only the raw/gz
+  //     creep tripwires are rebaselined.
+  { entry: "cloudflare.js", raw: 410 * 1024, gz: 123 * 1024, minGz: 43 * 1024 },
   // Client surface — `BaerlyClient<TConfig>` + fetcher plumbing.
   // Browser/runtime-agnostic; no kernel modules in the closure.
   // Budget history:
@@ -842,7 +854,12 @@ const BUDGETS: readonly Budget[] = [
   //   → raw −2 KiB (2026-06-24): W4-5 bundle hygiene — constants chunk no longer
   //     in dev closure (moved RESOLUTION constants to leaf; JSDoc trim).
   //     Measured: 37935 raw / 13618 gz.
-  { entry: "dev.js", raw: 38 * 1024, gz: 14 * 1024 },
+  //   → raw +2 KiB (2026-06-30): `assertValidStorageKey` reaches the LocalFsStorage
+  //     closure (the raw `Storage` key-namespace guard) with its full JSDoc +
+  //     self-explaining error message. Measured 40341 raw / 14447 gz. This dev-only
+  //     bundle has no min-gz axis, so gz is its tightest tripwire; rebaselined
+  //     gz 14→15 KiB rather than golf the doc/error (see the POLICY on index.js).
+  { entry: "dev.js", raw: 40 * 1024, gz: 15 * 1024 },
 ];
 
 // Static-import specifiers only. Dynamic `import(...)` is intentionally
@@ -1024,9 +1041,21 @@ describe("bundle size", () => {
           return `${a.line}\n    → rebaseline ${a.kind}: ${kib} * 1024 (= ${kib * 1024}, clears ${a.measured})`;
         })
         .join("\n");
+      // Carry the POLICY in the failure output itself, so it is read at the
+      // moment it matters instead of only living in the comments above. The
+      // guidance is axis-aware: min-gz is a hard ceiling, raw/gz are tripwires.
+      const policy = over.some((a) => a.kind === "min-gz")
+        ? "min-gz is the HARD ceiling — the real shipped-to-browser cost after a " +
+          "consumer bundler minifies. Over on min-gz is a genuine regression: " +
+          "investigate the closure and shrink it, do NOT just rebaseline."
+        : "raw/gz are creep tripwires, NOT hard limits. If this size change is " +
+          "intentional, rebaseline the KiB line above with a dated baseline note. " +
+          "Do NOT trim JSDoc / comments / error-message text or golf identifiers " +
+          "to fit — comments ship un-stripped, but doc + error quality outweigh a " +
+          "few bytes.";
       expect(
         over.length,
-        `${over.length} axis/axes over budget for dist/${entry}:\n${report}`,
+        `${over.length} axis/axes over budget for dist/${entry}:\n${report}\n\n  POLICY: ${policy}`,
       ).toBe(0);
     });
   }

--- a/tests/integration/conformance.test.ts
+++ b/tests/integration/conformance.test.ts
@@ -24,7 +24,10 @@ import { fc } from "@fast-check/vitest";
 import { describe } from "vitest";
 
 import { S3HttpStorage } from "@baerly/adapter-node";
-import { defineStorageConformanceSuite } from "@baerly/protocol/conformance";
+import {
+  type ConformanceOptions,
+  defineStorageConformanceSuite,
+} from "@baerly/protocol/conformance";
 
 import { createBucket } from "../fixtures/s3-fixtures.ts";
 import { MINIO_ACCESS_KEY, MINIO_ENDPOINT, MINIO_SECRET_KEY } from "../setup/ports.ts";
@@ -130,6 +133,27 @@ describe("conformance", () => {
       const sign = (req: Request): Promise<Request> => signer.sign(req);
 
       const isMinio = ep.name === "node-minio";
+      // Real Cloudflare R2's S3 `ListObjectsV2` is eventually consistent
+      // (list-after-write / list-after-delete lag), unlike AWS S3 (strong
+      // since Dec 2020) and the local Minio dev stack. Flag it so the
+      // conformance harness polls list/read-back assertions instead of
+      // asserting a single immediate snapshot over the wire.
+      const isR2 = ep.name === "cloudflare";
+      // aws / gcs / cloudflare are real remote HTTP endpoints where every
+      // op is a network round-trip, so the fast-check property tests must
+      // run at a reduced `numRuns` under a raised timeout (independent of
+      // the consistency model — AWS S3 is strongly consistent yet still
+      // remote). Without this the properties hammer the network 100× under
+      // the default 5s timeout, time out mid-iteration, and orphan-bleed
+      // writes into later tests. Minio is the local dev stack (127.0.0.1)
+      // and stays on the full local fuzz budget.
+      const isRemote = ep.name === "aws" || ep.name === "gcs" || isR2;
+      let conformanceOptions: ConformanceOptions | undefined;
+      if (isMinio) {
+        conformanceOptions = { keyArb: MINIO_KEY_ARB, prefixCharArb: MINIO_PREFIX_CHAR_ARB };
+      } else if (isRemote) {
+        conformanceOptions = { remoteNetwork: true, eventuallyConsistentList: isR2 };
+      }
       defineStorageConformanceSuite(
         `S3HttpStorage @ ${ep.name}`,
         async () => {
@@ -150,7 +174,7 @@ describe("conformance", () => {
             }),
           };
         },
-        isMinio ? { keyArb: MINIO_KEY_ARB, prefixCharArb: MINIO_PREFIX_CHAR_ARB } : undefined,
+        conformanceOptions,
       );
     });
   }

--- a/tests/integration/conformance.test.ts
+++ b/tests/integration/conformance.test.ts
@@ -29,12 +29,18 @@ import { defineStorageConformanceSuite } from "@baerly/protocol/conformance";
 import { createBucket } from "../fixtures/s3-fixtures.ts";
 import { MINIO_ACCESS_KEY, MINIO_ENDPOINT, MINIO_SECRET_KEY } from "../setup/ports.ts";
 
-// Minio's REST gateway rejects request paths whose resource component
-// is `.` or `..` (it validates URL paths as POSIX paths on the backing
-// filesystem). AWS S3 and R2 have no such restriction. Pin a `.`-free
-// key + prefix arbitrary for the Minio variant only; everything else
-// stays default. Mirror the pattern in
-// `packages/adapter-node/src/s3-http.conformance.test.ts`.
+// A bare `.` / `..` key is unaddressable over the S3 HTTP API on *every*
+// backend — RFC 3986 dot-segment removal (universal across every URL
+// parser) rewrites `<bucket>/.` → `<bucket>/` before the request is sent
+// — so the shared `DEFAULT_KEY_ARB` already excludes it and every adapter
+// rejects it with `InvalidConfig` (see the "key namespace" conformance
+// block + docs/spec/storage-compatibility.md). This extra `.`-free pin is
+// therefore now defense-in-depth for the Minio variant, whose REST gateway
+// additionally validates URL paths as POSIX paths on the backing
+// filesystem. It is redundant with the default arb for bare `.`/`..`;
+// dropping it (letting Minio exercise dot-containing keys like `a.b`) is a
+// safe follow-up once verified against a live `pnpm test:minio` run.
+// Mirror the pattern in `packages/adapter-node/src/s3-http.conformance.test.ts`.
 const MINIO_KEY_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
 const MINIO_KEY_ARB = fc.string({
   minLength: 1,


### PR DESCRIPTION
Hardens the Storage conformance contract against real remote backends (AWS S3, Cloudflare R2) and pins the cross-language wire contracts a language port must reproduce.

## The one behavior change

`get`/`put`/`delete` on all four Storage adapters now reject an empty key or one with a `.`/`..` path segment, throwing `BaerlyError("InvalidConfig")` client-side before any network call. Such keys are unaddressable over the S3/R2 HTTP API — RFC 3986 dot-segment removal rewrites `<bucket>/.` to the bucket root, so a naive `PUT` surfaced as a confusing bucket-root `403` instead of a clear error. `list(prefix)` is unaffected (a prefix rides the `?prefix=` query).

Patch bump: these keys never worked; this turns a wire-level 403 into a clear typed error. The kernel never emits them, and caller-controlled segments are already screened one layer up.

## Everything else (tests + docs, no shipped-behavior change)

- **Remote/eventual-consistency tolerance** in the Storage conformance suite: decouples network-latency accommodations (`remoteNetwork`) from list eventual-consistency (`eventuallyConsistentList`). Strict backends (Memory/LocalFs/Minio/AWS) keep single-shot assertions and full fuzz budget; only R2 polls to convergence.
- **Cross-language spec vectors**: JSON merge corners (incl. the two deliberate RFC 7396 divergences), UTF-8-vs-UTF-16 list sort, strict `commit_ts` ISO shape.
- **HTTP wire coverage**: `GET /v1/spec`, PATCH-merge semantics, routing fallthrough, header/204 contract.
- **S3 XML fidelity**: a malformed percent-escape in a list key now re-raises `InvalidResponse` instead of leaking a raw `URIError`; NUL + entity/CDATA round-trip tests.
- **Spec docs**: status→`BaerlyErrorCode` map, behavioral MUST-list, and ETag opacity, derived from `baerly.spec.json` + the adapter status mapping.

## Verification

`verify:agent`, `test:agent` (2359 passed), and `test:adapter-cloudflare` (Workerd R2, 141 passed) all green. The S3-HTTP arms vs real AWS/R2/MinIO were not re-run in this tree (no docker/credentials); the key guard is client-side so it never reaches the wire regardless.
