### PR TITLE
CI + observability noise cleanup

### DIFF
--- a/.changeset/canonical-4xx-warn-not-error.md
+++ b/.changeset/canonical-4xx-warn-not-error.md
@@ -1,0 +1,19 @@
+---
+'@gusto/baerly-storage': patch
+---
+
+Canonical HTTP log lines now classify by wire status alone: any 4xx is
+`warn`, not `error`, even when a structured error is attached. Previously
+an attached error forced `error` level regardless of status, so a `409
+Conflict` logged at `error`.
+
+**Why:** a 4xx is the caller's fault, not a server fault. The reachable
+409 is a duplicate-`_id` insert (a reused id or a double-submitted POST);
+ordinary storage write contention is absorbed internally by the log
+forward-probe and never reaches the client as a 409. Logging these at
+`error` polluted error budgets and could page on-call for normal
+operation. `error` is now reserved for genuine server faults: 5xx, a
+2xx/3xx that anomalously carries an error, or a thrown error with no wire
+status to classify by. The line still carries the structured
+`{ code, message }` on the failure path; only the stack (unneeded for a
+routine client error) drops off at `warn`.

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -29,7 +29,10 @@ you need the exact field list; use this page when a deployment is live.
 The threshold idea: baerly logs the request, not every internal step.
 At the end of each HTTP request, the kernel emits **one canonical log
 line**. More precisely, the line is `info` by default, rises to `warn`
-on 4xx, and rises to `error` on 5xx or a thrown error. It carries a
+on any 4xx — a client error is the caller's fault, not a server fault,
+so a `409 Conflict` (a duplicate-`_id` insert) stays `warn` — and rises
+to `error` only on a 5xx or an otherwise-unclassified thrown error. It
+carries a
 `request_id`, an `outcome` (`read` / `committed` / `conflict` /
 `error`), and the per-request `db.*` counters.
 

--- a/packages/server/src/http/router.test.ts
+++ b/packages/server/src/http/router.test.ts
@@ -299,12 +299,14 @@ describe("observability middleware", () => {
     expect(p["duration_ms"] as number).toBeGreaterThanOrEqual(0);
   });
 
-  test("failed request emits one canonical ERROR line (Conflict → 409)", async () => {
+  test("failed request emits one canonical WARN line (Conflict → 409)", async () => {
     // Register a route AFTER `createRouter` that throws Conflict
     // synthetically. Hono's compose catches the throw and routes it
     // through `onError`; the helper reconstructs the BaerlyError from
-    // the wire envelope so the canonical line's `error` property
-    // forces level = "error" via the canonical-line level picker.
+    // the wire envelope onto the canonical line's `error` property.
+    // A 409 is client-attributable and routine — so the line is `warn`,
+    // not `error`: status is authoritative and an attached error does not
+    // escalate a 4xx.
     const db = Db.create({
       storage: new MemoryStorage(),
       app: "router-test",
@@ -325,7 +327,7 @@ describe("observability middleware", () => {
     const lines = canonical();
     expect(lines).toHaveLength(1);
     const line = lines[0]!;
-    expect(line.level).toBe("error");
+    expect(line.level).toBe("warning");
     const p = line.properties;
     expect(p["status"]).toBe(409);
     expect(p["outcome"]).toBe("conflict");

--- a/packages/server/src/observability/canonical.test.ts
+++ b/packages/server/src/observability/canonical.test.ts
@@ -108,12 +108,49 @@ describe("flushCanonicalLine", () => {
       expect(records[0]!.level).toBe("info");
     });
 
-    test("error present → error level (overrides status)", () => {
+    test("client error (4xx) with an attached error → warning, not error", () => {
+      // A 4xx is the caller's fault, not a server fault. The
+      // reconstructed structured error that `withHttpObservability`
+      // attaches to every non-2xx line must NOT escalate it to `error`:
+      // status is authoritative for classification. Escalating routine
+      // validation/auth rejections to `error` would pollute error
+      // budgets and page responders. See the `pickLevel` doc.
+      flushCanonicalLine(createObservabilityContext(), new RequestScopedMetricsRecorder(), {
+        unit: "http",
+        outcome: "client_error",
+        status: 400,
+        error: new BaerlyError("SchemaError", "field failed validation"),
+      });
+      expect(records[0]!.level).toBe("warning");
+    });
+
+    test("409 Conflict with an attached error → warning (client-attributable, routine)", () => {
+      // A 409 is client-attributable and routine — no operator action.
+      // It stays `warn`.
+      flushCanonicalLine(createObservabilityContext(), new RequestScopedMetricsRecorder(), {
+        unit: "http",
+        outcome: "conflict",
+        status: 409,
+        error: new BaerlyError("Conflict", "write conflict"),
+      });
+      expect(records[0]!.level).toBe("warning");
+    });
+
+    test("error present on a 2xx status → error level (anomalous)", () => {
       flushCanonicalLine(createObservabilityContext(), new RequestScopedMetricsRecorder(), {
         unit: "http",
         outcome: "internal_error",
         status: 200,
         error: new BaerlyError("Internal", "boom"),
+      });
+      expect(records[0]!.level).toBe("error");
+    });
+
+    test("error present without a classifying status → error level", () => {
+      flushCanonicalLine(createObservabilityContext(), new RequestScopedMetricsRecorder(), {
+        unit: "http",
+        outcome: "internal_error",
+        error: new BaerlyError("Internal", "escaped throw, no wire status"),
       });
       expect(records[0]!.level).toBe("error");
     });

--- a/packages/server/src/observability/canonical.ts
+++ b/packages/server/src/observability/canonical.ts
@@ -11,11 +11,14 @@
  * Every HTTP request emits a line; level is computed from
  * status/error.
  *
- * Level mapping at emit time:
+ * Level mapping at emit time (wire status is authoritative):
  *
- * - `error` present → `error`
  * - `status >= 500` → `error`
- * - `status >= 400` → `warn`
+ * - `status >= 400` → `warn` (client error — a 4xx is the caller's
+ *   fault, not a server fault; an attached structured error, including
+ *   a 409 Conflict, does NOT escalate it)
+ * - `status` 2xx/3xx with an attached `error` → `error` (anomalous)
+ * - no `status`, `error` present → `error`
  * - otherwise → `info`
  */
 
@@ -211,9 +214,16 @@ export const flushUnauthorizedAndRespond = (
 type Level = "info" | "warn" | "error";
 
 const pickLevel = (opts: FlushCanonicalLineOptions): Level => {
-  if (opts.error !== undefined) {
-    return "error";
-  }
+  // Wire status is authoritative when present. A client error (4xx) is a
+  // `warn` even when a structured error is attached (as
+  // `withHttpObservability` reconstructs one for every non-2xx). This is
+  // deliberate: a 4xx is the caller's fault, not a server fault. The
+  // reachable 409 is a duplicate-`_id` insert (a reused id or a
+  // double-submitted POST); ordinary write contention is absorbed by the
+  // log forward-probe as a 412 counter, not a client 409. 401/404/400 are
+  // likewise the caller's fault. Escalating any of them to `error` would
+  // burn error budget and page on-call for normal operation. `error` is
+  // reserved for genuine server faults.
   if (opts.status !== undefined) {
     if (opts.status >= 500) {
       return "error";
@@ -221,8 +231,13 @@ const pickLevel = (opts: FlushCanonicalLineOptions): Level => {
     if (opts.status >= 400) {
       return "warn";
     }
+    // A 2xx/3xx that still carries an error is anomalous (a throw that
+    // resolved a success status) — surface it.
+    return opts.error !== undefined ? "error" : "info";
   }
-  return "info";
+  // No wire status to classify by (e.g. an escaped throw before a
+  // Response existed): an attached error is all we have to go on.
+  return opts.error !== undefined ? "error" : "info";
 };
 
 const buildProperties = (

--- a/scripts/check-exports.mjs
+++ b/scripts/check-exports.mjs
@@ -23,6 +23,11 @@ import { join } from "node:path";
 function run(cmd, args, extraOpts = {}) {
   const result = spawnSync(cmd, args, { stdio: "inherit", ...extraOpts });
   if (result.status !== 0) {
+    // A quiet call (stdout captured) has nothing on the console — replay
+    // the captured stdout so a failure keeps its full detail.
+    if (result.stdout) {
+      process.stderr.write(result.stdout);
+    }
     process.exit(result.status ?? 1);
   }
   return result;
@@ -33,7 +38,15 @@ if (!process.env.BAERLY_SKIP_BUILD) {
 }
 
 const outDir = mkdtempSync(join(tmpdir(), "baerly-attw-"));
-run("pnpm", ["pack", "--pack-destination", outDir]);
+// Capture pack's stdout rather than inheriting it: `pnpm pack` prints
+// the full "Tarball Contents" file listing (~200 lines) on every run,
+// which is pure noise on a green CI gate. We only need the .tgz path
+// (read from outDir below); on failure `run` replays the captured
+// output so nothing is lost.
+run("pnpm", ["pack", "--pack-destination", outDir], {
+  stdio: ["ignore", "pipe", "inherit"],
+  encoding: "utf8",
+});
 
 const tarball = readdirSync(outDir).find((f) => f.endsWith(".tgz"));
 if (!tarball) {

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -555,7 +555,12 @@ const BUDGETS: readonly Budget[] = [
   //     plus the namespaced "@gusto/baerly-storage" marker literal and its guard
   //     JSDoc (comments ship un-stripped). Measured 100568 raw / 27690 gz; min-gz
   //     (−701) under. Rebaseline the raw/gz creep tripwires per the POLICY.
-  { entry: "observability.js", raw: 99 * 1024, gz: 28 * 1024, minGz: 13 * 1024 },
+  //   → raw +1 KiB (2026-07-14): pickLevel now classifies canonical lines by
+  //     wire status (4xx incl. a lost-CAS 409 Conflict → warn, not error), and
+  //     its contract comment + the level-mapping docstring ship un-stripped.
+  //     Measured 101630 raw; gz (−726) and min-gz (−622) both comfortably under.
+  //     Rebaseline the raw creep tripwire per the POLICY (don't golf comments).
+  { entry: "observability.js", raw: 100 * 1024, gz: 28 * 1024, minGz: 13 * 1024 },
   // Maintenance loop — compactor + GC + sweep driver. Pulls
   // compactor.ts + gc.ts + the observability subgraph
   // transitively (storage decorator + logger config + canonical

--- a/tests/integration/observability.test.ts
+++ b/tests/integration/observability.test.ts
@@ -240,7 +240,7 @@ describe("observability integration — canonical line vs physical reality", () 
     expect(proxy.counts.list).toBe(0);
   });
 
-  test("duplicate-_id Conflict emits an error-level line with the canonical totals", async () => {
+  test("duplicate-_id Conflict emits a warning-level line with the canonical totals", async () => {
     const memory = new MemoryStorage();
     await bootstrap(memory);
 
@@ -295,9 +295,10 @@ describe("observability integration — canonical line vs physical reality", () 
     expect(records).toHaveLength(1);
     const record = records[0]!;
     const props = record.properties;
-    // Level mapping: any thrown error escalates to `error` level,
-    // overriding the 409 → warn mapping.
-    expect(record.level).toBe("error");
+    // Level mapping: this 409 is a duplicate-`_id` insert —
+    // client-attributable and routine — so it stays `warn`. Status is
+    // authoritative; an attached error does not escalate a 4xx to `error`.
+    expect(record.level).toBe("warning");
     expect(props["outcome"]).toBe("conflict");
     const err = props["error"] as { code: string };
     expect(err.code).toBe("Conflict");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -220,6 +220,19 @@ export default defineConfig({
           // behind --js-base-64 in current V8 (Node 24 / V8 13.6). Drop this
           // once Node ships the methods unflagged.
           execArgv: ["--js-base-64"],
+          // Quiet the observability logger for the default suite. Many
+          // integration tests boot a full HTTP app; its canonical
+          // per-request line logs at `info` through the console-json
+          // sink, flooding a green CI run with ~600 lines of pure noise
+          // (one JSON object per request). `warn` drops the per-request
+          // info lines while still surfacing client-error (4xx) and
+          // server-error (5xx) canonical lines — the ones worth reading.
+          // Tests that assert on log output reconfigure LogTape with
+          // their own explicit level + capturing sink (`reset: true`,
+          // last-call-wins), so this default never reaches them. Scoped
+          // to the default project; the `cloudflare-pool` project is
+          // unaffected (Workerd doesn't route this sink to a console).
+          env: { LOG_LEVEL: "warn" },
           // Default truncates assertion diffs at ~40 chars — useless for
           // fast-check shrinking failures on document trees. Full diffs only
           // print on failure, so log size is bounded.


### PR DESCRIPTION
Two independent noise reductions.

## `fix(observability)`: log 4xx at warn, not error

`pickLevel` escalated any canonical line with an attached error to `error`, regardless of status. Since a `BaerlyError` is reconstructed for every non-2xx, a 409 Conflict (a lost CAS race the writer retries) and ordinary 4xx client rejections both logged at `error`.

Now wire status is authoritative: 5xx → error, 4xx → warn, and a 2xx/3xx carrying an anomalous error (or an errored request with no wire status) → error. `error` is reserved for genuine server faults, so routine CAS contention and client rejections stop burning error budget and paging on-call. The failure line still carries the structured `{ code, message }`; only the stack drops off at warn.

## `chore(ci)`: quiet test + verify:package output

- Default vitest project boots full HTTP apps whose per-request canonical lines log at `info`, flooding a green run. Set `LOG_LEVEL=warn` on that project — client/server-error lines still surface; tests asserting on logs configure their own level + sink, so they're unaffected.
- Capture `pnpm pack` stdout in `check-exports.mjs` (replayed only on failure) so its ~200-line tarball listing no longer prints on a passing `verify:package`.

Net: `pnpm test` ~3132 → ~1279 lines; `verify:package` 283 → 147.

Includes a changeset and the observability.js raw-bundle rebaseline (+1 KiB comment bytes; gz/min-gz under budget).
