### PR TITLE
chore(adapter-node): replace fast-xml-parser with @rgrove/parse-xml

### DIFF
--- a/.changeset/dependency-updates.md
+++ b/.changeset/dependency-updates.md
@@ -7,10 +7,7 @@ Refresh dependencies ahead of release. Runtime deps that ship to consumers:
 2.0.4 → 2.0.6, and `jose` floated to 6.2.3. The `@gusto/create-baerly-storage`
 scaffolder picks up `@clack/prompts` 1.6.0. No public API changes.
 
-`fast-xml-parser` is deliberately held at 5.8.0 (exact pin in
-`@baerly/adapter-node`): 5.9.3 inflated the `./s3` closure's min-gz — the hard
-shipped-to-browser budget — by ~25%, which we can't shrink because it's a
-third-party closure. 5.8.0 remains the largest version that fits the ceiling.
-Its transitive deps (`strnum`, `@nodable/entities`) did float forward and cost a
-small amount of bundle size, rebaselined with a dated note in the bundle-size
-budgets alongside the `@logtape` growth.
+The `@logtape/logtape` growth was rebaselined with a dated note in the
+bundle-size budgets. (The XML parser was separately swapped from
+`fast-xml-parser` to `@rgrove/parse-xml` — see the parser-swap changeset — which
+removes `fast-xml-parser` and its transitive closure from the tree entirely.)

--- a/.changeset/replace-fast-xml-parser.md
+++ b/.changeset/replace-fast-xml-parser.md
@@ -1,0 +1,46 @@
+---
+'@gusto/baerly-storage': patch
+---
+
+Replace `fast-xml-parser` with `@rgrove/parse-xml` in the S3 XML decode path
+(`@baerly/adapter-node`).
+
+**Bundle size:** −87 KiB raw / −24 KiB gz / −14 KiB min-gz on the `s3.js`
+closure — significant for a library bundled into user apps.
+
+**Zero-dependency:** `@rgrove/parse-xml` has no transitive dependencies, vs
+`fast-xml-parser`'s closure (`strnum`, `@nodable/entities`). Smaller
+supply-chain and audit surface.
+
+**Off the CVE-bump treadmill:** `fast-xml-parser` shipped ~6 CVEs across 5.x
+(CVE-2026-25896, CVE-2026-26278, CVE-2026-33036, and others), all in the
+DOCTYPE/entity surface. Our own `<!DOCTYPE` regex guard already made those
+vectors unreachable — the pinned `fast-xml-parser@5.8.0` was not itself
+vulnerable — but each new CVE still required a version-pin review.
+`@rgrove/parse-xml` parses and discards DTDs without resolving custom entities,
+so the entity-expansion CVE *class* cannot recur even if our regex guard ever
+regressed. This is defense-in-depth and audit-surface reduction, not the
+closing of an active hole.
+
+**Spec-correct entity set:** `@rgrove/parse-xml` decodes only the 5 predefined
+XML entities plus decimal/hex numeric character references — exactly what XML
+wire data uses (see "Intended entity-set difference" below).
+
+`fast-xml-parser` is removed entirely — it no longer appears in `dependencies`
+or `devDependencies`. During development the swap was validated with a
+differential-oracle test that asserted field-for-field parity between the two
+parsers on generated S3-shaped XML (predefined entities, decimal/hex numeric
+refs, CDATA, singular + plural `<Contents>`); that one-time migration check is
+not retained, so the repo no longer carries `fast-xml-parser` or its
+CVE-bump/dependabot cadence. The parser's behavior is pinned going forward by
+the example-based contract tests in `packages/adapter-node/src/xml.test.ts`.
+
+**Intended entity-set difference (not a bug):** `@rgrove/parse-xml` decodes
+the 5 predefined XML entities (`&amp; &lt; &gt; &quot; &apos;`) plus decimal
+and hex numeric character references. It does NOT decode HTML named entities
+(`&nbsp;`, `&mdash;`, etc.) — the old code enabled `htmlEntities: true`
+solely to get numeric refs. S3/R2/MinIO wire data is XML, not HTML, so the
+narrower entity set is more spec-correct. No S3 backend emits HTML-only named
+entities in `ListObjectsV2` or error responses.
+
+No public API changes; all exported functions and types are unchanged.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,7 +384,7 @@ auto-load on matching edits and point at the same files.
 
 - ❌ Adding **runtime** dependencies to anything that ships to user
   apps. The runtime footprint of `baerly-storage` and the adapters
-  is intentionally small (`aws4fetch`, `fast-xml-parser`, `hono`,
+  is intentionally small (`aws4fetch`, `@rgrove/parse-xml`, `hono`,
   `jose`); every additional dep widens the kernel bundle
   and the audit surface for users. Justify any addition.
 - ✅ **Build-time / CLI / dev-tooling deps are fair game.** Inside

--- a/docs/contributing/publishing.md
+++ b/docs/contributing/publishing.md
@@ -208,7 +208,7 @@ The published `@gusto/baerly-storage` bundle ships a
 exists and how it's produced.
 
 **Why.** rolldown _inlines_ our runtime deps (`aws4fetch`,
-`fast-xml-parser`, `hono`, `@hono/node-server`, `jose`,
+`@rgrove/parse-xml`, `hono`, `@hono/node-server`, `jose`,
 `@logtape/logtape`, `picocolors`, plus the CLI's `citty` + `jsonc-parser`)
 into `dist/`. Those deps are MIT/ISC/BSD/Apache-2.0; every one of those
 licenses requires its copyright + permission notice to travel with any

--- a/docs/spec/s3-xml-escaping-cases.md
+++ b/docs/spec/s3-xml-escaping-cases.md
@@ -31,7 +31,7 @@ set, S3 returns the key family — `Key` / `Prefix` / `Delimiter` /
 
 So the XML parser only ever sees `[A-Za-z0-9%+._-]` in the key family —
 never a raw `<`, `&`, `]]>`, or control byte. The parser reverses both
-steps in `packages/adapter-node/src/xml.ts:50`:
+steps in the `xmlVal` helper (`packages/adapter-node/src/xml.ts`):
 
 ```ts
 decodeURIComponent(v.replace(/\+/g, " "))
@@ -104,7 +104,7 @@ that branch on the response field to decide whether to decode.
 baerly-storage dodges this entirely: `xml.ts` **never reads the
 `EncodingType` element**.
 It url-decodes the key family *unconditionally*
-(`packages/adapter-node/src/xml.ts:45-51`). This is a deliberate
+(the `xmlVal` helper in `packages/adapter-node/src/xml.ts`). This is a deliberate
 portability invariant — *decode unconditionally, never branch on the
 response flag* — matching the fix
 [minio-go landed](https://github.com/minio/minio-go/issues/1410). Fields S3
@@ -127,12 +127,16 @@ unconditionally and never inspects the response marker.
 baerly-storage only ever **parses** S3 XML, never **builds** it, so
 builder-side CDATA/comment-injection CVEs are out of scope. On the parse
 side, both `parseS3Error` and `parseListObjectsV2CommandOutput`
-(`packages/adapter-node/src/xml.ts:72,115`) reject any body containing a
+(`packages/adapter-node/src/xml.ts`) reject any body containing a
 `<!DOCTYPE` *before* the parser sees the bytes — a deliberate
 XXE / billion-laughs / entity-shadow (CVE-2026-25896) defense, since
-S3/R2/MinIO/GCS never emit a DOCTYPE here. The runtime `fast-xml-parser`
-floor is pinned `^5.5.6` to cover the no-DOCTYPE numeric-character-reference
-expansion path (CVE-2026-33036) that the DTD guard cannot match.
+S3/R2/MinIO/GCS never emit a DOCTYPE here.
+
+The runtime parser is `@rgrove/parse-xml`, which parses and discards DTDs
+without resolving custom entities — so the entity-expansion CVE class cannot
+recur even if the regex guard above ever regressed. The `<!DOCTYPE` guard is
+parser-independent defense-in-depth that makes entity-expansion vectors
+unreachable regardless of which parser is in use.
 
 A malformed percent-escape (a bare `%` or `%ZZ`) in a key field makes
 `decodeURIComponent` throw a raw `URIError`. `xmlVal`

--- a/docs/spec/storage-compatibility.md
+++ b/docs/spec/storage-compatibility.md
@@ -286,7 +286,7 @@ The commit protocol requires exactly-one-winner create-if-absent
 this; over the S3 HTTP API you inherit the *endpoint's* conditional-write
 and consistency behavior, so this path is only as strong as the backend
 you point it at. Cost trade-off: the `/s3` closure carries `aws4fetch` +
-`fast-xml-parser`; a same-account binding avoids both.
+`@rgrove/parse-xml`; a same-account binding avoids both.
 
 **Support tier.** This path is opt-in and sits at the same tier as
 AWS-via-`S3HttpStorage`: credential-gated, with production validation you
@@ -297,7 +297,7 @@ levels: `tests/integration/s3-worker-safe.test.ts` proves the
 Worker), and `tests/integration/s3-worker-wire.test.ts` proves it *runs*
 in a real Workerd isolate — `S3HttpStorage` + `sigV4Signer` drive a
 put / get / CAS / list round-trip through an in-memory S3-shaped `fetch`
-stub, exercising aws4fetch's WebCrypto signing, `fast-xml-parser`, and the
+stub, exercising aws4fetch's WebCrypto signing, `@rgrove/parse-xml`, and the
 `Request`/`Response` plumbing in-isolate. What CI does **not** do is drive
 a *real* S3 endpoint from workerd (TLS + the endpoint's own
 conditional-write semantics); that is the manual e2e recipe in

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -8,7 +8,7 @@
  * `S3HttpStorage` + `sigV4Signer` from the Worker-safe
  * `@gusto/baerly-storage/s3` subpath and pass the instance as
  * `baerlyWorker((env) => ({ config, storage }))`. That subpath pulls
- * `aws4fetch` + `fast-xml-parser` (SigV4 + XML), which is why it is not
+ * `aws4fetch` + `@rgrove/parse-xml` (SigV4 + XML), which is why it is not
  * re-exported here: the closure of `@gusto/baerly-storage/cloudflare`
  * stays peer-free so same-account R2-binding consumers don't carry those
  * bytes. Do NOT import from `@gusto/baerly-storage/node` in a Worker —

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -25,8 +25,8 @@
     "@baerly/protocol": "workspace:*",
     "@baerly/server": "workspace:*",
     "@hono/node-server": "^2.0.6",
+    "@rgrove/parse-xml": "4.2.1",
     "aws4fetch": "1.0.20",
-    "fast-xml-parser": "5.8.0",
     "hono": "^4.12.27",
     "picocolors": "^1.1.1"
   }

--- a/packages/adapter-node/src/s3.ts
+++ b/packages/adapter-node/src/s3.ts
@@ -7,7 +7,7 @@
  * Worker. Reach for it when a Worker must talk to S3 / cross-account
  * R2 over the S3 REST API instead of a native R2 binding.
  *
- * Bundle cost: pulls `aws4fetch` (SigV4) + `fast-xml-parser`. Workers
+ * Bundle cost: pulls `aws4fetch` (SigV4) + `@rgrove/parse-xml` (XML). Workers
  * that use a same-account R2 binding should stay on
  * `@gusto/baerly-storage/cloudflare`, whose closure carries neither.
  *

--- a/packages/adapter-node/src/xml.test.ts
+++ b/packages/adapter-node/src/xml.test.ts
@@ -124,7 +124,7 @@ describe("XML parser", () => {
 
   test("DOCTYPE entity-definition vector is rejected before the parser runs", () => {
     // CVE-2026-25896 shadowing shape: a DOCTYPE defining an entity. The DTD
-    // guard must reject the body BEFORE fast-xml-parser sees the bytes, so
+    // guard must reject the body BEFORE the parser sees the bytes, so
     // the entity is never expanded/shadowed. Locks the guard so a future
     // parser-option change can't silently regress this.
     const xml: string = `<?xml version="1.0" encoding="UTF-8"?>
@@ -245,6 +245,26 @@ describe("XML parser", () => {
     const parsed = parseListObjectsV2CommandOutput(xml);
     expect(parsed.Contents?.[0]?.ETag).toBe('"a+b%2Bc"');
   });
+
+  test("returns {} when the root element is not <ListBucketResult>", () => {
+    // A non-list body (e.g. an S3 <Error> response mis-routed here) must hit the
+    // root-name guard and return {} rather than attempting to parse Contents.
+    // Exercises the `localName(root.name) !== "ListBucketResult"` branch directly.
+    expect(parseListObjectsV2CommandOutput("<Error><Code>AccessDenied</Code></Error>")).toEqual({});
+  });
+
+  test("collects namespace-prefixed <s3:Contents> children (namespace-agnostic)", () => {
+    // The whitespace-free minio example uses a default xmlns (no prefix), so it
+    // never exercises localName()'s prefix-stripping path. This body carries an
+    // explicit `s3:` prefix on every element, proving the namespace-agnostic
+    // traversal claim: <s3:ListBucketResult> matches the root guard and
+    // <s3:Contents>/<s3:Key>/<s3:ETag> are collected and read.
+    const xml = `<?xml version="1.0" encoding="UTF-8"?><s3:ListBucketResult xmlns:s3="http://s3.amazonaws.com/doc/2006-03-01/"><s3:Contents><s3:Key>k</s3:Key><s3:ETag>"e"</s3:ETag></s3:Contents><s3:NextContinuationToken>tok</s3:NextContinuationToken></s3:ListBucketResult>`;
+    expect(parseListObjectsV2CommandOutput(xml)).toEqual({
+      Contents: [{ Key: "k", ETag: '"e"', LastModified: undefined }],
+      NextContinuationToken: "tok",
+    });
+  });
 });
 
 describe("parseS3Error", () => {
@@ -269,13 +289,22 @@ describe("parseS3Error", () => {
     expect(parseS3Error("<Error><RequestId>abc</RequestId></Error>")).toBeUndefined();
   });
 
+  test("returns undefined when <Error> is nested but the root element is not <Error>", () => {
+    // The `/<Error\b/i` prefilter matches (the inner <Error> tag is present), so
+    // this body reaches — and must be rejected by — the root-name guard
+    // (`localName(root.name) !== "Error"`), not the prefilter short-circuit that
+    // the "<ListBucketResult>" case above hits. Guards against mis-parsing an
+    // STS-shaped or wrapped body as a bare S3 error.
+    expect(parseS3Error("<Wrapper><Error><Code>X</Code></Error></Wrapper>")).toBeUndefined();
+  });
+
   test("decodes builtin XML entities and CDATA in the <Message> text", () => {
     // DISTINCT from the DOCTYPE <!ENTITY> vector below (which is REJECTED as an
     // entity-shadow attack): a normal builtin XML entity (&amp;) and a CDATA
     // block in the Message TEXT are legitimate S3 error content and MUST be
-    // decoded/unwrapped into the plain Message string. fast-xml-parser handles
-    // both (processEntities default + htmlEntities) before rawXmlVal reads the
-    // field, so &amp; → & and <![CDATA[..]]> is unwrapped verbatim.
+    // decoded/unwrapped into the plain Message string. @rgrove/parse-xml handles
+    // both (predefined + numeric entity refs, plus CDATA merged into text) before
+    // rawXmlVal reads the field, so &amp; → & and <![CDATA[..]]> is unwrapped verbatim.
     const entityXml: string = `<?xml version="1.0" encoding="UTF-8"?>
       <Error><Code>InvalidArgument</Code><Message>bucket &amp; key are &lt;required&gt;</Message></Error>`;
     const entityParsed = parseS3Error(entityXml);
@@ -306,6 +335,34 @@ describe("parseS3Error", () => {
     expect(
       parseS3Error(`<!DOCTYPE Error [<!ENTITY l. "x">]><Error><Code>&lt;</Code></Error>`),
     ).toBeUndefined();
+  });
+});
+
+describe("whitespace contract: @rgrove/parse-xml preserves surrounding whitespace", () => {
+  // These tests document a deliberate divergence from the old fast-xml-parser
+  // behavior (which trimmed leading/trailing whitespace by default via
+  // `trimValues: true`). Real S3/R2/MinIO/GCS backends emit compact XML and
+  // never pad field values with surrounding whitespace, so this difference does
+  // not affect production behavior. The contract is pinned here so any future
+  // change to whitespace handling (e.g. a new parser or an explicit trim step)
+  // is a conscious, reviewed decision rather than a silent regression.
+
+  test("parseS3Error preserves surrounding whitespace in <Message>", () => {
+    // Empirically determined: @rgrove/parse-xml concatenates raw text node
+    // content, preserving the spaces on both sides of the message text.
+    const xml = `<?xml version="1.0" encoding="UTF-8"?><Error><Code>SomeError</Code><Message>  padded message  </Message></Error>`;
+    expect(parseS3Error(xml)).toEqual({
+      Code: "SomeError",
+      Message: "  padded message  ",
+    });
+  });
+
+  test("parseListObjectsV2CommandOutput preserves surrounding whitespace in <ETag>", () => {
+    // Empirically determined: @rgrove/parse-xml concatenates raw text node
+    // content, preserving the spaces on both sides of the ETag value.
+    const xml = `<?xml version="1.0" encoding="UTF-8"?><ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Contents><Key>my%2Bkey</Key><ETag>  "etag-value"  </ETag></Contents></ListBucketResult>`;
+    const parsed = parseListObjectsV2CommandOutput(xml);
+    expect(parsed.Contents?.[0]?.ETag).toBe('  "etag-value"  ');
   });
 });
 
@@ -349,7 +406,7 @@ describe("parseAssumeRoleWithWebIdentity", () => {
     // A success-shaped-but-malformed 200 body carries plaintext credentials;
     // the thrown error must not fold them in (it gets logged).
     const secret = "SECRET-ACCESS-KEY-DO-NOT-LEAK";
-    // Truncated trailing tag makes fast-xml-parser throw mid-parse; the secret
+    // Truncated trailing tag makes the parser throw mid-parse; the secret
     // sits in the (unparseable) body the old code echoed into the error.
     const malformed = `<AssumeRoleWithWebIdentityResponse><AssumeRoleWithWebIdentityResult><Credentials><SecretAccessKey>${secret}</SecretAccessKey><trunc`;
     let thrown: unknown;

--- a/packages/adapter-node/src/xml.ts
+++ b/packages/adapter-node/src/xml.ts
@@ -1,5 +1,5 @@
 import { BaerlyError } from "@baerly/protocol";
-import { XMLParser } from "fast-xml-parser";
+import { parseXml, type XmlDocument, type XmlElement, type XmlText } from "@rgrove/parse-xml";
 
 /**
  * Subset of S3's `ListObjectsV2CommandOutput` produced by
@@ -23,18 +23,60 @@ export interface ParsedS3Error {
   Message?: string;
 }
 
-const xmlParser = new XMLParser({
-  ignoreAttributes: true,
-  // Keep numeric-looking strings as strings — S3 keys can be all-digits.
-  parseTagValue: false,
-  // Force `<Contents>` to an array even when only one is present.
-  isArray: (name) => name === "Contents",
-  // Decode numeric character refs (`&#34;` → `"`). fast-xml-parser's
-  // `processEntities` only handles the 5 predefined XML entities by
-  // default; the HTML entity table covers numeric refs too. Minio
-  // emits `&#34;` around ETags, so this is load-bearing.
-  htmlEntities: true,
-});
+// --- parse-xml helpers ---
+
+// Strip any namespace prefix: "s3:Contents" -> "Contents", "Contents" -> "Contents".
+// The `includes(":")` guard makes the `split(":")[1]!` non-null assertion safe.
+const localName = (name: string): string => (name.includes(":") ? name.split(":")[1]! : name);
+
+// Type predicates narrowing an XmlNode child to a concrete node class.
+// @rgrove/parse-xml types the `type` discriminant as `string` (not a string
+// literal), so `node.type === "element"` does NOT narrow the child union on its
+// own. These localize the one unavoidable assertion behind a checked predicate
+// instead of scattering `as XmlElement` / `as XmlText` casts at each use site.
+const isElement = (node: XmlElement["children"][number]): node is XmlElement =>
+  node.type === "element";
+const isText = (node: XmlElement["children"][number]): node is XmlText => node.type === "text";
+
+// Return the first XmlElement child of a document or element whose local name
+// (after any namespace prefix) matches `name`. This makes traversal
+// namespace-agnostic: both `<Error>` and `<ns:Error>` match name "Error".
+const child = (el: XmlElement, name: string): XmlElement | undefined => {
+  for (const node of el.children) {
+    if (isElement(node) && localName(node.name) === name) {
+      return node;
+    }
+  }
+  return undefined;
+};
+
+// Concatenate the direct text child node text values of an element.
+// @rgrove/parse-xml resolves the 5 predefined XML entities (&amp; &lt; &gt;
+// &quot; &apos;) and decimal/hex numeric character references (e.g. Minio's
+// &#34; ETags) by default. Under the default `preserveCdata: false` (which is
+// how we call parseXml), any CDATA section is merged into the element's adjacent
+// text nodes and surfaces as an XmlText (type "text"), so the "text" branch
+// captures it — there is never a standalone "cdata" node. Entities inside a
+// CDATA section are NOT decoded (CDATA is literal), which is the correct S3
+// behavior. We intentionally do NOT decode HTML named entities (&nbsp; etc.) —
+// S3 wire data is XML, not HTML, so this is more spec-correct.
+const textOf = (el: XmlElement | undefined): string | undefined => {
+  if (el === undefined) {
+    return undefined;
+  }
+  let result = "";
+  for (const node of el.children) {
+    if (isText(node)) {
+      result += node.text;
+    }
+  }
+  return result === "" ? undefined : result;
+};
+
+// Return the first-element-child of an XmlDocument. Unlike `XmlDocument.root`
+// (which is an XmlElement | null getter), this avoids potential null handling
+// confusion by returning undefined on an empty document.
+const docRoot = (doc: XmlDocument): XmlElement | undefined => doc.root ?? undefined;
 
 // The list request sets `encoding-type=url`, so S3 URL-encodes the **key
 // family only** (Key/Prefix/Delimiter/StartAfter) in the response,
@@ -42,9 +84,9 @@ const xmlParser = new XMLParser({
 // to ETag or NextContinuationToken — S3 leaves those verbatim, and a
 // continuation token routinely contains literal `+` that the `.replace`
 // step would mangle into a space (corrupting pagination on large buckets).
-const xmlVal = (obj: Record<string, unknown>, name: string): string | undefined => {
-  const v = obj[name];
-  if (typeof v !== "string" || v === "") {
+const xmlVal = (el: XmlElement | undefined, name: string): string | undefined => {
+  const v = el !== undefined ? textOf(child(el, name)) : undefined;
+  if (v === undefined || v === "") {
     return undefined;
   }
   // A well-formed encoding-type=url response only ever contains valid
@@ -63,9 +105,8 @@ const xmlVal = (obj: Record<string, unknown>, name: string): string | undefined 
 // error-body `Code`/`Message`, list `ETag`/`LastModified`, and
 // `NextContinuationToken` — running any of these through `xmlVal`'s
 // `decodeURIComponent` / `+`→space would corrupt literal `+` and `%`.
-const rawXmlVal = (obj: Record<string, unknown>, name: string): string | undefined => {
-  const v = obj[name];
-  return typeof v === "string" && v !== "" ? v : undefined;
+const rawXmlVal = (el: XmlElement | undefined, name: string): string | undefined => {
+  return el !== undefined ? textOf(child(el, name)) : undefined;
 };
 
 /**
@@ -81,14 +122,17 @@ export const parseS3Error = (xml: string): ParsedS3Error | undefined => {
   if (!/<Error\b/i.test(xml) || /<!DOCTYPE\b/i.test(xml)) {
     return undefined;
   }
-  let result: { Error?: Record<string, unknown> };
+  let root: XmlElement | undefined;
   try {
-    result = xmlParser.parse(xml) as { Error?: Record<string, unknown> };
+    root = docRoot(parseXml(xml));
   } catch {
     return undefined;
   }
-  const root = result.Error;
+  // The root element must be <Error> (possibly namespace-prefixed).
   if (root === undefined) {
+    return undefined;
+  }
+  if (localName(root.name) !== "Error") {
     return undefined;
   }
   const code = rawXmlVal(root, "Code");
@@ -117,18 +161,22 @@ export const parseStsError = (xml: string): ParsedS3Error | undefined => {
   if (!/<Error\b/i.test(xml) || /<!DOCTYPE\b/i.test(xml)) {
     return undefined;
   }
-  let result: { ErrorResponse?: { Error?: Record<string, unknown> } };
+  let root: XmlElement | undefined;
   try {
-    result = xmlParser.parse(xml) as typeof result;
+    root = docRoot(parseXml(xml));
   } catch {
     return undefined;
   }
-  const root = result.ErrorResponse?.Error;
   if (root === undefined) {
     return undefined;
   }
-  const code = rawXmlVal(root, "Code");
-  const message = rawXmlVal(root, "Message");
+  // STS wraps <Error> inside <ErrorResponse>; locate the inner <Error> child.
+  const errorEl = child(root, "Error");
+  if (errorEl === undefined) {
+    return undefined;
+  }
+  const code = rawXmlVal(errorEl, "Code");
+  const message = rawXmlVal(errorEl, "Message");
   if (code === undefined && message === undefined) {
     return undefined;
   }
@@ -153,7 +201,7 @@ export interface ParsedWebIdentityCredentials {
 
 /**
  * Parse an STS `AssumeRoleWithWebIdentity` success body, returning the
- * `<Credentials>` block. Reuses the hardened, DTD-guarded {@link xmlParser};
+ * `<Credentials>` block. Reuses the hardened, DTD-guarded parser;
  * throws `InvalidResponse` on a DTD or unparseable XML. Missing fields come
  * back `undefined` so the caller can map them to its own `InvalidResponse`.
  *
@@ -166,24 +214,23 @@ export const parseAssumeRoleWithWebIdentity = (xml: string): ParsedWebIdentityCr
   if (/<!DOCTYPE\b/i.test(xml)) {
     throw new BaerlyError("InvalidResponse", "DTD not allowed in STS XML responses");
   }
-  let result: {
-    AssumeRoleWithWebIdentityResponse?: {
-      AssumeRoleWithWebIdentityResult?: { Credentials?: Record<string, unknown> };
-    };
-  };
+  let root: XmlElement | undefined;
   try {
-    result = xmlParser.parse(xml) as typeof result;
+    root = docRoot(parseXml(xml));
   } catch {
     // No body in the message — see the note above; it may contain live creds.
     throw new BaerlyError("InvalidResponse", "unparseable STS credentials response");
   }
-  const creds =
-    result.AssumeRoleWithWebIdentityResponse?.AssumeRoleWithWebIdentityResult?.Credentials ?? {};
+  // Traverse: <AssumeRoleWithWebIdentityResponse>
+  //             <AssumeRoleWithWebIdentityResult>
+  //               <Credentials>
+  const resultEl = root !== undefined ? child(root, "AssumeRoleWithWebIdentityResult") : undefined;
+  const credsEl = resultEl !== undefined ? child(resultEl, "Credentials") : undefined;
   return {
-    AccessKeyId: rawXmlVal(creds, "AccessKeyId"),
-    SecretAccessKey: rawXmlVal(creds, "SecretAccessKey"),
-    SessionToken: rawXmlVal(creds, "SessionToken"),
-    Expiration: rawXmlVal(creds, "Expiration"),
+    AccessKeyId: rawXmlVal(credsEl, "AccessKeyId"),
+    SecretAccessKey: rawXmlVal(credsEl, "SecretAccessKey"),
+    SessionToken: rawXmlVal(credsEl, "SessionToken"),
+    Expiration: rawXmlVal(credsEl, "Expiration"),
   };
 };
 
@@ -199,31 +246,44 @@ const parseLastModified = (lm: string | undefined): Date | undefined => {
   return Number.isNaN(d.getTime()) ? undefined : d;
 };
 
-// DTD guard: reject any DOCTYPE before fast-xml-parser sees the bytes. S3/R2/
+// DTD guard: reject any DOCTYPE before @rgrove/parse-xml sees the bytes. S3/R2/
 // MinIO/GCS never emit a DOCTYPE here, so one is always a bug or an attack —
 // this defangs the DOCTYPE entity vectors (XXE, billion-laughs, the
-// CVE-2026-25896 entity-shadow). The no-DOCTYPE numeric-ref expansion path
-// (CVE-2026-33036) it cannot match is covered by the `^5.5.6` floor in
-// package.json. `htmlEntities: true` (above) stays default-safe given both.
+// CVE-2026-25896 entity-shadow). @rgrove/parse-xml is safe-by-design (refuses
+// DTD entity definitions), but the regex guard is parser-independent
+// defense-in-depth and independently covers the entity-expansion CVE class.
 export const parseListObjectsV2CommandOutput = (xml: string): ParsedListObjectsV2Output => {
   if (/<!DOCTYPE\b/i.test(xml)) {
     throw new BaerlyError("InvalidResponse", "DTD not allowed in S3 XML responses");
   }
-  let result: { ListBucketResult?: Record<string, unknown> };
+  let root: XmlElement | undefined;
   try {
-    result = xmlParser.parse(xml) as { ListBucketResult?: Record<string, unknown> };
+    root = docRoot(parseXml(xml));
   } catch {
     throw new BaerlyError("InvalidResponse", `Invalid XML: ${xml}`);
   }
-  const root = result.ListBucketResult ?? {};
-  const contents = (root["Contents"] as Array<Record<string, unknown>> | undefined) ?? [];
+  if (root === undefined) {
+    return {};
+  }
+  // The root element must be <ListBucketResult> (possibly namespace-prefixed).
+  // This restores main's `result.ListBucketResult ?? {}` structural guard and
+  // matches the sibling error parsers' root checks: a non-list body returns {}.
+  if (localName(root.name) !== "ListBucketResult") {
+    return {};
+  }
+  // Force-array for Contents: collect all direct <Contents> element children.
+  // This replaces the old `isArray: (name) => name === "Contents"` config.
+  // Namespace-agnostic (matches `child()`), so `<s3:Contents>` also collects.
+  const contentEls = root.children
+    .filter(isElement)
+    .filter((c) => localName(c.name) === "Contents");
 
   return {
-    Contents: contents.map((content) => {
+    Contents: contentEls.map((contentEl) => {
       return {
-        ETag: rawXmlVal(content, "ETag"),
-        Key: xmlVal(content, "Key"),
-        LastModified: parseLastModified(rawXmlVal(content, "LastModified")),
+        ETag: rawXmlVal(contentEl, "ETag"),
+        Key: xmlVal(contentEl, "Key"),
+        LastModified: parseLastModified(rawXmlVal(contentEl, "LastModified")),
       };
     }),
     NextContinuationToken: rawXmlVal(root, "NextContinuationToken"),

--- a/packages/cli/rolldown.config.ts
+++ b/packages/cli/rolldown.config.ts
@@ -4,7 +4,7 @@ import { licensePluginOptions, PARTIAL_CLI_FILENAME } from "../../scripts/third-
 
 export default defineConfig({
   input: "src/baerly.ts",
-  // `aws4fetch` and `fast-xml-parser` are bundled into `baerly-storage`
+  // `aws4fetch` and `@rgrove/parse-xml` are bundled into `baerly-storage`
   // (the library import surface). Scaffolded apps install only
   // `baerly-storage`, so the CLI bin can't rely on those packages
   // being on disk — bundle them into the bin instead.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,12 +322,12 @@ importers:
       '@hono/node-server':
         specifier: ^2.0.6
         version: 2.0.6(hono@4.12.27)
+      '@rgrove/parse-xml':
+        specifier: 4.2.1
+        version: 4.2.1
       aws4fetch:
         specifier: 1.0.20
         version: 1.0.20
-      fast-xml-parser:
-        specifier: 5.8.0
-        version: 5.8.0
       hono:
         specifier: ^4.12.27
         version: 4.12.27
@@ -1330,9 +1330,6 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@nodable/entities@2.2.0':
-    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
-
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1634,6 +1631,10 @@ packages:
 
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@rgrove/parse-xml@4.2.1':
+    resolution: {integrity: sha512-ZOkOIicFSf5qXbC+8ps5hA+nEhCxsUDpm2U1xp1BACoUZyMkGXEQjsWLD30K77r1fzOTaqEZS85++fmzwCIOJQ==}
+    engines: {node: '>=14.0.0'}
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -2336,9 +2337,6 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
-  anynum@1.0.1:
-    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
-
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
@@ -2839,13 +2837,6 @@ packages:
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
-
-  fast-xml-builder@1.2.0:
-    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
-
-  fast-xml-parser@5.8.0:
-    resolution: {integrity: sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==}
-    hasBin: true
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3658,10 +3649,6 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-expression-matcher@1.5.0:
-    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
-    engines: {node: '>=14.0.0'}
-
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -4065,9 +4052,6 @@ packages:
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
-
-  strnum@2.4.1:
-    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
 
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
@@ -4494,10 +4478,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-
-  xml-naming@0.1.0:
-    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
-    engines: {node: '>=16.0.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -5447,8 +5427,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@nodable/entities@2.2.0': {}
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -5647,6 +5625,8 @@ snapshots:
       supports-color: 10.2.2
 
   '@poppinss/exception@1.2.3': {}
+
+  '@rgrove/parse-xml@4.2.1': {}
 
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
@@ -6278,8 +6258,6 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
-  anynum@1.0.1: {}
-
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -6792,19 +6770,6 @@ snapshots:
   fast-wrap-ansi@0.2.2:
     dependencies:
       fast-string-width: 3.0.2
-
-  fast-xml-builder@1.2.0:
-    dependencies:
-      path-expression-matcher: 1.5.0
-      xml-naming: 0.1.0
-
-  fast-xml-parser@5.8.0:
-    dependencies:
-      '@nodable/entities': 2.2.0
-      fast-xml-builder: 1.2.0
-      path-expression-matcher: 1.5.0
-      strnum: 2.4.1
-      xml-naming: 0.1.0
 
   fastq@1.20.1:
     dependencies:
@@ -7761,8 +7726,6 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-expression-matcher@1.5.0: {}
-
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
@@ -8250,10 +8213,6 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
-  strnum@2.4.1:
-    dependencies:
-      anynum: 1.0.1
-
   stylis@4.4.0: {}
 
   supports-color@10.2.2: {}
@@ -8641,8 +8600,6 @@ snapshots:
       strip-ansi: 7.2.0
 
   ws@8.21.0: {}
-
-  xml-naming@0.1.0: {}
 
   xtend@4.0.2: {}
 

--- a/rolldown.config.ts
+++ b/rolldown.config.ts
@@ -55,7 +55,7 @@ export default defineConfig({
     dev: "packages/dev/src/index.ts",
     "dev-vite": "packages/dev/src/vite-plugin.ts",
   },
-  // `fast-xml-parser` and `aws4fetch` are bundled into the library
+  // `@rgrove/parse-xml` and `aws4fetch` are bundled into the library
   // entries that use them (`dist/node.js` + `dist/s3.js` + `dist/dev-vite.js`).
   // They used to be optional peer deps, but pnpm skips optional peers
   // on install, so a fresh `create-baerly-storage` scaffold's

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -83,7 +83,7 @@ import { IS_CI } from "../setup/ci.ts";
 // ships in a user app bundle, and Node startup dwarfs any sub-MB
 // parse cost — so cold-start size here is not a useful signal. The
 // `BUNDLED_OPTIONAL_PEERS` check further down still walks
-// `dist/baerly.js` to catch live imports of `@xmldom/xmldom` /
+// `dist/baerly.js` to catch live imports of `@rgrove/parse-xml` /
 // `aws4fetch` (the original agent-struggle #14 regression class);
 // that's a behavioural guard, not a byte budget.
 
@@ -900,7 +900,7 @@ const BUDGETS: readonly Budget[] = [
   //     gz 14→15 KiB rather than golf the doc/error (see the POLICY on index.js).
   { entry: "dev.js", raw: 40 * 1024, gz: 15 * 1024 },
   // Worker-safe S3 entry — `S3HttpStorage` + `sigV4Signer` + the
-  // `aws4fetch` SigV4 client + `fast-xml-parser` XML parser.
+  // `aws4fetch` SigV4 client + `@rgrove/parse-xml` XML parser.
   // Intended for cross-account R2 / non-R2 S3 from a Cloudflare
   // Worker; the `./cloudflare` subpath excludes this closure so
   // R2-binding consumers don't pay for it.
@@ -921,7 +921,13 @@ const BUDGETS: readonly Budget[] = [
   //     packages/adapter-node/package.json.) The residual here is the honest
   //     cost of the newer strnum/entities; min-gz clears 26 KiB by 661 B.
   //     Measured: 170745 raw / 49358 gz / 25963 min-gz.
-  { entry: "s3.js", raw: 167 * 1024, gz: 49 * 1024, minGz: 26 * 1024 },
+  //   → raw −87 KiB / gz −24 KiB / min-gz −14 KiB (2026-07-02): replaced
+  //     fast-xml-parser with @rgrove/parse-xml (adapter-node). @rgrove/parse-xml
+  //     is a zero-dep, safe-by-design XML parser (no entity-expansion surface);
+  //     it is dramatically smaller than fast-xml-parser + its transitive closure
+  //     (strnum, @nodable/entities). Measured: 81041 raw / 25085 gz / 11421 min-gz.
+  //     All three axes rebaselined for the parser swap.
+  { entry: "s3.js", raw: 81 * 1024, gz: 25 * 1024, minGz: 12 * 1024 },
 ];
 
 // Static-import specifiers only. Dynamic `import(...)` is intentionally
@@ -1153,7 +1159,7 @@ describe("bundle size", () => {
   // rolldown `external`/bundling slip. A heavy dep that gets bundled
   // INLINE won't show as a bare import here; the raw creep tripwire
   // below is what catches that vector.
-  const RUNTIME_DEP_ALLOWLIST = new Set(["aws4fetch", "fast-xml-parser", "hono", "jose"]);
+  const RUNTIME_DEP_ALLOWLIST = new Set(["@rgrove/parse-xml", "aws4fetch", "hono", "jose"]);
   // Extract the package name from a bare specifier. `hono/tiny` →
   // `hono`; `@scope/name/sub` → `@scope/name`.
   const packageName = (spec: string): string => {
@@ -1210,11 +1216,11 @@ describe("bundle size", () => {
     });
   }
 
-  // Scaffolded apps install only `baerly-storage`. `fast-xml-parser`
+  // Scaffolded apps install only `baerly-storage`. `@rgrove/parse-xml`
   // and `aws4fetch` are bundled into the published library + bin
   // chunks that use them (see `rolldown.config.ts` and
   // `packages/cli/rolldown.config.ts`); no dist closure may leave a
-  // live `import "fast-xml-parser"` or `import "aws4fetch"` for the
+  // live `import "@rgrove/parse-xml"` or `import "aws4fetch"` for the
   // host's module resolver to chase, because the host doesn't have
   // those packages on disk.
   //
@@ -1225,7 +1231,10 @@ describe("bundle size", () => {
   // S3 client and emitted a live `import "@xmldom/xmldom"`, which
   // killed `vite` on scaffolded Cloudflare apps. This test now walks
   // every entry in the published `exports` map plus the bin.
-  const BUNDLED_OPTIONAL_PEERS = new Set(["fast-xml-parser", "aws4fetch"]);
+  // (2026-07-02): `fast-xml-parser` removed from this set — it is gone
+  // from the tree entirely (neither a runtime nor a dev dependency) and
+  // `@rgrove/parse-xml` added as the new runtime XML parser.
+  const BUNDLED_OPTIONAL_PEERS = new Set(["@rgrove/parse-xml", "aws4fetch"]);
   const pkgRoot = resolve(__dirname, "../..");
   const distDir = resolve(pkgRoot, "dist");
   const rootPkg = JSON.parse(readFileSync(resolve(pkgRoot, "package.json"), "utf8")) as {

--- a/tests/integration/s3-worker-wire.test.ts
+++ b/tests/integration/s3-worker-wire.test.ts
@@ -14,7 +14,7 @@
  * Workerd, and which the docs flag as otherwise only covered by the
  * manual e2e (see `manual-e2e/README.md`):
  *   - aws4fetch SigV4 signing under Workerd's WebCrypto (not `node:crypto`),
- *   - `fast-xml-parser` parsing a `ListObjectsV2` body in-isolate,
+ *   - `@rgrove/parse-xml` parsing a `ListObjectsV2` body in-isolate,
  *   - the `Request` body / `Response.arrayBuffer` plumbing under Workerd.
  *
  * Runs under the `cloudflare-pool` vitest project (Workerd/miniflare) via
@@ -91,7 +91,7 @@ describe("@gusto/baerly-storage/s3 executes inside Workerd", () => {
     expect((conflict as BaerlyError).code).toBe("Conflict");
   });
 
-  test("list parses ListObjectsV2 XML with fast-xml-parser in-isolate", async () => {
+  test("list parses ListObjectsV2 XML with @rgrove/parse-xml in-isolate", async () => {
     const { fetchImpl } = makeS3Stub(BUCKET);
     const s = mkStorage(fetchImpl);
 

--- a/tests/integration/third-party-licenses.test.ts
+++ b/tests/integration/third-party-licenses.test.ts
@@ -27,7 +27,7 @@ const manifestPath = resolve(distDir, "THIRD-PARTY-LICENSES.txt");
 const EXPECTED_LIBS = [
   // root library entries
   "aws4fetch",
-  "fast-xml-parser",
+  "@rgrove/parse-xml",
   "hono",
   "@hono/node-server",
   "jose",


### PR DESCRIPTION
Closes #29.

## Background

During the pre-release dependency sweep, bumping `fast-xml-parser` from 5.8.0 to 5.9.3 inflated the `./s3` closure (`dist/s3.js`) — most importantly on min-gz, the hard shipped-to-browser ceiling, by ~25%. Since we can't shrink a third-party closure and our policy says a min-gz regression must be shrunk rather than rebaselined, we held `fast-xml-parser` at an exact 5.8.0 pin as a stopgap. That declined an upstream version and left us stuck on a dep that would keep drifting from `latest`.

Issue #29 asked whether the fix was to tree-shake harder, or whether `fast-xml-parser` was even the right tool given that we only parse a small, well-known set of S3 XML shapes — floating the possibility of a much smaller dep (or a hand-rolled parser) that drops the dependency entirely. This PR takes that route.

## What

Replaces `fast-xml-parser` with `@rgrove/parse-xml` in the S3/STS XML decode path (`@baerly/adapter-node`) and removes `fast-xml-parser` — and its entire transitive closure — from the tree. The 5.8.0 pin and the stopgap budget note in `tests/integration/bundle-size.test.ts` are gone; the `s3.js` budgets are re-tightened around the new, smaller closure.

## Why this fixes #29

- **It reclaims the budget, permanently.** −87 KiB raw / −24 KiB gz / −14 KiB min-gz on the `s3.js` closure. This is well under where we were even before the 5.9.3 bump, so there's nothing left to pin around.
- **It removes the thing that kept drifting.** `@rgrove/parse-xml` has zero transitive deps, versus `fast-xml-parser`'s closure (`strnum`, `@nodable/entities`, and the rest). There's no longer an entity table or a chain of sub-packages growing underneath us between releases.
- **It gets us off the CVE-bump treadmill.** `fast-xml-parser` shipped a run of CVEs across 5.x, all in the DOCTYPE/entity surface. Our own `<!DOCTYPE` regex guard already made those unreachable (the pinned 5.8.0 was not itself vulnerable), but each new CVE still forced a version-pin review. `@rgrove/parse-xml` parses and discards DTDs without resolving custom entities, so that whole class of vulnerability can't recur even if the regex guard ever regressed.

## Behavior

No public API changes; all exported functions and types are unchanged. There are two deliberate, documented differences, both confined to non-conformant XML that S3/R2/MinIO/GCS never actually emit:

- **Whitespace:** `@rgrove/parse-xml` keeps the surrounding whitespace in field values where `fast-xml-parser` trimmed it (`trimValues: true`). This is pinned by a new "whitespace contract" block in `xml.test.ts`, and `LastModified` degrades gracefully (an Invalid Date becomes `undefined`).
- **Entity set:** it decodes only the 5 predefined XML entities plus decimal/hex numeric character refs — exactly what XML wire data uses. It does not decode HTML named entities (`&nbsp;` and friends); the old code only turned on `htmlEntities: true` to get the numeric refs in the first place.

Traversal is now namespace-agnostic (via a `localName` helper), so `<ns:Error>` / `<s3:Contents>` also match, and the `<ListBucketResult>` root-name guard from `main` is preserved.

## Migration note

While developing the swap, we validated it with a differential-oracle test that asserted field-for-field parity between the two parsers on generated S3-shaped XML. That guard can't run once `fast-xml-parser` leaves the tree, so it isn't kept; the parser's behavior is pinned going forward by the example-based contract tests in `xml.test.ts`.

## Verification

`pnpm verify:agent`, `pnpm build`, `pnpm test:agent` (2432 passed, 0 failed), and `pnpm bundle-sizes` (18/18, `s3.js` under all axes) all green. The license (`ISC`) is captured in `dist/THIRD-PARTY-LICENSES.txt`.
