### PR TITLE
docs(changeset): tighten changesets for clarity pre release

### DIFF
--- a/.changeset/dependency-updates.md
+++ b/.changeset/dependency-updates.md
@@ -1,11 +1,17 @@
 ---
-'@gusto/baerly-storage': patch
+"@gusto/baerly-storage": patch
 ---
 
-Refresh dependencies ahead of release. Runtime deps that ship to consumers:
-`@logtape/logtape` 2.1.3 → 2.2.2, `hono` 4.12.25 → 4.12.27, `@hono/node-server`
-2.0.4 → 2.0.6, and `jose` floated to 6.2.3. The `@gusto/create-baerly-storage`
-scaffolder picks up `@clack/prompts` 1.6.0. No public API changes.
+Refresh dependencies ahead of release. No public API changes.
+
+Runtime deps that ship to consumers:
+
+- `@logtape/logtape` 2.1.3 → 2.2.2
+- `hono` 4.12.25 → 4.12.27
+- `@hono/node-server` 2.0.4 → 2.0.6
+- `jose` floated to 6.2.3
+
+The `@gusto/create-baerly-storage` scaffolder picks up `@clack/prompts` 1.6.0.
 
 The `@logtape/logtape` growth was rebaselined with a dated note in the
 bundle-size budgets. (The XML parser was separately swapped from

--- a/.changeset/fail-closed-ephemeral-storage.md
+++ b/.changeset/fail-closed-ephemeral-storage.md
@@ -5,28 +5,28 @@
 Fail closed on ephemeral storage in production
 
 `MemoryStorage` now refuses to construct in a detected deployment
-(`NODE_ENV=production` or a known PaaS marker) unless ephemerality is
-explicitly acknowledged. This prevents the silent-data-loss failure mode where
-an app falls back to in-memory storage in production — writes "succeed" into
-process RAM and vanish on every restart, with no loud signal.
+(`NODE_ENV=production` or a known PaaS marker) unless you explicitly acknowledge
+that it's ephemeral. This closes a silent-data-loss failure mode: an app that
+falls back to in-memory storage in production, where writes "succeed" into
+process RAM and vanish on every restart with no loud signal.
 
 **What changed**
 
 - `new MemoryStorage()` throws `BaerlyError("InvalidConfig")` in a detected
-  deployment. Tests and local dev are unaffected (neither sets those signals).
+  deployment. Tests and local dev are unaffected — neither sets those signals.
 - New `resolveStorageFromEnv(env?)` export on `@gusto/baerly-storage/node`: the
   safe, tested storage selector the Node example scaffolds now use, so apps
   don't hand-roll one with a silent fallback.
 - New `assertStorageReachable(storage)` export on `@gusto/baerly-storage/node`:
   an opt-in boot/readiness check that fails closed on an unreachable or
-  CAS-broken bucket (the wrong-bucket-name gap a missing-bucket guard can't
-  catch).
+  CAS-broken bucket — the wrong-bucket-name gap a missing-bucket guard can't
+  catch.
 - New pure `isDeployedEnv(env)` predicate on `@gusto/baerly-storage`.
 
 **Migration**
 
-- If you intentionally run in-memory storage in a deployed environment (e.g. a
-  throwaway demo), opt in explicitly — either in code:
+- To run in-memory storage in a deployment on purpose (e.g. a throwaway demo),
+  opt in explicitly — either in code:
 
   ```ts
   new MemoryStorage({ ephemeral: true })
@@ -44,11 +44,11 @@ process RAM and vanish on every restart, with no loud signal.
 **Platform note**
 
 - The guard is effectively Node-only. A Cloudflare Worker requires an R2
-  binding and has no silent in-memory fallback path, and the deploy-detection
+  binding and has no silent in-memory fallback, and the deploy-detection
   predicate reads `process.env`, which is empty on Workerd — so the guard never
   fires (and never needs to) on Cloudflare.
-- CI environments are never treated as deployed. When `CI` is set (to a
-  non-empty, non-`false` value) the PaaS-marker detection is suppressed, so
-  `MemoryStorage` still constructs in CI — including Kubernetes-hosted CI agents
-  that set `KUBERNETES_SERVICE_HOST`. An explicit `NODE_ENV=production` still
-  trips the guard.
+- CI is never treated as deployed. When `CI` is set to a non-empty, non-`false`
+  value, PaaS-marker detection is suppressed, so `MemoryStorage` still
+  constructs in CI — including Kubernetes-hosted CI agents that set
+  `KUBERNETES_SERVICE_HOST`. An explicit `NODE_ENV=production` still trips the
+  guard.

--- a/.changeset/irsa-web-identity-credentials.md
+++ b/.changeset/irsa-web-identity-credentials.md
@@ -1,30 +1,30 @@
 ---
-'@gusto/baerly-storage': minor
+"@gusto/baerly-storage": minor
 ---
 
-Add IRSA (web-identity) credential support for S3 on EKS. `fromEksPodIdentity()`
-only handled the EKS Pod Identity agent (`AWS_CONTAINER_CREDENTIALS_FULL_URI`);
-clusters that inject credentials via IRSA (`AWS_ROLE_ARN` +
-`AWS_WEB_IDENTITY_TOKEN_FILE`) threw `InvalidConfig` on first sign, so every S3
-call failed.
+Add IRSA (web-identity) credential support for S3 on EKS. Previously
+`fromEksPodIdentity()` handled only the EKS Pod Identity agent
+(`AWS_CONTAINER_CREDENTIALS_FULL_URI`). Clusters that inject credentials via
+IRSA (`AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`) threw `InvalidConfig` on
+first sign, so every S3 call failed.
 
 Two new credential providers in `@gusto/baerly-storage/node`:
 
 - `fromWebIdentity()` — exchanges the projected service-account token for
-  short-lived credentials via STS `AssumeRoleWithWebIdentity` (an unsigned call;
-  the token is the auth). Returns `expiration`, so the signing layer rotates the
-  ~1h credentials automatically. No AWS SDK dependency — uses `fetch` plus the
-  existing hardened XML parser.
-- `fromEks()` — auto-detects the mechanism per resolve (Pod Identity when
-  `AWS_CONTAINER_CREDENTIALS_FULL_URI` is present, otherwise IRSA), with a clear
-  `InvalidConfig` error when neither is configured. Prefer this over the
+  short-lived credentials via STS `AssumeRoleWithWebIdentity`. The call is
+  unsigned; the token is the auth. It returns `expiration`, so the signing layer
+  rotates the ~1h credentials automatically. No AWS SDK dependency — it uses
+  `fetch` plus the existing hardened XML parser.
+- `fromEks()` — auto-detects the mechanism on each resolve: Pod Identity when
+  `AWS_CONTAINER_CREDENTIALS_FULL_URI` is present, otherwise IRSA. It throws a
+  clear `InvalidConfig` when neither is configured. Prefer this over the
   mechanism-specific providers unless you have a reason to pin one.
 
-Both EKS providers now fail with actionable errors instead of a bare status: a
-missing/unreadable or empty projected token throws `InvalidConfig`, and a failed
-STS `AssumeRoleWithWebIdentity` call folds the STS error `Code`/`Message` (e.g.
-`InvalidIdentityToken`) into the thrown message so credential misconfigs are
-diagnosable at a glance.
+Both EKS providers now fail with actionable errors instead of a bare status. A
+missing, unreadable, or empty projected token throws `InvalidConfig`. A failed
+STS `AssumeRoleWithWebIdentity` call folds the STS error `Code`/`Message` (for
+example, `InvalidIdentityToken`) into the thrown message, so credential
+misconfigs are diagnosable at a glance.
 
 `fromEksPodIdentity()` keeps its behavior; it only gains the same
 `InvalidConfig` token-file guards.

--- a/.changeset/local-first-node.md
+++ b/.changeset/local-first-node.md
@@ -2,15 +2,15 @@
 "@gusto/baerly-storage": minor
 ---
 
-Node apps can now run with zero storage credentials by using the new
-`localFsStorage()` factory from `@gusto/baerly-storage/node`. The Node
-examples default to local filesystem storage for local development and
-promote to S3 or R2 when bucket environment variables are configured.
+Node apps can now run with zero storage credentials, using the new
+`localFsStorage()` factory from `@gusto/baerly-storage/node`. The Node examples
+default to local filesystem storage in development and promote to S3 or R2 once
+bucket environment variables are set.
 
-`localFsStorage()` is a local-dev convenience only — single-process, with
-no cross-process CAS and no crash durability — so the Node example servers
-fail loud in a detected deployment (`NODE_ENV=production` or a known PaaS)
-and require a real bucket: a missing/typo'd bucket aborts startup instead
-of running production on non-durable storage. There is deliberately no
-opt-in to run local-fs in a deployment; self-hosting without a cloud
-bucket, run MinIO on the box or use SQLite + Litestream.
+`localFsStorage()` is a local-dev convenience only — single-process, with no
+cross-process CAS and no crash durability. So the Node example servers fail loud
+in a detected deployment (`NODE_ENV=production` or a known PaaS) and require a
+real bucket: a missing or typo'd bucket aborts startup instead of running
+production on non-durable storage. There is deliberately no opt-in to run
+local-fs in a deployment. When self-hosting without a cloud bucket, run MinIO on
+the box or use SQLite + Litestream.

--- a/.changeset/path-optional-array-leaf.md
+++ b/.changeset/path-optional-array-leaf.md
@@ -3,52 +3,57 @@
 ---
 
 Fix `Path<T>` walking `Array.prototype` for optional array fields; export
-`PredicateArg` / `Predicate` / `Collection` for consumers
+`PredicateArg` / `Predicate` / `Collection`
 
 **Bug fix — optional array fields no longer poison predicate types**
 
-`Path<T>` (the dotted-path key type behind `Predicate<T>` / `.where(...)`)
-descended into `Array.prototype` when a field was an **optional** array. For a
-field `tags?: string[]`, the field type is `string[] | undefined`, and the
-`undefined` arm defeated the array-is-a-leaf check — so the path walker
-recursed into the array's methods and synthesized bogus keys like
-`` `tags.map.${string}` `` typed `undefined`.
+`Path<T>` is the dotted-path key type behind `Predicate<T>` and `.where(...)`.
+For an optional array field, it wrongly recursed into `Array.prototype` and
+synthesized bogus keys.
 
-Required array fields (`tags: string[]`) were unaffected; only the optional
+A field `tags?: string[]` has the type `string[] | undefined`. The `undefined`
+arm defeated the "an array is a leaf" check, so the path walker descended into
+the array's methods and produced keys like `` `tags.map.${string}` `` typed
+`undefined`. Required arrays (`tags: string[]`) were fine; only the optional
 form triggered it.
 
-The visible symptom: registering **any** collection with an optional array
-field (e.g. a Zod `z.array(z.string()).optional()`) broke structural
-assignability of a bound `Db<Config>` / `BaerlyClient<Config>` to a hand-rolled
-interface whose `collection(name: string)` takes a runtime string — because the
-generic collapses the row to the union of every row, and the synthetic
-`undefined`-typed prototype path made every index-signature predicate object
-non-assignable. Collections that never touched the array field were still
-affected.
+Symptom: declaring *any* collection with an optional array field (for example a
+Zod `z.array(z.string()).optional()`) broke assignability of a bound
+`Db<Config>` or `BaerlyClient<Config>` to a hand-rolled interface whose
+`collection(name: string)` takes a runtime string. Such an interface forces the
+row type to collapse to the union of every collection's row; the stray
+`undefined`-typed prototype path then made the resulting index-signature
+predicate object non-assignable. Collections that never touched the array field
+broke too.
 
-The fix runs the leaf test on `NonNullable<T[K]>`, so an optional array
-terminates path recursion exactly like a required one. `Path<{ tags?: string[]
-}>` is now `"tags"`, with no `Array.prototype` members.
+The fix runs the leaf test on `NonNullable<T[K]>`, so an optional array ends
+path recursion exactly like a required one. `Path<{ tags?: string[] }>` is now
+`"tags"`, with no `Array.prototype` members.
 
 **New public exports**
 
 - `PredicateArg` and `Predicate` are now exported from `@gusto/baerly-storage`.
 - `PredicateArg` is now exported from `@gusto/baerly-storage/client` (which
-  already exported `ClientCollection` and `Predicate`). The client handle type
-  remains `ClientCollection`; the in-process `Collection` type is exported only
-  from the root `@gusto/baerly-storage` entry, since the client's HTTP handle
-  is structurally distinct (read-only `.where(...)`, `TerminalOptions`).
+  already exported `ClientCollection` and `Predicate`).
 
-These let consumers name the `.where(...)` argument and predicate types
-directly instead of hand-rolling a structural interface to accept a `Db` or a
+The client handle type stays `ClientCollection`. The in-process `Collection`
+type is exported only from the root `@gusto/baerly-storage` entry, because the
+client's HTTP handle is structurally distinct (read-only `.where(...)`,
+`TerminalOptions`).
+
+These exports let you name the `.where(...)` argument and predicate types
+directly, instead of hand-rolling a structural interface to accept a `Db` or a
 `BaerlyClient`.
 
 **Migration**
 
-- No action required. Both changes are additive; existing typed call sites are
-  unaffected.
-- If you hand-rolled a structural `collection(name: string)` shim to read
-  collections by a runtime-computed name, you can now either import the real
-  types, or narrow at the boundary with
-  `(db as Db<UnboundConfig>).collection(name)` to open the row to
-  `DocumentData` for dynamic names.
+No action required. Both changes are additive; existing typed call sites are
+unaffected.
+
+If you hand-rolled a structural `collection(name: string)` shim to read
+collections by a runtime-computed name, you can now either import the real types
+or narrow at the boundary to open the row to `DocumentData` for dynamic names:
+
+```ts
+(db as Db<UnboundConfig>).collection(name)
+```

--- a/.changeset/replace-fast-xml-parser.md
+++ b/.changeset/replace-fast-xml-parser.md
@@ -1,46 +1,36 @@
 ---
-'@gusto/baerly-storage': patch
+"@gusto/baerly-storage": patch
 ---
 
-Replace `fast-xml-parser` with `@rgrove/parse-xml` in the S3 XML decode path
-(`@baerly/adapter-node`).
+Swap `fast-xml-parser` for `@rgrove/parse-xml` in the S3 XML decode path
+(`@baerly/adapter-node`). No public API changes — all exported functions and
+types are unchanged.
 
-**Bundle size:** −87 KiB raw / −24 KiB gz / −14 KiB min-gz on the `s3.js`
-closure — significant for a library bundled into user apps.
+**Smaller bundle:** −87 KiB raw / −24 KiB gz / −14 KiB min-gz on the `s3.js`
+closure. `@rgrove/parse-xml` also has zero transitive dependencies, where
+`fast-xml-parser` pulled in `strnum` and `@nodable/entities` — so the
+supply-chain and audit surface both shrink.
 
-**Zero-dependency:** `@rgrove/parse-xml` has no transitive dependencies, vs
-`fast-xml-parser`'s closure (`strnum`, `@nodable/entities`). Smaller
-supply-chain and audit surface.
-
-**Off the CVE-bump treadmill:** `fast-xml-parser` shipped ~6 CVEs across 5.x
-(CVE-2026-25896, CVE-2026-26278, CVE-2026-33036, and others), all in the
-DOCTYPE/entity surface. Our own `<!DOCTYPE` regex guard already made those
-vectors unreachable — the pinned `fast-xml-parser@5.8.0` was not itself
-vulnerable — but each new CVE still required a version-pin review.
-`@rgrove/parse-xml` parses and discards DTDs without resolving custom entities,
-so the entity-expansion CVE *class* cannot recur even if our regex guard ever
-regressed. This is defense-in-depth and audit-surface reduction, not the
-closing of an active hole.
-
-**Spec-correct entity set:** `@rgrove/parse-xml` decodes only the 5 predefined
-XML entities plus decimal/hex numeric character references — exactly what XML
-wire data uses (see "Intended entity-set difference" below).
-
-`fast-xml-parser` is removed entirely — it no longer appears in `dependencies`
-or `devDependencies`. During development the swap was validated with a
-differential-oracle test that asserted field-for-field parity between the two
-parsers on generated S3-shaped XML (predefined entities, decimal/hex numeric
-refs, CDATA, singular + plural `<Contents>`); that one-time migration check is
-not retained, so the repo no longer carries `fast-xml-parser` or its
-CVE-bump/dependabot cadence. The parser's behavior is pinned going forward by
-the example-based contract tests in `packages/adapter-node/src/xml.test.ts`.
+**CVE-class defense-in-depth (not an active-hole fix):** `fast-xml-parser`
+shipped ~6 CVEs across 5.x (CVE-2026-25896, CVE-2026-26278, CVE-2026-33036,
+and others), all in the DOCTYPE/entity surface. Our `<!DOCTYPE` regex guard
+already made those vectors unreachable — the pinned `fast-xml-parser@5.8.0`
+was never itself vulnerable — but each new CVE still forced a version-pin
+review. `@rgrove/parse-xml` parses and discards DTDs without resolving custom
+entities, so the entity-expansion CVE *class* cannot recur even if that regex
+guard ever regressed. Removing the dependency also ends its dependabot cadence.
 
 **Intended entity-set difference (not a bug):** `@rgrove/parse-xml` decodes
-the 5 predefined XML entities (`&amp; &lt; &gt; &quot; &apos;`) plus decimal
-and hex numeric character references. It does NOT decode HTML named entities
-(`&nbsp;`, `&mdash;`, etc.) — the old code enabled `htmlEntities: true`
-solely to get numeric refs. S3/R2/MinIO wire data is XML, not HTML, so the
-narrower entity set is more spec-correct. No S3 backend emits HTML-only named
-entities in `ListObjectsV2` or error responses.
+only the 5 predefined XML entities (`&amp; &lt; &gt; &quot; &apos;`) plus
+decimal and hex numeric character references. It does NOT decode HTML named
+entities (`&nbsp;`, `&mdash;`, etc.); the old code enabled `htmlEntities: true`
+solely to get numeric refs. S3/R2/MinIO wire data is XML, not HTML — no backend
+emits HTML-only named entities in `ListObjectsV2` or error responses — so the
+narrower set is more spec-correct.
 
-No public API changes; all exported functions and types are unchanged.
+The swap was validated during development with a one-time differential-oracle
+test asserting field-for-field parity between the two parsers on generated
+S3-shaped XML (predefined entities, decimal/hex numeric refs, CDATA, singular
+and plural `<Contents>`). That check is not retained; going forward, parser
+behavior is pinned by the example-based contract tests in
+`packages/adapter-node/src/xml.test.ts`.

--- a/.changeset/s3-from-worker.md
+++ b/.changeset/s3-from-worker.md
@@ -2,24 +2,34 @@
 "@gusto/baerly-storage": minor
 ---
 
-Cloudflare Workers can now use S3-compatible storage over HTTP instead of
-a native R2 binding, as an opt-in path. New Worker-safe
-`@gusto/baerly-storage/s3` subpath exports `S3HttpStorage` + `sigV4Signer`
-(closure has no `node:` builtins), and `baerlyWorker` accepts an optional
-`storage` in its factory options (defaulting to the `env.BUCKET` R2
-binding). `BaerlyEnv.BUCKET` is now optional so an S3-only Worker need not
-declare an R2 binding. `sigV4Signer` fails fast with `InvalidConfig` when
-`accessKeyId`, `secretAccessKey`, or `region` is empty or whitespace-only
-(e.g. a blank or accidentally-spaced wrangler `var`) rather than signing
-with blank credentials — or a malformed empty-region SigV4 scope — and
-drawing an opaque 403.
+Cloudflare Workers can now talk to S3-compatible storage over HTTP instead of a
+native R2 binding. This is opt-in; the R2 binding remains the default.
+
+New exports and options:
+
+- New Worker-safe subpath `@gusto/baerly-storage/s3` exports `S3HttpStorage` and
+  `sigV4Signer`. Their closure pulls in no `node:` builtins, so it loads in a
+  Worker.
+- `baerlyWorker` accepts an optional `storage` in its factory options. It
+  defaults to the `env.BUCKET` R2 binding.
+- `BaerlyEnv.BUCKET` is now optional, so an S3-only Worker need not declare an R2
+  binding.
+
+`sigV4Signer` fails fast with `InvalidConfig` when `accessKeyId`,
+`secretAccessKey`, or `region` is empty or whitespace-only (for example, a blank
+or accidentally-spaced wrangler `var`). This replaces signing with blank
+credentials — or building a malformed empty-region SigV4 scope — and drawing an
+opaque 403.
 
 This path ships at the same support tier as AWS-via-`S3HttpStorage`:
-credential-gated, operator-owned production validation. CI guards the
-closure under workerd on two levels — a bundle probe that it stays
-`node:`-free (loads in a Worker) and an in-isolate wire test that
-`S3HttpStorage` + `sigV4Signer` actually run there (signing, XML parse,
-request/response plumbing) against an in-memory S3 stub. CI does not drive
-a real S3 endpoint from workerd; verify yours with `baerly doctor
---bucket` before relying on it. Note `baerly deploy` / `doctor
+credential-gated, with production validation owned by the operator. CI guards the
+closure under workerd on two levels:
+
+- a bundle probe that it stays `node:`-free (so it loads in a Worker), and
+- an in-isolate wire test that `S3HttpStorage` + `sigV4Signer` actually run
+  there — signing, XML parse, request/response plumbing — against an in-memory
+  S3 stub.
+
+CI does not drive a real S3 endpoint from workerd. Verify yours with `baerly
+doctor --bucket` before relying on it. Note that `baerly deploy` and `doctor
 --target=cloudflare` still expect an R2 binding in `wrangler.jsonc`.

--- a/.changeset/storage-key-namespace.md
+++ b/.changeset/storage-key-namespace.md
@@ -5,26 +5,27 @@
 Reject `.` / `..` / empty object keys at the Storage boundary
 
 Every `Storage` adapter (`MemoryStorage`, `S3HttpStorage`, `r2BindingStorage`,
-`LocalFsStorage`) now validates each key on `get` / `put` / `delete` and throws
-`BaerlyError("InvalidConfig")` for an empty key or one whose `/`-delimited path
-has a `.` or `..` segment. Such a key is unaddressable over the S3/R2 HTTP API —
-RFC 3986 dot-segment removal rewrites `<bucket>/.` to the bucket root before the
-request is signed, so a naive PUT surfaces as a confusing bucket-root `403`
-rather than a clear error. The guard runs client-side, before any network call,
-so the rejection is identical across backends and portable to a language port.
+`LocalFsStorage`) now validates the key on `get` / `put` / `delete` and throws
+`BaerlyError("InvalidConfig")` when the key is empty or has a `.` or `..`
+segment in its `/`-delimited path. Such keys can't be addressed over the S3/R2
+HTTP API: RFC 3986 dot-segment removal rewrites `<bucket>/.` to the bucket root
+before the request is signed, so a naive PUT fails as a confusing bucket-root
+`403` instead of a clear error. The check runs client-side, before any network
+call, so every backend rejects identically and the behavior ports cleanly to
+other languages.
 
 **What changed**
 
 - `get` / `put` / `delete` on all adapters reject `""`, `.`, `..`, and any key
-  containing a `.`/`..` path segment with `InvalidConfig`. `list(prefix)` is
-  unaffected — a prefix rides the `?prefix=` query component, where `.`/`..`
+  with a `.` or `..` path segment, with `InvalidConfig`. `list(prefix)` is
+  unaffected — a prefix rides the `?prefix=` query component, where `.` / `..`
   are harmless.
-- The full-key 1024-byte ceiling continues to be enforced on the write path
+- The 1024-byte full-key ceiling is still enforced on the write path
   (`assertKeyWithinLimit`), where multi-segment keys are assembled.
 
 **Migration**
 
-- No action for normal use: the kernel never emits such keys, and
+- No action for normal use. The kernel never emits these keys, and
   caller-controlled segments (`_id`, `collection`, `app`, `tenant`) are already
   screened one layer up. If you call a `Storage` adapter directly with a bare
-  `.` / `..` / empty key, catch `BaerlyError` with `code === "InvalidConfig"`.
+  `.` / `..` / empty key, catch `BaerlyError` and check `code === "InvalidConfig"`.

--- a/.changeset/tier0-contract-governance.md
+++ b/.changeset/tier0-contract-governance.md
@@ -2,45 +2,44 @@
 "@gusto/baerly-storage": patch
 ---
 
-Ratify the contract-governance foundation: LogEntry is versionless, version
-axes are named and drift-gated, and backend capabilities are split into
-required vs. optional
+Write down the durable-contract promises: LogEntry is versionless, version axes
+are named and drift-gated, and backend capabilities are split into required vs.
+optional
 
-This is documentation and internal-tooling only — no public API, wire, or
-runtime behavior changes. It writes down compatibility promises the project
-was already relying on implicitly, so external consumers of the durable
-contract (the CDC-style `LogEntry` export, the bucket layout) can depend on
-them.
+Documentation and internal tooling only. Nothing changes in the emitted bytes,
+the public API, or runtime behavior — this just records compatibility promises
+the project already relied on, so anyone building on the durable contract (the
+CDC-style `LogEntry` export, the bucket layout) can depend on them in writing.
 
 **LogEntry is versionless and additive-only (ADR-005, `docs/adr/005-logentry-versionless.md`)**
 
 - `LogEntry` carries no `schema_version`; the live wire contract is owned by
-  `docs/spec/log-entry-shape.md`. Consumers **must ignore unknown keys** — new
-  optional fields can be added in a compatible release. Renaming a field,
+  `docs/spec/log-entry-shape.md`. Consumers **must ignore unknown keys** — a
+  compatible release can add new optional fields at any time. Renaming a field,
   repurposing a value, removing a field, or widening `op` requires an explicit
   compatibility decision, a migration note, and a versioned release.
 
 **Version matrix + drift gate**
 
-- `docs/contributing/version-matrix.json` names every version axis in one place
-  (package semver, `specVersion`, the per-artifact durable `schema_version`s,
-  the `layout_version` cordon, and a reserved conformance `corpusVersion`).
-- `docs/contributing/conventions/versioning.md` states the pre-1.0
-  compatibility rules: no breaking wire/schema/layout change ships as a patch;
-  while `0.x` it takes a minor plus a migration note.
-- `scripts/check-version-matrix.ts` gates drift in `verify` (derives
+- `docs/contributing/version-matrix.json` names every version axis in one place:
+  package semver, `specVersion`, the per-artifact durable `schema_version`s, the
+  `layout_version` cordon, and a reserved conformance `corpusVersion`.
+- `docs/contributing/conventions/versioning.md` states the pre-1.0 rules: no
+  breaking wire/schema/layout change ships as a patch; while `0.x` it takes a
+  minor plus a migration note.
+- `scripts/check-version-matrix.ts` fails `verify` on drift — it derives
   `specVersion` from the wire IR so the matrix can't diverge, and enforces
-  package lockstep plus LogEntry/layout/corpus sentinels). `gen:version-matrix`
+  package lockstep plus the LogEntry/layout/corpus sentinels. `gen:version-matrix`
   regenerates the artifact from the reference implementation.
 
 **Required vs. optional storage capabilities**
 
 - `docs/spec/capabilities.md` records what a backend MUST support to certify as
-  full `Storage` (CAS / exactly-one-winner conditional create is not optional),
-  what is optional, and a planned read-only `ReaderStorage` tier.
+  a full `Storage` (CAS — exactly-one-winner conditional create — is required,
+  not optional), what is optional, and a planned read-only `ReaderStorage` tier.
 
 **Migration**
 
 - No action required. Nothing in the emitted bytes, the public API, or runtime
-  behavior changes; `SNAPSHOT_SCHEMA_VERSION` replaces a `1` literal with a
-  named constant of the same value.
+  behavior changes. `SNAPSHOT_SCHEMA_VERSION` replaces a `1` literal with a named
+  constant of the same value.


### PR DESCRIPTION
Rewrite all nine pending 0.4.0 changesets in plainer, more legible English while keeping every identifier, version, error code, and migration block byte-accurate — they ship in `dist/CHANGELOG.md` and are read to recover the current API.

- No bump-level changes; the 0.4.0 minor bump is preserved.
- Frontmatter normalized to double quotes across all files.
- Docs gate (`pnpm verify:docs`) passes clean.

Notable tightenings: collapsed overlapping CVE/removal paragraphs in the XML-parser swap; turned the impenetrable `Path<T>` symptom paragraph into a followable causal chain; led `tier0-contract-governance` with its no-runtime-change promise; broke walls of text into scannable bullets.