### PR TITLE
chore(dependabot): drop redundant github-actions label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,5 +54,7 @@ updates:
       prefix: "ci"
       include: "scope"
     labels:
+      # npm version updates are disabled (see header), so every Dependabot PR
+      # here is a GitHub Actions bump — `dependencies` alone identifies them.
+      # A separate `github-actions` label added no filter value, so it's gone.
       - "dependencies"
-      - "github-actions"


### PR DESCRIPTION
npm version updates are disabled in this Dependabot config, so every PR in the GitHub Actions ecosystem block is an Actions bump. The `dependencies` label already identifies them, so the extra `github-actions` label added no filtering value.

This drops `github-actions` and replaces it with a comment explaining why the single `dependencies` label suffices.

Config-only; no code or lockfile changes.