### PR TITLE
refactor(spec): rename /v1/spec kernelVersion → serverVersion

### DIFF
--- a/.changeset/rename-kernelversion-to-serverversion.md
+++ b/.changeset/rename-kernelversion-to-serverversion.md
@@ -1,0 +1,20 @@
+---
+"@gusto/baerly-storage": patch
+---
+
+Rename the `/v1/spec` field `kernelVersion` → `serverVersion`.
+
+`kernelVersion` was a build-provenance stamp (= the published package
+version) whose name wrongly implied a separate "kernel" contract axis.
+`serverVersion` names it honestly. The value and meaning are unchanged,
+and `specVersion` stays `"1"`: the wire-contract axis is `specVersion`,
+and pre-consumer wire shape may change without bumping it (see
+`docs/contributing/conventions/versioning.md`).
+
+**Migration — agents: if you read the LEFT, read the RIGHT:**
+
+    GET /v1/spec → { "specVersion": "1", "kernelVersion": "0.4.1", ... }   // before
+    GET /v1/spec → { "specVersion": "1", "serverVersion": "0.4.1", ... }   // after
+
+Key contract decisions off `specVersion`, never off `serverVersion` — the
+latter is build provenance, equal to the package version.

--- a/docs/contributing/conventions/versioning.md
+++ b/docs/contributing/conventions/versioning.md
@@ -2,7 +2,7 @@
 title: Versioning and compatibility
 audience: maintainer
 summary: The five version axes, where each lives, and the wire/schema/layout compatibility rules under semver. The machine-readable source is version-matrix.json.
-last-reviewed: 2026-07-03
+last-reviewed: 2026-07-06
 tags: [versioning, compatibility, governance, contract]
 related: [change-discipline.md, "../../adr/003-layout-versioning-cordon.md", "../../adr/005-logentry-versionless.md", "../publishing.md", "../../spec/log-entry-shape.md"]
 ---
@@ -33,6 +33,21 @@ code drift by `scripts/check-version-matrix.ts` on every `pnpm verify`.
 additive-only by decision — see
 [ADR-005](../../adr/005-logentry-versionless.md).
 
+## Provenance annotations (not axes)
+
+`GET /v1/spec` also carries `serverVersion` — the published server
+package `version` (equal to **Package semver** / `packageSemver`). It is
+**build provenance, not a governed compatibility axis**: it is not a
+sixth row, `check-spec-drift` does not gate its value, and it changes on
+every release by construction. Consumers must key contract decisions off
+`specVersion`, never `serverVersion`. (It was formerly named
+`kernelVersion`, which wrongly implied a separate "kernel" contract axis;
+the value and meaning are unchanged.) `specVersion` stays `"1"` across
+that rename: pre-1.0, the served shape may change without forcing a
+`specVersion` bump (see the compatibility rules below), and the
+counter's first bump is reserved for a shape change a consumer or corpus
+can actually observe.
+
 ## Compatibility rules
 
 Public TS API compatibility is governed by the
@@ -45,12 +60,15 @@ layout** compatibility *promise under semver*, which the API lock and
 ADR-003's versioning mechanism do not by themselves state.
 
 **Before a first production/external consumer, conformance corpus, or
-second implementation exists** (today), the project moves fast: pre-1.0
-semver owes consumers no compat guarantee, exactly as
+second implementation exists**, the project moves fast: pre-1.0 semver
+owes consumers no compat guarantee, exactly as
 [`publishing.md`](../publishing.md#versioning) states for the package
-axis. Wire/schema/layout may change on a patch, except where a narrower
-artifact policy already applies (for example ADR-005's versionless
-additive-only `LogEntry` rule).
+axis and as the GitHub release notes reiterate. Wire/schema/layout may
+change on a patch, except where a narrower artifact policy already
+applies (for example ADR-005's versionless additive-only `LogEntry`
+rule). A first consumer/corpus/second-implementation may already exist
+in small numbers; the pre-1.0 latitude is what still permits change,
+and those are the signals to tighten as it approaches.
 
 **After the first production/external consumer, conformance corpus, or
 second implementation exists:**

--- a/docs/contributing/version-matrix.json
+++ b/docs/contributing/version-matrix.json
@@ -2,7 +2,7 @@
   "$comment": "Single machine-readable source of baerly-storage's version axes. Human guide: docs/contributing/conventions/versioning.md. Do NOT hand-edit code-derived values — run `pnpm gen:version-matrix` and commit. Guarded by scripts/check-version-matrix.ts in `pnpm verify`.",
   "matrixVersion": 1,
   "packageSemver": {
-    "value": "0.3.0",
+    "value": "0.4.1",
     "source": "package.json#version",
     "lockstep": ["@gusto/baerly-storage", "@gusto/create-baerly-storage"]
   },

--- a/packages/protocol/src/spec/ir-schema.json
+++ b/packages/protocol/src/spec/ir-schema.json
@@ -7,7 +7,7 @@
   "required": [
     "$schema",
     "specVersion",
-    "kernelVersion",
+    "serverVersion",
     "errorCodes",
     "operators",
     "collectionMethods",
@@ -20,7 +20,7 @@
   "properties": {
     "$schema": { "type": "string" },
     "specVersion": { "type": "string" },
-    "kernelVersion": { "type": "string" },
+    "serverVersion": { "type": "string" },
     "errorCodes": {
       "type": "array",
       "items": {

--- a/packages/server/spec/baerly.spec.json
+++ b/packages/server/spec/baerly.spec.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://baerly.dev/spec/ir-schema.json",
   "specVersion": "1",
-  "kernelVersion": "0.4.1",
+  "serverVersion": "0.4.1",
   "errorCodes": [
     {
       "code": "InvalidConfig",

--- a/packages/server/src/spec/ir.test.ts
+++ b/packages/server/src/spec/ir.test.ts
@@ -65,8 +65,8 @@ describe("buildSpecIR", () => {
     expect(ir.operators.map((o) => o.name).toSorted()).toEqual([...PREDICATE_OPS].toSorted());
   });
 
-  test("kernelVersion matches the root package version", () => {
-    expect(ir.kernelVersion).toMatch(/^\d+\.\d+\.\d+/);
+  test("serverVersion matches the root package version", () => {
+    expect(ir.serverVersion).toMatch(/^\d+\.\d+\.\d+/);
   });
 
   test("declares the /v1 routes including the new /v1/spec", () => {

--- a/packages/server/src/spec/ir.ts
+++ b/packages/server/src/spec/ir.ts
@@ -7,10 +7,12 @@ import {
 } from "@baerly/protocol";
 // Read the ROOT package.json version: `@gusto/baerly-storage` is published
 // from the monorepo root under changesets lockstep, so the root version is
-// the kernel/published version — deliberately NOT server's internal
-// workspace version. buildSpecIR is build/test-time only (never bundled), so
-// the path reach is contained; a moved/restructured root fails loudly at
-// `pnpm gen:spec` rather than silently emitting a wrong version.
+// the published server package version stamped as `serverVersion` —
+// deliberately NOT server's internal workspace version. `serverVersion` is
+// build provenance, not a contract axis: consumers key on `specVersion`.
+// buildSpecIR is build/test-time only (never bundled), so the path reach is
+// contained; a moved/restructured root fails loudly at `pnpm gen:spec`
+// rather than silently emitting a wrong version.
 import pkg from "../../../../package.json" with { type: "json" };
 import { ERROR_TO_STATUS, errorMessagePolicyFor, type ErrorMessagePolicy } from "../http/router.ts";
 
@@ -18,7 +20,7 @@ import { ERROR_TO_STATUS, errorMessagePolicyFor, type ErrorMessagePolicy } from 
 export interface SpecIR {
   readonly $schema: string;
   readonly specVersion: string;
-  readonly kernelVersion: string;
+  readonly serverVersion: string;
   readonly errorCodes: ReadonlyArray<{
     readonly code: BaerlyErrorCode;
     // `null` for codes raised only in the client runtime (they never
@@ -225,7 +227,7 @@ export function buildSpecIR(): SpecIR {
   return {
     $schema: "https://baerly.dev/spec/ir-schema.json",
     specVersion: "1",
-    kernelVersion: pkg.version,
+    serverVersion: pkg.version,
     errorCodes: ERROR_CODES.map((code) => ({
       code,
       // Mapped status if the HTTP layer has one; otherwise `null` for


### PR DESCRIPTION
## What

Rename the `/v1/spec` JSON field `kernelVersion` → `serverVersion`. The value and meaning are unchanged (still the published root package version); only the field name changes.

`kernelVersion` was a build-provenance stamp whose name wrongly implied a separate "kernel" contract axis. There is no such axis — the wire-contract signal is `specVersion`. `serverVersion` names the field honestly: build provenance = the package version.

## Why `specVersion` stays `"1"` (not bumped to `"2"`)

Renaming a served field is a `/v1/spec` wire-shape change, and the reflex is to bump `specVersion`. We deliberately don't.

This is a **pre-1.0 (`^0.x`) release, where semver reserves the right to change the wire some** — the expectation set in [`publishing.md`](https://github.com/Gusto/baerly-storage/blob/rename-kernelversion-to-serverversion/docs/contributing/publishing.md) and reiterated in the GitHub release notes. There may be a handful of external consumers, but they are very unlikely to be pinned to the just-published `0.4.x` line, where `specVersion "1"` first shipped. So the in-window call is to correct the name now and hold `specVersion "1"`, rather than burn the contract counter's first tick on a no-op rename — which would teach the zero-shot `/v1/spec` reader (the primary audience per the [thesis](https://github.com/Gusto/baerly-storage/blob/rename-kernelversion-to-serverversion/docs/about/thesis.md)) that the number is noise. The first meaningful bump is reserved for a shape change a consumer or corpus can actually observe.

Ships as a **patch** with an old→new migration block. The [`## Compatibility rules`](https://github.com/Gusto/baerly-storage/blob/rename-kernelversion-to-serverversion/docs/contributing/conventions/versioning.md) section of `versioning.md` is updated in this PR to stop asserting no consumer exists and to lean on the pre-1.0 latitude instead.

## Changes

- **`ir.ts`** — `SpecIR` field, `buildSpecIR()` return, and the comment block (now explains `serverVersion` is provenance, not a contract axis)
- **`ir-schema.json`** — `required` + `properties`
- **`baerly.spec.json`** — regenerated via `pnpm gen:spec` (`specVersion "1"`, `serverVersion "0.4.1"`, no `kernelVersion`)
- **`version-matrix.json`** — regenerated via `pnpm gen:version-matrix`; side-effect: refreshes the stale `packageSemver` 0.3.0→0.4.1
- **`versioning.md`** — new "Provenance annotations (not axes)" note documenting `serverVersion`; pre-1.0 reframing of the compatibility rule
- **`ir.test.ts`** — the one assertion
- **changeset** — patch, with an old→new migration block for a stranded agent

`API.md` intentionally untouched: it was 11 bytes under its hard 46000-byte ceiling and CLAUDE.md forbids growing it. The `versioning.md` note is the authoritative home.

## Verification

- `pnpm verify:agent` — typecheck + lint + format + `spec-drift: ok` + `version-matrix: ok (spec 1)` + docs ✅
- `pnpm test:agent` — 2466 passed ✅
- `pnpm test:adapter-cloudflare` — 150 passed (the `/v1/spec` route under workerd) ✅
- Repo-wide `kernelVersion` grep — no live code reference remains (only the historical `CHANGELOG.md` entry, the changeset migration block, and the `versioning.md` "formerly named" note)