### PR TITLE
docs(auth): document that reads are uncapped and tenant-wide

### DIFF
--- a/docs/guide/auth.md
+++ b/docs/guide/auth.md
@@ -2,7 +2,7 @@
 title: Authentication
 audience: operator
 summary: Production auth recipes for Cloudflare and Node, plus tenant pinning and authorization boundaries.
-last-reviewed: 2026-06-28
+last-reviewed: 2026-07-02
 tags: [auth, operations]
 related: ["../adr/001-tenant-cas-isolation.md", "client-auth.md", "operations.md"]
 ---
@@ -290,6 +290,22 @@ reach `baerlyWorker` / `baerlyNode`:
 - block direct client writes to protected collections before falling
   through to the default `/v1/*` handler.
 
+Reads are symmetric — and easy to overlook. `GET /v1/c/:collection`
+returns the **entire collection** unless you constrain it: there is no
+default row cap, and an authenticated non-owner sees every row under the
+tenant. Two consequences for your interceptor:
+
+- **Scope the rows.** Inject a predicate keyed to the verified identity
+  (`where owner_id = <verified sub>`) before delegating. Prefer a
+  predicate that hits a declared index — the engine then resolves
+  matched rows via an index walk instead of folding the whole
+  collection. A bare `?limit` clamp only bounds what is returned: the
+  engine still folds the whole collection into memory before applying
+  the limit, so a limit alone caps exposure but not read cost.
+- **Do not reject `?limit` to "force" a cap.** It backfires — a request
+  with no `?limit` takes the *uncapped* path and returns everything.
+  Clamp instead: `limit = min(requested ?? MAX, MAX)`.
+
 The trusted-fields recipe in
-[`packages/server/API.md`](../../packages/server/API.md) shows that
-pattern.
+[`packages/server/API.md`](../../packages/server/API.md) shows the
+write half of this pattern.

--- a/packages/server/API.md
+++ b/packages/server/API.md
@@ -913,7 +913,8 @@ export default {
 
 The client reads via the normal `GET /v1/c/messages` route and tails
 via `GET /v1/since?collection=messages&cursor=…` — both still served by
-`inner`. Only writes go through `/api/messages`.
+`inner`. Only writes go through `/api/messages`. Reads stay uncapped and
+tenant-wide — scope and clamp them in your route too (see RECIPES.md).
 
 **Known limitations of this recipe.** The custom-route `Db.create` is
 a second instance — it doesn't share `baerlyWorker`'s

--- a/packages/server/RECIPES.md
+++ b/packages/server/RECIPES.md
@@ -110,6 +110,13 @@ inside a `useQuery` callback.
   surface is the `.where(...)` method chain.
 - `.all()` on a hot path — page or cursor-iterate; `.all()` is for
   bounded result sets.
+- Relying on baerly to cap or scope a read. `GET /v1/c/:collection` (and
+  `.all()`) returns the **whole collection** — there is no default row
+  cap, and auth pins a tenant, not a row owner. Scope non-owner reads in
+  your own route: inject a `where owner_id = <verified id>` predicate
+  (ideally index-backed) and clamp `limit = min(requested ?? MAX, MAX)`.
+  Rejecting `?limit` backfires — it forces the uncapped path. See
+  `docs/guide/auth.md` § Authorization Boundary.
 
 ## Where to look next
 


### PR DESCRIPTION
The **Authorization Boundary** section in `auth.md` covered only the write
side. The symmetric read side was undocumented, and consumers hit it:
`GET /v1/c/:collection` (and `.all()`) returns the **entire collection** —
no default row cap, and auth pins a *tenant*, not a *row owner*, so an
authenticated non-owner sees every row under the tenant.

Adds the read-side guidance for a route interceptor:

- **Scope the rows** with an identity-keyed predicate (index-backed → the
  engine resolves matched rows via an index walk instead of folding the
  whole collection).
- **Clamp, don't reject `?limit`** — rejecting it forces the *uncapped*
  path. A bare limit still folds the whole collection, so it caps exposure,
  not read cost.

Mirrored as an anti-pattern in `RECIPES.md` and a one-line pointer on the
trusted-fields recipe in `API.md`.

Docs-only; `verify:docs` green. Every behavioral claim was traced to source
(`http/router.ts`, `query.ts`, `query-planner.ts`, `snapshot.ts`, `db.ts`).