### PR TITLE
feat(adapter-node): GOOG4-HMAC-SHA256 signer for native GCS API

### DIFF
--- a/packages/adapter-node/src/credentials/goog4-signer.test.ts
+++ b/packages/adapter-node/src/credentials/goog4-signer.test.ts
@@ -1,0 +1,387 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  goog4CanonicalRequest,
+  goog4Signer,
+  goog4StringToSign,
+  sigV4Signature,
+} from "./goog4-signer.ts";
+
+// SHA-256 of the empty body — a fixed, well-known value. Confirm against
+// the docs; it is the hashed-payload for any GET / empty-body PUT.
+const EMPTY_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+describe("sigV4Signature (AWS-vector oracle — proves the shared signing core)", () => {
+  // AWS publishes the aws-sig-v4-test-suite with a fixed key and a full .authz
+  // (Signature=) per case. GOOG4 is this core with four substituted constants,
+  // so reproducing AWS's signature proves the canonical-request / string-to-sign
+  // / key-chain / hex machinery in CI with zero infra — everything except the
+  // four GOOG4 constants. Vendor the vector file(s) and assert against them; the
+  // literal below is get-vanilla's published Signature — CONFIRM it against the
+  // vendored `get-vanilla.authz` before trusting it.
+  const AWS_SECRET = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+  const AWS_DATE = "20150830T123600Z";
+  const AWS_YMD = "20150830";
+  const AWS_SCOPE = `${AWS_YMD}/us-east-1/service/aws4_request`;
+
+  test("reproduces AWS get-vanilla's published Signature", async () => {
+    const canonical = goog4CanonicalRequest({
+      method: "GET",
+      url: "https://example.amazonaws.com/",
+      signedHeaders: { host: "example.amazonaws.com", "x-amz-date": AWS_DATE },
+      hashedPayload: EMPTY_SHA256,
+    });
+    const sts = await goog4StringToSign({
+      algorithm: "AWS4-HMAC-SHA256",
+      amzDate: AWS_DATE,
+      scope: AWS_SCOPE,
+      canonicalRequest: canonical,
+    });
+    const signature = await sigV4Signature({
+      keyPrefix: "AWS4",
+      terminator: "aws4_request",
+      service: "service",
+      region: "us-east-1",
+      secretAccessKey: AWS_SECRET,
+      yyyymmdd: AWS_YMD,
+      stringToSign: sts,
+    });
+    // From aws-sig-v4-test-suite/get-vanilla/get-vanilla.authz.
+    expect(signature).toBe("5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31");
+  });
+
+  // Query-canonicalization vector: proves goog4CanonicalRequest sorts by the
+  // ENCODED query key (not source order) — get-vanilla-query-order-key-case's
+  // request line is `GET /?Param2=value2&Param1=value1` but its .creq puts
+  // Param1 before Param2. Source: the published aws-sig-v4-test-suite, vendored
+  // at https://github.com/mongodb/libmongocrypt/tree/master/kms-message/aws-sig-v4-test-suite/get-vanilla-query-order-key-case
+  // (.req / .creq / .sts / .authz fetched verbatim from that mirror on
+  // 2026-07-14; Signature= below is copied unmodified from the .authz file —
+  // not self-derived).
+  test("reproduces AWS get-vanilla-query-order-key-case's published Signature", async () => {
+    const canonical = goog4CanonicalRequest({
+      method: "GET",
+      url: "https://example.amazonaws.com/?Param2=value2&Param1=value1",
+      signedHeaders: { host: "example.amazonaws.com", "x-amz-date": AWS_DATE },
+      hashedPayload: EMPTY_SHA256,
+    });
+    // From the case's .creq — proves query pairs are re-sorted by encoded key.
+    expect(canonical).toBe(
+      [
+        "GET",
+        "/",
+        "Param1=value1&Param2=value2",
+        "host:example.amazonaws.com",
+        `x-amz-date:${AWS_DATE}`,
+        "",
+        "host;x-amz-date",
+        EMPTY_SHA256,
+      ].join("\n"),
+    );
+    const sts = await goog4StringToSign({
+      algorithm: "AWS4-HMAC-SHA256",
+      amzDate: AWS_DATE,
+      scope: AWS_SCOPE,
+      canonicalRequest: canonical,
+    });
+    const signature = await sigV4Signature({
+      keyPrefix: "AWS4",
+      terminator: "aws4_request",
+      service: "service",
+      region: "us-east-1",
+      secretAccessKey: AWS_SECRET,
+      yyyymmdd: AWS_YMD,
+      stringToSign: sts,
+    });
+    // From get-vanilla-query-order-key-case.authz (Credential=AKIDEXAMPLE/...).
+    expect(signature).toBe("b97d918cfa904a5beff61c982a1b6f458b799221646efd99d3219ec94cdf2500");
+  });
+});
+
+describe("goog4CanonicalRequest query canonicalization (deterministic oracle-2)", () => {
+  // Locks the #1 fix directly: repeated keys must all survive (not just the
+  // first value `.get()` would return), and RFC-3986-strict encoding must
+  // escape !'()* in addition to what encodeURIComponent already escapes.
+  // Sort is by ENCODED key then ENCODED value, ascending.
+  test("canonicalizes repeated keys and RFC-3986-strict-escaped special characters", () => {
+    const canonical = goog4CanonicalRequest({
+      method: "GET",
+      url: "https://storage.googleapis.com/b/o?b=2&a=hello%20world&a=x%2Ay&c=%28p%29",
+      signedHeaders: { host: "storage.googleapis.com" },
+      hashedPayload: EMPTY_SHA256,
+    });
+    const query = canonical.split("\n")[2];
+    expect(query).toBe("a=hello%20world&a=x%2Ay&b=2&c=%28p%29");
+  });
+});
+
+describe("goog4CanonicalRequest (intermediate oracle)", () => {
+  test("builds the documented canonical request for a bare GET", () => {
+    const canonical = goog4CanonicalRequest({
+      method: "GET",
+      url: "https://storage.googleapis.com/example-bucket/cat.jpeg",
+      signedHeaders: {
+        host: "storage.googleapis.com",
+        "x-goog-content-sha256": EMPTY_SHA256,
+        "x-goog-date": "20250101T000000Z",
+      },
+      hashedPayload: EMPTY_SHA256,
+    });
+    // Canonical request = METHOD\nURI\nQUERY\nHEADERS\n\nSIGNED\nPAYLOADHASH,
+    // headers sorted by lowercased name, each terminated by \n.
+    expect(canonical).toBe(
+      [
+        "GET",
+        "/example-bucket/cat.jpeg",
+        "",
+        "host:storage.googleapis.com",
+        `x-goog-content-sha256:${EMPTY_SHA256}`,
+        "x-goog-date:20250101T000000Z",
+        "",
+        "host;x-goog-content-sha256;x-goog-date",
+        EMPTY_SHA256,
+      ].join("\n"),
+    );
+  });
+
+  // Mixed-case header names must canonicalize identically to their lowercase
+  // form: GOOG4 lowercases header names, so the value lookup has to key off the
+  // lowercased name too. A naive `signedHeaders[lowercased]` read against a
+  // mixed-case record returns undefined and crashes on `.trim()`. The internal
+  // caller always passes lowercase keys, but this function is exported.
+  test("normalizes mixed-case header names to their lowercase canonical form", () => {
+    const mixedCase = goog4CanonicalRequest({
+      method: "GET",
+      url: "https://storage.googleapis.com/example-bucket/cat.jpeg",
+      signedHeaders: {
+        Host: "storage.googleapis.com",
+        "X-Goog-Content-Sha256": EMPTY_SHA256,
+        "X-Goog-Date": "20250101T000000Z",
+      },
+      hashedPayload: EMPTY_SHA256,
+    });
+    const lowercase = goog4CanonicalRequest({
+      method: "GET",
+      url: "https://storage.googleapis.com/example-bucket/cat.jpeg",
+      signedHeaders: {
+        host: "storage.googleapis.com",
+        "x-goog-content-sha256": EMPTY_SHA256,
+        "x-goog-date": "20250101T000000Z",
+      },
+      hashedPayload: EMPTY_SHA256,
+    });
+    expect(mixedCase).toBe(lowercase);
+  });
+
+  // Guards the canonical-PATH fix: `URL.pathname` percent-encodes spaces but
+  // leaves SigV4-reserved sub-delims (`+()` here) raw, which GOOG4 requires
+  // encoded — otherwise an object key containing them signs differently from
+  // what GCS computes server-side (403 SignatureDoesNotMatch). Also confirms
+  // the already-percent-encoded space (`%20`) is left intact, not re-encoded
+  // into `%2520` (the double-encoding failure mode of a naive re-encode fix).
+  test("percent-encodes sub-delim path characters without double-encoding", () => {
+    const canonical = goog4CanonicalRequest({
+      method: "GET",
+      url: "https://storage.googleapis.com/example-bucket/a+b (c).json",
+      signedHeaders: {
+        host: "storage.googleapis.com",
+        "x-goog-content-sha256": EMPTY_SHA256,
+        "x-goog-date": "20250101T000000Z",
+      },
+      hashedPayload: EMPTY_SHA256,
+    });
+    const lines = canonical.split("\n");
+    expect(lines[1]).toBe("/example-bucket/a%2Bb%20%28c%29.json");
+  });
+
+  // GCS's enumerated canonical-path encode set includes `[` and `]`, which
+  // `URL.pathname` leaves raw — unlike `^`, which `URL.pathname` already
+  // encodes. A key carrying brackets would otherwise sign with raw `[]` while
+  // GCS canonicalizes them to %5B/%5D server-side (403 SignatureDoesNotMatch).
+  test("percent-encodes bracket characters GCS's canonical set requires", () => {
+    const canonical = goog4CanonicalRequest({
+      method: "GET",
+      url: "https://storage.googleapis.com/example-bucket/a[0]^b.json",
+      signedHeaders: { host: "storage.googleapis.com" },
+      hashedPayload: EMPTY_SHA256,
+    });
+    const lines = canonical.split("\n");
+    // `[` `]` → %5B %5D; `^` was already %5E via URL.pathname (not double-encoded).
+    expect(lines[1]).toBe("/example-bucket/a%5B0%5D%5Eb.json");
+  });
+});
+
+describe("goog4StringToSign (intermediate oracle)", () => {
+  test("builds GOOG4-HMAC-SHA256 string-to-sign from a canonical request", async () => {
+    const canonical = goog4CanonicalRequest({
+      method: "GET",
+      url: "https://storage.googleapis.com/example-bucket/cat.jpeg",
+      signedHeaders: {
+        host: "storage.googleapis.com",
+        "x-goog-content-sha256": EMPTY_SHA256,
+        "x-goog-date": "20250101T000000Z",
+      },
+      hashedPayload: EMPTY_SHA256,
+    });
+    const sts = await goog4StringToSign({
+      algorithm: "GOOG4-HMAC-SHA256",
+      amzDate: "20250101T000000Z",
+      scope: "20250101/auto/storage/goog4_request",
+      canonicalRequest: canonical,
+    });
+    const lines = sts.split("\n");
+    expect(lines[0]).toBe("GOOG4-HMAC-SHA256");
+    expect(lines[1]).toBe("20250101T000000Z");
+    expect(lines[2]).toBe("20250101/auto/storage/goog4_request");
+    // lines[3] is hex(SHA-256(canonicalRequest)) — 64 lowercase hex chars.
+    expect(lines[3]).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("goog4Signer", () => {
+  test("attaches a GOOG4-HMAC-SHA256 Authorization header with the right scope", async () => {
+    const sign = goog4Signer({
+      credentials: { accessKeyId: "GOOG_EXAMPLE_ID", secretAccessKey: "EXAMPLE_SECRET" },
+      now: () => Date.parse("2025-01-01T00:00:00Z"),
+    });
+    const signed = await sign(
+      new Request("https://storage.googleapis.com/example-bucket/cat.jpeg", { method: "GET" }),
+    );
+    const auth = signed.headers.get("Authorization")!;
+    expect(auth).toContain("GOOG4-HMAC-SHA256 ");
+    expect(auth).toContain("Credential=GOOG_EXAMPLE_ID/20250101/auto/storage/goog4_request");
+    expect(auth).toContain("SignedHeaders=host;x-goog-content-sha256;x-goog-date");
+    expect(auth).toMatch(/Signature=[0-9a-f]{64}$/);
+    // The signer must set the signed headers it committed to.
+    expect(signed.headers.get("x-goog-date")).toBe("20250101T000000Z");
+    expect(signed.headers.get("x-goog-content-sha256")).toBe(EMPTY_SHA256);
+  });
+
+  test("resolves a CredentialsProvider on each sign()", async () => {
+    let calls = 0;
+    const sign = goog4Signer({
+      credentials: async () => {
+        calls += 1;
+        return { accessKeyId: "GOOG_ID", secretAccessKey: "SECRET" };
+      },
+      now: () => Date.parse("2025-01-01T00:00:00Z"),
+    });
+    await sign(new Request("https://storage.googleapis.com/b/k", { method: "GET" }));
+    await sign(new Request("https://storage.googleapis.com/b/k", { method: "GET" }));
+    expect(calls).toBe(2);
+  });
+
+  // Load-bearing regression guard: the transport sets x-goog-if-generation-match
+  // before signing, and GCS 403s any x-goog-* header not in SignedHeaders — which
+  // would break EVERY conditional write (the whole commit path). A bodyless GET
+  // would still pass, so this specifically exercises a header-carrying PUT.
+  test("signs every x-goog-* header present, including x-goog-if-generation-match", async () => {
+    const sign = goog4Signer({
+      credentials: { accessKeyId: "GOOG_ID", secretAccessKey: "SECRET" },
+      now: () => Date.parse("2025-01-01T00:00:00Z"),
+    });
+    const signed = await sign(
+      new Request("https://storage.googleapis.com/example-bucket/log/1", {
+        method: "PUT",
+        headers: { "x-goog-if-generation-match": "0" },
+      }),
+    );
+    const auth = signed.headers.get("Authorization")!;
+    expect(auth).toMatch(/SignedHeaders=[^,]*x-goog-if-generation-match/);
+  });
+
+  // DELTA PROOF (oracle 3) — the live network call is gated; its captured
+  // fixture is not (see the frozen vector below, signed with EXAMPLE
+  // credentials rather than the real interop secret). Run this against the
+  // real bucket in credentials/gcs.json to prove the four GOOG4 constants
+  // are correct on the wire: a real GCS endpoint accepts the signature this
+  // signer produces.
+  test.skipIf(process.env["GCS_LIVE"] !== "1")(
+    "live: a signed conditional PUT/GET against a real bucket returns 200 and a round-trippable generation",
+    async () => {
+      // Relative to the repo root (vitest's cwd) — same convention as
+      // `tests/integration/conformance.test.ts`'s `loadCreds`.
+      const raw = await readFile(join("credentials", "gcs.json"), "utf8");
+      const config = JSON.parse(raw) as {
+        endpoint: string;
+        bucket: string;
+        credentials: { accessKeyId: string; secretAccessKey: string };
+      };
+      const key = `goog4-signer-live-test/${randomUUID()}`;
+      const url = `${config.endpoint}/${config.bucket}/${key}`;
+      // Real wall-clock `now` (omit `now`) — GCS rejects skewed x-goog-date.
+      const sign = goog4Signer({ credentials: config.credentials });
+
+      const body = "goog4-signer live oracle";
+      const putReq = await sign(
+        new Request(url, {
+          method: "PUT",
+          headers: { "x-goog-if-generation-match": "0" },
+          body,
+        }),
+      );
+      const putRes = await fetch(putReq);
+      expect(putRes.ok).toBe(true);
+      const generation = putRes.headers.get("x-goog-generation");
+      expect(generation).toBeTruthy();
+
+      try {
+        const getReq = await sign(new Request(url, { method: "GET" }));
+        const getRes = await fetch(getReq);
+        expect(getRes.ok).toBe(true);
+        await expect(getRes.text()).resolves.toBe(body);
+      } finally {
+        const deleteReq = await sign(new Request(url, { method: "DELETE" }));
+        await fetch(deleteReq);
+      }
+    },
+  );
+
+  // FROZEN VECTOR (CI-safe regression lock) — signs with EXAMPLE (non-secret)
+  // credentials and a pinned `now`, then asserts the ENTIRE Authorization
+  // header string against a literal captured from a first green run of this
+  // signer. This locks all four GOOG4 constants (GOOG4 / goog4_request /
+  // GOOG4-HMAC-SHA256 / storage) plus region "auto" against silent
+  // regression, runs unconditionally in CI, and commits no secret. The live
+  // oracle above is the proof that these constants are *correct* on the
+  // wire; this test is the proof that they don't silently drift afterward.
+  test("frozen vector: reproduces the full GOOG4 Authorization header (example creds)", async () => {
+    const sign = goog4Signer({
+      credentials: { accessKeyId: "GOOG_EXAMPLE_ID", secretAccessKey: "EXAMPLE_SECRET" },
+      now: () => Date.parse("2025-01-01T00:00:00Z"),
+    });
+    const signed = await sign(
+      new Request("https://storage.googleapis.com/example-bucket/cat.jpeg", { method: "GET" }),
+    );
+    expect(signed.headers.get("Authorization")).toBe(
+      "GOOG4-HMAC-SHA256 Credential=GOOG_EXAMPLE_ID/20250101/auto/storage/goog4_request, SignedHeaders=host;x-goog-content-sha256;x-goog-date, Signature=ba07407abb494c7fb619c47fb3ce91aa2993a258a0fc958f20532eab523c8348",
+    );
+  });
+
+  // CI-safe, no live gate: locks body handling — the signed Request must
+  // still carry the original body, and the computed x-goog-content-sha256
+  // must be the body's real hash, not the well-known empty-body constant
+  // (which would silently pass if the signer hashed the wrong thing).
+  test("preserves a non-empty body and hashes it (not the empty-body constant)", async () => {
+    const sign = goog4Signer({
+      credentials: { accessKeyId: "GOOG_ID", secretAccessKey: "SECRET" },
+      now: () => Date.parse("2025-01-01T00:00:00Z"),
+    });
+    const body = "goog4-signer body-preservation fixture";
+    const signed = await sign(
+      new Request("https://storage.googleapis.com/example-bucket/log/1", {
+        method: "PUT",
+        body,
+      }),
+    );
+    await expect(signed.clone().text()).resolves.toBe(body);
+    const digest = new Uint8Array(
+      await crypto.subtle.digest("SHA-256", new TextEncoder().encode(body)),
+    );
+    const expectedHash = [...digest].map((b) => b.toString(16).padStart(2, "0")).join("");
+    expect(signed.headers.get("x-goog-content-sha256")).toBe(expectedHash);
+    expect(signed.headers.get("x-goog-content-sha256")).not.toBe(EMPTY_SHA256);
+  });
+});

--- a/packages/adapter-node/src/credentials/goog4-signer.ts
+++ b/packages/adapter-node/src/credentials/goog4-signer.ts
@@ -1,0 +1,239 @@
+import type { Credentials, CredentialsProvider } from "./types.ts";
+
+/** GOOG4 signing-key prefix (vs AWS SigV4's "AWS4"). @see https://docs.cloud.google.com/storage/docs/authentication/signatures */
+const GOOG4_KEY_PREFIX = "GOOG4";
+/** Credential-scope terminator (vs SigV4's "aws4_request"). @see https://docs.cloud.google.com/storage/docs/authentication/signatures */
+const GOOG4_REQUEST = "goog4_request";
+/** Signing algorithm string. @see https://docs.cloud.google.com/storage/docs/authentication/signatures */
+const GOOG4_ALGORITHM = "GOOG4-HMAC-SHA256";
+/** GCS storage service name in the credential scope (vs SigV4's "s3"). @see https://docs.cloud.google.com/storage/docs/authentication/signatures */
+const GOOG4_SERVICE = "storage";
+/** GCS accepts "auto" as the signing region. @see https://docs.cloud.google.com/storage/docs/authentication/signatures */
+const GOOG4_REGION = "auto";
+
+const encoder = new TextEncoder();
+
+function toHex(bytes: Uint8Array): string {
+  let hex = "";
+  for (let i = 0; i < bytes.length; i++) {
+    hex += bytes[i]!.toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+async function sha256Hex(data: Uint8Array): Promise<string> {
+  // Copy into a fresh ArrayBuffer — see hashing.ts / microsoft/TypeScript#61375.
+  const view = new Uint8Array(data.byteLength);
+  view.set(data);
+  const digest = await crypto.subtle.digest("SHA-256", view);
+  return toHex(new Uint8Array(digest));
+}
+
+/** RFC-3986-strict percent-encoding for canonical query components: encodes
+ * everything except the unreserved set A-Za-z0-9-._~. encodeURIComponent
+ * already handles that set but leaves !'()* unescaped, so escape those too.
+ * @see https://docs.cloud.google.com/storage/docs/authentication/canonical-requests */
+function uriEncode(s: string): string {
+  return encodeURIComponent(s).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+/** Canonical-URI encoding for the request path. `URL.pathname` already
+ * percent-encodes spaces / non-ASCII / control chars (and `^` `` ` `` `{` `}`),
+ * but leaves GCS's enumerated reserved set raw — the sub-delims, `:@`, and
+ * `[]`. GCS canonicalizes the path it receives by percent-encoding exactly
+ * that set (`?=!#$&'()*+,:;@[]"`; `?#"` can't survive in `pathname`), so we
+ * must reproduce the same delta or a `[`/`]`-bearing key signs differently
+ * than GCS computes it (403 SignatureDoesNotMatch). Target only the delta so
+ * already-encoded `%XX` and the unreserved set stay intact (no double-encode).
+ * This is a denylist, not an allow-list, on purpose: over-encoding chars GCS
+ * leaves raw (`|` `` ` `` `{}` …) would itself cause a mismatch.
+ * @see https://docs.cloud.google.com/storage/docs/authentication/canonical-requests */
+function canonicalUri(pathname: string): string {
+  return pathname.replace(
+    /[!$&'()*+,;=:@[\]]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+async function hmac(key: Uint8Array, data: string): Promise<Uint8Array> {
+  const view = new Uint8Array(key.byteLength);
+  view.set(key);
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    view,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", cryptoKey, encoder.encode(data));
+  return new Uint8Array(sig);
+}
+
+/** Pure: build the GOOG4 canonical request string. Exported for the intermediates test. */
+export function goog4CanonicalRequest(input: {
+  method: string;
+  url: string;
+  signedHeaders: Record<string, string>;
+  hashedPayload: string;
+}): string {
+  const u = new URL(input.url);
+  // Normalize to lowercase keys once, so the sort order and the value lookup
+  // agree even if a caller passes mixed-case header names (`{ Host: ... }`).
+  // The internal caller already lowercases via `Headers` iteration, but this
+  // function is also exported for the intermediates test — normalizing here
+  // makes the lowercase-key invariant guaranteed rather than assumed.
+  const normalized: Record<string, string> = {};
+  for (const [name, value] of Object.entries(input.signedHeaders)) {
+    normalized[name.toLowerCase()] = value;
+  }
+  const names = Object.keys(normalized).toSorted();
+  const canonicalHeaders = names.map((n) => `${n}:${normalized[n]!.trim()}\n`).join("");
+  const signedHeaderList = names.join(";");
+  // Sort by encoded key then encoded value; a "key\0value" join makes the pair
+  // orderable with a single string comparison (avoids a nested ternary).
+  const query = [...u.searchParams]
+    .map(([k, v]) => [uriEncode(k), uriEncode(v)] as const)
+    .toSorted((a, b) => {
+      const ka = `${a[0]}\0${a[1]}`;
+      const kb = `${b[0]}\0${b[1]}`;
+      if (ka < kb) {
+        return -1;
+      }
+      return ka > kb ? 1 : 0;
+    })
+    .map(([k, v]) => `${k}=${v}`)
+    .join("&");
+  return [
+    input.method,
+    canonicalUri(u.pathname), // percent-encoded by URL, plus sub-delims/:@ per GOOG4
+    query,
+    canonicalHeaders, // trailing \n included per entry; joined below with \n
+    signedHeaderList,
+    input.hashedPayload,
+  ].join("\n");
+}
+
+/** Pure: build the SigV4-family string-to-sign. Async because it hashes the canonical request. */
+export async function goog4StringToSign(input: {
+  algorithm: string;
+  amzDate: string;
+  scope: string;
+  canonicalRequest: string;
+}): Promise<string> {
+  const hash = await sha256Hex(encoder.encode(input.canonicalRequest));
+  return [input.algorithm, input.amzDate, input.scope, hash].join("\n");
+}
+
+/**
+ * The SigV4-family signing machinery: four-stage HMAC key chain + final HMAC.
+ * Identical between GOOG4 and AWS SigV4 modulo the {keyPrefix, terminator,
+ * service, region} constants — which is exactly what the AWS-vector oracle
+ * exploits to prove this in CI. Exported for oracle 1.
+ */
+export async function sigV4Signature(input: {
+  keyPrefix: string;
+  terminator: string;
+  service: string;
+  region: string;
+  secretAccessKey: string;
+  yyyymmdd: string;
+  stringToSign: string;
+}): Promise<string> {
+  const dateKey = await hmac(
+    encoder.encode(input.keyPrefix + input.secretAccessKey),
+    input.yyyymmdd,
+  );
+  const dateRegionKey = await hmac(dateKey, input.region);
+  const dateSvcKey = await hmac(dateRegionKey, input.service);
+  const signingKey = await hmac(dateSvcKey, input.terminator);
+  return toHex(await hmac(signingKey, input.stringToSign));
+}
+
+function amzDateFrom(ms: number): { amzDate: string; yyyymmdd: string } {
+  const iso = new Date(ms).toISOString(); // 2025-01-01T00:00:00.000Z
+  const amzDate = iso.replace(/[:-]/g, "").replace(/\.\d{3}Z$/, "Z"); // 20250101T000000Z
+  return { amzDate, yyyymmdd: amzDate.slice(0, 8) };
+}
+
+export function goog4Signer(opts: {
+  credentials: Credentials | CredentialsProvider;
+  now?: () => number;
+}): (req: Request) => Promise<Request> {
+  const now = opts.now ?? (() => Date.now());
+  const resolve = async (): Promise<Credentials> =>
+    typeof opts.credentials === "function" ? opts.credentials() : opts.credentials;
+
+  return async (req) => {
+    const creds = await resolve();
+    const { amzDate, yyyymmdd } = amzDateFrom(now());
+    const scope = `${yyyymmdd}/${GOOG4_REGION}/${GOOG4_SERVICE}/${GOOG4_REQUEST}`;
+
+    const body = new Uint8Array(await req.clone().arrayBuffer());
+    const payloadHash = await sha256Hex(body);
+
+    const url = new URL(req.url);
+    const headers = new Headers(req.headers);
+    headers.set("host", url.host);
+    headers.set("x-goog-date", amzDate);
+    headers.set("x-goog-content-sha256", payloadHash);
+    // No session-token header: GCS HMAC interoperability keys are long-lived
+    // (access-ID + secret) with no STS-style temporary-credential concept, and
+    // GCS documents no header analogous to AWS's x-amz-security-token. A
+    // `sessionToken` on the shared Credentials shape (set by the AWS providers)
+    // is therefore intentionally ignored here rather than signed into a
+    // fabricated x-goog-security-token header.
+    // @see https://docs.cloud.google.com/storage/docs/authentication/signatures
+
+    // SignedHeaders MUST be computed dynamically from the request — this is the
+    // load-bearing correctness point. GCS rejects (403 SignatureDoesNotMatch)
+    // any x-goog-* header on the wire that is absent from SignedHeaders, and the
+    // transport (Task 1.1) sets x-goog-if-generation-match BEFORE calling sign().
+    // A fixed list would leave the precondition header unsigned → every
+    // conditional write (the whole commit path) fails, while a bodyless GET
+    // still passes — so this bug hides from any smoke test that does not
+    // exercise a conditional PUT. Scan the actual request headers instead.
+    const signedHeaders: Record<string, string> = {};
+    for (const [name, value] of headers) {
+      const lower = name.toLowerCase();
+      if (lower === "host" || lower === "content-type" || lower.startsWith("x-goog-")) {
+        signedHeaders[lower] = value;
+      }
+    }
+
+    const canonical = goog4CanonicalRequest({
+      method: req.method,
+      url: req.url,
+      signedHeaders,
+      hashedPayload: payloadHash,
+    });
+    const stringToSign = await goog4StringToSign({
+      algorithm: GOOG4_ALGORITHM,
+      amzDate,
+      scope,
+      canonicalRequest: canonical,
+    });
+    const signature = await sigV4Signature({
+      keyPrefix: GOOG4_KEY_PREFIX,
+      terminator: GOOG4_REQUEST,
+      service: GOOG4_SERVICE,
+      region: GOOG4_REGION,
+      secretAccessKey: creds.secretAccessKey,
+      yyyymmdd,
+      stringToSign,
+    });
+
+    const signedHeaderList = Object.keys(signedHeaders)
+      .map((n) => n.toLowerCase())
+      .toSorted()
+      .join(";");
+    headers.set(
+      "Authorization",
+      `${GOOG4_ALGORITHM} Credential=${creds.accessKeyId}/${scope}, ` +
+        `SignedHeaders=${signedHeaderList}, Signature=${signature}`,
+    );
+    return new Request(req, { headers });
+  };
+}


### PR DESCRIPTION
Adds a `goog4Signer` for `@baerly/adapter-node` that signs native GCS API requests with `GOOG4-HMAC-SHA256` using HMAC interoperability keys (access-ID + secret). The SigV4 key-derivation chain is shared with the existing AWS path; only the `{keyPrefix, terminator, service, region}` constants differ, which is what lets the AWS test vectors act as an oracle for the shared machinery.

### Correctness points worth knowing

- **`SignedHeaders` is computed from the actual request**, not a fixed list. The transport sets `x-goog-if-generation-match` before signing; a static list would leave that precondition header unsigned, so every conditional write (the whole commit path) would 403 while bodyless GETs still pass — invisible to any smoke test that doesn't exercise a conditional PUT.
- **No `x-goog-security-token` header.** GCS HMAC keys are long-lived with no STS-style temporary-credential concept. A `sessionToken` on the shared `Credentials` shape is ignored rather than signed into a fabricated header that would 403.
- **Canonical-path encoding is a denylist, not an RFC-3986 allow-list.** It reproduces exactly GCS's enumerated encode set (sub-delims, `:@`, `[]`) on top of what `URL.pathname` already encodes; over-encoding chars GCS leaves raw would itself cause a signature mismatch.

### Tests

Pinned against frozen GOOG4 vectors plus AWS `get-vanilla` / `query-order-key-case` oracle vectors for the shared signing chain, with deterministic coverage of query-sort ordering and bracket-bearing paths.
