### PR TITLE
fix(server): keep InternalMaintenanceOptions off the published .d.ts

### DIFF
--- a/.changeset/unpublish-internal-maintenance-options.md
+++ b/.changeset/unpublish-internal-maintenance-options.md
@@ -1,0 +1,56 @@
+---
+"@gusto/baerly-storage": patch
+---
+
+Stop publishing `InternalMaintenanceOptions` from
+`@gusto/baerly-storage/maintenance`.
+
+The type is documented as reachable only through the
+`@baerly/server/_internal/testing` subpath, which is deliberately absent
+from `publishConfig.exports`. It was nonetheless declared with
+`export interface` in `maintenance.ts` — a published entry point — so it
+landed in `dist/maintenance.d.ts` anyway.
+
+That mattered beyond the doc drift, because its `compact` / `gc` fields
+are typed as the `Internal*` widenings. Those are not name-exported, but
+they are reachable *structurally* through the field types, so an
+external caller got every internal knob with no cast and no `any`:
+
+```ts
+const o: InternalMaintenanceOptions = { gc: { graceMillis: 0 } };
+await runScheduledMaintenance(args, o); // forwarded straight to runGc
+```
+
+`graceMillis` is the one that matters. `GC_GRACE_PERIOD_MILLIS`
+documents that production MUST NOT go below the default outside a
+maintenance window, since that risks deleting an anchor a writer is
+about to find on retry. `0` is a valid integer, so no amount of input
+validation inside `runGc()` can tell it from a legitimate call — the
+only control is keeping the type off the published surface.
+
+Both option types move to a new non-published `maintenance-options.ts`,
+and `maintenance.ts` re-exports only the public `MaintenanceOptions`.
+That is the shape `compactor.ts` and `gc.ts` already had — declare the
+`Internal*` widening beside its public sibling in a module that is not
+an entry point — which `maintenance.ts` could not have, being published
+itself. Type-only throughout, so it erases at build time and no bundle
+axis moves. `MaintenanceOptions` is still exported from
+`@gusto/baerly-storage/maintenance` under the same name; only the
+declaration site moved.
+
+`tests/integration/internal-types-unpublished.test.ts` gates this in two
+layers, because each covers the other's blind spot. A `@ts-expect-error`
+pin fails the typecheck if `{ gc: { graceMillis: 0 } }` ever stops being
+a type error on the published entry — exact, but only for that knob. A
+name scan then walks every `publishConfig.exports` `.d.ts` and rejects
+any exported name starting with `Internal` — broad, but keyed on a
+naming convention, so it would miss a widening named otherwise. The scan
+also asserts the emitter shape it parses (trailing `export { ... }`
+blocks, which is what rolldown-dts produces): an inline
+`export interface` or an `export *` would otherwise yield no match and
+pass vacuously instead of going red.
+
+Typed as a `patch` deliberately. Removing an exported type is normally
+breaking, but this one is `@internal`, was never documented as public,
+and reaching it required consuming a type the package explicitly
+disclaims — so there is no supported usage to break.

--- a/packages/server/src/_internal/testing.ts
+++ b/packages/server/src/_internal/testing.ts
@@ -11,7 +11,7 @@
  */
 export type { InternalCompactOptions } from "../compactor.ts";
 export type { InternalRunGcOptions } from "../gc.ts";
-export type { InternalMaintenanceOptions } from "../maintenance.ts";
+export type { InternalMaintenanceOptions } from "../maintenance-options.ts";
 export { type CommitInput, type CommitResult, type WriterOptions, Writer } from "../writer.ts";
 export { assertPathSegment, MAX_SEGMENT_BYTES } from "../path-segment.ts";
 export {

--- a/packages/server/src/maintenance-options.ts
+++ b/packages/server/src/maintenance-options.ts
@@ -1,0 +1,57 @@
+/**
+ * Option types for `runScheduledMaintenance`, split out of
+ * `./maintenance.ts` because that module is a published entry point.
+ *
+ * `compactor.ts` and `gc.ts` declare their `Internal*` widening right
+ * next to the public sibling, which is safe because neither module is
+ * published and `maintenance.ts` re-exports only the narrow names.
+ * `maintenance.ts` has no such luxury — an `export interface` there
+ * lands in `dist/maintenance.d.ts` directly. Holding BOTH types here
+ * restores the same shape: a non-published module declares the pair,
+ * the published entry re-exports only the public one.
+ */
+import type { CompactOptions, InternalCompactOptions } from "./compactor.ts";
+import type { InternalRunGcOptions, RunGcOptions } from "./gc.ts";
+
+export interface MaintenanceOptions {
+  /** Forwarded to `compact()`. */
+  readonly compact?: CompactOptions;
+  /** Forwarded to `runGc()`. */
+  readonly gc?: RunGcOptions;
+  /** Forwarded to both primitives. */
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Internal-only widening of {@link MaintenanceOptions}. Surfaced via
+ * the `@baerly/server/_internal/testing` subpath (NOT in the published
+ * `publishConfig.exports`); production callers should use
+ * {@link MaintenanceOptions}.
+ *
+ * Publishing it would leak more than the name. The `compact` / `gc`
+ * fields are typed as the `Internal*` widenings, and field types are
+ * reachable structurally even when they are not themselves
+ * name-exported — so an external caller reaches every knob with no
+ * cast and no `any`:
+ *
+ * ```ts
+ * const o: InternalMaintenanceOptions = { gc: { graceMillis: 0 } };
+ * await runScheduledMaintenance(args, o); // forwarded straight to runGc
+ * ```
+ *
+ * `graceMillis` is the one that matters: `GC_GRACE_PERIOD_MILLIS`
+ * documents that production MUST NOT go below the default outside a
+ * maintenance window, since that risks deleting an anchor a writer is
+ * about to find on retry. `0` is a perfectly valid number, so no input
+ * validation can catch it — keeping the type unpublished is the only
+ * control that works. Pinned by
+ * `tests/integration/internal-types-unpublished.test.ts`.
+ *
+ * @internal
+ */
+export interface InternalMaintenanceOptions extends MaintenanceOptions {
+  /** @internal Internal compact options (budget caps). */
+  readonly compact?: InternalCompactOptions;
+  /** @internal Internal GC options (budget caps + clock seam + grace). */
+  readonly gc?: InternalRunGcOptions;
+}

--- a/packages/server/src/maintenance.test.ts
+++ b/packages/server/src/maintenance.test.ts
@@ -41,12 +41,12 @@ import {
   crossesGcBoundary,
   dispatchInlineAwaited,
   estimateTailBytes,
-  type InternalMaintenanceOptions,
   parseMaintenanceEnv,
   runBoundedMaintenance,
   runScheduledMaintenance,
   shouldFireMaintenance,
 } from "./maintenance.ts";
+import type { InternalMaintenanceOptions } from "./maintenance-options.ts";
 import { probeTailFrom } from "./log-tail.ts";
 import { createObservabilityContext, runWithContext } from "./observability/context.ts";
 import { RequestScopedMetricsRecorder } from "./observability/recorder.ts";

--- a/packages/server/src/maintenance.ts
+++ b/packages/server/src/maintenance.ts
@@ -36,13 +36,9 @@ import {
   readCurrentJson,
   WRITE_TICK_MIN_ENTRIES_TO_COMPACT,
 } from "@baerly/protocol";
-import {
-  compact,
-  type CompactOptions,
-  type CompactResult,
-  type InternalCompactOptions,
-} from "./compactor.ts";
-import { runGc, type InternalRunGcOptions, type RunGcOptions, type RunGcResult } from "./gc.ts";
+import { compact, type CompactResult, type InternalCompactOptions } from "./compactor.ts";
+import { runGc, type InternalRunGcOptions, type RunGcResult } from "./gc.ts";
+import type { InternalMaintenanceOptions, MaintenanceOptions } from "./maintenance-options.ts";
 import { probeTailFrom } from "./log-tail.ts";
 import { getCurrentContext } from "./observability/context.ts";
 
@@ -55,35 +51,15 @@ export {
   type RebuildIndexResult,
   rebuildIndex,
 } from "./rebuild-index.ts";
+// Public half only. `InternalMaintenanceOptions` is declared alongside
+// it but deliberately NOT re-exported here — this is a published entry,
+// and re-exporting the widening is exactly the leak being fixed.
+export type { MaintenanceOptions } from "./maintenance-options.ts";
 
 export interface MaintenanceArgs {
   readonly storage: Storage;
   /** Full bucket-relative key of the CAS pointer for the target collection. */
   readonly currentJsonKey: string;
-}
-
-export interface MaintenanceOptions {
-  /** Forwarded to `compact()`. */
-  readonly compact?: CompactOptions;
-  /** Forwarded to `runGc()`. */
-  readonly gc?: RunGcOptions;
-  /** Forwarded to both primitives. */
-  readonly signal?: AbortSignal;
-}
-
-/**
- * Internal-only widening of {@link MaintenanceOptions}. Surfaced via
- * the `@baerly/server/_internal/testing` subpath (NOT in the
- * published `publishConfig.exports`); production callers should use
- * {@link MaintenanceOptions}.
- *
- * @internal
- */
-export interface InternalMaintenanceOptions extends MaintenanceOptions {
-  /** @internal Internal compact options (budget caps). */
-  readonly compact?: InternalCompactOptions;
-  /** @internal Internal GC options (budget caps + clock seam + grace). */
-  readonly gc?: InternalRunGcOptions;
 }
 
 export interface MaintenanceResult {

--- a/tests/integration/internal-types-unpublished.test.ts
+++ b/tests/integration/internal-types-unpublished.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Anti-leak gate for the `Internal*Options` widenings.
+ *
+ * Each of `compact()` / `runGc()` / `runScheduledMaintenance()` takes a
+ * narrow public options type, with an `Internal*Options` widening that
+ * carries budget caps, clock seams, and the GC grace override. Those
+ * widenings are meant to reach test fixtures and the CLI through the
+ * `@baerly/server/_internal/testing` subpath, which is deliberately
+ * absent from `publishConfig.exports`.
+ *
+ * The failure this catches is subtle: a widening only has to be
+ * `export`ed from a module that HAPPENS to be a published entry point
+ * for it to land in that entry's `.d.ts`. It then pulls its transitive
+ * internal field types along structurally, even when those are not
+ * themselves name-exported — so an external caller reaches every knob
+ * with no cast and no `any`:
+ *
+ * ```ts
+ * const o: InternalMaintenanceOptions = { gc: { graceMillis: 0 } };
+ * await runScheduledMaintenance(args, o);
+ * ```
+ *
+ * `graceMillis: 0` is the sharp edge. `GC_GRACE_PERIOD_MILLIS` states
+ * that production MUST NOT go below the default outside a maintenance
+ * window, because that risks deleting an anchor a writer is about to
+ * find on retry. It is also a perfectly ordinary integer, so no input
+ * validation in `runGc()` can distinguish it from a legitimate call —
+ * keeping the type off the published surface is the only control.
+ *
+ * The gate has two layers, because each covers the other's blind spot:
+ *
+ *   1. A compile-time pin on the knob that actually risks data loss.
+ *      `@ts-expect-error` fails `tsgo --noEmit` if the call ever STOPS
+ *      being an error, so it pins the invariant itself rather than a
+ *      naming convention. Narrow but exact.
+ *   2. A name scan over every published entry `.d.ts`. Broad — it covers
+ *      entries nobody thought to pin — but its predicate is the
+ *      `Internal` prefix, which is a convention, not a contract. A
+ *      widening named otherwise would pass.
+ *
+ * Layer 2 reads the built `dist/`, so it depends on the `pretest` build
+ * the way `bundle-size.test.ts` does. Layer 1 resolves through the dev
+ * `exports` map and needs no build.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+import { type MaintenanceArgs, runScheduledMaintenance } from "@baerly/server/maintenance";
+
+const pkgRoot = resolve(__dirname, "../..");
+const pkg = JSON.parse(readFileSync(resolve(pkgRoot, "package.json"), "utf8")) as {
+  publishConfig: { exports: Record<string, { types?: string }> };
+};
+
+/**
+ * Collect the names an entry `.d.ts` exports. Handles `export {...}` and
+ * `export type {...}`, the inline `type ` modifier, and `X as Y` (the
+ * exported name is `Y`).
+ *
+ * Deliberately understands ONLY the trailing-brace form, which is what
+ * rolldown-dts emits today: a source-level `export interface Foo` arrives
+ * here as `declare interface Foo` plus a `Foo` entry in the trailing
+ * block. Rather than grow a parser for declaration forms that never
+ * appear, the caller asserts that precondition — see
+ * {@link assertBraceExportShape}.
+ */
+const exportedNames = (source: string): string[] =>
+  [...source.matchAll(/export\s+(?:type\s+)?\{([^}]*)\}/g)]
+    .flatMap((m) => m[1]!.split(","))
+    .map((spec) => spec.trim().replace(/^type\s+/, ""))
+    .map((spec) => (spec.includes(" as ") ? spec.slice(spec.lastIndexOf(" as ") + 4) : spec))
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0);
+
+/**
+ * Assert the emitter shape {@link exportedNames} depends on.
+ *
+ * Without this, the scan is unsound rather than merely incomplete: an
+ * inline `export interface InternalFoo` or an `export * from ...`
+ * produces no match, so the name silently vanishes and the entry passes
+ * — and the `names.length > 0` non-vacuity check does NOT save us,
+ * because unrelated brace exports on the same entry satisfy it.
+ *
+ * Asserting the precondition converts that silent degradation into a red
+ * test: if rolldown-dts ever changes shape, a human looks.
+ *
+ * Stated as a closed allow list — every top-level `export` line must be
+ * a brace re-export — rather than a deny list of declaration forms. A
+ * deny list has to enumerate `interface | type | class | const |
+ * function | enum | namespace | let | var | abstract class | default`
+ * and stays wrong the moment TypeScript grows another one; each miss is
+ * a silent pass, which is the exact failure this guard exists to
+ * prevent. The allow list is closed in both directions and shorter.
+ *
+ * Line-anchored on purpose: entry `.d.ts` files are not all thin shims
+ * (`./http` inlines ~1600 lines of `declare` + JSDoc), and a fenced
+ * `@example` can contain `export default {...}` — always indented under
+ * ` * `, so a true column-0 anchor skips it.
+ */
+const assertBraceExportShape = (source: string): void => {
+  const exportLines = source.split("\n").filter((line) => line.startsWith("export"));
+  expect(exportLines.length).toBeGreaterThan(0);
+  expect(exportLines.filter((line) => !/^export\s+(?:type\s+)?\{/.test(line))).toEqual([]);
+};
+
+const publishedEntries = Object.entries(pkg.publishConfig.exports)
+  .map(([subpath, cond]) => ({ subpath, types: cond.types }))
+  .filter((e): e is { subpath: string; types: string } => e.types !== undefined);
+
+describe("internal option widenings stay off the published type surface", () => {
+  test("publishConfig declares at least one typed entry (guards a vacuous pass)", () => {
+    expect(publishedEntries.length).toBeGreaterThan(0);
+  });
+
+  test.each(publishedEntries)("$subpath exports no Internal* name", ({ types }) => {
+    const source = readFileSync(resolve(pkgRoot, types), "utf8");
+    assertBraceExportShape(source);
+
+    const names = exportedNames(source);
+    // Non-vacuous: every published entry exports *something*.
+    expect(names.length).toBeGreaterThan(0);
+    expect(names.filter((n) => n.startsWith("Internal"))).toEqual([]);
+  });
+
+  test("no `_internal/*` subpath is published", () => {
+    // Scoped to the ROOT package's map (`@gusto/baerly-storage`), the only
+    // one that ships: `@baerly/server` is `private: true`, so its own
+    // `publishConfig` never executes and its `./_internal/*` subpaths are
+    // in-repo-only by construction. What this guards is someone adding an
+    // `_internal` subpath HERE to let bench/e2e reach internals through
+    // the published package — which would ship the widenings wholesale.
+    const internal = Object.keys(pkg.publishConfig.exports).filter((s) =>
+      s.startsWith("./_internal"),
+    );
+    expect(internal).toEqual([]);
+  });
+
+  test("the published maintenance surface rejects the internal GC grace override", () => {
+    // The exact invariant, pinned at compile time rather than by name.
+    // `@baerly/server/maintenance` and the published `./maintenance`
+    // subpath resolve to the same module (`packages/server/src/
+    // maintenance.ts`), so this covers the shipped entry.
+    //
+    // Never invoked — the assertion IS the `@ts-expect-error`. It fails
+    // `tsgo --noEmit` if this stops being a type error, i.e. if
+    // `graceMillis` becomes reachable from the published options type
+    // again. The runtime `expect` below only keeps the binding used.
+    const reopenedLeak = (args: MaintenanceArgs) =>
+      runScheduledMaintenance(
+        args,
+        // @ts-expect-error — `graceMillis` is an `InternalRunGcOptions`
+        // knob; the published `RunGcOptions` is `{ signal? }` only.
+        // GC_GRACE_PERIOD_MILLIS: production MUST NOT go below the default.
+        { gc: { graceMillis: 0 } },
+      );
+
+    expect(reopenedLeak).toBeTypeOf("function");
+  });
+});


### PR DESCRIPTION
## What

`InternalMaintenanceOptions` is documented as reachable only through the `@baerly/server/_internal/testing` subpath, which is deliberately absent from `publishConfig.exports`. It was still declared `export interface` in `maintenance.ts` — a published entry point — so it shipped in `dist/maintenance.d.ts` anyway.

## Why it matters beyond doc drift

Its `compact` / `gc` fields are typed as the `Internal*` widenings. Those are *not* name-exported, but field types are reachable structurally, so an external caller got every internal knob with no cast and no `any`. This typechecks clean against the published `.d.ts` on `main` today:

```ts
import { runScheduledMaintenance, type InternalMaintenanceOptions }
  from "@gusto/baerly-storage/maintenance";

const o: InternalMaintenanceOptions = { gc: { graceMillis: 0, now: () => new Date(0) } };
await runScheduledMaintenance(args, o);   // forwarded straight into runGc
```

`graceMillis` is the sharp edge. `GC_GRACE_PERIOD_MILLIS` (`constants.ts:239`) states:

> Production code MUST NOT call `runGc` with `graceMillis` below the default outside maintenance windows — going below the longest plausible writer-retry latency risks deleting an anchor a writer is about to find on retry.

`0` is an ordinary integer, so no input validation inside `runGc()` can separate it from a legitimate call. Keeping the type unpublished is the only control that works.

## How

`compactor.ts` and `gc.ts` never had this problem. Each declares its `Internal*` widening directly beside its public sibling, and `maintenance.ts` re-exports only the narrow name. That works because neither module is itself an entry point. `maintenance.ts` is, so it could not host the pair.

This restores the same shape:

- **Both** option types move to a new non-published `packages/server/src/maintenance-options.ts`, and `maintenance.ts` re-exports only the public `MaintenanceOptions`. Moving just the internal type would not have been enough — anything declaring `InternalMaintenanceOptions extends MaintenanceOptions` still has to import from `maintenance.ts`, which leaves a type-only import cycle. Moving the public half too is what removes it.
- `_internal/testing.ts` goes back to being a pure barrel: three parallel `export type` re-exports, no declaration of its own.
- `maintenance-options.ts` imports only from `compactor.ts` / `gc.ts`, and nothing on the `maintenance.ts` side is imported back into it, so no cycle forms.
- `maintenance-e2e.test.ts` and `bench/maintenance-backlog.ts` already reached the widening through the internal subpath; only the sibling `maintenance.test.ts` needed repointing.

`MaintenanceOptions` is still exported from `@gusto/baerly-storage/maintenance` under the same name — only its declaration site moved. Type-only throughout, so it all erases at build.

## Regression gate

`tests/integration/internal-types-unpublished.test.ts` gates this in two layers, because each covers the other's blind spot.

1. **A compile-time pin on the knob that actually risks data loss.** A `@ts-expect-error` on `{ gc: { graceMillis: 0 } }` against the published entry fails `tsgo --noEmit` the moment that stops being a type error. It pins the invariant itself rather than a naming convention — exact, but only for that one knob.
2. **A name scan over every published entry `.d.ts`.** Walks all 14 `publishConfig.exports` entries and rejects any exported name starting with `Internal`. Broad enough to cover entries nobody thought to pin, but its predicate is a naming convention, so a widening named otherwise would slip past.

Both layers were mutation-verified rather than assumed:

- Changing the pinned call to `{ gc: {} }` (i.e. the leak "reopens") makes `tsgo` fail with `TS2578: Unused '@ts-expect-error' directive`.
- Re-exporting `InternalMaintenanceOptions` from `maintenance.ts` and rebuilding makes the scan fail with `expected [ 'InternalMaintenanceOptions' ] to deeply equal []`.

That second case is worth noting: layer 1 does **not** catch a bare re-export, because re-exporting the type does not make `graceMillis` assignable to `runScheduledMaintenance`'s options parameter. The layers are complementary, not redundant.

The scan also asserts the emitter shape it parses. Whatever else a published entry `.d.ts` holds — some are near-empty shims, others (`./http` at 1638 lines, `./auth`, `./cloudflare`) inline their declarations — rolldown-dts names the public surface in one trailing `export { ... }` block, and that block is the only thing the scan reads. An inline `export interface` or an `export *` would match nothing and pass vacuously, and the `names.length > 0` non-vacuity check would not save us, since unrelated brace exports on the same entry satisfy it. Asserting the precondition turns that silent degradation into a red test.

The precondition is a **closed allow list** — every column-0 `export` line must be a brace re-export — not a deny list of declaration forms. A deny list has to enumerate `interface | type | class | const | function | enum | namespace | let | var | abstract class | default`, and every form it forgets is a silent pass, i.e. the exact failure the precondition exists to prevent. It also has the converse bug: `export type { ... }` is a legitimate re-export that the name parser already handles, but a `type\b` alternation rejects it, so an entry would go red spuriously the day rolldown-dts emits one. The allow list is closed in both directions, subsumes the separate `export *` assertion, and is shorter than what it replaces.

Column-0 anchoring is load-bearing rather than incidental: since entries are not all thin shims, a fenced `@example` in emitted JSDoc can contain `export default { fetch() {} }` — always indented under ` * `, so a true column-0 anchor skips it.

This layer was mutation-verified the same way, against a real entry rather than a synthetic string. Appending `export declare enum InternalKnob { A = 0 }` to `dist/maintenance.d.ts` **passes** under a deny list and fails under the allow list with `expected [ 'export declare enum InternalKnob { A = 0 }' ] to deeply equal []`. Same result for `export declare namespace`, `export declare abstract class`, `export declare let`, and `export default` — five forms a deny list waves through. `dist/` was restored byte-identical afterwards (shasum-compared).

## Verification

- `pnpm verify:agent` — exit 0
- `pnpm build && pnpm test:agent` — 2587 passed / 90 skipped, 187 files
- Every emitted `dist/**/*.js` is **byte-identical** to `origin/main` (all 57 files, shasum-compared across a build of each). Types erase; no bundle axis moves.
- Rebased onto `a8cc4a1f` and re-verified there, since the three upstream `log_seq_start` monotonicity commits touch `compactor.ts` and the `bundle-size.test.ts` budgets.

## Release note

Typed as a `patch` deliberately. Removing an exported type is nominally breaking, but this one is `@internal`, was never documented as public, and reaching it meant consuming a type the package explicitly disclaims — so there is no supported usage to break.

## Not in scope

Deliberately does **not** add input validation for `graceMillis` or `minEntriesToCompact`. `0` and `NaN` are respectively a valid value and equivalent to a valid value — this is a surface-area problem, not a validation one.

