### PR TITLE
chore(ci): finish CI-log noise cleanup (round 2)

### DIFF
--- a/packages/dev/src/vite-plugin.test.ts
+++ b/packages/dev/src/vite-plugin.test.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Writable } from "node:stream";
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import type { BaerlyAppConfig } from "@baerly/protocol";
 import { baerlyDev, baerlyDevAuth, loadDevVars } from "./vite-plugin.ts";
 
@@ -438,6 +438,12 @@ describe("baerlyDev — config loading", () => {
         rejections.push(reason);
       };
       process.on("unhandledRejection", onRejection);
+      // The injected `ssrLoadModule` rejection is surfaced to the developer
+      // via `console.error("[baerly-dev] setup failed:", …)` (vite-plugin.ts).
+      // Capture that expected stack instead of letting it print, and assert
+      // it fired — this test's point is that setup failure is *logged*, not
+      // crashed on.
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       try {
         start(baerlyDev({ banner: true }), server);
         httpServer.emit("listening");
@@ -446,7 +452,9 @@ describe("baerlyDev — config loading", () => {
         // a distinct derived promise from the same rejected `ready` would go
         // unhandled here even though the setup failure is already logged.
         expect(rejections).toEqual([]);
+        expect(errorSpy).toHaveBeenCalled();
       } finally {
+        errorSpy.mockRestore();
         process.off("unhandledRejection", onRejection);
       }
     } finally {

--- a/packages/server/src/index-crash-fuzz.test.ts
+++ b/packages/server/src/index-crash-fuzz.test.ts
@@ -34,7 +34,7 @@
  */
 
 import { fc, test } from "@fast-check/vitest";
-import { describe, expect } from "vitest";
+import { afterEach, beforeEach, describe, expect, vi } from "vitest";
 
 /**
  * Per-property timeout, in ms. At `FC_NUM_RUNS=100` (default
@@ -97,6 +97,18 @@ const provision = async (storage: Storage): Promise<void> => {
     snapshot_rows: 0,
   });
 };
+
+// This suite injects storage faults (`abortingStorage`). A crashed
+// commit's internal write-tick maintenance surfaces the injected abort
+// via the runner's intentional `console.error(error)` stack dump
+// (maintenance.ts) — expected-error noise on a green run. Suppress it;
+// the property asserts index parity via `expect`, never via console.
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("index emission survives a single crash anywhere in the commit", () => {
   test.prop({

--- a/packages/server/src/maintenance.test.ts
+++ b/packages/server/src/maintenance.test.ts
@@ -796,17 +796,28 @@ describe("runBoundedMaintenance", () => {
       list: inner.list.bind(inner),
     };
     let rejected = false;
-    const recorder = await withRecorder(async () => {
-      await runBoundedMaintenance({
-        storage: boom,
-        currentJsonKey: KEY,
-        prevSeq: 0,
-      }).catch(() => {
-        rejected = true;
+    // The runner surfaces an unexpected error's stack via `console.error`
+    // (maintenance.ts — the one intentional operator sink) since the
+    // caller swallows the throw. This test injects that error on purpose,
+    // so capture the dump instead of letting ~6 lines of expected-error
+    // noise print, and assert it fired — turning the noise into a signal.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const recorder = await withRecorder(async () => {
+        await runBoundedMaintenance({
+          storage: boom,
+          currentJsonKey: KEY,
+          prevSeq: 0,
+        }).catch(() => {
+          rejected = true;
+        });
       });
-    });
-    expect(rejected).toBe(false); // swallowed, did NOT reject
-    expect(counterTotal(recorder, "db.maintenance.unexpected_error_total")).toBeGreaterThan(0);
+      expect(rejected).toBe(false); // swallowed, did NOT reject
+      expect(errorSpy).toHaveBeenCalled(); // operator-facing stack was surfaced
+      expect(counterTotal(recorder, "db.maintenance.unexpected_error_total")).toBeGreaterThan(0);
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });
 

--- a/scripts/check-exports.mjs
+++ b/scripts/check-exports.mjs
@@ -54,4 +54,8 @@ if (!tarball) {
   process.exit(1);
 }
 
-run("pnpm", ["exec", "attw", join(outDir, tarball), "--profile", "esm-only"]);
+// `-f table` forces attw's compact grid (one row per subpath). Without it,
+// a non-TTY run (CI) falls back to the `ascii` format, which prints a
+// ~6-line block per entry point — ~90 lines that repeat the same ignored
+// node10/node16-CJS resolutions across all 13 subpaths.
+run("pnpm", ["exec", "attw", join(outDir, tarball), "--profile", "esm-only", "-f", "table"]);

--- a/scripts/prepare.mjs
+++ b/scripts/prepare.mjs
@@ -21,9 +21,28 @@ function isSecondaryWorktree() {
   }
 }
 
-function run(cmd, args) {
-  const result = spawnSync(cmd, args, { stdio: "inherit" });
+function run(cmd, args, { quiet = false } = {}) {
+  // `quiet` captures stdout/stderr instead of inheriting it: the rolldown
+  // build prints a ~125-line per-asset/chunk size table that has no clean
+  // CLI suppress flag and is pure noise on a green `pnpm install` (it runs
+  // via this hook on every CI install). On failure the captured output is
+  // replayed so nothing is lost. Same capture-and-replay-on-failure shape as
+  // scripts/check-exports.mjs, but that one inherits stderr (its noise is on
+  // stdout); here we also capture stderr to fully silence a green build, which
+  // means build warnings that don't fail the build are dropped on success.
+  const result = spawnSync(cmd, args, {
+    stdio: quiet ? ["inherit", "pipe", "pipe"] : "inherit",
+    ...(quiet ? { encoding: "utf8" } : {}),
+  });
   if (result.status !== 0) {
+    if (quiet) {
+      if (result.stdout) {
+        process.stdout.write(result.stdout);
+      }
+      if (result.stderr) {
+        process.stderr.write(result.stderr);
+      }
+    }
     process.exit(result.status ?? 1);
   }
 }
@@ -34,5 +53,5 @@ if (!isSecondaryWorktree()) {
 if (process.env.BAERLY_SKIP_BUILD) {
   console.log("prepare: BAERLY_SKIP_BUILD set — reusing current dist/, skipping build.");
 } else {
-  run("pnpm", ["run", "build"]);
+  run("pnpm", ["run", "build"], { quiet: true });
 }

--- a/tests/fixtures/randomized-cascade.ts
+++ b/tests/fixtures/randomized-cascade.ts
@@ -405,7 +405,15 @@ export const runCausalConsistencyCascade = (opts: {
         const N = opts.storages.length;
         const seed = opts.seed ?? Math.floor(Math.random() * 0x7fffffff);
         const rand = makeLcg(seed);
-        console.log(`[cascade] seed=${seed} N=${N} pollTickMs=${opts.pollTickMs}`);
+        // Progress trace of the causal-consistency broadcast simulation.
+        // Off by default — on a green run it emits ~200 lines of pure
+        // debug noise per suite. Set CASCADE_TRACE=1 to replay a failing
+        // interleaving. The failure-only CAUSAL VIOLATION dump below is
+        // always printed. (The seed also lands in that dump for replay.)
+        const traceCascade = !!process.env["CASCADE_TRACE"];
+        if (traceCascade) {
+          console.log(`[cascade] seed=${seed} N=${N} pollTickMs=${opts.pollTickMs}`);
+        }
         const clockOffsets =
           opts.clockOffsetsMs ?? Array.from({ length: N }, () => rand() * 2000 - 1000);
         // Portable failing-schedule artifact: every observation is
@@ -457,11 +465,13 @@ export const runCausalConsistencyCascade = (opts: {
         const handle = (client_id: number, val: CascadeMessage | undefined): void => {
           const label = system.client_labels[client_id];
           if (val !== undefined) {
-            console.log(
-              `${system.global_time}: ${label}@${system.client_clocks[
-                client_id
-              ]!} rcvd ${system.client_labels[val.sender]}@${val.send_time}`,
-            );
+            if (traceCascade) {
+              console.log(
+                `${system.global_time}: ${label}@${system.client_clocks[
+                  client_id
+                ]!} rcvd ${system.client_labels[val.sender]}@${val.send_time}`,
+              );
+            }
             system.observe({ ...val, receiver: client_id });
             schedule.push({
               tick: system.global_time,
@@ -501,7 +511,9 @@ export const runCausalConsistencyCascade = (opts: {
             expect(testFailed).toBe(false);
 
             const send_time = system.client_clocks[client_id]! - 1;
-            console.log(`${system.global_time}: ${label}@${send_time} broadcast`);
+            if (traceCascade) {
+              console.log(`${system.global_time}: ${label}@${send_time} broadcast`);
+            }
 
             // Drive the new write loop directly. Writer mints the
             // LogEntry; clock skew is per-instance and unused by the

--- a/tests/integration/maintenance-crash-fuzz.test.ts
+++ b/tests/integration/maintenance-crash-fuzz.test.ts
@@ -41,7 +41,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fc, test as propTest } from "@fast-check/vitest";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   BaerlyError,
   type Collection,
@@ -64,6 +64,22 @@ import {
 } from "@baerly/server/_internal/testing";
 import { abortingStorage } from "../fixtures/aborting-storage.ts";
 import { logStateCurrentJson } from "../fixtures/log-state.ts";
+
+// Every suite in this file injects storage faults (`abortingStorage`).
+// The maintenance runner's intentional operator-facing stack dump
+// (`console.error(error)` in maintenance.ts) then fires once per
+// injected abort — ~150 lines of *expected*-error noise on a green run.
+// Suppress it file-wide: correctness here is asserted through the
+// `expect(...)` invariants, never through console output, and no test
+// inspects `console.error`. A genuinely unexpected error still surfaces
+// as an assertion failure. Per-test spy + restore keeps other suites
+// (and a failing run's real diagnostics) untouched.
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 /**
  * Per-property timeout, in ms. At `FC_NUM_RUNS=100` (default

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -229,9 +229,10 @@ export default defineConfig({
           // server-error (5xx) canonical lines — the ones worth reading.
           // Tests that assert on log output reconfigure LogTape with
           // their own explicit level + capturing sink (`reset: true`,
-          // last-call-wins), so this default never reaches them. Scoped
-          // to the default project; the `cloudflare-pool` project is
-          // unaffected (Workerd doesn't route this sink to a console).
+          // last-call-wins), so this default never reaches them. The
+          // `cloudflare-pool` project sets the same level via its
+          // miniflare `bindings` below — the console-json sink DOES reach
+          // miniflare stdout, so it needs identical quieting.
           env: { LOG_LEVEL: "warn" },
           // Default truncates assertion diffs at ~40 chars — useless for
           // fast-check shrinking failures on document trees. Full diffs only
@@ -265,7 +266,17 @@ export default defineConfig({
             // exist on the env shape.
             miniflare: {
               r2Buckets: ["BUCKET"],
-              bindings: { APP: "http-conf", TENANT: "" },
+              // `LOG_LEVEL: "warn"` mirrors the default project's env
+              // (above): every booted worker logs a canonical per-request
+              // `info` line through the console-json sink, which miniflare
+              // routes to stdout and vitest captures — ~300 JSON lines of
+              // pure noise on a green run. `warn` drops them while keeping
+              // the 4xx/5xx canonical lines. The kernel logger reads the level
+              // from `globalThis.process.env.LOG_LEVEL` (not the `env` param),
+              // which Workerd populates from this text binding only because
+              // `nodejs_compat` is set below — drop that flag and the level
+              // silently falls back to `info`.
+              bindings: { APP: "http-conf", TENANT: "", LOG_LEVEL: "warn" },
               compatibilityDate: "2026-05-01",
               compatibilityFlags: ["nodejs_compat"],
             },


### PR DESCRIPTION
Follow-up to #56. A passing CI run was still ~2,967 log lines; roughly half was reducible tool/observability chatter. This sweep worked from the **actual CI-log stack lines** (not assumptions), which is how it caught the two sources the last pass missed.

## Commits

**`chore(ci): quiet four remaining CI-log noise sources`**
- **Cloudflare suite `LOG_LEVEL: "warn"`** — the default vitest project already sets this to drop the per-request canonical `info` line (~300 JSON objects/run), but the fix was never applied to the `cloudflare-pool` project, whose console-json sink *does* reach miniflare stdout (the prior comment claiming otherwise was stale and is corrected). The kernel logger reads the level from `globalThis.process.env.LOG_LEVEL` (not the `env` param), which Workerd populates from the text binding only because `nodejs_compat` is set — drop that flag and the level silently falls back to `info`. Keeps the 4xx/5xx `warning` lines. (~600 lines)
- **Cascade fixture** — gate the three per-broadcast progress `console.log`s behind `CASCADE_TRACE=1`; the failure-only causal-violation dump still always prints. (~200 lines)
- **Install build** — capture the `prepare` hook's build output, replay only on failure. rolldown prints a ~125-line asset/chunk size table with no CLI suppress flag. Same capture-and-replay-on-failure shape as `check-exports.mjs`, but that one keeps stderr live (its noise is on stdout) while this also captures stderr to fully silence a green build — the deliberate trade-off is that non-fatal build warnings are dropped on success.
- **verify:package** — pass `-f table` to attw so its 13 per-subpath ascii blocks collapse into one grid (90 → 28 lines).

**`test: suppress expected-error stack dumps in fault-injection suites`**
- ~145 stack-trace lines on a green run, all from tests that deliberately inject errors whose runner surfaces them via an intentional operator-facing `console.error` sink.
- Capture `console.error` per-test in all four emitters: `maintenance-crash-fuzz.test.ts` + `index-crash-fuzz.test.ts` (file-wide — entirely `abortingStorage` fault-injection), and `maintenance.test.ts` + `vite-plugin.test.ts` (scoped to the one fault-injecting test each, now asserting the sink WAS called — turning noise into signal).
- No source behavior changes; the operator-facing sinks are intentional and untouched.

## Scope / what's deliberately left alone
- The 93+37 asserted 4xx/5xx `warning` canonical lines (signal, worth reading).
- Blank-line padding (derived — shrinks as content drops).
- GitHub Actions step scaffolding for checkout/setup (~190 lines, not controllable).
- `test-infra.yml` is dispatch-only and never runs; it inherits these default-project fixes if it ever does.

## Verification
- Directly observed: rolldown table 125→0; attw 90→28; both still green.
- CF `LOG_LEVEL` proven by the existing `logger.test.ts` unit test ("warn filters info, keeps warning") + suite passes (152 tests).
- Fault-injection suites pass; `maintenance.test.ts`/`vite-plugin.test.ts` positively assert the `console.error` fired and was captured.
- Full pre-commit gate (tsgo typecheck, oxlint, oxfmt, example typechecks, layer/spec/version linters) green on both commits.

Marking **ready**: local levers were directly observed (rolldown/attw), and CI on this PR confirms the CF/cascade/stack reductions end-to-end (they can't be observed locally — this environment doesn't surface vitest test-console output).

Projected result: ~2,967 → ~1,700 lines.
