### PR TITLE
test: quiet the suite + rebaseline cloudflare min-gz

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,8 @@
   ],
   "type": "module",
   "exports": {
-    "./wrangler-patch": "./src/wrangler-patch.ts"
+    "./wrangler-patch": "./src/wrangler-patch.ts",
+    "./_internal/testing": "./src/_internal/testing.ts"
   },
   "scripts": {
     "build": "rolldown -c",

--- a/packages/cli/src/_internal/testing.ts
+++ b/packages/cli/src/_internal/testing.ts
@@ -1,0 +1,30 @@
+/**
+ * @internal — test-only helpers for the CLI package, exposed to sibling
+ * test files (relative import) and to `@gusto/create-baerly-storage`'s
+ * tests via the `@baerly/cli/_internal/testing` subpath. Like
+ * `@baerly/server/_internal/testing`, this subpath is intentionally NOT
+ * in `publishConfig.exports`, so the published surface does not carry it.
+ */
+
+/**
+ * Silence a write stream for the duration of a call, capturing what would
+ * have been written to it. CLI commands write findings/banners to
+ * `process.stdout` / `process.stderr`; tests swap `stream.write` for a
+ * buffer, assert on `captured`, and always `restore()` in a `finally`.
+ */
+export const captureStream = (
+  stream: NodeJS.WriteStream,
+): { restore: () => void; readonly captured: string[] } => {
+  const captured: string[] = [];
+  const original = stream.write.bind(stream);
+  stream.write = ((chunk: unknown): boolean => {
+    captured.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof stream.write;
+  return {
+    captured,
+    restore: () => {
+      stream.write = original;
+    },
+  };
+};

--- a/packages/cli/src/admin/dump.test.ts
+++ b/packages/cli/src/admin/dump.test.ts
@@ -21,6 +21,7 @@ import { CURRENT_JSON_SCHEMA_VERSION, createCurrentJson, type Storage } from "@b
 import { LocalFsStorage } from "@baerly/dev";
 import { Writer } from "@baerly/server/_internal/testing";
 import { runDump, canonicalStringify } from "./dump.ts";
+import { captureStream } from "../_internal/testing.ts";
 
 /**
  * Open a write-stream sink and return a `{ stream, finish }` pair.
@@ -55,23 +56,6 @@ const provision = async (storage: Storage): Promise<void> => {
     snapshot_bytes: 0,
     snapshot_rows: 0,
   });
-};
-
-const captureStream = (
-  stream: NodeJS.WriteStream,
-): { restore: () => void; readonly captured: string[] } => {
-  const captured: string[] = [];
-  const original = stream.write.bind(stream);
-  stream.write = ((chunk: unknown): boolean => {
-    captured.push(typeof chunk === "string" ? chunk : String(chunk));
-    return true;
-  }) as typeof stream.write;
-  return {
-    captured,
-    restore: () => {
-      stream.write = original;
-    },
-  };
 };
 
 describe("canonicalStringify", () => {

--- a/packages/cli/src/admin/dump.test.ts
+++ b/packages/cli/src/admin/dump.test.ts
@@ -201,13 +201,20 @@ describe("baerly admin dump", () => {
   });
 
   test("unknown flag rejected with exit 1", async () => {
-    const exitCode = await runDump([
-      `--bucket=file://${root}`,
-      `--app=${APP}`,
-      `--tenant=${TENANT}`,
-      `--collection=${COLL}`,
-      "--unknown=oops",
-    ]);
+    const stderr = captureStream(process.stderr);
+    let exitCode: number;
+    try {
+      exitCode = await runDump([
+        `--bucket=file://${root}`,
+        `--app=${APP}`,
+        `--tenant=${TENANT}`,
+        `--collection=${COLL}`,
+        "--unknown=oops",
+      ]);
+    } finally {
+      stderr.restore();
+    }
     expect(exitCode).toBe(1);
+    expect(stderr.captured.join("")).toContain("unknown flag");
   });
 });

--- a/packages/cli/src/admin/fsck.test.ts
+++ b/packages/cli/src/admin/fsck.test.ts
@@ -27,6 +27,7 @@ import { LocalFsStorage } from "@baerly/dev";
 import { allIndexKeysFor } from "@baerly/server";
 import { Writer } from "@baerly/server/_internal/testing";
 import { runFsck } from "./fsck.ts";
+import { captureStream } from "../_internal/testing.ts";
 
 const APP = "app";
 const TENANT = "tenant";
@@ -60,23 +61,6 @@ const seedRows = async (storage: Storage, count: number): Promise<void> => {
       body: { _id: `t-${i}`, status: i % 2 === 0 ? "open" : "closed" },
     });
   }
-};
-
-const captureStream = (
-  stream: NodeJS.WriteStream,
-): { restore: () => void; readonly captured: string[] } => {
-  const captured: string[] = [];
-  const original = stream.write.bind(stream);
-  stream.write = ((chunk: unknown): boolean => {
-    captured.push(typeof chunk === "string" ? chunk : String(chunk));
-    return true;
-  }) as typeof stream.write;
-  return {
-    captured,
-    restore: () => {
-      stream.write = original;
-    },
-  };
 };
 
 describe("baerly admin fsck — consistency check and corruption findings", () => {

--- a/packages/cli/src/admin/fsck.test.ts
+++ b/packages/cli/src/admin/fsck.test.ts
@@ -437,24 +437,38 @@ describe("baerly admin fsck — consistency check and corruption findings", () =
   });
 
   test("missing current.json surfaces InvalidConfig (exit 1)", async () => {
-    const exitCode = await runFsck([
-      `--bucket=file://${root}`,
-      `--app=${APP}`,
-      `--tenant=${TENANT}`,
-      `--collection=${COLL}`,
-    ]);
+    const stderr = captureStream(process.stderr);
+    let exitCode: number;
+    try {
+      exitCode = await runFsck([
+        `--bucket=file://${root}`,
+        `--app=${APP}`,
+        `--tenant=${TENANT}`,
+        `--collection=${COLL}`,
+      ]);
+    } finally {
+      stderr.restore();
+    }
     expect(exitCode).toBe(1);
+    expect(stderr.captured.join("")).toContain("current.json not found");
   });
 
   test("unknown flag rejected with exit 1", async () => {
     await provision(storage);
-    const exitCode = await runFsck([
-      `--bucket=file://${root}`,
-      `--app=${APP}`,
-      `--tenant=${TENANT}`,
-      `--collection=${COLL}`,
-      "--unknown=oops",
-    ]);
+    const stderr = captureStream(process.stderr);
+    let exitCode: number;
+    try {
+      exitCode = await runFsck([
+        `--bucket=file://${root}`,
+        `--app=${APP}`,
+        `--tenant=${TENANT}`,
+        `--collection=${COLL}`,
+        "--unknown=oops",
+      ]);
+    } finally {
+      stderr.restore();
+    }
     expect(exitCode).toBe(1);
+    expect(stderr.captured.join("")).toContain("unknown flag");
   });
 });

--- a/packages/cli/src/admin/rebuild-index.test.ts
+++ b/packages/cli/src/admin/rebuild-index.test.ts
@@ -24,23 +24,7 @@ import { LocalFsStorage } from "@baerly/dev";
 import { allIndexKeysFor } from "@baerly/server";
 import { Writer } from "@baerly/server/_internal/testing";
 import { runRebuildIndex } from "./rebuild-index.ts";
-
-const captureStream = (
-  stream: NodeJS.WriteStream,
-): { restore: () => void; readonly captured: string[] } => {
-  const captured: string[] = [];
-  const original = stream.write.bind(stream);
-  stream.write = ((chunk: unknown): boolean => {
-    captured.push(typeof chunk === "string" ? chunk : String(chunk));
-    return true;
-  }) as typeof stream.write;
-  return {
-    captured,
-    restore: () => {
-      stream.write = original;
-    },
-  };
-};
+import { captureStream } from "../_internal/testing.ts";
 
 const APP = "app";
 const TENANT = "tenant";

--- a/packages/cli/src/admin/rebuild-index.test.ts
+++ b/packages/cli/src/admin/rebuild-index.test.ts
@@ -25,6 +25,23 @@ import { allIndexKeysFor } from "@baerly/server";
 import { Writer } from "@baerly/server/_internal/testing";
 import { runRebuildIndex } from "./rebuild-index.ts";
 
+const captureStream = (
+  stream: NodeJS.WriteStream,
+): { restore: () => void; readonly captured: string[] } => {
+  const captured: string[] = [];
+  const original = stream.write.bind(stream);
+  stream.write = ((chunk: unknown): boolean => {
+    captured.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof stream.write;
+  return {
+    captured,
+    restore: () => {
+      stream.write = original;
+    },
+  };
+};
+
 const APP = "app";
 const TENANT = "tenant";
 const COLL = "tickets";
@@ -172,27 +189,41 @@ describe("baerly admin rebuild-index — orphan index-key reconciliation", () =>
 
   test("missing --on / --config surfaces InvalidConfig (exit 1)", async () => {
     await provision(storage);
-    const exitCode = await runRebuildIndex([
-      `--bucket=file://${root}`,
-      `--app=${APP}`,
-      `--tenant=${TENANT}`,
-      `--collection=${COLL}`,
-      "--index=by_status",
-    ]);
+    const stderr = captureStream(process.stderr);
+    let exitCode: number;
+    try {
+      exitCode = await runRebuildIndex([
+        `--bucket=file://${root}`,
+        `--app=${APP}`,
+        `--tenant=${TENANT}`,
+        `--collection=${COLL}`,
+        "--index=by_status",
+      ]);
+    } finally {
+      stderr.restore();
+    }
     expect(exitCode).toBe(1);
+    expect(stderr.captured.join("")).toContain("is required");
   });
 
   test("unknown flag rejected with exit 1", async () => {
     await provision(storage);
-    const exitCode = await runRebuildIndex([
-      `--bucket=file://${root}`,
-      `--app=${APP}`,
-      `--tenant=${TENANT}`,
-      `--collection=${COLL}`,
-      "--index=by_status",
-      "--on=status",
-      "--unknown=oops",
-    ]);
+    const stderr = captureStream(process.stderr);
+    let exitCode: number;
+    try {
+      exitCode = await runRebuildIndex([
+        `--bucket=file://${root}`,
+        `--app=${APP}`,
+        `--tenant=${TENANT}`,
+        `--collection=${COLL}`,
+        "--index=by_status",
+        "--on=status",
+        "--unknown=oops",
+      ]);
+    } finally {
+      stderr.restore();
+    }
     expect(exitCode).toBe(1);
+    expect(stderr.captured.join("")).toContain("unknown flag");
   });
 });

--- a/packages/cli/src/admin/restore.test.ts
+++ b/packages/cli/src/admin/restore.test.ts
@@ -19,29 +19,13 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { casUpdateCurrentJson, readCurrentJson } from "@baerly/protocol";
 import { LocalFsStorage } from "@baerly/dev";
 import { runRestore } from "./restore.ts";
+import { captureStream } from "../_internal/testing.ts";
 
 const APP = "app";
 const TENANT = "tenant";
 const COLL = "tickets";
 const CURRENT_JSON_KEY = `app/${APP}/tenant/${TENANT}/manifests/${COLL}/current.json`;
 const TABLE_PREFIX = `app/${APP}/tenant/${TENANT}/manifests/${COLL}`;
-
-const captureStream = (
-  stream: NodeJS.WriteStream,
-): { restore: () => void; readonly captured: string[] } => {
-  const captured: string[] = [];
-  const original = stream.write.bind(stream);
-  stream.write = ((chunk: unknown): boolean => {
-    captured.push(typeof chunk === "string" ? chunk : String(chunk));
-    return true;
-  }) as typeof stream.write;
-  return {
-    captured,
-    restore: () => {
-      stream.write = original;
-    },
-  };
-};
 
 const CANONICAL_NDJSON =
   `{"_id":"t-1","status":"open","title":"first"}\n` +

--- a/packages/cli/src/admin/restore.test.ts
+++ b/packages/cli/src/admin/restore.test.ts
@@ -81,11 +81,18 @@ describe("baerly admin restore", () => {
       { streams: { stdin: createReadStream(stdinPath) } },
     );
     expect(first).toBe(0);
-    const second = await runRestore(
-      [`--bucket=file://${root}`, `--app=${APP}`, `--tenant=${TENANT}`, `--collection=${COLL}`],
-      { streams: { stdin: createReadStream(stdinPath) } },
-    );
+    const stderr = captureStream(process.stderr);
+    let second: number;
+    try {
+      second = await runRestore(
+        [`--bucket=file://${root}`, `--app=${APP}`, `--tenant=${TENANT}`, `--collection=${COLL}`],
+        { streams: { stdin: createReadStream(stdinPath) } },
+      );
+    } finally {
+      stderr.restore();
+    }
     expect(second).toBe(3);
+    expect(stderr.captured.join("")).toContain("pass --force to truncate");
   });
 
   test("re-running with --force truncates and reseeds", async () => {
@@ -318,13 +325,20 @@ describe("baerly admin restore", () => {
   });
 
   test("unknown flag rejected with exit 1", async () => {
-    const exitCode = await runRestore([
-      `--bucket=file://${root}`,
-      `--app=${APP}`,
-      `--tenant=${TENANT}`,
-      `--collection=${COLL}`,
-      "--unknown=oops",
-    ]);
+    const stderr = captureStream(process.stderr);
+    let exitCode: number;
+    try {
+      exitCode = await runRestore([
+        `--bucket=file://${root}`,
+        `--app=${APP}`,
+        `--tenant=${TENANT}`,
+        `--collection=${COLL}`,
+        "--unknown=oops",
+      ]);
+    } finally {
+      stderr.restore();
+    }
     expect(exitCode).toBe(1);
+    expect(stderr.captured.join("")).toContain("unknown flag");
   });
 });

--- a/packages/cli/src/admin/usage.test.ts
+++ b/packages/cli/src/admin/usage.test.ts
@@ -24,6 +24,7 @@ import {
   estimateWritesPerMin,
   runUsage,
 } from "./usage.ts";
+import { captureStream } from "../_internal/testing.ts";
 
 interface SeedOpts {
   readonly count: number;
@@ -220,23 +221,6 @@ describe("discoverCollections", () => {
 });
 
 describe("baerly admin usage — query-cost reporting", () => {
-  const captureStream = (
-    stream: NodeJS.WriteStream,
-  ): { restore: () => void; readonly captured: string[] } => {
-    const captured: string[] = [];
-    const original = stream.write.bind(stream);
-    stream.write = ((chunk: unknown): boolean => {
-      captured.push(typeof chunk === "string" ? chunk : String(chunk));
-      return true;
-    }) as typeof stream.write;
-    return {
-      captured,
-      restore: () => {
-        stream.write = original;
-      },
-    };
-  };
-
   // Helper that bypasses MemoryStorage (which lives in a separate
   // process from runUsage's parseBucketUri lookup) and uses a temp
   // file:// bucket instead.

--- a/packages/cli/src/cost.test.ts
+++ b/packages/cli/src/cost.test.ts
@@ -26,6 +26,7 @@ import { LocalFsStorage } from "@baerly/dev";
 import { Writer } from "@baerly/server/_internal/testing";
 import { runCost } from "./cost.ts";
 import type { Trajectory } from "./cost/project.ts";
+import { captureStream } from "./_internal/testing.ts";
 
 const APP = "app";
 const TENANT = "tenant";
@@ -83,23 +84,6 @@ const seedEntriesDeterministic = async (storage: Storage, count: number): Promis
     );
     await storage.put(logObjectKey(TABLE_PREFIX, seq), body);
   }
-};
-
-const captureStream = (
-  stream: NodeJS.WriteStream,
-): { restore: () => void; readonly captured: string[] } => {
-  const captured: string[] = [];
-  const original = stream.write.bind(stream);
-  stream.write = ((chunk: unknown): boolean => {
-    captured.push(typeof chunk === "string" ? chunk : String(chunk));
-    return true;
-  }) as typeof stream.write;
-  return {
-    captured,
-    restore: () => {
-      stream.write = original;
-    },
-  };
 };
 
 describe("baerly cost", () => {

--- a/packages/cli/src/cost.test.ts
+++ b/packages/cli/src/cost.test.ts
@@ -333,15 +333,22 @@ describe("baerly cost", () => {
   });
 
   test("unknown flag rejected with exit 1", async () => {
-    const exitCode = await runCost([
-      `--bucket=file://${root}`,
-      `--app=${APP}`,
-      `--tenant=${TENANT}`,
-      `--collection=${COLL}`,
-      "--provider=r2",
-      "--unknown=oops",
-    ]);
+    const stderr = captureStream(process.stderr);
+    let exitCode: number;
+    try {
+      exitCode = await runCost([
+        `--bucket=file://${root}`,
+        `--app=${APP}`,
+        `--tenant=${TENANT}`,
+        `--collection=${COLL}`,
+        "--provider=r2",
+        "--unknown=oops",
+      ]);
+    } finally {
+      stderr.restore();
+    }
     expect(exitCode).toBe(1);
+    expect(stderr.captured.join("")).toContain("unknown flag");
   });
 
   // Advisory render tests: 3 entries at 10ms spacing → very high write rate

--- a/packages/cli/src/doctor/cloudflare.test.ts
+++ b/packages/cli/src/doctor/cloudflare.test.ts
@@ -24,6 +24,23 @@ interface CannedReply {
   readonly stderr?: string;
 }
 
+const captureStream = (
+  stream: NodeJS.WriteStream,
+): { restore: () => void; readonly captured: string[] } => {
+  const captured: string[] = [];
+  const original = stream.write.bind(stream);
+  stream.write = ((chunk: unknown): boolean => {
+    captured.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof stream.write;
+  return {
+    captured,
+    restore: () => {
+      stream.write = original;
+    },
+  };
+};
+
 const makeRunner = (overrides: { readonly [key: string]: CannedReply } = {}) => {
   const calls: string[][] = [];
   const lookup = (args: readonly string[]): CannedReply => {
@@ -135,7 +152,12 @@ describe("doctorCloudflare", () => {
     // because we only mocked the failing path. The intent of this
     // test is just to assert `r2 bucket create x` was issued.
     void infoCalls;
-    await doctorCloudflare(makeConfig(repoRoot), { runner, fix: true });
+    const stderr = captureStream(process.stderr);
+    try {
+      await doctorCloudflare(makeConfig(repoRoot), { runner, fix: true });
+    } finally {
+      stderr.restore();
+    }
     expect(calls).toContainEqual(["wrangler", "r2", "bucket", "info", "x"]);
     expect(calls).toContainEqual(["wrangler", "r2", "bucket", "create", "x"]);
   });

--- a/packages/cli/src/doctor/cloudflare.test.ts
+++ b/packages/cli/src/doctor/cloudflare.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { AppConfig } from "../config.ts";
 import type { ProcessRunner } from "../deploy/cloudflare.ts";
 import { doctorCloudflare, type DoctorFinding } from "./cloudflare.ts";
+import { captureStream } from "../_internal/testing.ts";
 
 const PROD_WRANGLER = `{
   "name": "x",
@@ -23,23 +24,6 @@ interface CannedReply {
   readonly stdout?: string;
   readonly stderr?: string;
 }
-
-const captureStream = (
-  stream: NodeJS.WriteStream,
-): { restore: () => void; readonly captured: string[] } => {
-  const captured: string[] = [];
-  const original = stream.write.bind(stream);
-  stream.write = ((chunk: unknown): boolean => {
-    captured.push(typeof chunk === "string" ? chunk : String(chunk));
-    return true;
-  }) as typeof stream.write;
-  return {
-    captured,
-    restore: () => {
-      stream.write = original;
-    },
-  };
-};
 
 const makeRunner = (overrides: { readonly [key: string]: CannedReply } = {}) => {
   const calls: string[][] = [];

--- a/packages/cli/src/export.test.ts
+++ b/packages/cli/src/export.test.ts
@@ -224,27 +224,41 @@ describe("baerly export — SQL dump + sidecar plan generation", () => {
   test("bad --target → InvalidConfig (exit 1)", async () => {
     await provision(storage);
     await seedRows(storage);
-    const exitCode = await runExport([
-      `--bucket=file://${root}`,
-      `--app=${APP}`,
-      `--tenant=${TENANT}`,
-      `--collection=${COLL}`,
-      "--target=oracle",
-      `--output=${outFile}`,
-    ]);
+    const stderr = captureStream(process.stderr);
+    let exitCode: number;
+    try {
+      exitCode = await runExport([
+        `--bucket=file://${root}`,
+        `--app=${APP}`,
+        `--tenant=${TENANT}`,
+        `--collection=${COLL}`,
+        "--target=oracle",
+        `--output=${outFile}`,
+      ]);
+    } finally {
+      stderr.restore();
+    }
     expect(exitCode).toBe(1);
+    expect(stderr.captured.join("")).toContain("--target");
   });
 
   test("missing current.json → InvalidConfig (exit 1)", async () => {
-    const exitCode = await runExport([
-      `--bucket=file://${root}`,
-      `--app=${APP}`,
-      `--tenant=${TENANT}`,
-      `--collection=${COLL}`,
-      "--target=sqlite",
-      `--output=${outFile}`,
-    ]);
+    const stderr = captureStream(process.stderr);
+    let exitCode: number;
+    try {
+      exitCode = await runExport([
+        `--bucket=file://${root}`,
+        `--app=${APP}`,
+        `--tenant=${TENANT}`,
+        `--collection=${COLL}`,
+        "--target=sqlite",
+        `--output=${outFile}`,
+      ]);
+    } finally {
+      stderr.restore();
+    }
     expect(exitCode).toBe(1);
+    expect(stderr.captured.join("")).toContain("not provisioned");
   });
 
   test("default --output writes SQL to stdout", async () => {
@@ -271,14 +285,21 @@ describe("baerly export — SQL dump + sidecar plan generation", () => {
 
   test("unknown flag rejected with exit 1", async () => {
     await provision(storage);
-    const exitCode = await runExport([
-      `--bucket=file://${root}`,
-      `--app=${APP}`,
-      `--tenant=${TENANT}`,
-      `--collection=${COLL}`,
-      "--target=sqlite",
-      "--unknown=oops",
-    ]);
+    const stderr = captureStream(process.stderr);
+    let exitCode: number;
+    try {
+      exitCode = await runExport([
+        `--bucket=file://${root}`,
+        `--app=${APP}`,
+        `--tenant=${TENANT}`,
+        `--collection=${COLL}`,
+        "--target=sqlite",
+        "--unknown=oops",
+      ]);
+    } finally {
+      stderr.restore();
+    }
     expect(exitCode).toBe(1);
+    expect(stderr.captured.join("")).toContain("unknown flag");
   });
 });

--- a/packages/cli/src/export.test.ts
+++ b/packages/cli/src/export.test.ts
@@ -27,6 +27,7 @@ import { CURRENT_JSON_SCHEMA_VERSION, createCurrentJson, type Storage } from "@b
 import { LocalFsStorage } from "@baerly/dev";
 import { Writer } from "@baerly/server/_internal/testing";
 import { runExport } from "./export.ts";
+import { captureStream } from "./_internal/testing.ts";
 
 const APP = "app";
 const TENANT = "tenant";
@@ -65,23 +66,6 @@ const seedRows = async (storage: Storage): Promise<void> => {
     docId: "t-3",
     body: { _id: "t-3", status: "open", title: "third" },
   });
-};
-
-const captureStream = (
-  stream: NodeJS.WriteStream,
-): { restore: () => void; readonly captured: string[] } => {
-  const captured: string[] = [];
-  const original = stream.write.bind(stream);
-  stream.write = ((chunk: unknown): boolean => {
-    captured.push(typeof chunk === "string" ? chunk : String(chunk));
-    return true;
-  }) as typeof stream.write;
-  return {
-    captured,
-    restore: () => {
-      stream.write = original;
-    },
-  };
 };
 
 describe("baerly export — SQL dump + sidecar plan generation", () => {

--- a/packages/cli/src/inspect.test.ts
+++ b/packages/cli/src/inspect.test.ts
@@ -233,13 +233,20 @@ describe("baerly inspect", () => {
   });
 
   test("unknown flag rejected with exit 1", async () => {
-    const exitCode = await runInspect([
-      `--bucket=file://${root}`,
-      `--app=${APP}`,
-      `--tenant=${TENANT}`,
-      `--collection=${COLL}`,
-      "--unknown=oops",
-    ]);
+    const stderr = captureStream(process.stderr);
+    let exitCode: number;
+    try {
+      exitCode = await runInspect([
+        `--bucket=file://${root}`,
+        `--app=${APP}`,
+        `--tenant=${TENANT}`,
+        `--collection=${COLL}`,
+        "--unknown=oops",
+      ]);
+    } finally {
+      stderr.restore();
+    }
     expect(exitCode).toBe(1);
+    expect(stderr.captured.join("")).toContain("unknown flag");
   });
 });

--- a/packages/cli/src/inspect.test.ts
+++ b/packages/cli/src/inspect.test.ts
@@ -20,6 +20,7 @@ import { CURRENT_JSON_SCHEMA_VERSION, createCurrentJson, type Storage } from "@b
 import { LocalFsStorage } from "@baerly/dev";
 import { Writer } from "@baerly/server/_internal/testing";
 import { runInspect } from "./inspect.ts";
+import { captureStream } from "./_internal/testing.ts";
 
 const APP = "app";
 const TENANT = "tenant";
@@ -37,23 +38,6 @@ const provision = async (storage: Storage): Promise<void> => {
     snapshot_bytes: 0,
     snapshot_rows: 0,
   });
-};
-
-const captureStream = (
-  stream: NodeJS.WriteStream,
-): { restore: () => void; readonly captured: string[] } => {
-  const captured: string[] = [];
-  const original = stream.write.bind(stream);
-  stream.write = ((chunk: unknown): boolean => {
-    captured.push(typeof chunk === "string" ? chunk : String(chunk));
-    return true;
-  }) as typeof stream.write;
-  return {
-    captured,
-    restore: () => {
-      stream.write = original;
-    },
-  };
 };
 
 describe("baerly inspect", () => {

--- a/packages/cli/src/subcommand.test.ts
+++ b/packages/cli/src/subcommand.test.ts
@@ -14,23 +14,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { BaerlyError } from "@baerly/protocol";
 import { defineBaerlySubcommand } from "./subcommand.ts";
-
-const captureStream = (
-  stream: NodeJS.WriteStream,
-): { restore: () => void; readonly captured: string[] } => {
-  const captured: string[] = [];
-  const original = stream.write.bind(stream);
-  stream.write = ((chunk: unknown): boolean => {
-    captured.push(typeof chunk === "string" ? chunk : String(chunk));
-    return true;
-  }) as typeof stream.write;
-  return {
-    captured,
-    restore: () => {
-      stream.write = original;
-    },
-  };
-};
+import { captureStream } from "./_internal/testing.ts";
 
 describe("defineBaerlySubcommand", () => {
   let originalCwd: string;

--- a/packages/create-baerly-storage/src/index.test.ts
+++ b/packages/create-baerly-storage/src/index.test.ts
@@ -27,6 +27,7 @@ import { join } from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import type { GitRunner } from "./git.ts";
 import { runCreateBaerly } from "./runner.ts";
+import { captureStream } from "@baerly/cli/_internal/testing";
 
 // This whole file is real-subprocess + full-template-copy integration:
 // `runCreateBaerly` copies ~129 template files and shells out to git. In
@@ -44,23 +45,6 @@ vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
  * explicit so the file passes on a barebones host.
  */
 const hasGit = spawnSync("git", ["--version"]).status === 0;
-
-const captureStream = (
-  stream: NodeJS.WriteStream,
-): { restore: () => void; readonly captured: string[] } => {
-  const captured: string[] = [];
-  const original = stream.write.bind(stream);
-  stream.write = ((chunk: unknown): boolean => {
-    captured.push(typeof chunk === "string" ? chunk : String(chunk));
-    return true;
-  }) as typeof stream.write;
-  return {
-    captured,
-    restore: () => {
-      stream.write = original;
-    },
-  };
-};
 
 describe("create-baerly-storage runner (non-TTY)", () => {
   let outRoot: string;

--- a/packages/create-baerly-storage/src/install.test.ts
+++ b/packages/create-baerly-storage/src/install.test.ts
@@ -9,7 +9,7 @@
  * code 0 → ok; non-zero → ok with code preserved so the caller can
  * warn.
  */
-import { mkdtemp, rm, writeFile, chmod } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile, chmod } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
@@ -18,19 +18,32 @@ import { defaultInstaller } from "./install.ts";
 describe("defaultInstaller", () => {
   let workDir: string;
   let binDir: string;
+  let invokedLog: string;
   let originalPath: string | undefined;
+  let originalInvokedLog: string | undefined;
 
   beforeAll(async () => {
     workDir = await mkdtemp(join(tmpdir(), "create-baerly-install-"));
     binDir = await mkdtemp(join(tmpdir(), "create-baerly-bin-"));
-    // Fake pnpm/npm/yarn — print `__pm_invoked__ <cwd>` then exit 0.
+    // Fake pnpm/npm/yarn — record `__pm_invoked__ <cwd> <args>` to a file
+    // then exit 0. The installer spawns with `stdio: "inherit"`, so an
+    // `echo` here would bleed the child's stdout onto the parent test
+    // tty. Writing the marker to `$INVOKED_LOG` (set per-run in the test)
+    // instead keeps the invocation assertable without the leak.
     for (const name of ["pnpm", "npm", "yarn"]) {
       const path = join(binDir, name);
-      await writeFile(path, `#!/bin/sh\necho "__pm_invoked__ $PWD $@"\nexit 0\n`, "utf8");
+      await writeFile(
+        path,
+        `#!/bin/sh\nprintf '__pm_invoked__ %s %s\\n' "$PWD" "$*" >> "$INVOKED_LOG"\nexit 0\n`,
+        "utf8",
+      );
       await chmod(path, 0o755);
     }
+    invokedLog = join(binDir, "invoked.log");
     originalPath = process.env["PATH"];
     process.env["PATH"] = `${binDir}:${originalPath ?? ""}`;
+    originalInvokedLog = process.env["INVOKED_LOG"];
+    process.env["INVOKED_LOG"] = invokedLog;
   });
 
   afterAll(async () => {
@@ -39,6 +52,11 @@ describe("defaultInstaller", () => {
     } else {
       process.env["PATH"] = originalPath;
     }
+    if (originalInvokedLog === undefined) {
+      delete process.env["INVOKED_LOG"];
+    } else {
+      process.env["INVOKED_LOG"] = originalInvokedLog;
+    }
     await rm(workDir, { recursive: true, force: true });
     await rm(binDir, { recursive: true, force: true });
   });
@@ -46,6 +64,15 @@ describe("defaultInstaller", () => {
   test("spawns the detected pm's install command in cwd and returns code 0", async () => {
     const result = await defaultInstaller.run("pnpm", workDir);
     expect(result.code).toBe(0);
+    // The fake pnpm recorded its cwd + args to the log file, proving the
+    // child actually ran `pnpm install` in `workDir` (code 0 alone can't
+    // distinguish a real spawn from a stub that never executed). Match on
+    // the basename + args rather than the full path: on macOS the child's
+    // `$PWD` resolves the `/private` → `/var` symlink, so the absolute
+    // prefix differs from the un-resolved `workDir` handed to `run()`.
+    const log = await readFile(invokedLog, "utf8");
+    const workDirName = workDir.slice(workDir.lastIndexOf("/") + 1);
+    expect(log).toMatch(new RegExp(`__pm_invoked__ .*/${workDirName} install`));
   });
 
   test("yarn dispatch invokes `yarn install`", async () => {

--- a/packages/create-baerly-storage/src/runner-wizard.test.ts
+++ b/packages/create-baerly-storage/src/runner-wizard.test.ts
@@ -11,6 +11,7 @@ import type * as ScaffoldModule from "./scaffold.ts";
 import { runWizard } from "./prompts.ts";
 import { scaffold } from "./scaffold.ts";
 import { runCreateBaerly } from "./runner.ts";
+import { captureStream } from "@baerly/cli/_internal/testing";
 
 vi.mock("./prompts.ts", () => ({
   runWizard: vi.fn<typeof runWizard>(),
@@ -25,30 +26,6 @@ vi.mock("./scaffold.ts", async () => {
 
 const runWizardMock = vi.mocked(runWizard);
 const scaffoldMock = vi.mocked(scaffold);
-
-/**
- * Silence a write stream for the duration of a call, capturing what
- * would have been written. The wizard branch forces `isTTY = true`, so
- * `runCreateBaerly` takes the interactive `outro(...)` path and emits a
- * clack banner (`✓ … / Next steps`) — without this it would bleed onto
- * the test tty. Mirrors the helper in `index.test.ts` / `cost.test.ts`.
- */
-const captureStream = (
-  stream: NodeJS.WriteStream,
-): { restore: () => void; readonly captured: string[] } => {
-  const captured: string[] = [];
-  const original = stream.write.bind(stream);
-  stream.write = ((chunk: unknown): boolean => {
-    captured.push(typeof chunk === "string" ? chunk : String(chunk));
-    return true;
-  }) as typeof stream.write;
-  return {
-    captured,
-    restore: () => {
-      stream.write = original;
-    },
-  };
-};
 
 describe("runner wizard → scaffold plumbing", () => {
   let originalIsTTY: boolean | undefined;

--- a/packages/create-baerly-storage/src/runner-wizard.test.ts
+++ b/packages/create-baerly-storage/src/runner-wizard.test.ts
@@ -26,6 +26,30 @@ vi.mock("./scaffold.ts", async () => {
 const runWizardMock = vi.mocked(runWizard);
 const scaffoldMock = vi.mocked(scaffold);
 
+/**
+ * Silence a write stream for the duration of a call, capturing what
+ * would have been written. The wizard branch forces `isTTY = true`, so
+ * `runCreateBaerly` takes the interactive `outro(...)` path and emits a
+ * clack banner (`✓ … / Next steps`) — without this it would bleed onto
+ * the test tty. Mirrors the helper in `index.test.ts` / `cost.test.ts`.
+ */
+const captureStream = (
+  stream: NodeJS.WriteStream,
+): { restore: () => void; readonly captured: string[] } => {
+  const captured: string[] = [];
+  const original = stream.write.bind(stream);
+  stream.write = ((chunk: unknown): boolean => {
+    captured.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof stream.write;
+  return {
+    captured,
+    restore: () => {
+      stream.write = original;
+    },
+  };
+};
+
 describe("runner wizard → scaffold plumbing", () => {
   let originalIsTTY: boolean | undefined;
 
@@ -66,7 +90,15 @@ describe("runner wizard → scaffold plumbing", () => {
       git: false,
     });
     // Omitting the positional `projectName` forces wantWizard=true.
-    const code = await runCreateBaerly([]);
+    const stdout = captureStream(process.stdout);
+    const stderr = captureStream(process.stderr);
+    let code: number;
+    try {
+      code = await runCreateBaerly([]);
+    } finally {
+      stdout.restore();
+      stderr.restore();
+    }
     expect(code).toBe(0);
     expect(scaffoldMock).toHaveBeenCalledTimes(1);
     const opts = scaffoldMock.mock.calls[0]?.[0];
@@ -87,7 +119,14 @@ describe("runner wizard → scaffold plumbing", () => {
     });
     // projectName missing → wizard fires; --starter=react is forwarded
     // as wizard input so the prompt can be skipped.
-    await runCreateBaerly(["--starter=react", "--target=cloudflare"]);
+    const stdout = captureStream(process.stdout);
+    const stderr = captureStream(process.stderr);
+    try {
+      await runCreateBaerly(["--starter=react", "--target=cloudflare"]);
+    } finally {
+      stdout.restore();
+      stderr.restore();
+    }
     expect(runWizardMock).toHaveBeenCalledTimes(1);
     const input = runWizardMock.mock.calls[0]?.[0];
     expect(input?.starter).toBe("react");

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -761,7 +761,20 @@ const BUDGETS: readonly Budget[] = [
   //     @logtape/logtape 2.1.3→2.2.2 (via the observability chunk) + hono
   //     4.12.25→4.12.27, both in this aggregator's closure. Only the raw/gz
   //     creep tripwires move; min-gz (measured 45027) stays under 44 KiB.
-  { entry: "cloudflare.js", raw: 415 * 1024, gz: 125 * 1024, minGz: 44 * 1024 },
+  //   → min-gz +1 KiB (2026-07-03): the snapshot `body.docs` array-shape guard
+  //     in snapshot.ts (`loadSnapshotAsMap` → BaerlyError("InvalidResponse", …),
+  //     added in 95648be2) reaches this closure via the maintenance/compactor
+  //     subgraph. Measured 45063, +7 past the 44 KiB min-gz line. Bisect
+  //     confirmed this guard is the sole cause (every commit after it is
+  //     docs/changeset-only and byte-neutral); it slipped onto main because CI
+  //     runs min-gz report-only. The bytes are a real, intentional validation
+  //     guard whose actionable error message is kept verbatim per the repo's
+  //     error-quality UX bar — golfing the string is a dead end anyway (gzip
+  //     already dedupes the shared `compact: snapshot …` prefix; the cost is the
+  //     guard's control flow, not its text). So the tripwire rebaselines rather
+  //     than degrade the message. raw/gz remain comfortably under their 415/125
+  //     KiB bounds (only min-gz crossed).
+  { entry: "cloudflare.js", raw: 415 * 1024, gz: 125 * 1024, minGz: 45 * 1024 },
   // Client surface — `BaerlyClient<TConfig>` + fetcher plumbing.
   // Browser/runtime-agnostic; no kernel modules in the closure.
   // Budget history:

--- a/tests/integration/lint-use-query.test.ts
+++ b/tests/integration/lint-use-query.test.ts
@@ -30,6 +30,12 @@ const runOnFixture = (source: string): { exitCode: number; stderr: string } => {
     execFileSync("node", [SCRIPT], {
       cwd: REPO_ROOT,
       encoding: "utf8",
+      // Capture stderr explicitly. `execFileSync`'s default stdio
+      // inherits the child's stderr to the parent, so the scanner's
+      // `console.error` findings would leak into the test terminal
+      // (and `e.stderr` on the thrown error would be empty). Piping
+      // stdin/stdout/stderr keeps every stream captured.
+      stdio: ["ignore", "pipe", "pipe"],
     });
     return { exitCode: 0, stderr: "" };
   } catch (error) {

--- a/tests/setup/logtape-exit-listener-leak.ts
+++ b/tests/setup/logtape-exit-listener-leak.ts
@@ -1,0 +1,48 @@
+// Suppress the `MaxListenersExceededWarning: … 11 exit listeners added to
+// [process]` that floods the (forked) test workers.
+//
+// Root cause is an upstream LogTape bug, not baerly code:
+// `@logtape/logtape@2.2.2`'s `configure()` calls
+// `process.on("exit", dispose)` on **every** invocation
+// (`dist/config.js` → `registerDisposeHook`) and never removes that hook
+// on `reset()`. `configureObservability`
+// (`packages/server/src/observability/logger.ts`) is documented as
+// idempotent — production adapters configure once at boot, but the test
+// suite reconfigures it in many `beforeEach` blocks across dozens of
+// files that share one forked worker process. Each `configure()` appends
+// another copy of the *same* `dispose` reference, and Node warns once the
+// count passes its default `MaxListeners` of 10.
+//
+// This is a pure test artifact: shipped code configures once, so the
+// kernel bundle carries no workaround. We fix it where the multiplicity
+// happens — the test process — by making `process.on/addListener("exit",
+// fn)` idempotent for an already-registered reference. That removes the
+// leak (the count never grows past one per distinct listener) rather than
+// masking it with `setMaxListeners`, and it only affects the `"exit"`
+// event with duplicate references, so genuinely-distinct listeners are
+// untouched.
+//
+// Guarded by `typeof process` so it's a no-op under Workerd, matching
+// LogTape's own env guard (Workerd has no `process` and never hits the
+// leaking branch anyway).
+
+if (typeof process !== "undefined" && typeof process.on === "function") {
+  const target = process as unknown as {
+    on: (event: string, listener: (...args: unknown[]) => void) => unknown;
+    addListener: (event: string, listener: (...args: unknown[]) => void) => unknown;
+    listeners: (event: string) => readonly ((...args: unknown[]) => void)[];
+  };
+
+  const dedupe = (original: (event: string, listener: (...args: unknown[]) => void) => unknown) =>
+    function (this: unknown, event: string, listener: (...args: unknown[]) => void): unknown {
+      if (event === "exit" && target.listeners("exit").includes(listener)) {
+        // Identical reference already registered — skip the duplicate so
+        // the listener count stays flat across repeated configure() calls.
+        return this;
+      }
+      return original.call(this, event, listener);
+    };
+
+  target.on = dedupe(target.on.bind(process));
+  target.addListener = dedupe(target.addListener.bind(process));
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -205,7 +205,14 @@ export default defineConfig({
             // real test suites and would fail to even import.
             "tests/fixtures/check-acceptance/**/*.test.ts",
           ],
-          setupFiles: ["tests/setup/fast-check.ts"],
+          setupFiles: [
+            "tests/setup/fast-check.ts",
+            // Silence the upstream LogTape `MaxListenersExceededWarning`
+            // exit-listener leak across the many `configureObservability`
+            // calls the suite makes in one forked worker. See the file
+            // header for the full root-cause writeup.
+            "tests/setup/logtape-exit-listener-leak.ts",
+          ],
           testTimeout: vitestTestTimeoutMs,
           hookTimeout: vitestTestTimeoutMs,
           // Process isolation. Vitest 4's default `pool: 'threads'` with


### PR DESCRIPTION
## What

`pnpm test:agent` was noisy and had one real failure. This makes the suite green and quiet with no change to what any test asserts. Three atomic commits:

1. **Silence incidental CLI/scaffold/lint output** — several passing tests exercised error/CLI paths but never captured the stdout/stderr they trigger, so a full run printed a wall of noise. Wrapped the invocations in the existing `captureStream` helper (or routed child output to a log file):
   - `cli`: `cost`, `inspect`, `export`, `admin/{dump,fsck,restore,rebuild-index}`, `doctor/cloudflare` (the `creating R2 bucket` line came from the doctor `--fix` test, not deploy).
   - `create-baerly-storage`: `install`'s fake PM writes its marker to a log file; `runner-wizard` captures the interactive clack banner.
   - `lint-use-query`: `execFileSync` was inheriting the child's stderr — pipe both streams so findings are captured.

2. **Neutralize a LogTape exit-listener leak** — the run printed repeated `MaxListenersExceededWarning` (11 exit listeners). Root cause is upstream: LogTape 2.2.2's `configure()` registers a `process.on('exit')` dispose hook that `reset()` never removes. Production calls `configureObservability` once so nothing ships broken, but the tests reconfigure across dozens of files sharing one forked worker. A setup file makes exit-listener registration idempotent (guarded by `typeof process`, no-op under Workerd) — removing the leak rather than masking it with `setMaxListeners`. The kernel-side dedupe was rejected because it blew the min-gz ceiling and is unnecessary for single-configure production.

3. **Rebaseline cloudflare.js min-gz 44→45 KiB** — the only real failure (`measured 45063`, +7 over the hard ceiling). Bisect pinned it to `95648be2`, which added a `body.docs` array-shape guard in `snapshot.ts` under a "behaviour-identical" refactor label. The guard is real, intentional validation with an actionable error message, kept verbatim per the repo's error-quality bar (golfing the string is a dead end — gzip dedupes the shared prefix, so the cost is control flow, not text). Rebaselined with a dated baseline note; raw/gz stay under bounds.

## Verification

- `pnpm test:agent` — **179 files passed / 4 skipped, 2446 tests passed**, exit 0.
- **Zero** noise lines remaining (CLI envelopes, `MaxListenersExceededWarning`, `__pm_invoked__`, lint-fixture findings, scaffold banner all gone).
- `pnpm bundle-sizes` — 18/18.
- `pnpm verify:agent` — green (pre-commit gate ran on every commit).

## Follow-ups (not in this PR)

- The `MaxListenersExceededWarning` is an **upstream LogTape 2.2.2 bug** (`configure` never removes its dispose hook) — worth filing upstream.
- The min-gz creep reached `main` because **CI runs min-gz report-only** and `95648be2` appears to have bypassed the pre-commit hook, so the tripwire only fired locally.
