### PR TITLE
refactor(protocol): extract shared sha256Hex leaf helper

### DIFF
--- a/packages/adapter-node/src/credentials/goog4-signer.ts
+++ b/packages/adapter-node/src/credentials/goog4-signer.ts
@@ -1,3 +1,4 @@
+import { sha256Hex } from "@baerly/protocol";
 import type { Credentials, CredentialsProvider } from "./types.ts";
 
 /** GOOG4 signing-key prefix (vs AWS SigV4's "AWS4"). @see https://docs.cloud.google.com/storage/docs/authentication/signatures */
@@ -13,20 +14,15 @@ const GOOG4_REGION = "auto";
 
 const encoder = new TextEncoder();
 
+// SHA-256 hex comes from `@baerly/protocol` (shared with snapshotHash /
+// versionFromContent). `toHex` stays local: `sigV4Signature` still needs to
+// hex-encode raw HMAC output, which is not a SHA-256 digest.
 function toHex(bytes: Uint8Array): string {
   let hex = "";
   for (let i = 0; i < bytes.length; i++) {
     hex += bytes[i]!.toString(16).padStart(2, "0");
   }
   return hex;
-}
-
-async function sha256Hex(data: Uint8Array): Promise<string> {
-  // Copy into a fresh ArrayBuffer — see hashing.ts / microsoft/TypeScript#61375.
-  const view = new Uint8Array(data.byteLength);
-  view.set(data);
-  const digest = await crypto.subtle.digest("SHA-256", view);
-  return toHex(new Uint8Array(digest));
 }
 
 /** RFC-3986-strict percent-encoding for canonical query components: encodes
@@ -172,6 +168,10 @@ export function goog4Signer(opts: {
     const scope = `${yyyymmdd}/${GOOG4_REGION}/${GOOG4_SERVICE}/${GOOG4_REQUEST}`;
 
     const body = new Uint8Array(await req.clone().arrayBuffer());
+    // `body` already owns a fresh ArrayBuffer, so `sha256Hex`'s defensive copy
+    // is redundant for this caller — but the shared helper keeps it for callers
+    // whose Uint8Array may be a view over a larger buffer (TS#61375). Not worth
+    // special-casing the shared helper; correctness over one avoided copy.
     const payloadHash = await sha256Hex(body);
 
     const url = new URL(req.url);

--- a/packages/protocol/src/hashing.ts
+++ b/packages/protocol/src/hashing.ts
@@ -1,3 +1,4 @@
+import { sha256Hex } from "./sha256.ts";
 import type { ContentVersionId } from "./types.ts";
 
 /**
@@ -32,16 +33,6 @@ const VERSION_HEX_LENGTH = 32;
  * @see docs/spec/log-entry-shape.md §"Content body layout"
  */
 export const versionFromContent = async (body: Uint8Array): Promise<ContentVersionId> => {
-  // Copy via fresh ArrayBuffer: tsgo narrows `Uint8Array` to
-  // `Uint8Array<ArrayBufferLike>`, which `crypto.subtle.digest` rejects
-  // (wants `ArrayBufferView<ArrayBuffer>`). See microsoft/TypeScript#61375.
-  const view = new Uint8Array(body.byteLength);
-  view.set(body);
-  const digest = await crypto.subtle.digest("SHA-256", view);
-  const bytes = new Uint8Array(digest);
-  let hex = "";
-  for (let i = 0; i < bytes.length; i++) {
-    hex += bytes[i]!.toString(16).padStart(2, "0");
-  }
+  const hex = await sha256Hex(body);
   return hex.slice(0, VERSION_HEX_LENGTH) as ContentVersionId;
 };

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -20,6 +20,7 @@ export * from "./indexes.ts";
 export * from "./json.ts";
 export * from "./query/index.ts";
 export * from "./schema.ts";
+export * from "./sha256.ts";
 export * from "./storage/index.ts";
 export * from "./time.ts";
 export * from "./types.ts";

--- a/packages/protocol/src/sha256.ts
+++ b/packages/protocol/src/sha256.ts
@@ -1,0 +1,26 @@
+/**
+ * SHA-256 of `bytes` as a 64-char lowercase hex string.
+ *
+ * Zero-import leaf module on purpose: co-locating this with heavier
+ * runtime (snapshot-hash.ts / hashing.ts) would drag that module into
+ * every consumer's bundle closure. Callers that want a truncated form
+ * (e.g. {@link versionFromContent}'s content keys) slice the return.
+ */
+export const sha256Hex = async (bytes: Uint8Array): Promise<string> => {
+  // Copy via fresh ArrayBuffer: tsgo narrows `Uint8Array` to
+  // `Uint8Array<ArrayBufferLike>`, which `crypto.subtle.digest` rejects
+  // (wants `ArrayBufferView<ArrayBuffer>`). See microsoft/TypeScript#61375.
+  const view = new Uint8Array(bytes.byteLength);
+  view.set(bytes);
+  const digest = await crypto.subtle.digest("SHA-256", view);
+  // Hand-rolled hex, not `Uint8Array.prototype.toHex()`: that TC39 method is
+  // declared by the `ESNext.TypedArrays` lib (so it type-checks) but is gated
+  // behind V8's `--js-base-64` flag in our Node floor (24.x) and isn't
+  // universal across workerd/Node unflagged — it would throw at runtime.
+  const out = new Uint8Array(digest);
+  let hex = "";
+  for (let i = 0; i < out.length; i++) {
+    hex += out[i]!.toString(16).padStart(2, "0");
+  }
+  return hex;
+};

--- a/packages/protocol/src/snapshot-hash.ts
+++ b/packages/protocol/src/snapshot-hash.ts
@@ -1,3 +1,5 @@
+import { sha256Hex } from "./sha256.ts";
+
 /**
  * SHA-256 of `bytes` as a 64-char lowercase hex string. Used to seal
  * snapshot filenames so a crashed mid-PUT can't produce a body that
@@ -8,18 +10,4 @@
  * content keys) — snapshot bodies are larger and longer-lived;
  * 256-bit collision resistance matters here.
  */
-export const snapshotHash = async (bytes: Uint8Array): Promise<string> => {
-  // Copy via fresh ArrayBuffer: tsgo narrows `Uint8Array` to
-  // `Uint8Array<ArrayBufferLike>`, which `crypto.subtle.digest` rejects
-  // (wants `ArrayBufferView<ArrayBuffer>`). See microsoft/TypeScript#61375
-  // and `versionFromContent` in ./hashing.ts for the same workaround.
-  const view = new Uint8Array(bytes.byteLength);
-  view.set(bytes);
-  const digest = await crypto.subtle.digest("SHA-256", view);
-  const out = new Uint8Array(digest);
-  let hex = "";
-  for (let i = 0; i < out.length; i++) {
-    hex += out[i]!.toString(16).padStart(2, "0");
-  }
-  return hex;
-};
+export const snapshotHash = (bytes: Uint8Array): Promise<string> => sha256Hex(bytes);


### PR DESCRIPTION
Follow-up to the PR #54 code review: kills the triplicated SHA-256 digest-to-hex machinery.

## What changed

Three call sites re-implemented byte-identical SHA-256-to-hex machinery — the microsoft/TypeScript#61375 fresh-`ArrayBuffer` copy, `crypto.subtle.digest("SHA-256")`, and a byte-to-hex loop:

- `packages/protocol/src/snapshot-hash.ts` → `snapshotHash()` (full 64-char hex)
- `packages/protocol/src/hashing.ts` → `versionFromContent()` (hex sliced to 32)
- `packages/adapter-node/src/credentials/goog4-signer.ts` → local `sha256Hex()`/`toHex()`

This adds `sha256Hex(bytes): Promise<string>` (full 64-char lowercase hex) to `@baerly/protocol` in its **own zero-import leaf module** (`packages/protocol/src/sha256.ts`), exported from the barrel. Kept in a leaf module on purpose so it doesn't drag snapshot-hash/hashing runtime into every consumer's bundle closure (the kernel-bundle anti-pattern in CLAUDE.md).

Refactored the three sites onto it:
- `snapshotHash` delegates to `sha256Hex` directly (it *is* the full-hex form).
- `versionFromContent` hashes then `.slice(0, VERSION_HEX_LENGTH)`, still returning the branded `ContentVersionId`.
- `goog4-signer` imports `sha256Hex` and drops its local copy.

## Deviations from the brief (both intentional)

- **`toHex` stays local in `goog4-signer.ts`.** The brief said to delete `toHex` too, but `sigV4Signature` still calls it to hex-encode raw HMAC output (not a SHA-256 digest), so removing it would break compilation. Left in place with a clarifying comment.
- **Review finding #3 (redundant body copy) skipped with a one-line note.** `goog4Signer` already buffers the body into a fresh `ArrayBuffer`, so the shared helper's defensive copy is redundant *for that caller* — but the helper keeps the copy for callers whose `Uint8Array` may be a view over a larger buffer (TS#61375). Not worth special-casing the shared helper; correctness over one avoided copy.

## Verification

Pure refactor — output bytes identical; existing `snapshot-hash` / `hashing` / `goog4-signer` tests pass unchanged.

- `pnpm build && pnpm test:agent` — 2500 passed / 90 skipped.
- `pnpm bundle-sizes` — all axes under budget, net-smaller. `index.js` (published kernel) min-gz `-372`; `s3.js` min-gz `-863`. **min-gz does not regress on any entry.**
- `pnpm verify:agent` — green (typecheck / lint / format / layers / docs).