### PR TITLE
docs: remove references to unshipped future work

### DIFF
--- a/bench/fold-cost.ts
+++ b/bench/fold-cost.ts
@@ -9,12 +9,11 @@
  *   - **snapshot row count** (the per-entry parse / merge / serialize
  *     axis — many tiny docs).
  *
- * This is the bench that will eventually REPLACE the *modelled* numbers
- * in `docs/about/graduation.md` ("≈ 11 ms CPU per MB of snapshot
- * rebuilt", and the PROVISIONAL `E = 2048` row ceiling) with *measured*
- * ones, so the snapshot ceilings `C` / `E` can rise on a more capable
- * host later (paid Cloudflare is MEMORY-bound where free is CPU-bound,
- * so BOTH axes are reported). This bench MEASURES ONLY — it changes no
+ * This bench MEASURES the actual CPU/memory cost of a snapshot fold, to
+ * compare against the *modelled* numbers in `docs/about/graduation.md`
+ * ("≈ 11 ms CPU per MB of snapshot rebuilt", and the PROVISIONAL
+ * `E = 2048` row ceiling). It reports BOTH axes because paid Cloudflare
+ * is MEMORY-bound where free is CPU-bound. MEASURES ONLY — it changes no
  * production behaviour and no constant.
  *
  * What a "fold" is here: each iteration runs the real

--- a/bench/storage.ts
+++ b/bench/storage.ts
@@ -41,9 +41,7 @@ export interface BenchStorageOpts {
  * 8 bytes/double = ~4 MB max memory per `CountingStorage`. Multi-
  * million-op runs hit this ceiling; nearest-rank p50/p95/p99 stay
  * stable under FIFO drop for the quasi-stationary workloads the
- * load-harness presets produce. If a future workload class needs full-
- * run latency retention, switch this file to a reservoir sampler —
- * out of scope for ticket 50.
+ * load-harness presets produce.
  */
 const MAX_LATENCY_SAMPLES_PER_OP = 100_000;
 

--- a/docs/adr/003-layout-versioning-cordon.md
+++ b/docs/adr/003-layout-versioning-cordon.md
@@ -3,7 +3,7 @@ title: Layout versioning and the reserved-namespace cordon
 audience: adr
 doc_type: adr
 summary: ADR 003 — schema_version is a per-artifact shape sentinel; the bucket key-layout axis is distinct and deferred (layout_version, additive-optional); the leading-underscore namespace is reserved now. The tolerant-reader rule lives in extending.md; this record keeps the reservation and the rejected upcaster/cordon paths.
-last-reviewed: 2026-06-28
+last-reviewed: 2026-07-16
 tags: [decision, adr, runtime-model]
 related: [README.md, "../about/thesis.md", "../contributing/extending.md", 001-tenant-cas-isolation.md, 002-ephemeral-coordination.md]
 ---
@@ -12,8 +12,7 @@ related: [README.md, "../about/thesis.md", "../contributing/extending.md", 001-t
 
 ## Status
 
-Accepted (2026-06-01). The "Likely v2 shape" note below is **non-binding**,
-pending real v2 requirements; everything else is firm.
+Accepted (2026-06-01).
 
 ## Decision
 
@@ -73,9 +72,3 @@ coordination request-bounded in [ADR-002](002-ephemeral-coordination.md).
   reservation, which subsumes `_v<N>` and matches the Mongo/Firestore
   convention.
 
-## Likely v2 shape — non-binding
-
-An incompatible future change is expected to introduce `layout_version`
-and cordon bulk data under `_v<N>/`. How a reader detects the layout, how
-migration runs, and whether a `migrate` verb returns are **deferred to
-v2's real requirements** — no mechanism is specified here.

--- a/docs/adr/005-logentry-versionless.md
+++ b/docs/adr/005-logentry-versionless.md
@@ -47,7 +47,7 @@ introduce one.
 
 ## Consequences
 
-- The conformance corpus (Tier B) may freeze `LogEntry` fixtures under
+- The conformance corpus may freeze `LogEntry` fixtures under
   the "versionless v1" label without waiting on a field addition.
 - `version-matrix.json` records `LogEntry` as
   `{ value: null, policy: "versionless-additive-only" }`; the drift

--- a/docs/contributing/conventions/versioning.md
+++ b/docs/contributing/conventions/versioning.md
@@ -27,7 +27,7 @@ code drift by `scripts/check-version-matrix.ts` on every `pnpm verify`.
 | **`specVersion`** | `/v1/spec` IR + HTTP/API contract shape — NOT bucket layout | `buildSpecIR().specVersion` (`packages/server/src/spec/ir.ts`) | `"1"` |
 | **Per-artifact `schema_version`** | durable control-object schema (`current.json`, `gc/pending.json`, snapshot) | the `*_SCHEMA_VERSION` constants in `packages/protocol/src/constants.ts` | 3 / 1 / 1 |
 | **`layout_version`** | bucket key-layout axis only | deferred; reserved namespace per [ADR-003](../../adr/003-layout-versioning-cordon.md) | implicit 1 (absent) |
-| **Conformance corpus version** | checked-in fixture/test-data artifact | not yet introduced (Tier B) | — |
+| **Conformance corpus version** | checked-in fixture/test-data artifact | not yet introduced | — |
 
 `LogEntry` carries **no** `schema_version`. It is versionless and
 additive-only by decision — see
@@ -79,8 +79,7 @@ second implementation exists:**
 - After `1.0`: it requires a **major** bump (aligns with the API surface
   lock's v1.0 hardening trigger — there is one hardening story, not two).
 - Fixture regeneration requires a changeset, a schema/version impact
-  note, and a fixture-diff summary (a future Tier B drift gate is
-  planned to enforce the mechanics).
+  note, and a fixture-diff summary.
 - Keep at least one previous-corpus readback fixture after the first
   compatibility promise.
 
@@ -96,5 +95,5 @@ second implementation exists:**
   both gate it.
 - **`layout_version`**: do not add until a real key-layout change
   exists; that is an ADR-003 amendment, not a silent matrix edit.
-- **Corpus version**: introduced by Tier B; until then the matrix
-  records `null` / `not-yet-introduced`.
+- **Corpus version**: not yet introduced; the matrix records `null` /
+  `not-yet-introduced`.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -26,8 +26,7 @@ Binding descriptions of how the live protocol behaves today.
 - [storage-compatibility.md](storage-compatibility.md) — the minimal S3 API
   surface the protocol depends on.
 - [capabilities.md](capabilities.md) — required-vs-optional storage
-  capability split (CAS mandatory; supportsAbort optional; ReaderStorage
-  tier planned).
+  capability split (CAS mandatory; supportsAbort optional).
 - [log-entry-shape.md](log-entry-shape.md) — the `LogEntry` wire
   contract. Debezium-style CDC envelope; versionless/additive-only
   `0.3.0` public early-access baseline, with pre-1.0 breaks following

--- a/docs/spec/capabilities.md
+++ b/docs/spec/capabilities.md
@@ -2,8 +2,8 @@
 title: Storage capabilities — required vs optional
 audience: spec
 doc_type: current-contract
-summary: What a backend MUST support to certify as full Storage (CAS, exactly-one-winner), what is optional, and the planned read-only ReaderStorage tier.
-last-reviewed: 2026-07-03
+summary: What a backend MUST support to certify as full Storage (CAS, exactly-one-winner), and what is optional.
+last-reviewed: 2026-07-16
 tags: [storage, conformance, capabilities, cas, contract]
 related: ["sync-protocol.md", "storage-compatibility.md"]
 ---
@@ -62,14 +62,3 @@ Until the suite grows structured waiver metadata, any **new** optional
 skip MUST carry an **owner and an expiry** in the call-site comment next
 to the opt-out. A bare boolean opt-out with no owner/expiry trail is a
 review defect.
-
-## Planned: `ReaderStorage` (read-only tier)
-
-A read-only implementation (e.g. an analytics-only Python client) need
-not implement conditional writes. The planned `ReaderStorage` interface
-exposes only `get` + `list` and certifies against a read-only subset of
-the conformance suite. **Not yet implemented** — there is one monolithic
-`Storage` today. When introduced, write certification stays gated on the
-full CAS/race blocks above; `ReaderStorage` certification covers reads
-only. This tier is the home for the roadmap's read-only Python
-milestones (Tier E, M1–M3).

--- a/docs/spec/causal-consistency-checking.md
+++ b/docs/spec/causal-consistency-checking.md
@@ -298,7 +298,7 @@ Seeded replay: the cascade logs an integer `seed` at start and dumps the
 observed schedule on any causal-consistency violation, so a failing
 interleaving can be inspected and the injected entropy replayed by
 passing the seed back. (Timer-driven interleaving remains wall-clock
-dependent; fully deterministic replay is future work.)
+dependent, so replay is not fully deterministic.)
 
 ## Conclusion
 

--- a/docs/spec/s3-xml-escaping-cases.md
+++ b/docs/spec/s3-xml-escaping-cases.md
@@ -144,7 +144,3 @@ A malformed percent-escape (a bare `%` or `%ZZ`) in a key field makes
 `BaerlyError("InvalidResponse")` so the storage layer surfaces a typed,
 catchable error rather than an unhandled runtime exception (covered by
 `xml.test.ts`).
-
-> Latent hardening (noted as an invariant, not yet implemented):
-> `baerly doctor --bucket` should probe that the backend honors
-> `encoding-type=url`.

--- a/packages/dev/README.md
+++ b/packages/dev/README.md
@@ -13,10 +13,6 @@ Currently:
   cross-`Baerly`-instance visibility without standing up Minio. Single-
   process design center; multi-process scenarios should use Minio.
 
-Planned (stubs):
-
-- miniflare runner for Worker-side dev.
-
 Dependency direction is one-way: `@baerly/dev` → `@baerly/protocol`.
 Never import the other way around.
 

--- a/packages/protocol/src/indexes.ts
+++ b/packages/protocol/src/indexes.ts
@@ -51,10 +51,7 @@ export interface IndexDefinition {
    * clause on the final indexed field beyond that equality prefix.
    *
    * Top-level fields only — dotted-path `on` values throw
-   * `SchemaError` from `projectIndexValues`. A future change widens
-   * the projector to dotted paths (mirroring what
-   * `packages/server/src/query.ts` already does on the predicate
-   * side).
+   * `SchemaError` from `projectIndexValues`.
    */
   readonly on: string | readonly string[];
 


### PR DESCRIPTION
Makes the checked-in tree a point-in-time snapshot by removing references to unshipped future work. Guiding rule for every edit: keep a future reference **only** if it frames the thesis or defines the project as it is now; otherwise remove it, since the tree is what an LLM reads zero-shot and "planned X" prose misleads that reader.

## Changes

- **Remove** unshipped features / TODOs / internal ticket refs:
  - `ReaderStorage` read-only tier (`capabilities.md`, spec `README`)
  - planned miniflare dev-runner stub note (`packages/dev/README.md`)
  - not-yet-implemented `baerly doctor` probe TODO (s3-xml spec)
  - future-work code comments (`protocol/indexes.ts` dotted-path widen, `bench/storage.ts` "ticket 50") — comment-only, no behavior change
- **Rewrite** to keep the present-tense core, drop the tracking tail:
  - conformance-corpus axis stated in present tense, "Tier B" roadmap label dropped (`versioning.md`, ADR-005)
  - non-binding "Likely v2 shape" speculation dropped from ADR-003 (the present deferred-axis decision stays)
  - replay + fold-cost limits described in present tense (causal-consistency spec, `bench/fold-cost.ts`)

## Scope note

A further change that would have dropped the `"Tier B golden bucket fixtures"` sentinel from the version-matrix JSON/guard/test was **deliberately excluded** as churn — that string legitimately survives on `main`.

## Verification

`pnpm verify` exits 0 (typecheck, lint, examples, format, docs + mermaid validation, `check-spec-drift`, `check-version-matrix`). The comment-only commit also passed `pnpm bundle-sizes`. A repo-wide sweep confirms no removed pattern survives except the intentionally-kept sentinel.