### PR TITLE
Pin patched undici, dompurify, and js-yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ overrides:
   esbuild: ^0.28.1
   qs: '>=6.15.2'
   ws: '>=8.21.0'
+  undici@<7.28.0: ^7.28.0
+  dompurify@<3.4.11: ^3.4.11
+  js-yaml@<3.15.0: ^3.15.0
 
 importers:
 
@@ -2716,8 +2719,8 @@ packages:
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
-  dompurify@3.4.10:
-    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   dts-resolver@3.0.0:
     resolution: {integrity: sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q==}
@@ -3101,8 +3104,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@4.2.0:
@@ -4166,10 +4169,6 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
-
-  undici@7.24.8:
-    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
-    engines: {node: '>=20.18.1'}
 
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
@@ -6658,7 +6657,7 @@ snapshots:
 
   dom-accessibility-api@0.5.16: {}
 
-  dompurify@3.4.10:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7048,7 +7047,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -7360,7 +7359,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.21
-      dompurify: 3.4.10
+      dompurify: 3.4.11
       es-toolkit: 1.47.1
       katex: 0.16.47
       khroma: 2.1.0
@@ -7570,7 +7569,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.24.8
+      undici: 7.28.0
       workerd: 1.20260609.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -7904,7 +7903,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -8320,8 +8319,6 @@ snapshots:
   undici-types@7.24.6: {}
 
   undici-types@8.3.0: {}
-
-  undici@7.24.8: {}
 
   undici@7.28.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,7 +44,24 @@ linkWorkspacePackages: true
 #     via @cloudflare/vite-plugin + miniflare + wrangler on ws@8.20.1.
 #     8.21.0 is a patch bump (already in the tree via happy-dom) and
 #     dedupes ws to a single version.
+#   - undici >= 7.28.0: GHSA-hm92-r4w5-c3mj + GHSA-vmh5-mc38-953g
+#     (SOCKS5 proxy high-sev), plus four medium/low Set-Cookie/cache
+#     issues, pulled via @cloudflare/vitest-pool-workers -> wrangler +
+#     miniflare on undici@7.24.8. The example apps' newer miniflare
+#     already resolves 7.28.0; the version-scoped selector lifts only
+#     the stale copy. 7.x-internal patch bump.
+#   - dompurify >= 3.4.11: GHSA-cmwh-pvxp-8882 (ALLOWED_ATTR
+#     pollution), pulled via mermaid on dompurify@3.4.10 (docs mermaid
+#     validation only). mermaid accepts ^3, so a 3.x patch bump.
+#   - js-yaml >= 3.15.0: GHSA-h67p-54hq-rp68 (quadratic-complexity
+#     merge-key DoS), pulled via read-yaml-file -> @manypkg ->
+#     changesets on js-yaml@3.14.2 (release tooling). The 3.x-scoped
+#     selector patches that copy while leaving the separate 4.2.0
+#     copy untouched.
 overrides:
   esbuild: ^0.28.1
   qs: ">=6.15.2"
   ws: ">=8.21.0"
+  undici@<7.28.0: "^7.28.0"
+  dompurify@<3.4.11: "^3.4.11"
+  js-yaml@<3.15.0: "^3.15.0"


### PR DESCRIPTION
Clears all 8 open Dependabot alerts. Every one is a dev-only dependency buried deep in the tree, which is why updating our direct dependencies didn't fix them — the packages that pull these in still ship the vulnerable versions.

Rather than dismiss them, this pins the patched versions in the `pnpm-workspace.yaml` overrides block (right alongside the esbuild/qs/ws pins already there). The version-scoped selectors only touch the vulnerable copies.

- **undici → ^7.28.0** — 6 alerts (2 high). Comes in through the Cloudflare test tooling (vitest-pool-workers → wrangler/miniflare).
- **dompurify → ^3.4.11** — comes in through mermaid, which we only use to validate diagrams in the docs.
- **js-yaml → ^3.15.0** — comes in through changesets (release tooling). Leaves the separate, unaffected 4.2.0 copy alone.

None of these are reachable in our toolchain or ship in the runtime bundle, but the patches are clean semver bumps so pinning them is cheaper than carrying permanently-open alerts.

Verified: `pnpm why` shows no vulnerable versions left, and `verify:agent`, `test:agent`, and `test:adapter-cloudflare` all pass.