### PR TITLE
docs: route speculative work + key corpus sentinel on state

### DIFF
--- a/docs/contributing/conventions/change-discipline.md
+++ b/docs/contributing/conventions/change-discipline.md
@@ -2,7 +2,7 @@
 title: Conventions for changing code
 audience: coder
 summary: How to make non-trivial changes — fix at the root, understand before changing, hold the surface to a best-in-class DX bar, no silent compat shims, one canonical form per operation, types over JSDoc.
-last-reviewed: 2026-06-28
+last-reviewed: 2026-07-17
 tags: [conventions, discipline]
 related: [docs.md, tests.md, "../../about/thesis.md"]
 ---
@@ -168,6 +168,25 @@ one-canonical-form test _but_ satisfies one of these three tests stays:
    happy-path PaaS audience doesn't need (Dockerfile, `healthz`,
    explicit Node start entry) stay if they unblock a real
    deploy population.
+
+## Where speculative work goes
+
+The checked-in tree describes what *is* — present tense, so an LLM reads it
+zero-shot without mistaking aspiration for contract. Future-work prose does not
+belong inline in specs, reference docs, or source comments. When an idea surfaces,
+route it by its commitment level; commitment is signaled by an affirmative act
+(filing, labeling, merging), never by the mere existence of a written note.
+
+- **Present-tense decision** (a real boundary the project holds) → stays in the
+  tree. Non-goals (thesis § "What this deliberately is not", README § "When (not)
+  to use it") and ADR "deferred axis" *decisions* are "what is" and belong here.
+  Keep the decision; drop the speculative *mechanism* — record that an axis is
+  deferred, not the shape it might one day take.
+- **Concrete, would-probably-accept-a-PR** → a GitHub Issue, `backlog` label, no
+  milestone. An open issue means "intent," not "scheduled."
+- **Fuzzy / strategic / "wouldn't it be nice"** → GitHub Discussions, off the
+  tree. Keep it out of the repo so a written note is never mistaken for a
+  commitment the project has made.
 
 ## Operator-burden test for new mechanisms
 

--- a/docs/contributing/version-matrix.json
+++ b/docs/contributing/version-matrix.json
@@ -38,6 +38,6 @@
   "corpusVersion": {
     "value": null,
     "status": "not-yet-introduced",
-    "introducedBy": "Tier B golden bucket fixtures"
+    "source": "docs/contributing/conventions/versioning.md"
   }
 }

--- a/scripts/check-version-matrix.ts
+++ b/scripts/check-version-matrix.ts
@@ -23,7 +23,7 @@ export type MatrixShape = {
     LogEntry: { value: null; policy: string };
   };
   layoutVersion: { value: number; implicit: boolean; deferred: boolean };
-  corpusVersion: { value: null; status: "not-yet-introduced" | "introduced"; introducedBy: string };
+  corpusVersion: { value: null; status: "not-yet-introduced" | "introduced"; source: string };
 };
 
 /** The live code-derived axes the matrix must not diverge from. */
@@ -46,9 +46,10 @@ export type PackageIdentity = {
 /**
  * Structural invariants `--write` must NOT auto-fix: the package
  * lockstep, and the doc-only sentinels (LogEntry / layout / corpus).
- * Each names a conscious decision that needs an ADR, not a silent matrix
- * edit, so a mismatch blocks even regeneration. Returns human-readable
- * violation messages ([] = clean).
+ * Each names a conscious decision governed by an owning doc (an ADR for
+ * LogEntry / layout, the versioning guide for the not-yet-introduced
+ * corpus axis), not a silent matrix edit, so a mismatch blocks even
+ * regeneration. Returns human-readable violation messages ([] = clean).
  *
  * Package semver's *value* is a governed drift axis (see
  * `collectDriftViolations`), not a structural one: `changeset:version`
@@ -101,13 +102,9 @@ export const collectStructuralViolations = (
       "layoutVersion sentinel changed; this needs an ADR-003 amendment, not a silent matrix edit",
     );
   }
-  if (
-    matrix.corpusVersion.value !== null ||
-    matrix.corpusVersion.status !== "not-yet-introduced" ||
-    matrix.corpusVersion.introducedBy !== "Tier B golden bucket fixtures"
-  ) {
+  if (matrix.corpusVersion.value !== null || matrix.corpusVersion.status !== "not-yet-introduced") {
     out.push(
-      "corpusVersion sentinel changed; introduce the Tier B corpus gate before changing the matrix",
+      "corpusVersion sentinel changed; the corpus version is not yet introduced — do not add it via a silent matrix edit",
     );
   }
   return out;

--- a/tests/unit/version-matrix.test.ts
+++ b/tests/unit/version-matrix.test.ts
@@ -24,7 +24,7 @@ const baseMatrix = (): MatrixShape => ({
   corpusVersion: {
     value: null,
     status: "not-yet-introduced",
-    introducedBy: "Tier B golden bucket fixtures",
+    source: "docs/contributing/conventions/versioning.md",
   },
 });
 


### PR DESCRIPTION
Two follow-ups to the `docs/remove-future-work-references` cleanup that did not make it into that merge.

## Commits

- **`refactor(version-matrix): key corpus sentinel on state, not a roadmap name`** — The `corpusVersion` axis is a reserved-but-not-yet-introduced slot. Its guard keyed off the roadmap string `"Tier B golden bucket fixtures"`, which had already been removed from the `versioning.md` prose in the merged branch — so guard and doc had drifted. Represent the slot the way every other axis does: guard-checked state (`value: null` + `status`) plus a non-load-bearing `source:` doc pointer. Dropping the `introducedBy` check costs no protection — flipping the slot to introduced still trips on `value` or `status`. The `source:` points at the versioning guide rather than an ADR (as LogEntry/layout do), because no corpus ADR exists and the guide is what documents the axis; the guard JSDoc now records that distinction.

- **`docs(change-discipline): document where speculative work goes`** — Adds a "Where speculative work goes" section: the tree describes what *is* in present tense, and an idea is routed by commitment level — present-tense decision stays in the tree, concrete would-accept-a-PR goes to a GitHub Issue, fuzzy/strategic goes to GitHub Discussions.

## Verification

`pnpm verify:agent` + `pnpm test:agent` green (corpus commit, carried from the prior branch); `pnpm verify:docs` green for the change-discipline edit; lefthook pre-commit gates passed on both commits.