### PR TITLE
test(dev): stop vite-plugin tests leaking "setup failed" stderr

### DIFF
--- a/packages/dev/src/vite-plugin.test.ts
+++ b/packages/dev/src/vite-plugin.test.ts
@@ -140,6 +140,16 @@ const captureMiddleware = (plugin: ReturnType<typeof baerlyDev>): CapturedMw => 
   return captured[0]!;
 };
 
+/**
+ * Await a plugin's background setup (exposed as `api.whenSettled`) so a
+ * throwaway data dir isn't `rm`'d out from under the un-awaited
+ * `ensureTable`/`storage.put` that `configureServer` kicks off — which
+ * otherwise surfaces a misleading `[baerly-dev] setup failed: ENOENT`
+ * stack and races teardown against setup.
+ */
+const whenSettled = (plugin: ReturnType<typeof baerlyDev>): Promise<void> =>
+  (plugin.api as { whenSettled: Promise<void> }).whenSettled;
+
 let tmp: string;
 let middlewares: CapturedMw[];
 
@@ -404,17 +414,27 @@ describe("baerlyDev — config loading", () => {
     const root = await mkdtemp(join(tmpdir(), "baerly-nodefault-"));
     try {
       const { captured, server } = makeServer(root, async () => ({}));
-      start(baerlyDev({ banner: false }), server);
-      const res = makeRes();
-      captured[0]!(makeReq("/v1/healthz"), res, () => {
-        throw new Error("next should not be called");
-      });
-      for (let i = 0; i < 50 && res.statusCode === 0; i += 1) {
-        await new Promise((r) => setTimeout(r, 20));
+      // The invalid-config rejection is surfaced to the developer via
+      // `console.error("[baerly-dev] setup failed:", …)` (vite-plugin.ts).
+      // Capture that expected stack instead of letting it dump to stderr,
+      // and assert it fired — mirrors the "banner does not crash" test.
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        start(baerlyDev({ banner: false }), server);
+        const res = makeRes();
+        captured[0]!(makeReq("/v1/healthz"), res, () => {
+          throw new Error("next should not be called");
+        });
+        for (let i = 0; i < 50 && res.statusCode === 0; i += 1) {
+          await new Promise((r) => setTimeout(r, 20));
+        }
+        expect(res.statusCode).toBe(503);
+        const body = JSON.parse(res.written.join("")) as { message: string };
+        expect(body.message).toContain("must default-export a BaerlyAppConfig object");
+        expect(errorSpy).toHaveBeenCalled();
+      } finally {
+        errorSpy.mockRestore();
       }
-      expect(res.statusCode).toBe(503);
-      const body = JSON.parse(res.written.join("")) as { message: string };
-      expect(body.message).toContain("must default-export a BaerlyAppConfig object");
     } finally {
       await rm(root, { recursive: true, force: true });
     }
@@ -474,7 +494,7 @@ describe("baerlyDev — auth resolution", () => {
   };
 
   test('auth: "none" → middleware does NOT inject Authorization on /v1/*', async () => {
-    await withDataDir((dir) => {
+    await withDataDir(async (dir) => {
       const plugin = baerlyDev({
         config: baseConfig("none"),
         dataDir: dir,
@@ -485,11 +505,12 @@ describe("baerlyDev — auth resolution", () => {
       mw(req, makeRes(), () => {});
       expect(req.headers["authorization"]).toBeUndefined();
       expect(headersFromRaw(req).get("authorization")).toBeNull();
+      await whenSettled(plugin);
     });
   });
 
   test('auth: "shared-secret" + secret → middleware injects Bearer <secret>', async () => {
-    await withDataDir((dir) => {
+    await withDataDir(async (dir) => {
       const plugin = baerlyDev({
         config: baseConfig("shared-secret"),
         secret: "s3cr3t",
@@ -501,6 +522,7 @@ describe("baerlyDev — auth resolution", () => {
       mw(req, makeRes(), () => {});
       expect(req.headers["authorization"]).toBe("Bearer s3cr3t");
       expect(headersFromRaw(req).get("authorization")).toBe("Bearer s3cr3t");
+      await whenSettled(plugin);
     });
   });
 
@@ -517,7 +539,7 @@ describe("baerlyDev — auth resolution", () => {
   });
 
   test("verifier override wins over config.auth + does NOT inject Bearer", async () => {
-    await withDataDir((dir) => {
+    await withDataDir(async (dir) => {
       const plugin = baerlyDev({
         config: baseConfig("shared-secret"),
         secret: "ignored",
@@ -533,6 +555,7 @@ describe("baerlyDev — auth resolution", () => {
       mw(req, makeRes(), () => {});
       // Override owns the auth seam — no bearer injection.
       expect(req.headers["authorization"]).toBeUndefined();
+      await whenSettled(plugin);
     });
   });
 });

--- a/packages/dev/src/vite-plugin.ts
+++ b/packages/dev/src/vite-plugin.ts
@@ -317,9 +317,21 @@ export function baerlyDev(opts: BaerlyDevOptions): Plugin {
   // preserves fail-fast startup on misconfig. When `config` is omitted it's
   // loaded lazily in `configureServer` (see below) and auth resolves there.
   const eagerAuth = opts.config !== undefined ? resolveAuth(opts, opts.config) : undefined;
+  // Readiness handle: resolves once configureServer's async setup settles
+  // (success OR failure). The setup runs un-awaited in the background (Vite
+  // doesn't await configureServer's internal promises), so without this
+  // there is no way to know it has finished touching the data dir. Exposed
+  // via Vite's `api` field so a caller — or a test that provisions a
+  // throwaway data dir — can await settle before tearing that dir down,
+  // rather than racing the in-flight `ensureTable`/`storage.put`.
+  let markSettled!: () => void;
+  const whenSettled = new Promise<void>((settle) => {
+    markSettled = settle;
+  });
   return {
     name: "baerly-dev",
     apply: "serve",
+    api: { whenSettled },
     configureServer(server) {
       // Everything below runs at dev-server startup, NOT at plugin-factory
       // time. That lets callers omit `config` and instead have us load
@@ -383,6 +395,10 @@ export function baerlyDev(opts: BaerlyDevOptions): Plugin {
       ready.catch((error: unknown) => {
         console.error("[baerly-dev] setup failed:", error);
       });
+      // Settle the exposed readiness handle regardless of outcome — a
+      // failed setup is still "done", and awaiters (see `api.whenSettled`)
+      // only need to know the background work has stopped touching storage.
+      void ready.then(markSettled, markSettled);
 
       server.middlewares.use((req, res, next) => {
         const url = req.url;


### PR DESCRIPTION
## What

A CI-log audit of the four `ci.yml` commands (plus the dispatch-only `test-infra` suites and the `MINIO=1` local suites) found the output is almost entirely intentional structured logs — with two genuine exceptions, both in `packages/dev/src/vite-plugin.test.ts`, both dumping a misleading `[baerly-dev] setup failed` stack on a **green** run.

## Fixes

1. **Teardown race (latent flake).** The `baerlyDev — auth resolution` tests deleted their throwaway data dir while `baerlyDev()`'s un-awaited `configureServer` setup was still writing into it (`ensureTable` → `LocalFsStorage.put`), racing teardown and surfacing a misleading `ENOENT`. Fixed at the root: `baerlyDev()` now exposes a `whenSettled` readiness handle (via Vite's `api` field), resolved once the background setup settles, and the tests `await` it before the data dir is torn down.
2. **Unsuppressed expected error.** The "no default export" negative test now spies + asserts `console.error` — mirroring its sibling "banner does not crash" test — instead of letting the expected `BaerlyError` dump to stderr.

This completes the suppress-and-assert pattern from `1b5c0c3d` for the two `vite-plugin` cases it didn't cover. The operator-facing `console.error` sink is unchanged; only the `whenSettled` handle is added.

## Verification

- `packages/dev/src/vite-plugin.test.ts`: 29/29 pass, **0** occurrences of `setup failed` / `ENOENT` in the captured output (was leaking both before).
- `pnpm verify:agent` clean; full default suite green (2503 passed, 90 skipped).
- Pre-commit gate (bundle-size / format / lint / typecheck) green.

## Audit scope (for reference)

Confirmed **no** other genuine issues across: `pnpm verify`, `pnpm verify:package` (attw+publint), `pnpm test:adapter-cloudflare`, `test:adapter-node` (Minio conformance), `test:export-smoke`, `test:export-round-trip`, and the full `MINIO=1` suite (incl. the `node-minio` fault-injection variant of `randomized.test.ts`, which was verified already quiet — its noise is gated at the source in `randomized-cascade.ts`).