### PR TITLE
feat(dev): baerlyDev loads baerly.config itself (configPath / convention)

### DIFF
--- a/.changeset/baerly-dev-config-loading.md
+++ b/.changeset/baerly-dev-config-loading.md
@@ -1,0 +1,27 @@
+---
+'@gusto/baerly-storage': minor
+---
+
+`baerlyDev` can now load `baerly.config` itself instead of requiring the caller
+to import it and pass the object.
+
+`BaerlyDevOptions.config` is now optional; two new resolution modes:
+
+- `configPath` — absolute path to the config module, loaded lazily at
+  dev-server startup via Vite's `ssrLoadModule`.
+- **convention** (nothing passed) — loads `<viteRoot>/src/baerly.config.ts`,
+  mirroring how `reactRouter()` loads `react-router.config.ts`.
+
+Passing an explicit `config` object still works and is unchanged, including
+fail-fast verifier resolution at factory time.
+
+**Why:** when an app's `vite.config.ts` imports its `baerly.config` to pass the
+object in, Nx's `@nx/vite` / `@nx/vitest` inference plugins bundle that config
+during project-graph creation, dragging the config module's transitive imports
+(`@gusto/baerly-storage/config`, `zod`) into the config bundle. Those fail to
+resolve in CI and crash graph creation, forcing every baerly app into the root
+`nx.json` inference-plugin exclusion lists — a global edit that marks the whole
+monorepo affected. Letting `baerlyDev` load the config itself keeps the caller's
+`vite.config` import-free, so the exclusion is no longer needed. See
+Gusto/web#25730 for the motivating case (and the interim `yarn patch` it ships
+until this releases).

--- a/packages/dev/src/vite-plugin.test.ts
+++ b/packages/dev/src/vite-plugin.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { mkdtemp, rm } from "node:fs/promises";
 import { existsSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -372,6 +373,60 @@ describe("baerlyDev — config loading", () => {
       // The /v1 request routed (config came from the object), but the loader
       // was never consulted.
       expect(requested).toEqual([]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("config module with no default export surfaces a clear InvalidConfig message, not a bare TypeError", async () => {
+    const root = await mkdtemp(join(tmpdir(), "baerly-nodefault-"));
+    try {
+      const { captured, server } = makeServer(root, async () => ({}));
+      start(baerlyDev({ banner: false }), server);
+      const res = makeRes();
+      captured[0]!(makeReq("/v1/healthz"), res, () => {
+        throw new Error("next should not be called");
+      });
+      for (let i = 0; i < 50 && res.statusCode === 0; i += 1) {
+        await new Promise((r) => setTimeout(r, 20));
+      }
+      expect(res.statusCode).toBe(503);
+      const body = JSON.parse(res.written.join("")) as { message: string };
+      expect(body.message).toContain("must default-export a BaerlyAppConfig object");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("banner does not crash the process when lazy config load rejects", async () => {
+    const root = await mkdtemp(join(tmpdir(), "baerly-bannerfail-"));
+    try {
+      const httpServer = new EventEmitter() as EventEmitter & { address: () => null };
+      httpServer.address = () => null;
+      const server = {
+        middlewares: { use: () => {} },
+        httpServer,
+        config: { root },
+        ssrLoadModule: async () => {
+          throw new Error("boom");
+        },
+      };
+      const rejections: unknown[] = [];
+      const onRejection = (reason: unknown): void => {
+        rejections.push(reason);
+      };
+      process.on("unhandledRejection", onRejection);
+      try {
+        start(baerlyDev({ banner: true }), server);
+        httpServer.emit("listening");
+        await new Promise((r) => setTimeout(r, 100));
+        // Before the fix, the banner's `ready.then` had no rejection handler:
+        // a distinct derived promise from the same rejected `ready` would go
+        // unhandled here even though the setup failure is already logged.
+        expect(rejections).toEqual([]);
+      } finally {
+        process.off("unhandledRejection", onRejection);
+      }
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/dev/src/vite-plugin.test.ts
+++ b/packages/dev/src/vite-plugin.test.ts
@@ -360,6 +360,28 @@ describe("baerlyDev — config loading", () => {
     }
   });
 
+  test("lazily-loaded shared-secret config injects Bearer before the listener runs", async () => {
+    const root = await mkdtemp(join(tmpdir(), "baerly-lazy-secret-"));
+    try {
+      const { captured, server } = makeServer(root, async () => ({
+        default: baseConfig("shared-secret"),
+      }));
+      // No explicit `config` → auth resolves lazily once the config loads.
+      // The bearer isn't known at middleware-registration time, so injection
+      // must happen inside the `ready.then`, still before `listener(req, res)`.
+      start(baerlyDev({ secret: "lazy-secret", dataDir: root, banner: false }), server);
+      const req = makeReq("/v1/healthz");
+      captured[0]!(req, makeRes(), () => {});
+      for (let i = 0; i < 50 && req.headers["authorization"] === undefined; i += 1) {
+        await new Promise((r) => setTimeout(r, 20));
+      }
+      expect(req.headers["authorization"]).toBe("Bearer lazy-secret");
+      expect(headersFromRaw(req).get("authorization")).toBe("Bearer lazy-secret");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("explicit config object never calls ssrLoadModule", async () => {
     const root = await mkdtemp(join(tmpdir(), "baerly-explicit-"));
     try {

--- a/packages/dev/src/vite-plugin.test.ts
+++ b/packages/dev/src/vite-plugin.test.ts
@@ -290,6 +290,94 @@ describe("baerlyDev — default dataDir", () => {
   });
 });
 
+describe("baerlyDev — config loading", () => {
+  // Fake server exposing the bits the config loader touches: `config.root`
+  // (for the convention path + default dataDir) and a capturing `ssrLoadModule`.
+  const makeServer = (
+    root: string,
+    loader: (id: string) => Promise<Record<string, unknown>>,
+  ): { captured: CapturedMw[]; server: unknown } => {
+    const captured: CapturedMw[] = [];
+    return {
+      captured,
+      server: {
+        middlewares: { use: (mw: CapturedMw) => captured.push(mw) },
+        httpServer: null,
+        config: { root },
+        ssrLoadModule: loader,
+      },
+    };
+  };
+
+  const start = (plugin: ReturnType<typeof baerlyDev>, server: unknown): void => {
+    const configureServer = plugin.configureServer;
+    if (typeof configureServer !== "function") {
+      throw new Error("configureServer must be a function");
+    }
+    configureServer.call(null as never, server as never);
+  };
+
+  // Kick a /v1 request and wait until `requested` is populated (the async
+  // config load happens off the middleware's first matching request).
+  const driveAndWait = async (captured: CapturedMw[], requested: string[]): Promise<void> => {
+    captured[0]!(makeReq("/v1/healthz"), makeRes(), () => {});
+    for (let i = 0; i < 50 && requested.length === 0; i += 1) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+  };
+
+  test("loads config by convention from <root>/src/baerly.config.ts when config omitted", async () => {
+    const root = await mkdtemp(join(tmpdir(), "baerly-conv-"));
+    try {
+      const requested: string[] = [];
+      const { captured, server } = makeServer(root, async (id) => {
+        requested.push(id);
+        return { default: baseConfig("none") };
+      });
+      start(baerlyDev({ banner: false }), server);
+      await driveAndWait(captured, requested);
+      expect(requested).toEqual([join(root, "src/baerly.config.ts")]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("loads config from configPath override when provided", async () => {
+    const root = await mkdtemp(join(tmpdir(), "baerly-cfgpath-"));
+    try {
+      const requested: string[] = [];
+      const custom = join(root, "elsewhere", "baerly.config.ts");
+      const { captured, server } = makeServer(root, async (id) => {
+        requested.push(id);
+        return { default: baseConfig("none") };
+      });
+      start(baerlyDev({ configPath: custom, banner: false }), server);
+      await driveAndWait(captured, requested);
+      expect(requested).toEqual([custom]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("explicit config object never calls ssrLoadModule", async () => {
+    const root = await mkdtemp(join(tmpdir(), "baerly-explicit-"));
+    try {
+      const requested: string[] = [];
+      const { captured, server } = makeServer(root, async (id) => {
+        requested.push(id);
+        return { default: baseConfig("none") };
+      });
+      start(baerlyDev({ config: baseConfig("none"), banner: false }), server);
+      await driveAndWait(captured, requested);
+      // The /v1 request routed (config came from the object), but the loader
+      // was never consulted.
+      expect(requested).toEqual([]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("baerlyDev — auth resolution", () => {
   const withDataDir = async (fn: (dataDir: string) => void | Promise<void>): Promise<void> => {
     const dir = await mkdtemp(join(tmpdir(), "baerly-dev-auth-"));

--- a/packages/dev/src/vite-plugin.ts
+++ b/packages/dev/src/vite-plugin.ts
@@ -16,8 +16,29 @@ export interface BaerlyDevOptions {
    * table set (`Object.keys(config.collections)`) are derived from it.
    * Per-collection schemas/indexes flow through to the in-process
    * listener the same way `baerlyNode` / `baerlyWorker` pipe them.
+   *
+   * **Optional.** If omitted, the config is loaded at dev-server startup
+   * from `configPath`, or — if that's also omitted — by convention from
+   * `<viteRoot>/src/baerly.config.ts`.
+   *
+   * Prefer omitting it (convention or `configPath`). Passing the object
+   * means the caller's `vite.config` must `import` the config module,
+   * which forces Nx's `@nx/vite` / `@nx/vitest` inference plugins to
+   * bundle that module — and its transitive imports — while creating the
+   * project graph. That pulls unresolved imports into the config bundle
+   * and forces the app into the root `nx.json` inference-exclusion lists.
+   * Letting `baerlyDev` load the config itself (below) keeps the caller's
+   * `vite.config` import-free, the same way `reactRouter()` loads
+   * `react-router.config.ts` by convention.
    */
-  readonly config: BaerlyAppConfig;
+  readonly config?: BaerlyAppConfig;
+  /**
+   * Absolute path to the `baerly.config` module (its default export is
+   * the `BaerlyAppConfig`). Loaded lazily via Vite's `ssrLoadModule` at
+   * dev-server startup. Overrides the `<viteRoot>/src/baerly.config.ts`
+   * convention. Ignored when `config` is provided.
+   */
+  readonly configPath?: string;
   /**
    * Shared-secret token. **Optional.** Required only when
    * `config.auth === "shared-secret"` and `verifier` is unset — in
@@ -262,40 +283,68 @@ export function loadDevVars<K extends string>(
  * the listener without putting the secret in the browser bundle.
  * Branch 3 leaves the `Authorization` header alone.
  *
- * Verifier resolution happens eagerly at factory time so a misconfig
- * fails Vite startup, not the first `/v1/*` round-trip.
+ * When an explicit `config` object is passed, verifier resolution happens
+ * eagerly at factory time so a misconfig fails Vite startup, not the first
+ * `/v1/*` round-trip. When the config is loaded lazily (`configPath` or the
+ * `<viteRoot>/src/baerly.config.ts` convention), that resolution is deferred
+ * to dev-server startup, once the config is available.
  */
-export function baerlyDev(opts: BaerlyDevOptions): Plugin {
+function resolveAuth(opts: BaerlyDevOptions, config: BaerlyAppConfig) {
   // Resolution order: opts.verifier → config.auth.shared-secret →
-  // config.auth.none → throw. Mirrors `baerlyWorker` / `baerlyNode`.
-  // The synthetic `readEnv` hoists `opts.secret` to `SHARED_SECRET`
-  // so the same resolver works — `baerlyDev` takes the secret as a
-  // typed option rather than reading `process.env` directly.
+  // config.auth.none → throw. Mirrors `baerlyWorker` / `baerlyNode`. The
+  // synthetic `readEnv` hoists `opts.secret` to `SHARED_SECRET` so the same
+  // resolver works — `baerlyDev` takes the secret as a typed option rather
+  // than reading `process.env` directly.
   const verifier = resolveVerifier({
     factoryVerifier: opts.verifier,
-    config: opts.config,
+    config,
     readEnv: (k) => (k === "SHARED_SECRET" ? opts.secret : process.env[k]),
   });
-
-  // Bearer injection only matters in the shared-secret branch (and
-  // only when no override owns auth). For "none" or any custom
-  // verifier, the `Authorization` header reaches the listener
-  // unchanged.
+  // Bearer injection only matters in the shared-secret branch (and only when
+  // no override owns auth). For "none" or any custom verifier, the
+  // `Authorization` header reaches the listener unchanged.
   const bearerForInjection: string | undefined =
-    opts.verifier === undefined && opts.config.auth === "shared-secret" ? opts.secret : undefined;
+    opts.verifier === undefined && config.auth === "shared-secret" ? opts.secret : undefined;
+  return { verifier, bearerForInjection };
+}
 
+export function baerlyDev(opts: BaerlyDevOptions): Plugin {
+  // Eager, factory-time auth resolution when a `config` object is passed —
+  // preserves fail-fast startup on misconfig. When `config` is omitted it's
+  // loaded lazily in `configureServer` (see below) and auth resolves there.
+  const eagerAuth = opts.config !== undefined ? resolveAuth(opts, opts.config) : undefined;
   return {
     name: "baerly-dev",
     apply: "serve",
     configureServer(server) {
-      // Mount in the configureServer body (not a post-hook) so the
-      // middleware runs BEFORE Vite's internal SPA history fallback.
-      // Otherwise /v1/* requests get caught by the SPA fallback and
-      // served the index.html shell.
-      const app = opts.config.app;
-      const tenant = opts.config.tenant;
-      const tables = Object.keys(opts.config.collections);
+      // Everything below runs at dev-server startup, NOT at plugin-factory
+      // time. That lets callers omit `config` and instead have us load
+      // `baerly.config` here (via `configPath`, or by convention) — so their
+      // `vite.config` never imports the config module. Resolving it here
+      // rather than in the factory is what keeps baerly apps out of Nx's
+      // inference-plugin exclusion lists (see `BaerlyDevOptions.config`).
+      //
+      // Mount the middleware in the configureServer body (not a post-hook) so
+      // it runs BEFORE Vite's internal SPA history fallback; otherwise /v1/*
+      // requests get caught by the fallback and served the index.html shell.
       const ready = (async () => {
+        // Resolution order for the config source: explicit `config` object →
+        // explicit `configPath` → convention `<viteRoot>/src/baerly.config.ts`.
+        const config: BaerlyAppConfig =
+          opts.config ??
+          (
+            (await server.ssrLoadModule(
+              opts.configPath ?? resolve(server.config.root, "src/baerly.config.ts"),
+            )) as { default: BaerlyAppConfig }
+          ).default;
+
+        // Reuse the eager (factory-time) auth resolution when a `config` object
+        // was passed; otherwise resolve now that the loaded config is available.
+        const { verifier, bearerForInjection } = eagerAuth ?? resolveAuth(opts, config);
+
+        const app = config.app;
+        const tenant = config.tenant;
+        const tables = Object.keys(config.collections);
         const storage = new LocalFsStorage({
           root: opts.dataDir ?? resolve(server.config.root, ".baerly-data"),
         });
@@ -303,15 +352,15 @@ export function baerlyDev(opts: BaerlyDevOptions): Plugin {
           await ensureTable(storage, { app, tenant, table });
         }
         if (opts.seed !== undefined) {
-          const db = Db.create({ storage, app, tenant, config: opts.config });
+          const db = Db.create({ storage, app, tenant, config });
           await opts.seed(db);
         }
-        const requestHandler = baerlyNode({
-          config: opts.config,
-          storage,
-          verifier,
-        }).fetch;
-        return getRequestListener(requestHandler);
+        const requestHandler = baerlyNode({ config, storage, verifier }).fetch;
+        return {
+          listener: getRequestListener(requestHandler),
+          bearerForInjection,
+          appName: config.app,
+        };
       })();
 
       // Surface setup failures eagerly; without this an unhandled
@@ -326,17 +375,23 @@ export function baerlyDev(opts: BaerlyDevOptions): Plugin {
           next();
           return;
         }
-        // Inject the bearer token server-side so the SPA never sees
-        // the secret. Only runs for `config.auth === "shared-secret"`
-        // without a `verifier:` override — otherwise the header
-        // reaches the listener unchanged. Mutates both `req.headers`
-        // and `req.rawHeaders` — see `injectAuthorizationHeader`'s
-        // JSDoc.
-        if (bearerForInjection !== undefined) {
-          injectAuthorizationHeader(req, `Bearer ${bearerForInjection}`);
+        // Inject the bearer token server-side so the SPA never sees the secret.
+        // Only for `config.auth === "shared-secret"` without a `verifier:`
+        // override — otherwise the header reaches the listener unchanged.
+        // Mutates both `req.headers` and `req.rawHeaders` (see
+        // `injectAuthorizationHeader`'s JSDoc). When auth resolved eagerly
+        // (explicit `config`), inject synchronously here — before the async
+        // listener resolves — preserving the pre-lazy-load timing. When the
+        // config is loaded lazily, the bearer isn't known yet, so injection
+        // happens in the `ready.then` below (still before the listener runs).
+        if (eagerAuth?.bearerForInjection !== undefined) {
+          injectAuthorizationHeader(req, `Bearer ${eagerAuth.bearerForInjection}`);
         }
         ready.then(
-          (listener) => {
+          ({ listener, bearerForInjection }) => {
+            if (eagerAuth === undefined && bearerForInjection !== undefined) {
+              injectAuthorizationHeader(req, `Bearer ${bearerForInjection}`);
+            }
             listener(req as never, res as never);
           },
           (error: unknown) => {
@@ -355,10 +410,12 @@ export function baerlyDev(opts: BaerlyDevOptions): Plugin {
               ? (address as AddressInfo).port
               : undefined;
           const url = port !== undefined ? `http://localhost:${port}/` : "http://localhost/";
-          printDevBanner({
-            name: opts.config.app,
-            primaryUrl: { label: "App", url },
-            ...(opts.hints !== undefined && { hints: opts.hints }),
+          ready.then(({ appName }) => {
+            printDevBanner({
+              name: appName,
+              primaryUrl: { label: "App", url },
+              ...(opts.hints !== undefined && { hints: opts.hints }),
+            });
           });
         });
       }

--- a/packages/dev/src/vite-plugin.ts
+++ b/packages/dev/src/vite-plugin.ts
@@ -50,9 +50,13 @@ export interface BaerlyDevOptions {
    * when `verifier` is supplied (the operator owns the auth seam).
    *
    * Throwing the symmetric `InvalidConfig` on a misconfig matches
-   * production behaviour: forgetting `SHARED_SECRET` in dev fails
-   * fast at `vite dev` startup with the same locked wording the
-   * adapter would emit.
+   * production behaviour: forgetting `SHARED_SECRET` in dev throws
+   * with the same locked wording the adapter would emit. With an
+   * explicit `config` object this fails fast at `vite dev` startup
+   * (factory-time resolution); when the config is loaded lazily
+   * (`configPath` / convention) the throw is deferred to dev-server
+   * startup and surfaces as a per-request 503 rather than aborting
+   * the Vite process.
    */
   readonly secret?: string;
   /**
@@ -340,11 +344,7 @@ export function baerlyDev(opts: BaerlyDevOptions): Plugin {
           // (or a misnamed) default export would otherwise silently become
           // `undefined` here, surfacing later as a bare `TypeError` on the first
           // `config.app` read with no hint that the real problem is the export.
-          if (
-            mod.default === undefined ||
-            typeof mod.default !== "object" ||
-            mod.default === null
-          ) {
+          if (typeof mod.default !== "object" || mod.default === null) {
             throw new BaerlyError(
               "InvalidConfig",
               `baerly-dev: ${configPath} must default-export a BaerlyAppConfig object`,

--- a/packages/dev/src/vite-plugin.ts
+++ b/packages/dev/src/vite-plugin.ts
@@ -4,7 +4,7 @@ import { resolve } from "node:path";
 import { getRequestListener } from "@hono/node-server";
 import type { Plugin } from "vite";
 import { baerlyNode } from "@baerly/adapter-node";
-import type { BaerlyAppConfig, Verifier } from "@baerly/protocol";
+import { BaerlyError, type BaerlyAppConfig, type Verifier } from "@baerly/protocol";
 import { Db, resolveVerifier } from "@baerly/server";
 import { type DevBannerHint, printDevBanner } from "./dev-banner.ts";
 import { ensureTable } from "./ensure-table.ts";
@@ -270,12 +270,12 @@ export function loadDevVars<K extends string>(
  * `baerlyNode` / `baerlyWorker`):
  *
  *   1. `opts.verifier` set → use as-is.
- *   2. else `opts.config.auth === "shared-secret"` → require
+ *   2. else `config.auth === "shared-secret"` → require
  *      `opts.secret`; build `sharedSecret({ secret, tenantPrefix:
  *      config.tenant })`. Throws `BaerlyError("InvalidConfig", ...)`
- *      at Vite startup when `opts.secret` is empty/unset — same
- *      locked wording the production adapter would emit.
- *   3. else `opts.config.auth === "none"` → pin every request to
+ *      when `opts.secret` is empty/unset — same locked wording the
+ *      production adapter would emit.
+ *   3. else `config.auth === "none"` → pin every request to
  *      `config.tenant`; no header check.
  *
  * Bearer injection on `/v1/*` only fires in branch 2 (and only when
@@ -330,13 +330,28 @@ export function baerlyDev(opts: BaerlyDevOptions): Plugin {
       const ready = (async () => {
         // Resolution order for the config source: explicit `config` object →
         // explicit `configPath` → convention `<viteRoot>/src/baerly.config.ts`.
-        const config: BaerlyAppConfig =
-          opts.config ??
-          (
-            (await server.ssrLoadModule(
-              opts.configPath ?? resolve(server.config.root, "src/baerly.config.ts"),
-            )) as { default: BaerlyAppConfig }
-          ).default;
+        let config: BaerlyAppConfig;
+        if (opts.config !== undefined) {
+          config = opts.config;
+        } else {
+          const configPath = opts.configPath ?? resolve(server.config.root, "src/baerly.config.ts");
+          const mod = (await server.ssrLoadModule(configPath)) as { default?: unknown };
+          // Mirrors packages/cli/src/config.ts's loadAppConfig: a module with no
+          // (or a misnamed) default export would otherwise silently become
+          // `undefined` here, surfacing later as a bare `TypeError` on the first
+          // `config.app` read with no hint that the real problem is the export.
+          if (
+            mod.default === undefined ||
+            typeof mod.default !== "object" ||
+            mod.default === null
+          ) {
+            throw new BaerlyError(
+              "InvalidConfig",
+              `baerly-dev: ${configPath} must default-export a BaerlyAppConfig object`,
+            );
+          }
+          config = mod.default as BaerlyAppConfig;
+        }
 
         // Reuse the eager (factory-time) auth resolution when a `config` object
         // was passed; otherwise resolve now that the loaded config is available.
@@ -410,13 +425,20 @@ export function baerlyDev(opts: BaerlyDevOptions): Plugin {
               ? (address as AddressInfo).port
               : undefined;
           const url = port !== undefined ? `http://localhost:${port}/` : "http://localhost/";
-          ready.then(({ appName }) => {
-            printDevBanner({
-              name: appName,
-              primaryUrl: { label: "App", url },
-              ...(opts.hints !== undefined && { hints: opts.hints }),
-            });
-          });
+          ready
+            .then(({ appName }) => {
+              printDevBanner({
+                name: appName,
+                primaryUrl: { label: "App", url },
+                ...(opts.hints !== undefined && { hints: opts.hints }),
+              });
+            })
+            // A rejected `ready` is already logged by the `ready.catch` above.
+            // Each `.then()`/`.catch()` call creates its own derived promise,
+            // so without this, a config-load failure here would be a SECOND,
+            // unguarded rejection — the exact "unhandled rejection kills the
+            // dev server" failure that catch was added to prevent.
+            .catch(() => {});
         });
       }
     },


### PR DESCRIPTION
## What

`baerlyDev` can now load `baerly.config` itself instead of requiring the caller to import it and pass the object in.

- `BaerlyDevOptions.config` is now **optional**.
- New `configPath?: string` — absolute path to the config module, loaded lazily at dev-server startup via `server.ssrLoadModule`.
- **Convention** (nothing passed): loads `<viteRoot>/src/baerly.config.ts` — the same way `reactRouter()` loads `react-router.config.ts`.
- Passing an explicit `config` object is unchanged, **including fail-fast verifier resolution at factory time** (a `shared-secret` config with no secret still throws at `baerlyDev(...)`); lazy modes resolve auth at dev-server startup instead.
- Bearer injection timing is preserved for the explicit-config path (synchronous in the middleware); for lazy modes it happens once the config resolves, still before the listener runs.
- A config module with no default export throws a clear `InvalidConfig` error (mirroring `packages/cli/src/config.ts`'s `loadAppConfig`) instead of a bare `TypeError` deep in setup. Any lazy-load failure — bad `configPath`, missing export, a throw in the config module — is caught, logged, and surfaced as a 503; it never crashes the dev server, including on the banner-print path.

Resolution order: explicit `config` → `configPath` → convention.

## Why

When an app's `vite.config.ts` imports its `baerly.config` to pass the object into `baerlyDev`, Nx's `@nx/vite` / `@nx/vitest` **inference plugins** — which load every project's vite config during project-graph creation by esbuild-bundling and importing it — inline that local config module and hoist its transitive imports (`@gusto/baerly-storage/config`, `zod`) to the top of the config bundle. Those fail to resolve in CI's graph-creation environment and **crash graph creation for the whole monorepo**.

The workaround has been to add each baerly app to the root `nx.json` inference-plugin **exclusion lists** — but editing `nx.json` is a global change that marks **all ~178 projects affected**, forcing a full-repo CI build for what should be a one-app change. (Plain React Router apps don't hit this precisely because `reactRouter()` loads `react-router.config.ts` itself — the app's `vite.config` never imports it.)

Letting `baerlyDev` load the config itself keeps the caller's `vite.config` import-free, so **baerly apps no longer need the `nx.json` exclusion** (and no longer trigger a whole-repo rebuild).

## Motivating case & rollout

- **Gusto/web#25730** (new `flips` app) proved this end-to-end: with an interim `yarn patch` of this exact change, flips dropped its `nx.json` exclusion and its `buildkite/web` build went green with the affected set collapsing from 178 → ~9.
- That PR ships the interim patch; once this releases, a follow-up there bumps `@gusto/baerly-storage` and deletes the patch.
- Existing baerly apps (holler, yeet, growth-mgmt) keep passing a `config` object and are **unaffected** — they can migrate to the convention at their leisure.

## Testing

- `pnpm typecheck` ✓
- `pnpm verify:agent` ✓, full `pnpm test:agent` ✓ (2476 passed)
- `packages/dev/src/vite-plugin.test.ts` — 28 tests covering convention load, `configPath` override, explicit-config precedence, missing-default-export handling, and setup-failure resilience on the banner path.
- Changeset added (`minor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)