### PR TITLE
fix(observability): coexist with a host app's LogTape config

### DIFF
--- a/.changeset/logtape-host-config-coexistence.md
+++ b/.changeset/logtape-host-config-coexistence.md
@@ -1,0 +1,23 @@
+---
+"@gusto/baerly-storage": minor
+---
+
+Observability: coexist with a host app's LogTape config instead of clobbering it.
+
+baerly is a library, and LogTape's guidance is that only the application
+configures LogTape. Previously the Node and Cloudflare adapters called
+`configure({ reset: true })` at boot unconditionally, which silently wiped
+the sinks and loggers of any app that had already configured LogTape (and,
+depending on boot order, could itself be wiped). The documented "leave the
+field unset to skip configuration" escape hatch never actually worked.
+
+Now:
+
+- `configureObservability` checks `getConfig()` first. When LogTape is
+  already configured by something other than baerly, it leaves that config
+  intact and emits a single `["logtape", "meta"]` notice rather than
+  resetting it. baerly's own config is still reconfigured last-call-wins, so
+  standalone servers and dev hot-reload are unchanged.
+- `baerlyNode` / `baerlyWorker` accept `observability: false` to skip
+  auto-configuration entirely, for apps that own the process-wide
+  (isolate-wide on Workers) LogTape configuration themselves.

--- a/docs/contributing/conventions/observability.md
+++ b/docs/contributing/conventions/observability.md
@@ -256,3 +256,9 @@ global; a leaked sink in test A poisons test B with stale records.
 - ❌ Don't read `process.env` directly for level / sample rate.
   Pass through the typed `ObservabilityConfig` option so the
   envvar fallback lives in one place (the logger config).
+- ❌ Don't make `configureObservability` unconditionally
+  `reset`-configure. baerly is a library; an embedding app may own
+  LogTape. `configureObservability` checks `getConfig()` and skips
+  (with one meta-logger notice) when a non-baerly config is already
+  installed, and the adapters honor `observability: false` to opt out
+  entirely. Preserve both when touching the boot path.

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -284,6 +284,33 @@ const datadogSink: Sink = (record) => {
 };
 ```
 
+## Embedding baerly in an app that already uses LogTape
+
+baerly is a library, and [LogTape's guidance](https://logtape.org/manual/library)
+is that only the *application* configures LogTape — a library must not
+reset another app's logging config. The adapters auto-configure at boot
+for the common zero-config case (a scaffolded standalone server), but
+they will **never clobber a config you installed first**:
+
+- If your app calls `configure()` (or `configureSync()`) before
+  `baerlyNode` / `baerlyWorker` boots, baerly detects the existing
+  config, leaves it untouched, and emits one `["logtape", "meta"]`
+  notice. baerly's `["baerly", …]` categories then route through
+  whatever sinks your config wired for them (its root/catch-all sink,
+  or nowhere). To capture baerly's logs, add a logger for the
+  `["baerly"]` category in your own `configure()` call.
+- To stop baerly from touching LogTape at all — even when it boots
+  first — pass **`observability: false`**:
+
+  ```ts
+  baerlyNode({ config, storage, verifier, observability: false });
+  // or, on Cloudflare:
+  baerlyWorker((env) => ({ config, observability: false }));
+  ```
+
+  Your app then owns the process-wide (isolate-wide on Workers) LogTape
+  configuration end to end.
+
 ## Cost-ballooning anti-patterns
 
 - ❌ **Don't log request bodies.** baerly-storage stores arbitrary
@@ -316,7 +343,9 @@ const datadogSink: Sink = (record) => {
 - [`docs/about/cost-model.md`](../about/cost-model.md) — how class-A counts map to
   S3 / R2 spend.
 - Public API: JSDoc on `baerlyNode` (Node) and `baerlyWorker`
-  (Cloudflare). Both expose `observability?: ObservabilityConfig`.
+  (Cloudflare). Both expose `observability?: ObservabilityConfig | false`
+  (`false` opts out of auto-configuration — see "Embedding baerly"
+  above).
 - LogTape itself: <https://logtape.org/>. The kernel uses LogTape's
   `Sink` / `Logger` types directly; anything in the LogTape ecosystem
   works as a drop-in.

--- a/packages/adapter-cloudflare/src/worker.test.ts
+++ b/packages/adapter-cloudflare/src/worker.test.ts
@@ -16,7 +16,7 @@ import {
   SHARED_SECRET_MISSING_MESSAGE,
   type Verifier,
 } from "@baerly/protocol";
-import { reset, type LogRecord, type Sink } from "@logtape/logtape";
+import { getConfig, reset, type LogRecord, type Sink } from "@logtape/logtape";
 import { afterEach, describe, expect, test } from "vitest";
 import { r2BindingStorage } from "./r2-binding-storage.ts";
 import { baerlyWorker, type BaerlyEnv } from "./worker.ts";
@@ -343,6 +343,37 @@ describe("baerlyWorker observability", () => {
     );
     expect(warn).toBeDefined();
     expect(warn!.level).toBe("warning");
+  });
+});
+
+describe("baerlyWorker observability opt-out", () => {
+  afterEach(async () => {
+    await reset();
+  });
+
+  const healthzRequest = (): Request<unknown, IncomingRequestCfProperties> =>
+    new Request("https://x/v1/healthz") as Request<unknown, IncomingRequestCfProperties>;
+
+  test("observability:false skips lazy configuration on first fetch", async () => {
+    await reset();
+    const handler = baerlyWorker(() => ({ config: testConfig, observability: false }));
+    const env: BaerlyEnv = { BUCKET: getBinding(), APP: "t" };
+
+    await handler.fetch!(healthzRequest(), env, mockExecutionContext());
+
+    // The worker never called configureObservability: LogTape stays
+    // unconfigured so the embedding Worker can own configuration.
+    expect(getConfig()).toBeNull();
+  });
+
+  test("observability omitted auto-configures on first fetch (default-on)", async () => {
+    await reset();
+    const handler = baerlyWorker(() => ({ config: testConfig }));
+    const env: BaerlyEnv = { BUCKET: getBinding(), APP: "t" };
+
+    await handler.fetch!(healthzRequest(), env, mockExecutionContext());
+
+    expect(getConfig()).not.toBeNull();
   });
 });
 

--- a/packages/adapter-cloudflare/src/worker.ts
+++ b/packages/adapter-cloudflare/src/worker.ts
@@ -254,12 +254,14 @@ export interface BaerlyWorkerOptions {
    * - `sink` defaults to `"console-json"` (Cloudflare's stdout is
    *   ingested by Workers Logs as JSON-shaped records).
    *
-   * Leave the field unset to skip configuration entirely — the
-   * default LogTape configuration is a no-op sink. Adapters that
-   * skip configuration still emit through the bag/operator pipe; only
-   * the LogTape `console.log` side becomes silent.
+   * When the field is unset (or `{}`), baerly auto-configures on first
+   * `fetch`. Pass `false` to skip configuration entirely — the escape
+   * hatch for Workers that embed baerly and own the isolate-wide
+   * LogTape configuration themselves. (baerly also never clobbers a
+   * host config it detects; `false` additionally suppresses the
+   * configure attempt and its meta-logger notice.)
    */
-  readonly observability?: ObservabilityConfig;
+  readonly observability?: ObservabilityConfig | false;
   /**
    * Opt-in dev affordance. When set, `GET /` returns a small
    * human-readable HTML page that links to {@link DevLandingOptions.uiUrl},
@@ -368,7 +370,7 @@ export function baerlyWorker<E extends BaerlyEnv = BaerlyEnv>(
     // scheduled invocation runs the configure. LogTape's `configure`
     // is idempotent (we always pass `reset: true`); a thundering-herd
     // race on the cold-start tick just re-runs the same config.
-    if (!observabilityConfigured) {
+    if (!observabilityConfigured && resolved.options.observability !== false) {
       await configureObservability(resolveCfSink(resolved.options.observability));
       observabilityConfigured = true;
       // Emit the auth=none startup banner exactly once per isolate.

--- a/packages/adapter-cloudflare/src/worker.ts
+++ b/packages/adapter-cloudflare/src/worker.ts
@@ -246,8 +246,9 @@ export interface BaerlyWorkerOptions {
    * Worker calls {@link configureObservability} lazily on first
    * `fetch` / `scheduled` invocation (CF Worker modules can't
    * `await` at the top level). `configureObservability` is
-   * idempotent — passing `{ reset: true }` to LogTape — so
-   * re-invocation is harmless.
+   * idempotent over baerly's own config — it re-runs with
+   * `{ reset: true }`, last call wins — and skips over a host config
+   * it detects, so re-invocation is harmless.
    *
    * - `level` falls through to `env.LOG_LEVEL` (when typed option
    *   is undefined).

--- a/packages/adapter-node/src/baerly-node.ts
+++ b/packages/adapter-node/src/baerly-node.ts
@@ -46,7 +46,7 @@ export interface BaerlyNodeOptions {
    * `GET /v1/healthz` always bypasses the verifier.
    */
   readonly verifier?: Verifier;
-  readonly observability?: ObservabilityConfig;
+  readonly observability?: ObservabilityConfig | false;
   readonly dev?: DevLandingOptions;
   readonly webRoot?: string;
   readonly sinceTimeoutMs?: number;

--- a/packages/adapter-node/src/server.test.ts
+++ b/packages/adapter-node/src/server.test.ts
@@ -29,10 +29,46 @@ import {
   WRITE_TICK_GC_MAX_SWEEPS,
 } from "@baerly/protocol";
 import { configureObservability } from "@baerly/server/observability";
-import { reset, type LogRecord, type Sink } from "@logtape/logtape";
+import { getConfig, reset, type LogRecord, type Sink } from "@logtape/logtape";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { createApp, type CreateAppOptions } from "./app.ts";
 import { createFetchHandler, nodeMaintenanceDispatch, resolveDefaultSink } from "./server.ts";
+
+describe("createFetchHandler observability opt-out", () => {
+  afterEach(async () => {
+    await reset();
+  });
+
+  // configureObservability runs fire-and-forget at factory time; draining a
+  // macrotask lets its async configure() land before we assert.
+  const drain = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+  test("observability:false skips auto-configuration, leaving LogTape untouched", async () => {
+    await reset();
+    expect(getConfig()).toBeNull();
+
+    const verifier: Verifier = async () => ({ tenantPrefix: "acme", identity: {} });
+    createFetchHandler({
+      app: "t",
+      storage: new MemoryStorage(),
+      verifier,
+      observability: false,
+    });
+
+    // The factory did NOT call configureObservability: LogTape stays
+    // unconfigured, so an embedder can own configuration entirely.
+    await drain();
+    expect(getConfig()).toBeNull();
+  });
+
+  test("observability omitted still auto-configures (default-on)", async () => {
+    await reset();
+    const verifier: Verifier = async () => ({ tenantPrefix: "acme", identity: {} });
+    createFetchHandler({ app: "t", storage: new MemoryStorage(), verifier });
+    await drain();
+    expect(getConfig()).not.toBeNull();
+  });
+});
 
 describe("nodeMaintenanceDispatch", () => {
   test("runs inline (no dispatch override) with Node-tier caps + phasesPerTick:both", () => {

--- a/packages/adapter-node/src/server.ts
+++ b/packages/adapter-node/src/server.ts
@@ -47,15 +47,19 @@ export interface CreateFetchHandlerOptions {
   readonly config?: BaerlyConfig;
   /**
    * LogTape config (level/sink) with `LOG_LEVEL` envvar fallback.
-   * When the field is unset, the default sink is auto-selected: the
-   * local `prettyConsoleSink()` when `process.stdout.isTTY === true`
-   * (developer terminals), `"console-json"` otherwise (production
-   * hosts where stdout is piped to a log aggregator). The typed
-   * `sink` field always wins. Pass `{}` to opt into TTY
-   * auto-detection at default level. Pass `undefined` (the field's
-   * absence) to skip `configureObservability` entirely.
+   * When the field is unset (or `{}`), baerly auto-configures LogTape:
+   * the default sink is the local `prettyConsoleSink()` when
+   * `process.stdout.isTTY === true` (developer terminals),
+   * `"console-json"` otherwise (production hosts where stdout is piped
+   * to a log aggregator). The typed `sink` field always wins.
+   *
+   * Pass `false` to skip `configureObservability` entirely — the
+   * escape hatch for apps that embed baerly and own the process-wide
+   * LogTape configuration themselves. (baerly also never clobbers a
+   * host config it detects at boot; `false` additionally suppresses the
+   * boot-time configure attempt and its meta-logger notice.)
    */
-  readonly observability?: ObservabilityConfig;
+  readonly observability?: ObservabilityConfig | false;
   /** Override the long-poll budget. Forwarded to `createRouter`. */
   readonly sinceTimeoutMs?: number;
   /** Override the long-poll inner-poll cadence. Forwarded to `createRouter`. */
@@ -132,8 +136,12 @@ export const nodeMaintenanceDispatch = (
 export function createFetchHandler(
   opts: CreateFetchHandlerOptions,
 ): (req: Request) => Promise<Response> {
-  // Factory-time, idempotent.
-  void configureObservability(resolveDefaultSink(opts.observability ?? {}));
+  // Factory-time, idempotent. `observability: false` opts out entirely
+  // (embedder owns LogTape config); otherwise auto-configure — this is a
+  // no-op when a host config is already present (see configureObservability).
+  if (opts.observability !== false) {
+    void configureObservability(resolveDefaultSink(opts.observability ?? {}));
+  }
   const wrappedStorage = observableStorage(opts.storage);
 
   return async (request: Request): Promise<Response> => {

--- a/packages/server/src/observability/logger.test.ts
+++ b/packages/server/src/observability/logger.test.ts
@@ -1,4 +1,4 @@
-import { reset, type LogRecord, type Sink } from "@logtape/logtape";
+import { configure, getConfig, reset, type LogRecord, type Sink } from "@logtape/logtape";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { CATEGORY, configureObservability, getLogger } from "./logger.ts";
 
@@ -87,6 +87,61 @@ describe("configureObservability + getLogger", () => {
     getLogger(CATEGORY.http).info("event");
     expect(r1).toHaveLength(0);
     expect(r2).toHaveLength(1);
+  });
+});
+
+describe("configureObservability — host-config coexistence", () => {
+  afterEach(async () => {
+    await reset();
+  });
+
+  test("does not clobber a foreign LogTape config already installed by the host", async () => {
+    const host = collectingSink();
+    await configure({
+      reset: true,
+      sinks: { host: host.sink },
+      loggers: [{ category: "host", sinks: ["host"], lowestLevel: "info" }],
+    });
+
+    // baerly boots into an app that already owns LogTape.
+    await configureObservability({ level: "info", sink: () => {} });
+
+    // The host's config survived untouched: its logger still routes to
+    // its sink, and baerly did not register its own sink.
+    getLogger(["host"]).info("still-here");
+    expect(host.records.map((r) => r.message.join(""))).toContain("still-here");
+    const cfg = getConfig();
+    expect(cfg && Object.keys(cfg.sinks)).toEqual(["host"]);
+  });
+
+  test("warns via the meta logger when it declines to configure over a host config", async () => {
+    const host = collectingSink();
+    await configure({
+      reset: true,
+      sinks: { host: host.sink },
+      loggers: [
+        { category: "host", sinks: ["host"], lowestLevel: "info" },
+        { category: ["logtape", "meta"], sinks: ["host"], lowestLevel: "warning" },
+      ],
+    });
+
+    await configureObservability({});
+
+    expect(
+      host.records.some((r) => r.category.join(".") === "logtape.meta" && r.level === "warning"),
+    ).toBe(true);
+  });
+
+  test("still reconfigures its own prior config (last call wins)", async () => {
+    const first = collectingSink();
+    await configureObservability({ level: "info", sink: first.sink });
+    const second = collectingSink();
+    // Second baerly call over baerly's own config must still take effect.
+    await configureObservability({ level: "info", sink: second.sink });
+
+    getLogger(CATEGORY.http).info("event");
+    expect(first.records).toHaveLength(0);
+    expect(second.records).toHaveLength(1);
   });
 });
 

--- a/packages/server/src/observability/logger.ts
+++ b/packages/server/src/observability/logger.ts
@@ -28,16 +28,19 @@
  * the rest of the project's vocabulary; we translate at the
  * configure boundary.
  *
- * ## Idempotency
+ * ## Idempotency & host-config coexistence
  *
- * `configureObservability` is safe to call multiple times. LogTape's
- * own `configure` will reject re-configuration without `reset: true`;
- * we always pass `reset: true` so the last call wins and operators
- * can hot-swap config in dev without restarting.
+ * Safe to call repeatedly: over baerly's own config (or none) we
+ * reconfigure with `reset: true` so the last call wins. But baerly is
+ * a library — an embedding app may own LogTape. To avoid clobbering a
+ * host config, we skip (with one meta-logger notice) when {@link
+ * getConfig} shows a config we didn't install. Embedders opt out fully
+ * via the adapter's `observability: false`.
  */
 
 import {
   configure,
+  getConfig,
   getLogger as logtapeGetLogger,
   type Logger,
   type LogLevel,
@@ -94,28 +97,58 @@ export interface ObservabilityConfig {
 }
 
 /**
+ * Sink id baerly registers under. Doubles as our config-ownership
+ * marker: a LogTape config carrying a sink under this key is one we
+ * installed, so re-running {@link configureObservability} may safely
+ * reset it. A config *without* this key belongs to the host app and
+ * we must not clobber it.
+ */
+const BAERLY_SINK_ID = "baerly";
+
+/**
  * Wire LogTape's global config.
  *
- * Idempotent — call as many times as you like. The adapter boot
- * path calls it once at init; tests call it once per
- * `beforeEach`.
+ * Idempotent over baerly's own config — call as many times as you
+ * like and the last call wins. The adapter boot path calls it once at
+ * init; tests call it once per `beforeEach`. When LogTape is already
+ * configured by the host application (see the module doc), this is a
+ * no-op apart from a one-line meta-logger notice.
  */
 export const configureObservability = async (config: ObservabilityConfig = {}): Promise<void> => {
+  const existing = getConfig();
+  if (existing !== null && !isBaerlyOwnedConfig(existing)) {
+    // Host app already configured LogTape — libraries must not reset
+    // another app's config. Leave it; baerly's categories fall through
+    // to the host's routing.
+    logtapeGetLogger(["logtape", "meta"]).warn(
+      "LogTape already configured by the host; baerly left it intact. Add a " +
+        '["baerly"] logger to route baerly logs, or pass observability:false.',
+    );
+    return;
+  }
+
   const level = resolveLevel(config.level);
   const sink = resolveSink(config.sink);
 
   await configure({
     reset: true,
-    sinks: { primary: sink },
+    sinks: { [BAERLY_SINK_ID]: sink },
     loggers: [
       // Bind every `baerly.*` category to our sink at the chosen level.
-      { category: "baerly", sinks: ["primary"], lowestLevel: level },
+      { category: "baerly", sinks: [BAERLY_SINK_ID], lowestLevel: level },
       // LogTape itself logs to a meta category; route it to the same
       // sink at `error` so we see config issues without spamming.
-      { category: ["logtape", "meta"], sinks: ["primary"], lowestLevel: "error" },
+      { category: ["logtape", "meta"], sinks: [BAERLY_SINK_ID], lowestLevel: "error" },
     ],
   });
 };
+
+/**
+ * Is this LogTape config one baerly installed? Detected by the marker
+ * sink id — see {@link BAERLY_SINK_ID}.
+ */
+const isBaerlyOwnedConfig = (cfg: ReturnType<typeof getConfig> & object): boolean =>
+  Object.prototype.hasOwnProperty.call(cfg.sinks, BAERLY_SINK_ID);
 
 /**
  * Thin re-export. Identical shape to `@logtape/logtape`'s `getLogger`.

--- a/packages/server/src/observability/logger.ts
+++ b/packages/server/src/observability/logger.ts
@@ -102,8 +102,14 @@ export interface ObservabilityConfig {
  * installed, so re-running {@link configureObservability} may safely
  * reset it. A config *without* this key belongs to the host app and
  * we must not clobber it.
+ *
+ * Deliberately namespaced rather than a bare `"baerly"`: this key
+ * gates a destructive `reset`, so a host must never be able to trip it
+ * by coincidentally naming one of its own sinks the same thing. The id
+ * is internal (never surfaced on the wire) and depends only on
+ * LogTape's documented `Config.sinks` shape.
  */
-const BAERLY_SINK_ID = "baerly";
+const BAERLY_SINK_ID = "@gusto/baerly-storage";
 
 /**
  * Wire LogTape's global config.

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -486,12 +486,15 @@ const BUDGETS: readonly Budget[] = [
   //     consolidation into the shared `maintenance` chunk + rolldown
   //     1.1.0→1.1.3 from `pnpm dedupe`. Measured 354182 raw / 104921 gz;
   //     min-gz under.
-  //   → 348 KiB raw (2026-07-06): host-config coexistence — configureObservability
-  //     now checks getConfig() and skips (with a meta notice) rather than reset a
-  //     host app's LogTape config; flows through the observability chunk. Measured
-  //     355598 raw; gz (104xxx) + min-gz (−640) still under. Per the POLICY, raw is
-  //     a creep tripwire → rebaseline rather than golf the guard.
-  { entry: "http.js", raw: 348 * 1024, gz: 103 * 1024, minGz: 36 * 1024 },
+  //   → 348 KiB raw / 104 KiB gz (2026-07-06): host-config coexistence —
+  //     configureObservability now checks getConfig() and skips (with a meta
+  //     notice) rather than reset a host app's LogTape config, and the
+  //     ownership marker is namespaced to "@gusto/baerly-storage" (un-guessable
+  //     so a host can't trip the destructive reset). Flows through the
+  //     observability chunk; the namespaced literal + guard JSDoc nudge gz over.
+  //     Measured 355931 raw / 105574 gz; min-gz (−659) under. Per the POLICY,
+  //     raw/gz are creep tripwires → rebaseline rather than golf the guard.
+  { entry: "http.js", raw: 348 * 1024, gz: 104 * 1024, minGz: 36 * 1024 },
   // Observability primitives — ObservabilityContext, the
   // request-scoped MetricsRecorder, LogTape config + the
   // JSON sink only (the pretty sink + picocolors now live in
@@ -542,10 +545,12 @@ const BUDGETS: readonly Budget[] = [
   //     wrapper over logtape, so the newer logtape closure lands here most
   //     visibly. Deliberate upstream upgrade, not code creep.
   //     Measured: 98776 raw / 27034 gz / 12477 min-gz.
-  //   → raw +1 KiB (2026-07-06): host-config coexistence — the getConfig()
-  //     ownership check + skip-and-warn path in configureObservability. Measured
-  //     100235 raw; gz (27xxx) + min-gz (−683) under. Rebaseline the raw tripwire.
-  { entry: "observability.js", raw: 98 * 1024, gz: 27 * 1024, minGz: 13 * 1024 },
+  //   → raw +2 KiB / gz +1 KiB (2026-07-06): host-config coexistence — the
+  //     getConfig() ownership check + skip-and-warn path in configureObservability,
+  //     plus the namespaced "@gusto/baerly-storage" marker literal and its guard
+  //     JSDoc (comments ship un-stripped). Measured 100568 raw / 27690 gz; min-gz
+  //     (−701) under. Rebaseline the raw/gz creep tripwires per the POLICY.
+  { entry: "observability.js", raw: 99 * 1024, gz: 28 * 1024, minGz: 13 * 1024 },
   // Maintenance loop — compactor + GC + sweep driver. Pulls
   // compactor.ts + gc.ts + the observability subgraph
   // transitively (storage decorator + logger config + canonical

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -486,7 +486,12 @@ const BUDGETS: readonly Budget[] = [
   //     consolidation into the shared `maintenance` chunk + rolldown
   //     1.1.0→1.1.3 from `pnpm dedupe`. Measured 354182 raw / 104921 gz;
   //     min-gz under.
-  { entry: "http.js", raw: 346 * 1024, gz: 103 * 1024, minGz: 36 * 1024 },
+  //   → 348 KiB raw (2026-07-06): host-config coexistence — configureObservability
+  //     now checks getConfig() and skips (with a meta notice) rather than reset a
+  //     host app's LogTape config; flows through the observability chunk. Measured
+  //     355598 raw; gz (104xxx) + min-gz (−640) still under. Per the POLICY, raw is
+  //     a creep tripwire → rebaseline rather than golf the guard.
+  { entry: "http.js", raw: 348 * 1024, gz: 103 * 1024, minGz: 36 * 1024 },
   // Observability primitives — ObservabilityContext, the
   // request-scoped MetricsRecorder, LogTape config + the
   // JSON sink only (the pretty sink + picocolors now live in
@@ -537,7 +542,10 @@ const BUDGETS: readonly Budget[] = [
   //     wrapper over logtape, so the newer logtape closure lands here most
   //     visibly. Deliberate upstream upgrade, not code creep.
   //     Measured: 98776 raw / 27034 gz / 12477 min-gz.
-  { entry: "observability.js", raw: 97 * 1024, gz: 27 * 1024, minGz: 13 * 1024 },
+  //   → raw +1 KiB (2026-07-06): host-config coexistence — the getConfig()
+  //     ownership check + skip-and-warn path in configureObservability. Measured
+  //     100235 raw; gz (27xxx) + min-gz (−683) under. Rebaseline the raw tripwire.
+  { entry: "observability.js", raw: 98 * 1024, gz: 27 * 1024, minGz: 13 * 1024 },
   // Maintenance loop — compactor + GC + sweep driver. Pulls
   // compactor.ts + gc.ts + the observability subgraph
   // transitively (storage decorator + logger config + canonical
@@ -795,7 +803,11 @@ const BUDGETS: readonly Budget[] = [
   //   → 417 KiB raw (2026-07-04): maintenance env-parse consolidation into
   //     the shared `maintenance` chunk + rolldown 1.1.0→1.1.3 from `pnpm
   //     dedupe`. Measured 426799 raw; gz/min-gz under.
-  { entry: "cloudflare.js", raw: 417 * 1024, gz: 125 * 1024, minGz: 45 * 1024 },
+  //   → 419 KiB raw / 126 KiB gz (2026-07-06): host-config coexistence — the
+  //     configureObservability skip-and-warn path (observability chunk) plus the
+  //     worker's `observability: false` opt-out guard + JSDoc. Measured 428259 raw
+  //     / 128281 gz; min-gz (−811) stays under. Rebaseline the raw/gz tripwires.
+  { entry: "cloudflare.js", raw: 419 * 1024, gz: 126 * 1024, minGz: 45 * 1024 },
   // Client surface — `BaerlyClient<TConfig>` + fetcher plumbing.
   // Browser/runtime-agnostic; no kernel modules in the closure.
   // Budget history:


### PR DESCRIPTION
## What & why

baerly is a library, and [LogTape's guidance](https://logtape.org/manual/library) is that only the *application* configures LogTape. The Node and Cloudflare adapters called `configure({ reset: true })` at boot **unconditionally**, silently wiping the sinks/loggers of any app that had already configured LogTape (and, depending on boot order, getting wiped itself). The documented "leave the field unset to skip configuration" escape hatch never actually worked — the Node factory always configured.

## Changes

- **`configureObservability` now coexists with a host config.** It checks `getConfig()` and, when LogTape is already configured by something other than baerly, leaves that config intact and emits a single `["logtape","meta"]` notice instead of resetting it. Ownership is detected via a marker sink id. baerly's own config still reconfigures last-call-wins, so standalone servers and dev hot-reload are unchanged.
- **`observability: false` opt-out.** `baerlyNode` / `baerlyWorker` accept `observability: false` to skip auto-configuration entirely, for embedders that own the process-/isolate-wide LogTape config themselves.
- **Namespaced ownership marker.** The marker sink id is `"@gusto/baerly-storage"`, not a bare `"baerly"`, so a host can't trip the destructive `reset` by coincidentally naming one of its own sinks the same word. Chosen over config-object-identity comparison, which would couple correctness to an undocumented LogTape internal and add mutable module-global state. (Second commit — review-driven hardening.)

## Tests

Added coverage across the kernel and both adapters:
- kernel: does-not-clobber-foreign-config, meta-warning-on-decline, last-call-wins over baerly's own config
- adapters: `observability: false` skips; omitted auto-configures (default-on)

## Verification

`pnpm verify:agent`, `pnpm bundle-sizes`, and the affected test suites (kernel observability, node adapter, cloudflare-pool worker) all green. Raw/gz bundle **creep tripwires** rebaselined on `http`/`observability`/`cloudflare` for the new guard path + comments (comments ship un-stripped); **min-gz — the hard ceiling — stays well under** on every entry.

## Compatibility

`minor` bump (new `observability: false` option + behavior fix). The `unset` path still auto-configures exactly as before in practice; the only behavior change is that a *host-owned* config is now preserved rather than clobbered.