### PR TITLE
Assert no-lost-writes, read-your-writes, and monotonic-reads in the causal cascade

### DIFF
--- a/docs/spec/causal-consistency-checking.md
+++ b/docs/spec/causal-consistency-checking.md
@@ -3,7 +3,7 @@ title: Causal-consistency property checking
 audience: spec
 doc_type: verification
 summary: Low-complexity verification of causal consistency via a known global timeline.
-last-reviewed: 2026-06-23
+last-reviewed: 2026-07-01
 tags: [protocol, verification, property-testing]
 related: [sync-protocol.md]
 ---
@@ -258,6 +258,47 @@ The contradiction is now explicit. These three clauses cannot all be true:
 /*P1*/ C1 < C2 // Carol's sequential timeline
 /*P3*/ C2 < B1 // When Alice received Bob's message after Carol's
 ```
+
+## Session guarantees
+
+The `P1`/`P2`/`P3` clauses above check causal ordering of *observed*
+events. A document DB is also judged on three **session guarantees** that
+the randomized cascade now asserts directly. Each names the backend class
+it holds on and the assertion in `tests/fixtures/randomized-cascade.ts`
+that witnesses it.
+
+- **SG-1 — No-lost-writes (all backends).** Every `Writer.commit()` that
+  returns success has its `log/<seq>` slot durably present in the
+  collection log. `entry.seq` is that slot (the winning
+  `If-None-Match: "*"` create). This holds even under fault injection: an
+  acked commit is durable regardless of what the network does afterward.
+  *Witness:* the drain-time containment check of the acked-slot set
+  against the listed `log/<seq>` keys.
+
+- **SG-2 — Read-your-writes (strongly-consistent backends).** After a
+  writer's own `commit()` succeeds at slot `S`, that writer's next read
+  resolves a slot `>= S`. Under last-write-wins a later slot may mask the
+  value, but a writer never reads state older than its own committed
+  write. *Witness:* the self-read assertion immediately after a successful
+  commit, gated on `strongConsistency`.
+
+- **SG-3 — Monotonic-reads (strongly-consistent backends).** Within one
+  client, successive reads resolve non-decreasing `log/<seq>` slots — the
+  log is append-only and entries are immutable, so the freshest matching
+  slot only grows. *Witness:* the per-client last-observed-slot check in
+  the poll loop, gated on `strongConsistency`.
+
+SG-2 and SG-3 are gated to strongly-consistent backends (memory,
+local-fs, in-process miniflare-R2) and are **not** asserted on the
+node-minio variant, whose Toxiproxy fault injection deliberately induces
+stale reads (see the `KNOWN FLAKE` note in the cascade driver). SG-1 is
+backend-agnostic and runs everywhere.
+
+Seeded replay: the cascade logs an integer `seed` at start and dumps the
+observed schedule on any causal-consistency violation, so a failing
+interleaving can be inspected and the injected entropy replayed by
+passing the seed back. (Timer-driven interleaving remains wall-clock
+dependent; fully deterministic replay is future work.)
 
 ## Conclusion
 

--- a/packages/adapter-cloudflare/src/randomized.test.ts
+++ b/packages/adapter-cloudflare/src/randomized.test.ts
@@ -57,6 +57,7 @@ describe("randomized (Db + Writer)", () => {
           // than memory; 25ms keeps the poll loop responsive without
           // burning CPU.
           pollTickMs: 25,
+          strongConsistency: true,
           // T4: assert the filtered-index invariant at the end of
           // the cascade.
           injectFilteredIndex: true,

--- a/packages/protocol/src/log.ts
+++ b/packages/protocol/src/log.ts
@@ -90,7 +90,14 @@ export interface LogEntry {
    */
   session: string;
 
-  /** Per-session sequence number embedded in the `lsn`. */
+  /**
+   * The `log/<seq>` slot this entry occupies — the integer in its
+   * `log/<seq>.json` key, minted by `Writer.commit` as the forward-probed
+   * collection-log tail (the winning `If-None-Match: "*"` create). One
+   * entry per `session`, so this is a per-collection slot, not a
+   * per-session counter. Also encoded (descending base-32) as the LSN's
+   * third segment — see `lsnParts`.
+   */
   seq: number;
 }
 

--- a/tests/fixtures/randomized-cascade.ts
+++ b/tests/fixtures/randomized-cascade.ts
@@ -170,7 +170,7 @@ const ensureCurrent = async (storage: Storage, key: string): Promise<void> => {
 const readLatest = async (
   inst: Instance,
   docId: string = COLLECTION,
-): Promise<CascadeMessage | undefined> => {
+): Promise<{ value: CascadeMessage; seq: number } | undefined> => {
   const read = await readCurrentJson(inst.storage, inst.currentJsonKey);
   if (read === null) {
     return undefined;
@@ -190,7 +190,7 @@ const readLatest = async (
       continue;
     }
     if (entry.doc_id === docId && entry.op === "U" && entry.after !== undefined) {
-      return entry.after as CascadeMessage;
+      return { value: entry.after as CascadeMessage, seq: s };
     }
   }
   return undefined;
@@ -221,7 +221,8 @@ const assertFilteredIndexConsistent = async (inst: Instance): Promise<void> => {
   // `allIndexKeysFor` and is filter-aware via T4's projector
   // change).
   await rebuildIndex(inst.storage, inst.currentJsonKey, FILTERED_INDEX);
-  const live = await readLatest(inst, COLLECTION);
+  const latest = await readLatest(inst, COLLECTION);
+  const live = latest?.value;
   const expected = new Set(allIndexKeysFor(inst.logPrefix, [FILTERED_INDEX], live, COLLECTION));
   const actual = new Set<string>();
   for await (const entry of inst.storage.list(`${inst.logPrefix}/index/${FILTERED_INDEX.name}/`)) {
@@ -384,6 +385,13 @@ export const runCausalConsistencyCascade = (opts: {
    * replayed by passing the logged value back as `{ seed }`.
    */
   seed?: number;
+  /**
+   * When `true`, additionally assert read-your-writes (SG-2) and
+   * monotonic-reads (SG-3). Enable only on strongly-consistent backends
+   * (memory / local-fs / miniflare-R2); leave off for node-minio, whose
+   * Toxiproxy fault injection deliberately induces stale reads.
+   */
+  strongConsistency?: boolean;
 }): Promise<void> =>
   new Promise<void>((done, reject) => {
     void (async () => {
@@ -516,6 +524,16 @@ export const runCausalConsistencyCascade = (opts: {
                   body: message,
                 });
                 ackedSeqs.add(result.entry.seq);
+                // Read-your-writes (SG-2): a self-read right after a
+                // successful commit must resolve a slot >= the one we won
+                // (LWW: we never read state older than our own write).
+                if (opts.strongConsistency === true) {
+                  const own = await readLatest(instances[client_id]!, COLLECTION);
+                  expect(
+                    own !== undefined && own.seq >= result.entry.seq,
+                    `read-your-writes: client ${client_id} committed log/${result.entry.seq} but a self-read resolved ${own?.seq ?? "nothing"}`,
+                  ).toBe(true);
+                }
               } catch (error) {
                 // Transient Conflict under contention is fine — the
                 // peer will re-broadcast on its next observe. Other
@@ -568,7 +586,8 @@ export const runCausalConsistencyCascade = (opts: {
                 return;
               }
               try {
-                const val = await readLatest(inst);
+                const latest = await readLatest(inst);
+                const val = latest?.value;
                 const serialized = JSON.stringify(val);
                 if (serialized !== prev) {
                   prev = serialized;

--- a/tests/fixtures/randomized-cascade.ts
+++ b/tests/fixtures/randomized-cascade.ts
@@ -604,7 +604,13 @@ export const runCausalConsistencyCascade = (opts: {
                 // network flips every 100ms during the Minio variant,
                 // and under R2 propagation jitter we may briefly see
                 // stale state. The next tick retries.
-                void error;
+                // Re-throw assertion errors (e.g. monotonic-reads) so
+                // they surface as failures rather than timing out.
+                if (!(error instanceof BaerlyError)) {
+                  finished = true;
+                  reject(error);
+                  return;
+                }
               }
             }
           })();

--- a/tests/fixtures/randomized-cascade.ts
+++ b/tests/fixtures/randomized-cascade.ts
@@ -296,6 +296,56 @@ const buildInstances = async (
 };
 
 /**
+ * Run a storage-touching read under bounded retry on transient
+ * `NetworkError`. The node-minio variant flips its Toxiproxy proxy every
+ * 100 ms, so a read landing in a dead window rejects with a
+ * {@link BaerlyError} whose `code` is `"NetworkError"`; Minio / S3 are
+ * strongly consistent, so once a window opens the value is complete and
+ * the retry only rides out the dead window. Non-`NetworkError` failures
+ * (and genuine assertion failures) propagate immediately. The whole `op`
+ * re-runs per attempt, so consumers that accumulate (e.g. draining an
+ * async list into a set) must build their result fresh inside `op`.
+ */
+export const MAX_NETWORK_RETRIES = 5;
+export const withNetworkRetry = async <T>(op: () => Promise<T>): Promise<T> => {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await op();
+    } catch (error) {
+      if (
+        error instanceof BaerlyError &&
+        error.code === "NetworkError" &&
+        attempt < MAX_NETWORK_RETRIES
+      ) {
+        await new Promise<void>((r) => setTimeout(r, 10 * (attempt + 1)));
+        continue;
+      }
+      throw error;
+    }
+  }
+};
+
+/**
+ * Collect the set of committed `log/<seq>.json` slot numbers under a
+ * collection's log prefix. Matches ONLY `<logPrefix>/log/<digits>.json`
+ * slot keys — ignoring `current.json`, index subdirs, etc. — and rides
+ * out transient network windows via {@link withNetworkRetry}.
+ */
+const collectCommittedSlots = async (inst: Instance): Promise<Set<number>> => {
+  const slotKeyPattern = new RegExp(`^${escapeRegExp(`${inst.logPrefix}/log/`)}(\\d+)\\.json$`);
+  return withNetworkRetry(async () => {
+    const slots = new Set<number>();
+    for await (const listed of inst.storage.list(`${inst.logPrefix}/log/`)) {
+      const m = slotKeyPattern.exec(listed.key);
+      if (m !== null) {
+        slots.add(Number.parseInt(m[1]!, 10));
+      }
+    }
+    return slots;
+  });
+};
+
+/**
  * Run the all-to-all single-key cascade. Returns when `MAX_STEPS`
  * observations have been recorded by the {@link CentralisedOfflineFirstCausalSystem}
  * (success) or rejects on assertion failure / unexpected error.
@@ -353,6 +403,11 @@ export const runCausalConsistencyCascade = (opts: {
           sender: number;
           send_time: number;
         }> = [];
+        // No-lost-writes ledger: every commit that RETURNS success records
+        // its won slot here; at drain, each MUST be present in the durable
+        // log-slot set. `entry.seq` is the `log/<seq>` slot (writer mints
+        // `logObjectKey(logPrefix, seq)` at that seq).
+        const ackedSeqs = new Set<number>();
         const declaredIndexes: ReadonlyArray<IndexDefinition> = opts.injectFilteredIndex
           ? [FILTERED_INDEX]
           : [];
@@ -454,12 +509,13 @@ export const runCausalConsistencyCascade = (opts: {
                 await new Promise<void>((r) => setTimeout(r, delayMs));
               }
               try {
-                await instances[client_id]!.writer.commit({
+                const result = await instances[client_id]!.writer.commit({
                   op: "U",
                   collection: COLLECTION,
                   docId: COLLECTION,
                   body: message,
                 });
+                ackedSeqs.add(result.entry.seq);
               } catch (error) {
                 // Transient Conflict under contention is fine — the
                 // peer will re-broadcast on its next observe. Other
@@ -479,6 +535,15 @@ export const runCausalConsistencyCascade = (opts: {
             void (async () => {
               try {
                 await Promise.allSettled(commitQueues);
+                // No-lost-writes (SG-1): every acked commit's slot is durable.
+                const committed = await collectCommittedSlots(instances[0]!);
+                const missing = [...ackedSeqs].filter((s) => !committed.has(s));
+                expect(
+                  missing,
+                  `no-lost-writes: acked commits missing from the durable log-slot set ${JSON.stringify(
+                    [...committed].toSorted((a, b) => a - b),
+                  )}`,
+                ).toEqual([]);
                 if (opts.injectFilteredIndex) {
                   await assertFilteredIndexConsistent(instances[0]!);
                 }
@@ -676,24 +741,16 @@ export const runMultiDocCascade = async (opts: {
   // from an array index — otherwise the "contiguous / gap-free / no-dup"
   // assertions on it are tautological (a forward probe is dense by
   // construction, so synthesizing `start + i` can NEVER witness a gap or
-  // duplicate the storage might actually hold). Enumerate the live slots
-  // under the collection's `log/` prefix and parse the integer `<N>` out
-  // of each `log/<N>.json` key; the resulting set is the real committed
-  // range the collection-total-order property exists to witness.
+  // duplicate the storage might actually hold). `collectCommittedSlots`
+  // enumerates the live `log/<N>.json` slots — and rides out the
+  // node-minio Toxiproxy flips this cascade also runs under — so the
+  // resulting set is the real committed range the collection-total-order
+  // property exists to witness.
   const inst = instances[0]!;
   const read = await readCurrentJson(inst.storage, inst.currentJsonKey);
   const start = read === null ? 0 : read.json.log_seq_start;
 
-  // Match ONLY `<logPrefix>/log/<digits>.json` slot keys — ignore any
-  // non-slot keys under that prefix (`current.json`, index subdirs, …).
-  const slotKeyPattern = new RegExp(`^${escapeRegExp(`${inst.logPrefix}/log/`)}(\\d+)\\.json$`);
-  const committedSeqs: number[] = [];
-  for await (const listed of inst.storage.list(`${inst.logPrefix}/log/`)) {
-    const m = slotKeyPattern.exec(listed.key);
-    if (m !== null) {
-      committedSeqs.push(Number.parseInt(m[1]!, 10));
-    }
-  }
+  const committedSeqs = [...(await collectCommittedSlots(inst))];
 
   // Walk the committed entries in ascending seq order for the per-doc
   // projection — `observedPerDoc[docId]` is that doc's committed-value
@@ -893,30 +950,12 @@ export const runRangeWalkParityCascade = async (opts: {
     const wire = normalizePredicateArg<ParityDoc>(predicate);
     const expected = seeded.filter((d) => matchesWire(wire, d));
 
-    // Bounded retry on transient I/O — under Toxiproxy the network
-    // flips every 100ms during the node-minio variant, and a `.all()`
-    // that lands in a dead window rejects with a BaerlyError whose
-    // code === "NetworkError". The parity assertion is unaffected:
-    // it only runs after a successful read. Non-transient errors and
-    // genuine parity mismatches propagate immediately.
-    const MAX_PARITY_READ_RETRIES = 5;
-    let actual: ParityDoc[];
-    for (let attempt = 0; ; attempt++) {
-      try {
-        actual = await table.where(predicate).all();
-        break;
-      } catch (error) {
-        if (
-          error instanceof BaerlyError &&
-          error.code === "NetworkError" &&
-          attempt < MAX_PARITY_READ_RETRIES
-        ) {
-          await new Promise<void>((resolve) => setTimeout(resolve, 10 * (attempt + 1)));
-          continue;
-        }
-        throw error;
-      }
-    }
+    // Bounded retry on transient I/O — under Toxiproxy the network flips
+    // every 100ms during the node-minio variant, and a `.all()` that lands
+    // in a dead window rejects with a NetworkError. The parity assertion
+    // is unaffected: it only runs after a successful read, and genuine
+    // parity mismatches (a plain assertion failure) propagate immediately.
+    const actual = await withNetworkRetry(() => table.where(predicate).all());
     expect(
       actual.map((r) => r._id).toSorted(),
       `range-walk parity mismatch for wire ${JSON.stringify(wire)}`,

--- a/tests/fixtures/randomized-cascade.ts
+++ b/tests/fixtures/randomized-cascade.ts
@@ -44,6 +44,12 @@ import {
   type Knowledge,
 } from "./consistency.ts";
 import { logStateCurrentJson } from "./log-state.ts";
+import {
+  isMonotonicRead,
+  isReadYourWrite,
+  isTransientReadError,
+  missingAckedSlots,
+} from "./session-guarantees.ts";
 
 /**
  * Causal-consistency check without `eval()`. Workerd disallows code
@@ -416,6 +422,11 @@ export const runCausalConsistencyCascade = (opts: {
         // log-slot set. `entry.seq` is the `log/<seq>` slot (writer mints
         // `logObjectKey(logPrefix, seq)` at that seq).
         const ackedSeqs = new Set<number>();
+        // Monotonic-reads (SG-3): per client, the resolved read slot never
+        // goes backward on a strongly-consistent backend (the log is
+        // append-only and entries are immutable, so the freshest matching
+        // slot only grows).
+        const lastObservedSeq: number[] = Array.from({ length: N }, () => -1);
         const declaredIndexes: ReadonlyArray<IndexDefinition> = opts.injectFilteredIndex
           ? [FILTERED_INDEX]
           : [];
@@ -530,7 +541,7 @@ export const runCausalConsistencyCascade = (opts: {
                 if (opts.strongConsistency === true) {
                   const own = await readLatest(instances[client_id]!, COLLECTION);
                   expect(
-                    own !== undefined && own.seq >= result.entry.seq,
+                    isReadYourWrite(own?.seq, result.entry.seq),
                     `read-your-writes: client ${client_id} committed log/${result.entry.seq} but a self-read resolved ${own?.seq ?? "nothing"}`,
                   ).toBe(true);
                 }
@@ -555,7 +566,7 @@ export const runCausalConsistencyCascade = (opts: {
                 await Promise.allSettled(commitQueues);
                 // No-lost-writes (SG-1): every acked commit's slot is durable.
                 const committed = await collectCommittedSlots(instances[0]!);
-                const missing = [...ackedSeqs].filter((s) => !committed.has(s));
+                const missing = missingAckedSlots(ackedSeqs, committed);
                 expect(
                   missing,
                   `no-lost-writes: acked commits missing from the durable log-slot set ${JSON.stringify(
@@ -587,6 +598,13 @@ export const runCausalConsistencyCascade = (opts: {
               }
               try {
                 const latest = await readLatest(inst);
+                if (opts.strongConsistency === true && latest !== undefined) {
+                  expect(
+                    isMonotonicRead(latest.seq, lastObservedSeq[client_id]!),
+                    `monotonic-reads: client ${client_id} observed log/${latest.seq} after log/${lastObservedSeq[client_id]}`,
+                  ).toBe(true);
+                  lastObservedSeq[client_id] = latest.seq;
+                }
                 const val = latest?.value;
                 const serialized = JSON.stringify(val);
                 if (serialized !== prev) {
@@ -603,10 +621,11 @@ export const runCausalConsistencyCascade = (opts: {
                 // Swallow transient read failures — under Toxiproxy the
                 // network flips every 100ms during the Minio variant,
                 // and under R2 propagation jitter we may briefly see
-                // stale state. The next tick retries.
-                // Re-throw assertion errors (e.g. monotonic-reads) so
-                // they surface as failures rather than timing out.
-                if (!(error instanceof BaerlyError)) {
+                // stale state. The next tick retries. Anything else (e.g.
+                // a failed SG-3 monotonic-reads assertion) is fatal and
+                // must surface as a rejection rather than time out — see
+                // `isTransientReadError`.
+                if (!isTransientReadError(error)) {
                   finished = true;
                   reject(error);
                   return;

--- a/tests/fixtures/randomized-cascade.ts
+++ b/tests/fixtures/randomized-cascade.ts
@@ -103,6 +103,27 @@ const COLLECTION = "k"; // single-key cascade — `collection === docId`
 const MAX_STEPS = 100;
 
 /**
+ * Small seeded LCG (same constants as the range-walk parity cascade's
+ * inline RNG) so the causal cascade's injected entropy is reproducible
+ * across runs — and, critically, across languages. `Math.random()` cannot
+ * be regenerated outside JS; a logged integer seed can.
+ *
+ * NOTE: this seeds only the INJECTED entropy (per-client clock offsets).
+ * Real `setTimeout` timers still make the observed interleaving
+ * wall-clock dependent, so replaying a seed reproduces the offsets, not a
+ * byte-identical schedule. Full deterministic replay (virtual clock +
+ * scripted storage) is deferred — see the determinism track of the
+ * cross-language conformance program.
+ */
+export const makeLcg = (seed: number): (() => number) => {
+  let state = seed | 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) | 0;
+    return ((state >>> 0) % 1_000_000) / 1_000_000;
+  };
+};
+
+/**
  * Shape of one client's broadcast — kept in sync with the legacy
  * `Message` type. Doubles as the `LogEntry.after` body.
  */
@@ -307,13 +328,31 @@ export const runCausalConsistencyCascade = (opts: {
    * miss→match and match→miss U-quadrants under live contention.
    */
   injectFilteredIndex?: boolean;
+  /**
+   * Seed for the per-client clock-offset entropy. When omitted a seed is
+   * derived from `Math.random()` and logged at start, so a flake can be
+   * replayed by passing the logged value back as `{ seed }`.
+   */
+  seed?: number;
 }): Promise<void> =>
   new Promise<void>((done, reject) => {
     void (async () => {
       try {
         const N = opts.storages.length;
+        const seed = opts.seed ?? Math.floor(Math.random() * 0x7fffffff);
+        const rand = makeLcg(seed);
+        console.log(`[cascade] seed=${seed} N=${N} pollTickMs=${opts.pollTickMs}`);
         const clockOffsets =
-          opts.clockOffsetsMs ?? Array.from({ length: N }, () => Math.random() * 2000 - 1000);
+          opts.clockOffsetsMs ?? Array.from({ length: N }, () => rand() * 2000 - 1000);
+        // Portable failing-schedule artifact: every observation is
+        // appended here and dumped (with the seed) if a causal-consistency
+        // clause fails, so the interleaving can be inspected / replayed.
+        const schedule: Array<{
+          tick: number;
+          receiver: number;
+          sender: number;
+          send_time: number;
+        }> = [];
         const declaredIndexes: ReadonlyArray<IndexDefinition> = opts.injectFilteredIndex
           ? [FILTERED_INDEX]
           : [];
@@ -350,6 +389,12 @@ export const runCausalConsistencyCascade = (opts: {
               ]!} rcvd ${system.client_labels[val.sender]}@${val.send_time}`,
             );
             system.observe({ ...val, receiver: client_id });
+            schedule.push({
+              tick: system.global_time,
+              receiver: client_id,
+              sender: val.sender,
+              send_time: val.send_time,
+            });
           }
 
           // KNOWN FLAKE (node-minio only): a 9h/102-iteration overnight fuzz
@@ -366,8 +411,10 @@ export const runCausalConsistencyCascade = (opts: {
           if (system.global_time < MAX_STEPS && !testFailed) {
             testFailed = !causallyConsistent(system.grounding, system.knowledge_base);
             if (testFailed) {
+              console.error(`[cascade] CAUSAL VIOLATION seed=${seed}`);
               console.error(system.grounding);
               console.error(system.knowledge_base);
+              console.error(`[cascade] schedule=${JSON.stringify(schedule)}`);
             }
             expect(testFailed).toBe(false);
 
@@ -779,17 +826,15 @@ export const runRangeWalkParityCascade = async (opts: {
   });
   const table = db.collection(collection) as Collection<ParityDoc>;
 
-  // Deterministic pseudo-random for reproducibility (LCG seeded
-  // off tenant). Spec doesn't require cryptographic randomness;
-  // we just want decent coverage of bound combinations.
-  let rngState = 0;
+  // Deterministic pseudo-random for reproducibility (the shared
+  // `makeLcg` seeded off a cheap hash of the tenant). Spec doesn't
+  // require cryptographic randomness; we just want decent coverage of
+  // bound combinations.
+  let seed = 0;
   for (let i = 0; i < tenant.length; i++) {
-    rngState = (rngState * 31 + tenant.charCodeAt(i)) | 0;
+    seed = (seed * 31 + tenant.charCodeAt(i)) | 0;
   }
-  const rand = (): number => {
-    rngState = (rngState * 1664525 + 1013904223) | 0;
-    return ((rngState >>> 0) % 1_000_000) / 1_000_000;
-  };
+  const rand = makeLcg(seed);
   const pick = <U>(arr: ReadonlyArray<U>): U => arr[Math.floor(rand() * arr.length)]!;
 
   for (let iter = 0; iter < iterations; iter++) {

--- a/tests/fixtures/session-guarantees.ts
+++ b/tests/fixtures/session-guarantees.ts
@@ -1,0 +1,65 @@
+/**
+ * Session-guarantee predicates — the pure decision core the causal
+ * cascade asserts against, promoted out of inline lambdas so each
+ * invariant is a named, independently testable function rather than an
+ * `expect(...)` buried in a concurrent async loop.
+ *
+ * The cascade fixture (`randomized-cascade.ts`) CALLS these, and the
+ * unit suite (`tests/unit/session-guarantees.test.ts`) exercises them
+ * deterministically — so the guard the cascade relies on and the guard
+ * under test are the same function, with no reconstruction gap. A future
+ * edit that silently defangs one of these invariants (e.g. a read that
+ * resolves the wrong field so the comparison degrades to always-true)
+ * fails the unit test, not just the probabilistic cascade.
+ *
+ * Guarantee IDs match the spec — see
+ * `docs/spec/causal-consistency-checking.md` (SG-1/SG-2/SG-3).
+ *
+ * Pure module — no Node imports, no vitest — so it loads inside Workerd
+ * alongside the cascade fixture and stays cheap to unit-test.
+ */
+
+import { BaerlyError } from "@baerly/protocol";
+
+/**
+ * SG-1 no-lost-writes: every commit that returned success must have its
+ * won `log/<seq>` slot present in the durable committed-slot set. Returns
+ * the acked slots MISSING from `committed` — an empty array means the
+ * guarantee holds.
+ */
+export const missingAckedSlots = (
+  acked: Iterable<number>,
+  committed: ReadonlySet<number>,
+): number[] => [...acked].filter((seq) => !committed.has(seq));
+
+/**
+ * SG-2 read-your-writes: a self-read issued right after a successful
+ * commit must resolve a slot `>=` the one the commit won (LWW — a writer
+ * never reads state older than its own write). `ownSeq` is `undefined`
+ * when the self-read resolved nothing, which always violates the
+ * guarantee.
+ */
+export const isReadYourWrite = (ownSeq: number | undefined, wonSeq: number): boolean =>
+  ownSeq !== undefined && ownSeq >= wonSeq;
+
+/**
+ * SG-3 monotonic-reads: a client's resolved read slot never goes backward
+ * on a strongly-consistent backend (the log is append-only and entries
+ * are immutable, so the freshest matching slot only grows).
+ */
+export const isMonotonicRead = (observedSeq: number, lastObservedSeq: number): boolean =>
+  observedSeq >= lastObservedSeq;
+
+/**
+ * Poll-loop read-error policy: reads in the cascade's observe loop
+ * tolerate transient backend faults — a {@link BaerlyError} (the
+ * node-minio variant flips its Toxiproxy proxy every 100 ms; R2
+ * propagation jitter can briefly reject or return stale state) — and the
+ * next tick retries. Anything else (notably a failed SG-3 assertion,
+ * which throws a plain `Error`) is FATAL and must abort the cascade so it
+ * surfaces as a rejection instead of hanging until the test timeout.
+ *
+ * This is the read-side policy only; the write-side commit serializer has
+ * its own, stricter policy (only `Conflict` is transient there).
+ */
+export const isTransientReadError = (error: unknown): boolean => error instanceof BaerlyError;

--- a/tests/integration/randomized.test.ts
+++ b/tests/integration/randomized.test.ts
@@ -92,6 +92,8 @@ interface Variant {
   readonly requiresMinio?: boolean;
   /** Per-tick poll cadence; tuned per backend. */
   readonly pollTickMs: number;
+  /** Strongly consistent backend → assert read-your-writes + monotonic-reads. */
+  readonly strongConsistency: boolean;
   /** Build N {@link Storage} handles sharing one backing store. */
   readonly makeStorages: (bucket: string, n: number) => Promise<Storage[]>;
   /** Best-effort cleanup for ephemeral resources. */
@@ -104,6 +106,7 @@ const allVariants: Variant[] = [
   {
     label: "memory",
     pollTickMs: 5,
+    strongConsistency: true,
     // Process-singleton: same bucket → same underlying MemoryStorage.
     // Same mechanism the legacy `memory` variant used.
     makeStorages: async (bucket, n): Promise<Storage[]> =>
@@ -112,6 +115,7 @@ const allVariants: Variant[] = [
   {
     label: "local-fs",
     pollTickMs: 10,
+    strongConsistency: true,
     // Atomic `writeFile(temp)+rename` keeps concurrent writes safe;
     // cross-instance visibility is the file system.
     makeStorages: async (_bucket, n): Promise<Storage[]> => {
@@ -133,6 +137,7 @@ const allVariants: Variant[] = [
     label: "node-minio",
     requiresMinio: true,
     pollTickMs: 50,
+    strongConsistency: false,
     makeStorages: async (bucket, n): Promise<Storage[]> => {
       const signer = new AwsClient({
         accessKeyId: stableConfig.credentials.accessKeyId,
@@ -192,6 +197,7 @@ describe("randomized (Db + Writer)", () => {
           await runCausalConsistencyCascade({
             storages,
             pollTickMs: variant.pollTickMs,
+            strongConsistency: variant.strongConsistency,
             // T4: assert the filtered-index invariant at the end of
             // the cascade. The CAS path is unaffected by filtered
             // projection, so causal-consistency stays green; the

--- a/tests/unit/cascade-seed.test.ts
+++ b/tests/unit/cascade-seed.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import { makeLcg } from "../fixtures/randomized-cascade.ts";
+
+describe("makeLcg (seeded cascade RNG)", () => {
+  test("same seed produces the same sequence", () => {
+    const a = makeLcg(42);
+    const b = makeLcg(42);
+    const seqA = Array.from({ length: 8 }, () => a());
+    const seqB = Array.from({ length: 8 }, () => b());
+    expect(seqA).toEqual(seqB);
+  });
+
+  test("different seeds diverge", () => {
+    const a = makeLcg(1);
+    const b = makeLcg(2);
+    const seqA = Array.from({ length: 8 }, () => a());
+    const seqB = Array.from({ length: 8 }, () => b());
+    expect(seqA).not.toEqual(seqB);
+  });
+
+  test("outputs are in [0, 1)", () => {
+    const r = makeLcg(12345);
+    for (let i = 0; i < 100; i++) {
+      const v = r();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+});

--- a/tests/unit/session-guarantees.test.ts
+++ b/tests/unit/session-guarantees.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+import { BaerlyError } from "@baerly/protocol";
+import {
+  isMonotonicRead,
+  isReadYourWrite,
+  isTransientReadError,
+  missingAckedSlots,
+} from "../fixtures/session-guarantees.ts";
+
+// These predicates are the decision core the causal cascade asserts
+// against (SG-1/SG-2/SG-3 + the poll-loop read-error policy). The cascade
+// exercises them under concurrency; here we pin the exact boundary each
+// one draws, so a refactor that silently makes an assertion un-fireable
+// (e.g. a comparison that degrades to always-true) turns red here.
+
+describe("SG-1 missingAckedSlots (no-lost-writes)", () => {
+  test("holds when every acked slot is durable", () => {
+    expect(missingAckedSlots([1, 2, 3], new Set([1, 2, 3, 4]))).toEqual([]);
+  });
+
+  test("reports acked slots absent from the durable set", () => {
+    expect(missingAckedSlots([1, 2, 3], new Set([1, 3]))).toEqual([2]);
+  });
+
+  test("reports every missing slot, preserving acked order", () => {
+    expect(missingAckedSlots([5, 2, 9], new Set([2]))).toEqual([5, 9]);
+  });
+
+  test("empty ack ledger trivially holds", () => {
+    expect(missingAckedSlots([], new Set([1, 2]))).toEqual([]);
+  });
+});
+
+describe("SG-2 isReadYourWrite", () => {
+  test("holds when the self-read resolves the won slot", () => {
+    expect(isReadYourWrite(7, 7)).toBe(true);
+  });
+
+  test("holds when the self-read resolves a newer slot", () => {
+    expect(isReadYourWrite(8, 7)).toBe(true);
+  });
+
+  test("violated when the self-read resolves an older slot", () => {
+    expect(isReadYourWrite(6, 7)).toBe(false);
+  });
+
+  test("violated when the self-read resolved nothing", () => {
+    expect(isReadYourWrite(undefined, 0)).toBe(false);
+  });
+});
+
+describe("SG-3 isMonotonicRead", () => {
+  test("holds when the read advances", () => {
+    expect(isMonotonicRead(5, 4)).toBe(true);
+  });
+
+  test("holds when the read repeats the last slot", () => {
+    expect(isMonotonicRead(5, 5)).toBe(true);
+  });
+
+  test("holds against the -1 sentinel (first observation)", () => {
+    expect(isMonotonicRead(0, -1)).toBe(true);
+  });
+
+  test("violated when the read goes backward", () => {
+    expect(isMonotonicRead(4, 5)).toBe(false);
+  });
+});
+
+describe("isTransientReadError (poll-loop read-error policy)", () => {
+  test("BaerlyError is transient — swallowed, retried next tick", () => {
+    expect(isTransientReadError(new BaerlyError("NetworkError", "flip"))).toBe(true);
+  });
+
+  test("a failed assertion (plain Error) is fatal — must surface", () => {
+    expect(isTransientReadError(new Error("monotonic-reads violated"))).toBe(false);
+  });
+
+  test("a non-error throw is fatal", () => {
+    expect(isTransientReadError("boom")).toBe(false);
+  });
+});

--- a/tests/unit/with-network-retry.test.ts
+++ b/tests/unit/with-network-retry.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "vitest";
+import { BaerlyError } from "@baerly/protocol";
+import { MAX_NETWORK_RETRIES, withNetworkRetry } from "../fixtures/randomized-cascade.ts";
+
+// withNetworkRetry rides out the node-minio Toxiproxy flips the cascade
+// runs under. Its branches — retry only on NetworkError, bounded attempts,
+// propagate everything else — are load-bearing (an unbounded or
+// wrong-predicate retry would hang or mask real failures), so pin them
+// deterministically here rather than leaning on the probabilistic cascade.
+
+const networkError = (): BaerlyError => new BaerlyError("NetworkError", "toxiproxy flip");
+
+describe("withNetworkRetry", () => {
+  test("returns the op result without retrying on success", async () => {
+    let calls = 0;
+    const result = await withNetworkRetry(async () => {
+      calls++;
+      return "ok";
+    });
+    expect(result).toBe("ok");
+    expect(calls).toBe(1);
+  });
+
+  test("retries a transient NetworkError, then returns", async () => {
+    let calls = 0;
+    const result = await withNetworkRetry(async () => {
+      calls++;
+      if (calls < 3) {
+        throw networkError();
+      }
+      return calls;
+    });
+    expect(result).toBe(3);
+    expect(calls).toBe(3);
+  });
+
+  test("propagates a non-NetworkError immediately (no retry)", async () => {
+    let calls = 0;
+    await expect(
+      withNetworkRetry(async () => {
+        calls++;
+        throw new BaerlyError("Conflict", "someone else won the slot");
+      }),
+    ).rejects.toMatchObject({ code: "Conflict" });
+    expect(calls).toBe(1);
+  });
+
+  test("propagates a plain assertion error immediately (no retry)", async () => {
+    let calls = 0;
+    await expect(
+      withNetworkRetry(async () => {
+        calls++;
+        throw new Error("parity mismatch");
+      }),
+    ).rejects.toThrow("parity mismatch");
+    expect(calls).toBe(1);
+  });
+
+  test("gives up after MAX_NETWORK_RETRIES and throws the last NetworkError", async () => {
+    let calls = 0;
+    await expect(
+      withNetworkRetry(async () => {
+        calls++;
+        throw networkError();
+      }),
+    ).rejects.toMatchObject({ code: "NetworkError" });
+    // One initial attempt + MAX_NETWORK_RETRIES retries.
+    expect(calls).toBe(MAX_NETWORK_RETRIES + 1);
+  });
+});


### PR DESCRIPTION
Promotes three session guarantees into the causal-consistency contract and asserts them directly in the randomized cascade, alongside the existing P1/P2/P3 causal-ordering checks.

- **SG-1 no-lost-writes** (all backends): every acked `commit()` slot is present in the durable `log/<seq>` set at drain.
- **SG-2 read-your-writes** (strong backends): a self-read after commit resolves a slot `>= S`.
- **SG-3 monotonic-reads** (strong backends): a client's resolved read slot never decreases.

SG-2/SG-3 are gated to strongly-consistent backends (memory, local-fs, miniflare-R2); node-minio stays off since its Toxiproxy fault injection deliberately induces stale reads. Each guarantee names its backend class and witnessing assertion in the spec, so a port can satisfy the same contract.

Also:
- **Fix:** the poll loop's `void error` swallowed *everything*, so an assertion failure inside it timed out at 60s instead of failing fast. Non-`BaerlyError` throws now re-propagate — this is what gives SG-3 teeth.
- Seeds the injected clock-offset entropy (portable integer seed) and dumps the observed schedule on a causal violation, for reproducible/portable triage. Full deterministic replay remains future work.
- Corrects the `LogEntry.seq` JSDoc the SG-1 contract cites (it read "per-session sequence number"; it's the global `log/<seq>` slot).

## Verification
- `pnpm verify`, `pnpm test` (memory + local-fs), `pnpm test:adapter-cloudflare` (miniflare-R2) — all green.
- Stress: memory/local-fs cascade 5/5, cloudflare-r2 cascade 3/3.