### PR TITLE
feat(release): gate generated-artifact freshness (spec + version-matrix)

### DIFF
--- a/docs/contributing/publishing.md
+++ b/docs/contributing/publishing.md
@@ -2,7 +2,7 @@
 title: Publishing
 audience: maintainer
 summary: "How to publish @gusto/baerly-storage + @gusto/create-baerly-storage publicly to npmjs.com."
-last-reviewed: 2026-06-16
+last-reviewed: 2026-07-10
 tags: [publishing, release, npm]
 related: ["development.md", "../../CLAUDE.md"]
 ---
@@ -17,8 +17,12 @@ Apache-2.0, so anyone can install them without auth.
 ## Cutting a release
 
 Versioning and the changelog are driven by [Changesets](https://github.com/changesets/changesets).
-Publishing goes through `pnpm release`, which builds first and passes
+Publishing goes through `pnpm release`, which gates on artifact freshness, builds, validates packaging, and passes
 `--access public` explicitly.
+
+Generated artifacts (`baerly.spec.json`, `version-matrix.json`) must be
+fresh at publish time. `pnpm changeset:version` regenerates both
+automatically; `pnpm release` refuses to publish a stale one.
 
 1. **While developing** — for any user-facing change, add a changeset:
 
@@ -54,13 +58,15 @@ Publishing goes through `pnpm release`, which builds first and passes
    pnpm release
    ```
 
-   `pnpm release` runs `pnpm build` (which copies the updated `CHANGELOG.md`
-   into `dist/CHANGELOG.md`), validates both packages with `check:exports`
+   `pnpm release` first checks that generated artifacts are fresh
+   (`verify:artifacts`, aborting closed on any drift), then runs
+   `pnpm build` (which copies the updated `CHANGELOG.md` into
+   `dist/CHANGELOG.md`), validates both packages with `check:exports`
    + `check:publint` (a finding aborts before publishing), then publishes
    both with `--access public`.
 
 > **Prefer `pnpm release` over `changeset publish`.** `pnpm release`
-> (`scripts/publish.mjs`) builds first, so `dist/` is fresh and
+> (`scripts/publish.mjs`) builds before packing, so `dist/` is fresh and
 > `dist/CHANGELOG.md` is current before the tarball is cut.
 
 | Package                        | Path                              | Bin                     |
@@ -151,14 +157,18 @@ release time, not on every PR.
 
 `pnpm release` (`scripts/publish.mjs`) is the sanctioned path. It:
 
-1. builds,
-2. **validates both published packages** as a pre-publish gate —
+1. **checks generated artifacts are fresh** — `verify:artifacts`
+   (`check-spec-drift` + `check-version-matrix`). A stale checked-in
+   `baerly.spec.json` or `version-matrix.json` aborts the release
+   closed, before the build even runs. This runs on `--dry-run` too.
+2. builds,
+3. **validates both published packages** as a pre-publish gate —
    `check:exports` (attw: every entry point resolves for consumers) and
    `check:publint` (publint: both manifests are well-formed). A finding
    aborts the release closed, before any bytes reach npm; nothing is
    published. This runs on `--dry-run` too. The gate reuses the build
-   from step 1 (`BAERLY_SKIP_BUILD=1`), so it doesn't rebuild `dist/`.
-3. publishes both packages with an **explicit** `--access public`
+   from step 2 (`BAERLY_SKIP_BUILD=1`), so it doesn't rebuild `dist/`.
+4. publishes both packages with an **explicit** `--access public`
    (pnpm has historically dropped `publishConfig.access` on the wire,
    so the flag is passed by hand to be safe).
 
@@ -185,11 +195,28 @@ ls node_modules/@gusto/baerly-storage/dist/
 
 Expected: `dist/index.js`, `dist/API.md`, `dist/baerly.js` present.
 
+Presence isn't enough — assert the published tarball's content matches
+the published version too. This catches drift that any local gate
+missed, e.g. a manual `pnpm publish` bypassing `publish.mjs` entirely.
+Run from the repo root, so `package.json` reflects the version you
+just published:
+
+```sh
+V=$(node -p "require('./package.json').version")
+npm pack "@gusto/baerly-storage@$V"            # downloads the published tarball
+tar -xzOf "gusto-baerly-storage-$V.tgz" package/dist/baerly.spec.json \
+  | node -e 'const s=JSON.parse(require("fs").readFileSync(0));const v=process.argv[1];if(s.serverVersion!==v){console.error(`FAIL: published spec serverVersion ${s.serverVersion} != ${v}`);process.exit(1)}console.log("ok:",s.serverVersion)' "$V"
+rm -f "gusto-baerly-storage-$V.tgz"
+```
+
+Expected: `ok: <version>`. A hand-corrupted or stale tarball makes it
+exit 1.
+
 Scaffold smoke:
 
 ```sh
 cd /tmp
-pnpm create @gusto/baerly-storage@latest -- baerly-smoke-app --target=cloudflare
+pnpm create @gusto/baerly-storage@latest baerly-smoke-app --target=cloudflare
 cd baerly-smoke-app
 pnpm install
 pnpm baerly doctor --target=cloudflare

--- a/docs/contributing/version-matrix.json
+++ b/docs/contributing/version-matrix.json
@@ -2,7 +2,7 @@
   "$comment": "Single machine-readable source of baerly-storage's version axes. Human guide: docs/contributing/conventions/versioning.md. Do NOT hand-edit code-derived values — run `pnpm gen:version-matrix` and commit. Guarded by scripts/check-version-matrix.ts in `pnpm verify`.",
   "matrixVersion": 1,
   "packageSemver": {
-    "value": "0.4.1",
+    "value": "0.5.0",
     "source": "package.json#version",
     "lockstep": ["@gusto/baerly-storage", "@gusto/create-baerly-storage"]
   },

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -37,6 +37,18 @@ pre-commit:
     docs:
       glob: "*.md"
       run: pnpm run verify:docs
+    # Generated-artifact freshness. The other code commands are `.ts`-globbed,
+    # so a release commit that stages only package.json / .changeset / the
+    # version bump runs zero artifact validation locally otherwise. Fire the
+    # drift checks whenever a file that can move a generated artifact is staged.
+    artifacts:
+      glob:
+        - "package.json"
+        - "packages/create-baerly-storage/package.json"
+        - ".changeset/*.md"
+        - "packages/server/spec/baerly.spec.json"
+        - "docs/contributing/version-matrix.json"
+      run: pnpm run verify:artifacts
     # Bundle budgets live in `pnpm test` (bundle-size.test.ts) and CI, NOT
     # in `pnpm verify` above — so a kernel/maintenance edit that blows a
     # budget commits green and only goes red when you finally run the full

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "baerly": "node dist/baerly.js",
     "release": "node scripts/publish.mjs",
     "changeset": "changeset",
-    "changeset:version": "changeset version && node scripts/gen-spec.ts && rm -f packages/create-baerly-storage/CHANGELOG.md",
+    "changeset:version": "changeset version && node scripts/gen-spec.ts && node scripts/check-version-matrix.ts --write && rm -f packages/create-baerly-storage/CHANGELOG.md",
     "prepare": "node scripts/prepare.mjs",
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",

--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
     "verify:agent": "tsgo --noEmit --pretty false && oxlint --format=unix --quiet tests packages && pnpm run verify:rest && pnpm run verify:docs",
     "verify:spec": "node scripts/check-spec-drift.ts",
     "verify:version-matrix": "node scripts/check-version-matrix.ts",
+    "verify:artifacts": "node scripts/check-spec-drift.ts && node scripts/check-version-matrix.ts",
     "verify:docs": "node scripts/verify-docs.mjs && node scripts/verify-docs-taxonomy.mjs && remark . --quiet --frail --no-stdout && node scripts/verify-mermaid.mjs",
     "verify:doc-taxonomy": "node scripts/verify-docs-taxonomy.mjs",
     "verify:doc-links": "remark . --quiet --frail --no-stdout",

--- a/scripts/check-version-matrix.ts
+++ b/scripts/check-version-matrix.ts
@@ -28,6 +28,7 @@ export type MatrixShape = {
 
 /** The live code-derived axes the matrix must not diverge from. */
 export type CodeVersions = {
+  packageVersion: string;
   specVersion: string;
   currentJson: number;
   gcPending: number;
@@ -49,10 +50,13 @@ export type PackageIdentity = {
  * edit, so a mismatch blocks even regeneration. Returns human-readable
  * violation messages ([] = clean).
  *
- * Package semver is intentionally NOT here: `package.json#version` is
- * its own source of truth, it changes every release, and nothing
- * consumes the matrix's copy — gating it as drift would only red CI on
- * every version bump. `--write` still refreshes the recorded value.
+ * Package semver's *value* is a governed drift axis (see
+ * `collectDriftViolations`), not a structural one: `changeset:version`
+ * regenerates it via `--write` on every bump, so a green tree always has
+ * `matrix.packageSemver.value === package.json#version` — drift only
+ * fires when a bump happened but regeneration didn't run. The lockstep
+ * *shape* (which packages, and that they move together) is still
+ * structural and lives here.
  */
 export const collectStructuralViolations = (
   matrix: MatrixShape,
@@ -116,6 +120,7 @@ export const collectStructuralViolations = (
  */
 export const collectDriftViolations = (matrix: MatrixShape, code: CodeVersions): string[] => {
   const checks: Array<[path: string, expected: string | number, actual: unknown]> = [
+    ["packageSemver.value", code.packageVersion, matrix.packageSemver.value],
     ["specVersion.value", code.specVersion, matrix.specVersion.value],
     [
       "schemaVersions.current.json.value",
@@ -169,6 +174,7 @@ const runCli = (): void => {
   const rootPkg = readPackage(pkgPath, fail);
   const createPkg = readPackage(createPkgPath, fail);
   const code: CodeVersions = {
+    packageVersion: rootPkg.version,
     specVersion: buildSpecIR().specVersion,
     currentJson: CURRENT_JSON_SCHEMA_VERSION,
     gcPending: GC_PENDING_SCHEMA_VERSION,

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -59,6 +59,21 @@ function statusOf(name) {
 
 const problems = [];
 
+// Fail fast on stale generated artifacts (spec / version matrix) before
+// even building — no point packaging a checked-in artifact that no longer
+// matches the code it was generated from.
+console.log("\n▶ Checking generated artifacts are fresh…");
+try {
+  run("pnpm run verify:artifacts");
+} catch {
+  console.error(
+    "\n✗ RELEASE ABORTED — a checked-in generated artifact is stale " +
+      "(spec-drift or version-matrix). Run `pnpm gen:spec` / " +
+      "`pnpm gen:version-matrix`, commit, and re-run. Nothing published.",
+  );
+  process.exit(1);
+}
+
 // Build once and run the packaging-contract gate (attw + publint on the
 // packed tarball) before any bytes hit npm. verify:package builds via
 // build-if-needed (BAERLY_SKIP_BUILD is unset here, so it builds).

--- a/tests/integration/dist-generated-artifacts.test.ts
+++ b/tests/integration/dist-generated-artifacts.test.ts
@@ -1,0 +1,37 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+const ROOT = resolve(__dirname, "../..");
+const read = (p: string) => JSON.parse(readFileSync(resolve(ROOT, p), "utf8"));
+
+describe("dist generated artifacts are fresh vs the package version", () => {
+  const pkgVersion = read("package.json").version as string;
+
+  // `check-spec-drift` (in `verify`, not `test`) enforces that the
+  // checked-in spec's `serverVersion` equals `package.json`'s version — it
+  // reads the live `package.json` and byte-compares. But `check-spec-drift`
+  // never inspects `dist/`. This test is the test-suite tripwire for the
+  // rolldown `closeBundle` copy step (validating dist is byte-identical to
+  // the checked-in source).
+  test("dist/baerly.spec.json serverVersion matches package version", () => {
+    const distSpec = resolve(ROOT, "dist/baerly.spec.json");
+    if (!existsSync(distSpec)) {
+      throw new Error("dist/baerly.spec.json missing — run `pnpm build` before `pnpm test`");
+    }
+    expect(read("dist/baerly.spec.json").serverVersion).toBe(pkgVersion);
+  });
+
+  test("checked-in spec is byte-identical to the shipped dist copy", () => {
+    expect(readFileSync(resolve(ROOT, "dist/baerly.spec.json"), "utf8")).toBe(
+      readFileSync(resolve(ROOT, "packages/server/spec/baerly.spec.json"), "utf8"),
+    );
+  });
+});
+
+// `version-matrix.json`'s `packageSemver` freshness is not duplicated here —
+// it's owned by `scripts/check-version-matrix.ts`, which is wired into
+// `verify:rest` (so `pnpm verify` / CI / `verify:agent`), the lefthook
+// pre-commit hook, and the release gate. Adding a second hard-coded
+// assertion of the same fact here would just be two places that can drift
+// from each other.

--- a/tests/unit/version-matrix.test.ts
+++ b/tests/unit/version-matrix.test.ts
@@ -29,6 +29,7 @@ const baseMatrix = (): MatrixShape => ({
 });
 
 const baseCode = (): CodeVersions => ({
+  packageVersion: "0.3.0",
   specVersion: "1",
   currentJson: 3,
   gcPending: 1,
@@ -81,14 +82,13 @@ describe("check-version-matrix: drift", () => {
     ]);
   });
 
-  // A package-version bump alone must NOT trip the drift gate: package.json
-  // is that axis's own source of truth and it moves every release. Lockstep
-  // is enforced structurally instead (see below).
-  test("package semver is not a drift axis", () => {
+  test("a stale packageSemver is caught", () => {
     const matrix = baseMatrix(); // still records the old 0.3.0
-    const bumpedCode = baseCode();
-    // Even though the released version moved on, no drift is reported.
-    expect(collectDriftViolations(matrix, bumpedCode)).toEqual([]);
+    const code = baseCode();
+    code.packageVersion = "0.4.0"; // package.json moved on; matrix wasn't regenerated
+    expect(collectDriftViolations(matrix, code)).toEqual([
+      expect.stringContaining("packageSemver.value"),
+    ]);
   });
 });
 


### PR DESCRIPTION
Harden the release path so a stale checked-in generated artifact (`baerly.spec.json`, `version-matrix.json`) can't ship. Motivated by real drift: the matrix recorded `0.4.1` while `package.json` was already `0.5.0`.

- **Root cause:** `changeset:version` never regenerated the matrix. It now runs `check-version-matrix.ts --write`, so a release bump keeps it fresh automatically.
- **`packageSemver` is now a drift axis** in `check-version-matrix.ts`, like `specVersion` — a safety net for out-of-band bumps.
- **`verify:artifacts`** (spec-drift + version-matrix) runs as the first, fail-fast gate in `publish.mjs` (before build, on `--dry-run` too), and via a new lefthook `artifacts` command that covers release-shaped commits the `.ts`/`.md` globs miss.
- **`dist-generated-artifacts.test.ts`** covers the one gap `check-spec-drift` leaves: it validates the checked-in source spec but never the `dist/baerly.spec.json` copy from rolldown's `closeBundle`. The test asserts dist `serverVersion` matches the package version and is byte-identical to the source spec.

Verified: `verify:artifacts` green, 13 tests pass, `main` self-consistent at `0.5.0`.

Note: the dist test reads `dist/`, so it needs a fresh build — `pnpm test` rebuilds, `pnpm test:agent` doesn't (same caveat as `bundle-size.test.ts`).
