### PR TITLE
fix: enforce log_seq_start monotonicity at both current.json floor writers

### DIFF
--- a/.changeset/current-json-floor-monotonicity.md
+++ b/.changeset/current-json-floor-monotonicity.md
@@ -1,0 +1,44 @@
+---
+"@gusto/baerly-storage": patch
+---
+
+Enforce `log_seq_start` monotonicity on the `current.json` coordination
+object, and validate the compactor's seq-arithmetic options at the seam
+they arrive on.
+
+`casUpdateCurrentJson` now rejects a mutator that lowers the fold floor,
+throwing `BaerlyError{code:"Internal"}`; equality is still permitted,
+since a `tail_hint` refresh or `last_warned_seq` stamp holds the floor
+fixed. No *production* mutator writes the floor, so no shipping caller
+could regress it — this closes the gap for future ones, where a lowered
+floor would let a stale long-poll cursor pass the
+`cursorSeq < log_seq_start` re-bootstrap check and silently resume into
+the wrong generation.
+
+`compact()` cannot route through that helper, because it must CAS on the
+etag of the read it folded from. It instead validates `maxEntriesPerRun`
+and `knownTail` as non-negative integers before any I/O, throwing
+`BaerlyError{code:"InvalidConfig"}`. That keeps its fold end monotone by
+construction, and it closes a non-finite input path in the same stroke.
+A `NaN` is false under every range comparison in the fold, so before
+this change it reached the CAS and wrote `log_seq_start: null`
+(`JSON.stringify` renders `NaN` as `null`), after which every read path
+— `admin restore --force` included, since it reads `current.json` before
+reaching its own floor exemption — fails with `InvalidResponse`.
+`snapshotKey` gained the same `Number.isInteger` check, so a non-finite
+seq can no longer be padded into a `…-00000000000NaN-…` filename. No
+in-tree caller supplies a non-finite value, but the seam is reachable
+from JS callers, from in-repo casts, and through the
+`@baerly/server/_internal/testing` subpath.
+
+`baerly admin restore --force` is unaffected and remains the one path
+that lowers the floor deliberately — a truncate reseeds to one past the
+highest surviving log object, which may be below the old floor when a
+budget-bounded GC sweep has left sub-floor objects behind.
+
+Out of scope, tracked as #73: `/v1/since` gates re-bootstrap on a
+bare `cursorSeq < log_seq_start` with no generation discriminator, so a
+`--force` reseed that lowers the floor lets a stale pre-restore cursor
+resume into the new generation and silently gap its stream. Until that
+is closed in code, `docs/guide/backups.md` documents draining long-poll
+readers as part of the cutover.

--- a/docs/guide/backups.md
+++ b/docs/guide/backups.md
@@ -167,7 +167,14 @@ restore performs only the initial `current.json` seed/reseed write.
 
 For production recovery, treat restore as a cutover to a proven copy,
 not as an overwrite of the live prefix. Do not restore over the live
-prefix while writers are still active. The safe cutover shape is:
+prefix while writers are still active. Drain or disconnect long-poll
+readers too, not just writers: a `--force` reseed can lower the
+collection's live log floor (`log_seq_start`), and long-poll clients
+detect a folded-away cursor by testing it against that floor, so a
+lowered floor lets a stale pre-restore cursor pass the check. Such a
+client silently resumes into the new generation instead of getting the
+re-bootstrap error, and misses restored rows below its cursor. The safe
+cutover shape is:
 
 1. Pause writers or put the app in read-only mode.
 2. Restore into a separate recovery bucket or tenant prefix.

--- a/docs/spec/sync-protocol.md
+++ b/docs/spec/sync-protocol.md
@@ -442,7 +442,9 @@ These are the load-bearing rules.
    than backend-guaranteed.
 5. **Snapshots cover a prefix.** If `log_seq_start > 0`,
    `current.snapshot` names a snapshot that covers
-   `[0, log_seq_start)`.
+   `[0, log_seq_start)` (carve-out: `baerly admin restore --force`
+   leaves `snapshot: null` with a possibly-positive floor, because a
+   truncate drops those entries rather than folding them).
 6. **`current.json` is compaction state; the commit path does not write
    it.** The compactor's fold CAS is the only steady-state writer of
    the snapshot pointer, `log_seq_start`, and snapshot counters.
@@ -474,6 +476,25 @@ These are the load-bearing rules.
     commit/read path uses the field for authority. Readers decide
     visibility from `seq`, the snapshot, the trusted log range, and the
     forward-probe.
+12. **The fold floor is monotone.** `current.json`'s `log_seq_start`
+    never decreases in steady state. `casUpdateCurrentJson`
+    (`packages/protocol/src/coordination/current-json.ts`) rejects a
+    mutator that lowers it with `BaerlyError{code:"Internal"}`; equality
+    is permitted, so a `tail_hint` refresh or a `last_warned_seq` stamp
+    holds the floor fixed. Two floor writers bypass that helper
+    (invariant 6 names the `current.json` writers). The compactor's fold
+    CAS (`packages/server/src/compactor.ts`) must CAS on the etag of the
+    read it folded from, so it issues its own `If-Match` PUT; it stays
+    monotone by construction instead, because its fold end is
+    `min(probedTail, log_seq_start + maxEntriesPerRun)` and both the
+    probed tail and the validated budget are `>= 0` relative to the
+    pre-fold floor. `baerly admin restore --force` is the deliberate
+    operator exemption: it reseeds a truncated collection to one past
+    the highest _surviving_ log object, which can sit below the old
+    floor when a bounded GC sweep has left sub-floor log objects in
+    place. That is sound because the reseed value is strictly greater
+    than every log object still present, so the committing `log/<seq>`
+    create cannot collide with the old generation.
 
 ## LSNs, wall clocks, and downstream consumers
 

--- a/packages/cli/src/admin/restore.test.ts
+++ b/packages/cli/src/admin/restore.test.ts
@@ -114,6 +114,117 @@ describe("baerly admin restore", () => {
     expect(head?.json.writer_fence.epoch).toBeGreaterThanOrEqual(1);
   });
 
+  test("--force may reset log_seq_start below the old floor — the deliberate admin exemption", async () => {
+    // `casUpdateCurrentJson` rejects any floor regression. `--force` is the
+    // one path that lowers the floor on purpose, and it reaches storage by
+    // its own If-Match PUT rather than through that helper. This test pins
+    // the exemption so it cannot be closed by accident.
+    //
+    // Why it is sound: the reseed floor is `max(listed log seq) + 1`, so it
+    // is strictly above every log object still present and the committing
+    // `log/<seq>` create cannot collide with the old generation. GC decides
+    // content liveness by reachability rather than by the floor, and the
+    // reseed sets `snapshot: null`, so the old generation becomes
+    // unreachable and is swept as `orphan-content` — the intent of
+    // truncating. See the FLOOR EXEMPTION comment in `restore.ts`.
+    //
+    // This case is the empty-prefix extreme (floor → 0); the next test
+    // covers the partial-sweep case, which is what actually happens under
+    // a budget-bounded GC.
+    await writeFile(stdinPath, CANONICAL_NDJSON, "utf8");
+    await expect(
+      runRestore(
+        [`--bucket=file://${root}`, `--app=${APP}`, `--tenant=${TENANT}`, `--collection=${COLL}`],
+        { streams: { stdin: createReadStream(stdinPath) } },
+      ),
+    ).resolves.toBe(0);
+
+    // Drive the collection to the post-compaction steady state: floor
+    // advanced to the tail, every stale log object swept by GC.
+    await casUpdateCurrentJson(storage, CURRENT_JSON_KEY, (c) => ({
+      ...c,
+      log_seq_start: c.tail_hint,
+    }));
+    for await (const entry of storage.list(`${TABLE_PREFIX}/log/`)) {
+      await storage.delete(entry.key);
+    }
+    const before = await readCurrentJson(storage, CURRENT_JSON_KEY);
+    expect(before?.json.log_seq_start).toBe(2);
+
+    await writeFile(stdinPath, `{"_id":"v-1","x":1}\n`, "utf8");
+    await expect(
+      runRestore(
+        [
+          `--bucket=file://${root}`,
+          `--app=${APP}`,
+          `--tenant=${TENANT}`,
+          `--collection=${COLL}`,
+          "--force",
+        ],
+        { streams: { stdin: createReadStream(stdinPath) } },
+      ),
+    ).resolves.toBe(0);
+
+    // The floor legitimately went 2 → 0: the log prefix was empty, so there
+    // was nothing to skip past.
+    const head = await readCurrentJson(storage, CURRENT_JSON_KEY);
+    expect(head?.json.log_seq_start).toBe(0);
+    expect(head?.json.tail_hint).toBe(1);
+  });
+
+  test("--force reseeds above surviving log objects even when that lowers the floor", async () => {
+    // The realistic shape, and the one the exemption's soundness argument
+    // actually rests on. GC's sweep is budget-bounded and walks `log/` in
+    // lex order, so it routinely clears the TOP of the old range while
+    // leaving sub-floor objects behind. The reseed must then land strictly
+    // above the highest survivor — which can be below the old floor.
+    //
+    // Here: fold the whole range (floor → 2), then sweep only `log/1`.
+    // `log/0` survives, so `truncatedNext` is 1 — below the old floor of 2,
+    // with an old-generation object still on the bucket. That refutes any
+    // "the floor only drops once every entry beneath it is gone" reading.
+    await writeFile(stdinPath, CANONICAL_NDJSON, "utf8");
+    await expect(
+      runRestore(
+        [`--bucket=file://${root}`, `--app=${APP}`, `--tenant=${TENANT}`, `--collection=${COLL}`],
+        { streams: { stdin: createReadStream(stdinPath) } },
+      ),
+    ).resolves.toBe(0);
+
+    await casUpdateCurrentJson(storage, CURRENT_JSON_KEY, (c) => ({
+      ...c,
+      log_seq_start: c.tail_hint,
+    }));
+    await storage.delete(`${TABLE_PREFIX}/log/1.json`);
+    const before = await readCurrentJson(storage, CURRENT_JSON_KEY);
+    expect(before?.json.log_seq_start).toBe(2);
+
+    await writeFile(stdinPath, `{"_id":"v-1","x":1}\n`, "utf8");
+    await expect(
+      runRestore(
+        [
+          `--bucket=file://${root}`,
+          `--app=${APP}`,
+          `--tenant=${TENANT}`,
+          `--collection=${COLL}`,
+          "--force",
+        ],
+        { streams: { stdin: createReadStream(stdinPath) } },
+      ),
+    ).resolves.toBe(0);
+
+    // Floor 2 → 1: strictly above the surviving `log/0`, and below the old
+    // floor. The survivor is still on the bucket — GC sweeps it later as an
+    // unreachable orphan, and readers never walk below the new floor.
+    const head = await readCurrentJson(storage, CURRENT_JSON_KEY);
+    expect(head?.json.log_seq_start).toBe(1);
+    const survivors: string[] = [];
+    for await (const entry of storage.list(`${TABLE_PREFIX}/log/`)) {
+      survivors.push(entry.key);
+    }
+    expect(survivors).toContain(`${TABLE_PREFIX}/log/0.json`);
+  });
+
   test("--force chooses old tail from log keys without decoding malformed old entries", async () => {
     await writeFile(stdinPath, CANONICAL_NDJSON, "utf8");
     const first = await runRestore(

--- a/packages/cli/src/admin/restore.ts
+++ b/packages/cli/src/admin/restore.ts
@@ -162,9 +162,46 @@ const bundle = defineBaerlySubcommand({
       const collectionPrefix = currentJsonKey.slice(0, currentJsonKey.lastIndexOf("/"));
       const truncatedNext = await tailFromListedLogKeys(bucket.storage, collectionPrefix);
       baseSeq = truncatedNext;
+      // FLOOR EXEMPTION — deliberate. `casUpdateCurrentJson` rejects any
+      // write that lowers `log_seq_start`; this PUT is not routed through
+      // it, so `--force` can reseed BELOW the old floor. (The compactor's
+      // fold CAS also bypasses that helper, but it is monotone by
+      // construction — it validates its seq-arithmetic options at the
+      // seam rather than asserting the floor at the fold. `--force` is
+      // the only path that intentionally lowers the floor.)
+      //
+      // Why lowering is sound. `truncatedNext` is strictly greater than
+      // every log object still on the bucket, so the writer's committing
+      // `log/<seq>` create cannot collide with an old-generation object —
+      // that 412 hazard is the whole point of the reseed (see above). It
+      // can land below the old floor whenever GC has swept the objects at
+      // the top of the old range but not all of them: the sweep is
+      // budget-bounded and walks `log/` in lex order (`0,1,10,11,2,...`),
+      // so sub-floor objects routinely survive a pass. Old floor 12 with
+      // `log/8`, `log/9` left behind yields `truncatedNext` 10 < 12.
+      //
+      // Nothing is lost by that. GC decides content liveness by
+      // reachability, not by the floor: it keeps a hash iff the hash is
+      // reachable from the current snapshot or from `[log_seq_start,
+      // tail)` (see `collectLiveContentHashes` in `gc.ts`). Resetting
+      // `snapshot` to `null` here makes the whole old generation
+      // unreachable, so its content is marked `orphan-content` and swept
+      // after the grace period — which is precisely what truncating
+      // means. Readers never see the survivors: they walk from the new
+      // floor, and `fsck` bounds itself by listed keys, so orphans below
+      // it produce no findings.
+      //
+      // Do not "repair" this with `Math.max`; that reseeds a floor above
+      // `tail_hint`, trips `assertCurrentJson`, and breaks truncate.
+      // `restore.test.ts` pins both the empty-prefix and partial-sweep
+      // cases.
       const reseeded: CurrentJson = {
         schema_version: CURRENT_JSON_SCHEMA_VERSION,
         snapshot: null,
+        // Also resets `tail_hint` unclamped, so an over-claimed old hint
+        // moves DOWN here (unlike the final stamp below, which clamps).
+        // Safe: the hint is a non-authoritative lower bound, and the
+        // forward-probe finds the true tail regardless.
         tail_hint: truncatedNext,
         log_seq_start: truncatedNext,
         writer_fence: {

--- a/packages/protocol/src/coordination/current-json.test.ts
+++ b/packages/protocol/src/coordination/current-json.test.ts
@@ -176,6 +176,29 @@ describe("casUpdateCurrentJson", () => {
       code: "InvalidResponse",
     });
   });
+
+  plainTest("rejects a mutator that lowers log_seq_start", async () => {
+    const s = new MemoryStorage();
+    await createCurrentJson(s, "k", seedJson({ tail_hint: 5000, log_seq_start: 5000 }));
+    await expect(
+      casUpdateCurrentJson(s, "k", (c) => ({ ...c, log_seq_start: 0 })),
+    ).rejects.toMatchObject({ code: "Internal" });
+    // The rejection must happen before the PUT — the floor on disk is intact.
+    const got = await readCurrentJson(s, "k");
+    expect(got!.json.log_seq_start).toBe(5000);
+  });
+
+  plainTest("permits a re-write that holds log_seq_start steady", async () => {
+    // The boundary: monotone means non-decreasing. A compactor pass that
+    // advances `tail_hint` without folding anything leaves the floor equal,
+    // and must not be rejected. Fails if the guard is written `<=`.
+    const s = new MemoryStorage();
+    await createCurrentJson(s, "k", seedJson({ tail_hint: 5000, log_seq_start: 5000 }));
+    await casUpdateCurrentJson(s, "k", (c) => ({ ...c, tail_hint: 6000 }));
+    const got = await readCurrentJson(s, "k");
+    expect(got!.json.log_seq_start).toBe(5000);
+    expect(got!.json.tail_hint).toBe(6000);
+  });
 });
 
 /**
@@ -308,6 +331,34 @@ describe("CurrentJson schema (PBT)", () => {
       snapshot_bytes: fc.integer({ min: 0, max: 1_000_000 }),
       snapshot_rows: fc.integer({ min: 0, max: 10_000 }),
     }),
+  );
+
+  test.prop({
+    initial: validCurrentJson,
+    delta: fc.integer({ min: -1000, max: 1000 }),
+  })(
+    "floor admission: the CAS accepts a floor move iff it does not decrease",
+    async ({ initial, delta }) => {
+      const s = new MemoryStorage();
+      await createCurrentJson(s, "k", initial);
+      const target = initial.log_seq_start + delta;
+      // Only exercise floors `assertCurrentJson` already accepts
+      // (`0 <= log_seq_start <= tail_hint`), so the sole possible
+      // rejection reason is the monotonicity admission check. This
+      // covers the whole ordering, not the two sampled points above.
+      if (target < 0 || target > initial.tail_hint) {
+        return;
+      }
+      const attempt = casUpdateCurrentJson(s, "k", (c) => ({ ...c, log_seq_start: target }));
+      const shouldReject = target < initial.log_seq_start;
+      if (shouldReject) {
+        await expect(attempt).rejects.toMatchObject({ code: "Internal" });
+      } else {
+        await attempt;
+      }
+      const got = await readCurrentJson(s, "k");
+      expect(got!.json.log_seq_start).toBe(shouldReject ? initial.log_seq_start : target);
+    },
   );
 
   test.prop({

--- a/packages/protocol/src/coordination/current-json.ts
+++ b/packages/protocol/src/coordination/current-json.ts
@@ -87,11 +87,17 @@ export interface CurrentJson {
    * {@link createCurrentJson} set this to `0`; the compactor advances
    * it on every fold.
    *
-   * Invariants the compactor maintains:
+   * Invariants:
    *   - `0 <= log_seq_start <= tail_hint`
-   *   - `log_seq_start` advances monotonically (never decreases)
+   *   - `log_seq_start` advances monotonically (never decreases).
+   *     {@link casUpdateCurrentJson} rejects a mutator that lowers it;
+   *     `compact()` is monotone by construction once its seq-arithmetic
+   *     options are validated at the seam; `baerly admin restore
+   *     --force` is the deliberate truncate exemption.
    *   - `log_seq_start > 0` implies `snapshot !== null` (the snapshot
-   *     covers `[0, log_seq_start)`)
+   *     covers `[0, log_seq_start)`) — except after a `--force`
+   *     truncate, which resets `snapshot` to `null` while reseeding
+   *     the floor above any surviving old-generation log object.
    */
   log_seq_start: number;
 
@@ -272,6 +278,19 @@ export async function createCurrentJson(
  * @throws BaerlyError{code:"InvalidResponse"} — `key` does not exist
  *         (use {@link createCurrentJson} instead) or body doesn't
  *         parse / fails the shape guard.
+ * @throws BaerlyError{code:"Internal"} — the mutator lowered
+ *         `log_seq_start`. The floor is monotone non-decreasing;
+ *         equality is permitted (a `tail_hint` refresh or
+ *         `last_warned_seq` stamp holds it fixed). No *production*
+ *         mutator writes the floor, so no shipping caller can regress
+ *         it; this guards future ones, and the protocol suite
+ *         exercises the branch directly. Two floor writers bypass this
+ *         function and are NOT covered by it: `compact()`, which must
+ *         CAS on the etag of the read it folded from and so issues its
+ *         own If-Match PUT (its fold end cannot dip below the pre-fold
+ *         floor once its options are validated at the seam), and
+ *         `baerly admin restore --force`, the deliberate truncate
+ *         exemption.
  */
 export async function casUpdateCurrentJson(
   storage: Storage,
@@ -292,6 +311,20 @@ export async function casUpdateCurrentJson(
   // targets Node ≥24 so it is safe.
   const next = mutator(structuredClone(existing.json));
   assertCurrentJson(next, key);
+  // Floor monotonicity is an admission-control invariant, not a shape
+  // one: it needs both sides of the transition, so `assertCurrentJson`
+  // cannot see it. A regressed floor makes a stale pre-fold reader
+  // cursor pass the `cursorSeq < log_seq_start` re-bootstrap check
+  // (http/since.ts) instead of failing it. `Internal`, not
+  // `InvalidResponse`: the fault is a local caller's mutator, not a
+  // malformed storage response. See `CurrentJson.log_seq_start` and
+  // docs/spec/sync-protocol.md invariant 12.
+  if (next.log_seq_start < existing.json.log_seq_start) {
+    throw new BaerlyError(
+      "Internal",
+      `current.json at ${key}: log_seq_start must not decrease (${String(existing.json.log_seq_start)} → ${String(next.log_seq_start)})`,
+    );
+  }
   const body = encodeJson(next);
   const putOpts: StoragePutOptions = {
     ifMatch: existing.etag,

--- a/packages/server/src/compactor.test.ts
+++ b/packages/server/src/compactor.test.ts
@@ -21,7 +21,7 @@ import {
 import { describe, expect, test } from "vitest";
 import { logStateCurrentJson, seedLogEntries } from "../../../tests/fixtures/log-state.ts";
 import { compact, type InternalCompactOptions } from "./compactor.ts";
-import { loadSnapshotAsMap } from "./snapshot.ts";
+import { loadSnapshotAsMap, snapshotKey } from "./snapshot.ts";
 import { createObservabilityContext, runWithContext } from "./observability/index.ts";
 import { runGc } from "./gc.ts";
 import { Writer } from "./writer.ts";
@@ -92,6 +92,97 @@ describe("compact", () => {
     expect(res.newSnapshotKey).toBeDefined();
     // L9/<12-digit min>-<12-digit max>-<64 hex>.json under collectionPrefix.
     expect(res.newSnapshotKey).toMatch(/\/snapshot\/L9\/0{12}-0{10}40-[0-9a-f]{64}\.json$/);
+  });
+
+  // The seq-arithmetic options ride an unvalidated seam
+  // (`InternalCompactOptions`), reached by JS callers, in-repo casts,
+  // and the `@baerly/server/_internal/testing` subpath. NaN is
+  // the dangerous one and the reason this check exists rather than a
+  // fold-floor assertion: NaN is false under every `<`/`>` guard in
+  // `compact()`, so it would reach the fold, write a snapshot at a
+  // `…-00000000000NaN-…` key, and CAS `log_seq_start: null` — bricking
+  // the collection against every read path, `restore --force` included.
+  // A negative value is the benign case (it would merely lower the floor).
+  describe.each([
+    ["maxEntriesPerRun", "negative", { maxEntriesPerRun: -1 }],
+    ["maxEntriesPerRun", "NaN", { maxEntriesPerRun: Number.NaN }],
+    ["maxEntriesPerRun", "Infinity", { maxEntriesPerRun: Number.POSITIVE_INFINITY }],
+    ["maxEntriesPerRun", "fractional", { maxEntriesPerRun: 1.5 }],
+    ["knownTail", "NaN", { knownTail: Number.NaN }],
+    ["knownTail", "negative", { knownTail: -1 }],
+  ])("rejects %s = %s at the seam", (_option, _shape, overrides) => {
+    test("fails closed before touching storage", async () => {
+      const s = new MemoryStorage();
+      await bootstrap(s, KEY);
+      const writer = new Writer({ storage: s, currentJsonKey: KEY });
+      for (let i = 0; i < 20; i++) {
+        await writer.commit({
+          op: "I",
+          collection: COLL,
+          docId: `d${i}`,
+          body: { _id: `d${i}`, n: i },
+        });
+      }
+      const before = await readCurrentJson(s, KEY);
+
+      await expect(
+        compact({ storage: s, currentJsonKey: KEY }, {
+          minEntriesToCompact: 1,
+          ...overrides,
+        } as InternalCompactOptions),
+      ).rejects.toMatchObject({ code: "InvalidConfig" });
+
+      // Nothing moved: the floor is intact, no snapshot pointer, and no
+      // orphan snapshot object was left on the bucket.
+      const after = await readCurrentJson(s, KEY);
+      expect(after?.json.log_seq_start).toBe(before?.json.log_seq_start);
+      expect(after?.json.snapshot).toBeNull();
+      const snapshots: string[] = [];
+      for await (const entry of s.list(`${KEY.slice(0, KEY.lastIndexOf("/"))}/snapshot/`)) {
+        snapshots.push(entry.key);
+      }
+      expect(snapshots).toEqual([]);
+    });
+  });
+
+  test("snapshotKey rejects a non-finite seq rather than padding it into the key", () => {
+    // Defense in depth one layer under the seam check above: every
+    // comparison in the range guard is false against NaN, so without an
+    // explicit integer test `pad(NaN)` yields a `000000000NaN` filename.
+    const hash = "a".repeat(64);
+    expect(() => snapshotKey("p/c", 0, Number.NaN, hash)).toThrowError(
+      expect.objectContaining({ code: "InvalidConfig" }),
+    );
+    expect(() => snapshotKey("p/c", Number.NaN, 10, hash)).toThrowError(
+      expect.objectContaining({ code: "InvalidConfig" }),
+    );
+    expect(() => snapshotKey("p/c", 0, Number.POSITIVE_INFINITY, hash)).toThrowError(
+      expect.objectContaining({ code: "InvalidConfig" }),
+    );
+    // The valid case still builds the zero-padded key.
+    expect(snapshotKey("p/c", 0, 40, hash)).toBe(
+      `p/c/snapshot/L9/${"0".repeat(12)}-${"0".repeat(10)}40-${hash}.json`,
+    );
+  });
+
+  test("a validated fold still advances the floor from a healthy default", async () => {
+    // Guards the guard: the seam check must not reject the ordinary
+    // no-overrides call, where `maxEntriesPerRun` defaults to
+    // MAX_SAFE_INTEGER and `knownTail` is absent.
+    const s = new MemoryStorage();
+    await bootstrap(s, KEY);
+    const writer = new Writer({ storage: s, currentJsonKey: KEY });
+    for (let i = 0; i < 5; i++) {
+      await writer.commit({
+        op: "I",
+        collection: COLL,
+        docId: `d${i}`,
+        body: { _id: `d${i}`, n: i },
+      });
+    }
+    const res = await compact({ storage: s, currentJsonKey: KEY }, { minEntriesToCompact: 1 });
+    expect(res.written).toBe(true);
+    expect(res.logSeqStartAfter).toBeGreaterThan(res.logSeqStartBefore);
   });
 
   test("is idempotent: re-running with no new writes is a no-op", async () => {

--- a/packages/server/src/compactor.ts
+++ b/packages/server/src/compactor.ts
@@ -167,6 +167,11 @@ const APPLICATION_JSON = "application/json";
  * `./maintenance.ts`) decides whether to schedule another run. The
  * orphan snapshot file just written will be swept by `runGc()`.
  *
+ * @throws BaerlyError code="InvalidConfig" — `maxEntriesPerRun` or
+ *   `knownTail` (the `InternalCompactOptions` seam) is not a
+ *   non-negative integer. Checked before any I/O: a non-finite value
+ *   would otherwise slip the range guards and write an unreadable
+ *   `current.json`.
  * @throws BaerlyError code="InvalidResponse" — `current.json` is
  *   present but malformed, or a snapshot body fails its schema /
  *   collection cross-check.
@@ -207,6 +212,36 @@ export const compact = async (
   const ceilingEntries = internal.ceilingEntries ?? Number.POSITIVE_INFINITY;
   const collectionPrefix = currentJsonKey.slice(0, currentJsonKey.lastIndexOf("/"));
   const collectionName = collectionPrefix.slice(collectionPrefix.lastIndexOf("/") + 1);
+
+  // Validate the options that feed seq arithmetic, before any I/O.
+  // `InternalCompactOptions` is an unvalidated seam — reached by JS
+  // callers, in-repo casts, and the `_internal/testing` subpath. A
+  // non-finite value must never reach the fold: NaN slips
+  // every `<`/`>` guard below (`Math.min(nextSeq, NaN)` is NaN), lands a
+  // snapshot at a `…-00000000000NaN-…` key, and CASes
+  // `log_seq_start: null` — JSON.stringify renders NaN as null — after
+  // which every read path throws InvalidResponse, including
+  // `admin restore --force`, which reads `current.json` before reaching
+  // its own floor exemption. Nothing shipped can repair that.
+  //
+  // Validating here rather than asserting the floor at the fold also
+  // buys the monotonicity invariant outright: with `maxPerRun >= 0` and
+  // `nextSeq >= logSeqStartBefore` (guaranteed by `probeFloor`),
+  // `foldEnd >= logSeqStartBefore` holds by construction, so the floor
+  // cannot regress here — and a rejected run costs no orphan snapshot,
+  // because nothing has been written yet. The ceilings are deliberately
+  // not checked: a NaN there fails the viability comparisons closed
+  // (defer), which is the safe direction.
+  const requireSeqOption = (name: string, value: number): void => {
+    if (!Number.isInteger(value) || value < 0) {
+      throw new BaerlyError(
+        "InvalidConfig",
+        `compact(${collectionName}): ${name} must be a non-negative integer, got ${String(value)}`,
+      );
+    }
+  };
+  requireSeqOption("maxEntriesPerRun", maxPerRun);
+  requireSeqOption("knownTail", internal.knownTail ?? 0);
 
   // ── Step 1. Read current.json fresh. ────────────────────────────
   const read = await readCurrentJson(
@@ -257,6 +292,11 @@ export const compact = async (
     };
   }
 
+  // `foldEnd >= logSeqStartBefore` by construction: `maxPerRun` is a
+  // validated non-negative integer and `nextSeq >= logSeqStartBefore`
+  // via `probeFloor`. Step 7's CAS bypasses `casUpdateCurrentJson`'s
+  // floor guard (it must If-Match the etag we folded from), so that
+  // construction is what keeps this writer monotone.
   const foldEnd = Math.min(nextSeq, logSeqStartBefore + maxPerRun);
 
   // ── Step 2. Load the previous snapshot (if any) as the fold base.

--- a/packages/server/src/snapshot.ts
+++ b/packages/server/src/snapshot.ts
@@ -50,7 +50,17 @@ export const snapshotKey = (
   maxSeq: number,
   sha256: string,
 ): string => {
-  if (minSeq < 0 || maxSeq < 0 || minSeq > maxSeq || maxSeq > MAX_SEQ) {
+  // `Number.isInteger` first: every `<`/`>` below is false against NaN,
+  // so a non-finite seq would sail through and `pad()` it into a
+  // `000000000NaN` filename.
+  if (
+    !Number.isInteger(minSeq) ||
+    !Number.isInteger(maxSeq) ||
+    minSeq < 0 ||
+    maxSeq < 0 ||
+    minSeq > maxSeq ||
+    maxSeq > MAX_SEQ
+  ) {
     throw new BaerlyError("InvalidConfig", `snapshotKey: invalid range [${minSeq}, ${maxSeq})`);
   }
   if (!/^[0-9a-f]{64}$/.test(sha256)) {

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -329,7 +329,16 @@ const BUDGETS: readonly Budget[] = [
   //     (measured 234566 vs the old 234496 ceiling), the same class of
   //     shared-chunk boundary shift the ./s3 note above records. gz/min-gz
   //     unaffected; this is a tripwire rebaseline, not a shipped-cost change.
-  { entry: "index.js", raw: 230 * 1024, gz: 72 * 1024, minGz: 20 * 1024 },
+  //   → 231 KiB raw / 73 KiB gz (2026-08-01): floor-monotonicity work on
+  //     `current.json` — the `casUpdateCurrentJson` admission guard plus the
+  //     expanded `@throws` contract and `CurrentJson.log_seq_start` invariant
+  //     JSDoc. Almost entirely comment/JSDoc bytes, which rolldown ships
+  //     un-stripped: min-gz (the minified hard ceiling, where comments are
+  //     gone) barely moved. Measured 236371 raw / 74129 gz / 20252 min-gz
+  //     (min-gz 228 B under). Deliberate doc-quality spend, not code creep —
+  //     per the POLICY above, raw/gz are creep tripwires and are rebaselined
+  //     rather than paid for by golfing comments.
+  { entry: "index.js", raw: 231 * 1024, gz: 73 * 1024, minGz: 20 * 1024 },
   // The three auth verifier factories (bearerJwt, sharedSecret,
   // cloudflareAccess) plus the transitive jose closure pulled in by
   // bearerJwt's createRemoteJWKSet + jwtVerify. Adding a fourth
@@ -507,7 +516,17 @@ const BUDGETS: readonly Budget[] = [
   //   → 350 KiB raw (2026-07-15): dep sweep — hono 4.12.27→4.12.30 patch.
   //     Deliberate upstream bump, not code creep. Measured 358079 raw;
   //     gz/min-gz under.
-  { entry: "http.js", raw: 350 * 1024, gz: 104 * 1024, minGz: 36 * 1024 },
+  //   → 352 KiB raw / 105 KiB gz (2026-08-01): floor-monotonicity admission
+  //     guard in `casUpdateCurrentJson` — rejects a CAS that lowers
+  //     `log_seq_start`, which `assertCurrentJson` cannot see (it needs both
+  //     sides of the transition) — plus `compact()`'s seq-option validation
+  //     covering the fold CAS that bypasses that helper, and the JSDoc for
+  //     both. gz needed the bump: it sat 260 B under before this change, so
+  //     the mostly-comment delta crossed the axis. min-gz (the hard ceiling,
+  //     comments stripped) stays 315 B under. Measured 359799 raw / 106796 gz
+  //     / 36549 min-gz. Deliberate safety + doc change; raw/gz rebaselined
+  //     rather than golfing the comments.
+  { entry: "http.js", raw: 352 * 1024, gz: 105 * 1024, minGz: 36 * 1024 },
   // Observability primitives — ObservabilityContext, the
   // request-scoped MetricsRecorder, LogTape config + the
   // JSON sink only (the pretty sink + picocolors now live in
@@ -663,7 +682,12 @@ const BUDGETS: readonly Budget[] = [
   //     source-of-truth win for the BAERLY_MAINTENANCE_* contract. Also
   //     rolldown 1.1.0→1.1.3 from `pnpm dedupe`. Measured 127151 raw /
   //     38915 gz / 11298 min-gz.
-  { entry: "maintenance.js", raw: 125 * 1024, gz: 39 * 1024, minGz: 12 * 1024 },
+  //   → 127 KiB raw (2026-08-01): floor-monotonicity work — `compact()`'s
+  //     seq-option validation (this closure owns the compactor) and the
+  //     `casUpdateCurrentJson` guard, plus JSDoc on both. Measured 129227 raw
+  //     / 39688 gz / 11471 min-gz; gz (248 B) and min-gz (817 B) both stay
+  //     under, only the raw tripwire moves.
+  { entry: "maintenance.js", raw: 127 * 1024, gz: 39 * 1024, minGz: 12 * 1024 },
   // Cloudflare Workers adapter — re-exports the kernel barrel
   // (Db, Writer, etc.) plus the R2-binding `Storage` impl
   // and the `baerlyCloudflare` helper. Aggregator: closure
@@ -838,7 +862,13 @@ const BUDGETS: readonly Budget[] = [
   //     patch in this aggregator's closure. Deliberate upstream bump, not code
   //     creep. Measured 430785 raw / 129071 gz; min-gz under. Only the raw/gz
   //     creep tripwires move.
-  { entry: "cloudflare.js", raw: 421 * 1024, gz: 127 * 1024, minGz: 45 * 1024 },
+  //   → 423 KiB raw (2026-08-01): floor-monotonicity admission guard in
+  //     `casUpdateCurrentJson` plus `compact()`'s seq-option validation
+  //     (same change as http.js above; shared current-json + maintenance
+  //     chunks). Measured 432505 raw / 129632 gz / 45580 min-gz; gz (416 B)
+  //     and min-gz (500 B) both stay under, only raw moves. Deliberate
+  //     safety change.
+  { entry: "cloudflare.js", raw: 423 * 1024, gz: 127 * 1024, minGz: 45 * 1024 },
   // Client surface — `BaerlyClient<TConfig>` + fetcher plumbing.
   // Browser/runtime-agnostic; no kernel modules in the closure.
   // Budget history:
@@ -975,7 +1005,12 @@ const BUDGETS: readonly Budget[] = [
   //     self-explaining error message. Measured 40341 raw / 14447 gz. This dev-only
   //     bundle has no min-gz axis, so gz is its tightest tripwire; rebaselined
   //     gz 14→15 KiB rather than golf the doc/error (see the POLICY on index.js).
-  { entry: "dev.js", raw: 40 * 1024, gz: 15 * 1024 },
+  //   → 41 KiB raw (2026-08-01): floor-monotonicity work — this closure pulls
+  //     the `current-json` chunk, so it carries the `casUpdateCurrentJson`
+  //     guard and its expanded JSDoc. Measured 41442 raw / 14808 gz; gz stays
+  //     552 B under (no min-gz axis on this entry). Comment-dominated
+  //     rebaseline, not code creep.
+  { entry: "dev.js", raw: 41 * 1024, gz: 15 * 1024 },
   // Worker-safe S3 entry — `S3HttpStorage` + `sigV4Signer` + the
   // `aws4fetch` SigV4 client + `@rgrove/parse-xml` XML parser.
   // Intended for cross-account R2 / non-R2 S3 from a Cloudflare


### PR DESCRIPTION
`current.json`'s `log_seq_start` is the fold floor: readers treat everything below it as covered by the snapshot, and a long-poll client detects a folded-away cursor by testing it against that floor. The invariant that the floor never decreases was documented in prose and enforced nowhere. `assertCurrentJson` validates integrality, non-negativity, and `<= tail_hint`, but it sees one state at a time, so it structurally cannot check a transition property.

This enforces it at both writers that move the floor, and closes a destructive input path found along the way.

## `casUpdateCurrentJson` — admission check

A mutator that lowers the floor is now rejected with `BaerlyError{code:"Internal"}`. Equality is permitted, since the `tail_hint` refresh and the `last_warned_seq` stamp in `maintenance.ts` both hold the floor fixed.

`Internal` rather than `InvalidResponse` because the fault is a local caller's mutator, not a malformed storage response — and `InvalidResponse` maps to HTTP 502 ("storage upstream failed"), which would misattribute a programmer error to the bucket. Both land in the same CLI exit-3 bucket and no catcher discriminates on this path.

This half is hardening, not a live-bug fix: no production mutator writes the floor through this helper. What it buys is a future caller that would — a lowered floor lets a stale long-poll cursor pass the `cursorSeq < log_seq_start` re-bootstrap check in `http/since.ts` and silently resume into the wrong generation.

## `compact()` — monotone by construction

The compactor cannot route through that helper: its fold CAS must `If-Match` the etag of the read it folded from. So it is kept monotone by construction instead. `maxEntriesPerRun` and `knownTail` are validated as non-negative integers before any I/O, which makes `foldEnd >= logSeqStartBefore` hold for free (given `nextSeq >= logSeqStartBefore` via `probeFloor`), and a rejected run costs no orphan snapshot because nothing has been written yet.

That validation also closes a path that could brick a collection. `NaN` is false under every `<`/`>` comparison in `compact()`, so it would reach the fold, write a snapshot at a `…-00000000000NaN-…` key, and CAS `log_seq_start: null` — `JSON.stringify` renders `NaN` as `null`. Every read path then fails `InvalidResponse`, **including `admin restore --force`**, which reads `current.json` before reaching its own floor exemption. Nothing shipped could repair that. `snapshotKey` gets the same `Number.isInteger` treatment one layer down.

No in-tree caller supplies a non-finite value, but the seam is reachable by plain-JS callers, by in-repo `as InternalCompactOptions` casts, and through the `@baerly/server/_internal/testing` subpath that `bench/maintenance-backlog.ts` uses.

## `admin restore --force` — the deliberate exemption

`--force` reseeds a truncated collection through its own `If-Match` PUT, so the guard does not see it and the reseed may land below the old floor. That exemption was implicit — readable only by noticing which function the PUT does not call. It is now explicit and pinned by two tests.

The property the reseed actually relies on is that `truncatedNext` is strictly greater than every log object still present, so the writer's committing `log/<seq>` create cannot collide with the old generation. It can sit below the old floor because GC's sweep is budget-bounded and walks `log/` in lex order (`0,1,10,11,2,...`), routinely clearing the top of the old range while leaving sub-floor objects behind — old floor 12 with `log/8` and `log/9` surviving reseeds to 10.

Nothing is lost by that. GC decides content liveness by reachability (`collectLiveContentHashes`), not by the floor, and the reseed sets `snapshot: null`, so the old generation becomes unreachable and is swept as `orphan-content` — which is what truncating means.

Both tests are load-bearing: "repairing" the reseed with `Math.max(head.json.log_seq_start, truncatedNext)` fails them and no other test, because that reseeds a floor above `tail_hint` and trips `assertCurrentJson`.

## Docs

`sync-protocol.md` gains invariant 12 (the floor is monotone; names the enforcement point and both bypassing writers). Invariant 5 gets a truncate carve-out — `--force` leaves `snapshot: null` with a possibly-positive floor, which the unqualified "if `log_seq_start > 0`, `current.snapshot` covers `[0, log_seq_start)`" reading forbids. The `CurrentJson.log_seq_start` JSDoc already had that carve-out and the spec did not.

`docs/guide/backups.md` extends the restore warning to long-poll readers; it previously covered writers only.

## Out of scope

Tracked as #73: `/v1/since` gates re-bootstrap on a bare `cursorSeq < log_seq_start` with no generation discriminator, so a `--force` reseed that lowers the floor lets a stale pre-restore cursor resume into the new generation and silently gap its stream. Until that is closed in code, draining long-poll readers during a restore cutover is the documented mitigation.

## Bundle budgets

Rebaselines the raw/gz creep tripwires on five entries (`index`, `http`, `maintenance`, `cloudflare`, `dev`) with dated notes and measured figures. The delta is comment/JSDoc-dominated and rolldown ships comments un-stripped, so `min-gz` — the hard ceiling, where comments are gone — stays under on every entry: index 228 B, http 315 B, maintenance 817 B, cloudflare 500 B.

## Verification

`pnpm verify` and `pnpm test` both green (2570 passed, 4 skipped). Each of the three commits was verified independently, since these land individually under rebase-merge.

One thing to know: `tests/integration/maintenance-profile-equivalence.test.ts` timed out twice at 120,314 ms against its 120,000 ms limit while the machine was loaded, then passed in isolation (64 s) and in clean full runs. This is a pre-existing margin flake, not something this branch introduces — the runtime code is identical across all three commits (the only source delta between commit 1 and the tip is comment-only), and the tip passes. That timeout probably wants raising separately; a loaded CI runner will hit it.
