### PR TITLE
fix(gc): give the grace period its full length on every backend

### DIFF
--- a/.changeset/drop-storage-list-entry-last-modified.md
+++ b/.changeset/drop-storage-list-entry-last-modified.md
@@ -1,0 +1,36 @@
+---
+"@gusto/baerly-storage": minor
+---
+
+Remove `lastModified` from `StorageListEntry`. A listed object is now
+`key` + `etag` only.
+
+The field existed to serve one consumer: GC anchored a candidate's
+`due_at` on it. That anchoring was a bug — it was populated only by the
+S3/GCS/R2 adapters, so it made the grace period `max(0, grace − object
+age)` on exactly those backends while reading full-length everywhere the
+test suite ran. With the anchor corrected to `now() + grace`, nothing
+read the field, and three adapters were still minting a `Date` per
+listed entry on every LIST for a value with no consumer.
+
+Nothing else wanted it. `baerly admin usage` had already declined it,
+reading `commit_ts` from the `LogEntry` body instead and documenting
+that as the cross-backend-uniform choice. A per-entry server clock is
+not something the protocol should carry speculatively; the wall-clock
+needs that are real are served by `StoragePutResult.serverDate`, which
+drives the adaptive clock-skew loop and is unaffected.
+
+Marked `minor` rather than `patch` because `StorageListEntry` is
+exported from the public barrel and `docs/contributing/extending.md`
+names `Storage` as an extension point, so this narrows published type
+surface. There are no third-party adapters, and all five in-tree impls
+(`MemoryStorage`, `LocalFsStorage`, `S3HttpStorage`, `GcsHttpStorage`,
+`r2BindingStorage`) are updated, so no known consumer breaks. A custom
+adapter that yielded `lastModified` would now fail its excess-property
+check and can drop the line.
+
+The storage conformance suite previously projected the field out of its
+list-entry comparison as adapter-optional — which is precisely why it
+could not see the GC bug. It now compares entries whole, so a
+backend-specific field cannot be reintroduced without a conformance
+failure.

--- a/.changeset/gc-grace-anchor-on-mark.md
+++ b/.changeset/gc-grace-anchor-on-mark.md
@@ -12,16 +12,17 @@ horizon to `(entry.lastModified ?? now()) + grace` — anchored, when the
 adapter surfaced it, to when the *object* was written rather than to
 when we *marked* it.
 
-`StorageListEntry.lastModified` is optional, and which adapters populate
-it splits exactly along the local/production line: `MemoryStorage` and
-`LocalFsStorage` omit it and took the `now()` fallback; the S3, GCS and
-R2 adapters populate it from server-side headers. On those three the
-effective grace was `max(0, grace − object age)`, so past the seven-day
-`GC_GRACE_PERIOD_MILLIS` default it was **zero** — a candidate was marked
-already-due and swept on the next pass with no absorber. Stale-log and
-orphan candidates are precisely the objects old enough to hit this. The
-constant's own contract tells operators not to lower the knob; the
-anchoring defeated it regardless of what they set.
+`StorageListEntry.lastModified` was optional, and which adapters
+populated it split exactly along the local/production line:
+`MemoryStorage` and `LocalFsStorage` omitted it and took the `now()`
+fallback; the S3, GCS and R2 adapters populated it from server-side
+headers. On those three the effective grace was `max(0, grace − object
+age)`, so past the seven-day `GC_GRACE_PERIOD_MILLIS` default it was
+**zero** — a candidate was marked already-due and swept on the next pass
+with no absorber. Stale-log and orphan candidates are precisely the
+objects old enough to hit this. The constant's own contract tells
+operators not to lower the knob; the anchoring defeated it regardless of
+what they set.
 
 `computeDueAt` now anchors on the mark — `now() + grace`, unconditionally
 — and no longer reads `lastModified`. This is strictly more conservative
@@ -29,18 +30,21 @@ than the old behaviour on every backend, so it cannot delete anything
 sooner than before; on the local-clock backends it is unchanged.
 
 No test could see this. The default suite runs `memory` and `local-fs`,
-both on the fallback path, and `pnpm test:parity` cannot either — the
-storage conformance suite projects `lastModified` out of its comparison
+both on the fallback path, and `pnpm test:parity` could not either — the
+storage conformance suite projected `lastModified` out of its comparison
 as adapter-optional. The regression test therefore lists through a
-delegating `Storage` that surfaces a month-old `lastModified`, which is
-the only way to reach the production shape from `MemoryStorage`.
+delegating `Storage` that attaches a month-old timestamp to every listed
+entry, which was the only way to reach the production shape from
+`MemoryStorage`.
+
+With the anchor corrected the field had no reader left, and it is
+removed from `StorageListEntry` in this same release — see the
+accompanying `minor` entry. A listed object is now `key` + `etag` only.
+The regression test keeps attaching a timestamp anyway, via a cast, to
+assert that `computeDueAt` reads nothing off the entry at runtime.
 
 Not retroactive: candidates already recorded in `gc/pending.json` keep
 the `due_at` they were marked with, so the first pass after upgrading
 still sweeps that backlog on the old horizon. Nothing is deleted sooner
 than it would have been without this fix — the full window applies to
 everything marked from here on.
-
-`StorageListEntry.lastModified` is now unread by the kernel and
-documented as informational. Adapters still populate it; it is not
-removed from the `Storage` contract.

--- a/.changeset/gc-grace-anchor-on-mark.md
+++ b/.changeset/gc-grace-anchor-on-mark.md
@@ -1,0 +1,46 @@
+---
+"@gusto/baerly-storage": patch
+---
+
+Give GC's grace period its full length on every storage backend. It was
+silently near-zero on all of them except the two the test suite runs.
+
+`runGc` marks an orphan candidate with a `due_at` horizon and only
+deletes it once that horizon passes, so a writer still retrying towards
+an anchor we judged dead has a window to land. `computeDueAt` set that
+horizon to `(entry.lastModified ?? now()) + grace` — anchored, when the
+adapter surfaced it, to when the *object* was written rather than to
+when we *marked* it.
+
+`StorageListEntry.lastModified` is optional, and which adapters populate
+it splits exactly along the local/production line: `MemoryStorage` and
+`LocalFsStorage` omit it and took the `now()` fallback; the S3, GCS and
+R2 adapters populate it from server-side headers. On those three the
+effective grace was `max(0, grace − object age)`, so past the seven-day
+`GC_GRACE_PERIOD_MILLIS` default it was **zero** — a candidate was marked
+already-due and swept on the next pass with no absorber. Stale-log and
+orphan candidates are precisely the objects old enough to hit this. The
+constant's own contract tells operators not to lower the knob; the
+anchoring defeated it regardless of what they set.
+
+`computeDueAt` now anchors on the mark — `now() + grace`, unconditionally
+— and no longer reads `lastModified`. This is strictly more conservative
+than the old behaviour on every backend, so it cannot delete anything
+sooner than before; on the local-clock backends it is unchanged.
+
+No test could see this. The default suite runs `memory` and `local-fs`,
+both on the fallback path, and `pnpm test:parity` cannot either — the
+storage conformance suite projects `lastModified` out of its comparison
+as adapter-optional. The regression test therefore lists through a
+delegating `Storage` that surfaces a month-old `lastModified`, which is
+the only way to reach the production shape from `MemoryStorage`.
+
+Not retroactive: candidates already recorded in `gc/pending.json` keep
+the `due_at` they were marked with, so the first pass after upgrading
+still sweeps that backlog on the old horizon. Nothing is deleted sooner
+than it would have been without this fix — the full window applies to
+everything marked from here on.
+
+`StorageListEntry.lastModified` is now unread by the kernel and
+documented as informational. Adapters still populate it; it is not
+removed from the `Storage` contract.

--- a/packages/adapter-cloudflare/src/r2-binding-storage.ts
+++ b/packages/adapter-cloudflare/src/r2-binding-storage.ts
@@ -147,7 +147,6 @@ class R2BindingStorageImpl implements Storage {
         yield {
           key: obj.key,
           etag: quoteEtag(obj.etag),
-          lastModified: obj.uploaded,
         };
         yielded += 1;
       }
@@ -202,8 +201,9 @@ class R2BindingStorageImpl implements Storage {
  *    binding returns bare hex. CAS round-trips strip and re-apply
  *    the quotes.
  *  - `serverDate` from `R2Object.uploaded` — a real server clock,
- *    suitable for the kernel's adaptive-clock-skew loop.
- *  - `StorageListEntry.lastModified` from the same clock.
+ *    suitable for the kernel's adaptive-clock-skew loop. `list()`
+ *    yields `key` + `etag` only; `StorageListEntry` carries no
+ *    per-entry timestamp.
  *
  * Errors map to `BaerlyError` via the same convention as
  * `S3HttpStorage`: `AccessDenied` for binding-level permission

--- a/packages/adapter-node/src/gcs-http.ts
+++ b/packages/adapter-node/src/gcs-http.ts
@@ -277,7 +277,6 @@ export class GcsHttpStorage implements Storage {
           // for a malformed row and, like every list etag, is CAS-unused.
           key: entry.Key,
           etag: entry.Generation ?? "",
-          ...(entry.LastModified !== undefined && { lastModified: entry.LastModified }),
         };
         yielded += 1;
         if (opts?.maxKeys !== undefined && yielded >= opts.maxKeys) {

--- a/packages/adapter-node/src/s3-http.ts
+++ b/packages/adapter-node/src/s3-http.ts
@@ -293,7 +293,6 @@ export class S3HttpStorage implements Storage {
         yield {
           key: entry.Key,
           etag: entry.ETag ?? "",
-          ...(entry.LastModified !== undefined && { lastModified: entry.LastModified }),
         };
         yielded += 1;
         if (opts?.maxKeys !== undefined && yielded >= opts.maxKeys) {

--- a/packages/adapter-node/src/xml.ts
+++ b/packages/adapter-node/src/xml.ts
@@ -240,8 +240,14 @@ export const parseAssumeRoleWithWebIdentity = (xml: string): ParsedWebIdentityCr
 
 // `new Date(badString)` yields an Invalid Date (a non-null Date whose
 // getTime() is NaN) rather than throwing — surface `undefined` for a
-// malformed `LastModified` so it never leaks into a `StorageListEntry`.
-// GC then falls back to `now()` for the tombstone `due_at` anchor.
+// malformed `LastModified` rather than propagating a NaN-valued Date.
+//
+// Nothing downstream reads this today: `StorageListEntry` is `key` +
+// `etag` only, so both `S3HttpStorage.list` and `GcsHttpStorage.list`
+// drop the parsed value on the floor. It is retained only as a faithful
+// mirror of the S3 list-response shape. If you are here to add a
+// consumer, read the `StorageListEntry` JSDoc first — GC used to anchor
+// its `due_at` on this and that was a bug.
 const parseLastModified = (lm: string | undefined): Date | undefined => {
   if (lm === undefined) {
     return undefined;

--- a/packages/cli/src/admin/usage.ts
+++ b/packages/cli/src/admin/usage.ts
@@ -30,13 +30,14 @@
  * wired" finding pending the follow-up work in
  * `docs/followups/agent-friendliness.md` entry 10.
  *
- * Why GET each entry instead of relying on list-time
- * `Last-Modified`: `MemoryStorage` (the test backend) intentionally
- * does NOT surface `lastModified` on `list()`, and the
- * cross-backend story stays uniform if we always read `commit_ts`
- * from the `LogEntry` body. Sample size is bounded (`SAMPLE_SIZE`
- * GETs per collection), so the cost is acceptable for an opt-in
- * operator command.
+ * Why GET each entry instead of relying on a list-time
+ * `Last-Modified`: `StorageListEntry` carries no timestamp — it is
+ * `key` + `etag` only — and the cross-backend story stays uniform if
+ * we always read `commit_ts` from the `LogEntry` body. (This command
+ * declined the field back when it existed, for the same reason; it
+ * was removed once GC stopped anchoring on it.) Sample size is
+ * bounded (`SAMPLE_SIZE` GETs per collection), so the cost is
+ * acceptable for an opt-in operator command.
  *
  * @see docs/about/thesis.md — M-size ceiling rationale.
  * @see docs/spec/log-entry-shape.md — `LogEntry.commit_ts` contract.

--- a/packages/protocol/src/storage/conformance.ts
+++ b/packages/protocol/src/storage/conformance.ts
@@ -697,15 +697,20 @@ export function defineStorageConformanceSuite(
         );
       });
 
-      test("returns the current etag for each entry", async () => {
+      test("returns the current etag for each entry, and nothing else", async () => {
         const a = await s.put("a", new TextEncoder().encode("alpha"));
         const b = await s.put("b", new TextEncoder().encode("beta"));
-        // `StorageListEntry.lastModified` is optional per the type;
-        // some adapters (R2 binding, S3) populate it from server-side
-        // headers. Project to the load-bearing fields only.
+        // Compared WHOLE, not projected to `{ key, etag }`: `toEqual`
+        // fails on extra own properties, so this pins the entry shape
+        // exactly. `StorageListEntry` used to carry an optional
+        // `lastModified` that the S3/GCS/R2 adapters populated and
+        // this assertion projected away as adapter-optional — which
+        // is why the suite could not see GC anchoring its grace
+        // period on it (see `computeDueAt` in `gc.ts`). The field is
+        // gone; keep the comparison strict so a backend-specific
+        // field cannot be reintroduced without a conformance failure.
         await expectEventuallyEqual(
-          () =>
-            collect(s.list("")).then((entries) => entries.map(({ key, etag }) => ({ key, etag }))),
+          () => collect(s.list("")),
           [
             { key: "a", etag: a.etag },
             { key: "b", etag: b.etag },

--- a/packages/protocol/src/storage/memory.ts
+++ b/packages/protocol/src/storage/memory.ts
@@ -166,9 +166,7 @@ export class MemoryStorage implements Storage {
     // `serverDate` is intentionally returned — the kernel's adaptive
     // clock-skew loop consumes the write-time server clock. `list()`
     // deliberately omits `lastModified`: the in-memory impl has no
-    // independent server clock, and its only consumer (GC's `due_at`
-    // anchor) falls back to `now()` when it is absent, so omitting it
-    // changes nothing.
+    // independent server clock, and no kernel path reads the field.
     return { etag, serverDate: new Date() };
   }
 

--- a/packages/protocol/src/storage/memory.ts
+++ b/packages/protocol/src/storage/memory.ts
@@ -165,8 +165,7 @@ export class MemoryStorage implements Storage {
     });
     // `serverDate` is intentionally returned — the kernel's adaptive
     // clock-skew loop consumes the write-time server clock. `list()`
-    // deliberately omits `lastModified`: the in-memory impl has no
-    // independent server clock, and no kernel path reads the field.
+    // needs no such clock: `StorageListEntry` is `key` + `etag` only.
     return { etag, serverDate: new Date() };
   }
 

--- a/packages/protocol/src/storage/types.ts
+++ b/packages/protocol/src/storage/types.ts
@@ -110,11 +110,10 @@ export interface StorageListEntry {
   readonly etag: string;
   /**
    * Server's `Last-Modified` for the listed object, when the backend
-   * surfaces it. GC uses it to anchor a tombstone's `due_at` to the
-   * object's server-side write time (`gc.ts`); when absent, GC falls
-   * back to the local clock (`now()`). It is therefore an optional
-   * precision hint, never load-bearing for correctness — impls
+   * surfaces it. Informational: no kernel path reads it, and impls
    * without a server clock (e.g. {@link MemoryStorage}) may omit it.
+   * GC's `due_at` deliberately does not — see `computeDueAt` in
+   * `gc.ts` for why anchoring on it is a bug.
    *
    * The protocol's clock-skew handling rides on
    * {@link StoragePutResult.serverDate} (the write-time server clock),

--- a/packages/protocol/src/storage/types.ts
+++ b/packages/protocol/src/storage/types.ts
@@ -105,19 +105,24 @@ export interface StoragePutOptions {
   readonly signal?: AbortSignal;
 }
 
+/**
+ * A listed object. `key` + `etag` only — deliberately not a mirror of
+ * whatever the backend's LIST response happens to carry.
+ *
+ * There is no `lastModified`. One existed, populated from server-side
+ * headers by the S3/GCS/R2 adapters and omitted by the clock-less
+ * impls. Its only consumer anchored GC's `due_at` on it, which made
+ * the grace period `max(0, grace − object age)` on exactly the
+ * adapters that populated it — see `computeDueAt` in `gc.ts`. With
+ * that anchor corrected the field had no reader, and a server clock
+ * per listed entry is not something the protocol should carry
+ * speculatively. Wall-clock needs are served by
+ * {@link StoragePutResult.serverDate} (the write-time server clock,
+ * which drives the adaptive clock-skew loop) or by reading
+ * `LogEntry.commit_ts`, which is what `baerly admin usage` does and
+ * documents as the cross-backend-uniform choice.
+ */
 export interface StorageListEntry {
   readonly key: string;
   readonly etag: string;
-  /**
-   * Server's `Last-Modified` for the listed object, when the backend
-   * surfaces it. Informational: no kernel path reads it, and impls
-   * without a server clock (e.g. {@link MemoryStorage}) may omit it.
-   * GC's `due_at` deliberately does not — see `computeDueAt` in
-   * `gc.ts` for why anchoring on it is a bug.
-   *
-   * The protocol's clock-skew handling rides on
-   * {@link StoragePutResult.serverDate} (the write-time server clock),
-   * not on this field.
-   */
-  readonly lastModified?: Date;
 }

--- a/packages/server/src/gc.test.ts
+++ b/packages/server/src/gc.test.ts
@@ -12,6 +12,7 @@ import {
   type GcPending,
   type Storage,
   type StorageGetOptions,
+  type StorageListEntry,
   GC_GRACE_PERIOD_MILLIS,
   GC_PENDING_SCHEMA_VERSION,
   MAX_PARALLEL_LOG_READS,
@@ -167,26 +168,27 @@ describe("runGc", () => {
 
   // ── grace anchoring ──────────────────────────────────────────────
   // `due_at` measures the writer-retry window from the MARK, never
-  // from the listed object's write time. That distinction is
-  // invisible to every backend this file runs on: `lastModified` is
-  // optional on `StorageListEntry`, and `MemoryStorage` /
-  // `LocalFsStorage` — the two the default suite covers — omit it,
-  // so they take the `now()` path and always saw the full window.
-  // The S3, GCS and R2 adapters populate it from server headers, so
-  // anchoring there would give an effective grace of
-  // `max(0, grace − object age)` — zero for anything older than the
-  // 7-day default, which stale-log and orphan candidates typically
-  // are. `pnpm test:parity` cannot see it either: the storage
-  // conformance suite projects `lastModified` out of its comparison
-  // as adapter-optional. This wrapper is the only way to reach the
-  // production shape from `MemoryStorage`.
-  const withListedLastModified = (inner: Storage, lastModified: Date): Storage => ({
+  // from the listed object's write time. GC used to anchor on an
+  // optional `StorageListEntry.lastModified` that only the S3/GCS/R2
+  // adapters populated, giving production an effective grace of
+  // `max(0, grace − object age)` — zero past the 7-day default, for
+  // exactly the old objects GC marks — while `MemoryStorage` and
+  // `LocalFsStorage`, the backends this suite runs, omitted it and
+  // showed a full window.
+  //
+  // The field is gone, so the type no longer permits this and the
+  // storage conformance suite compares list entries whole. The cast
+  // below is what keeps the behavioural guard alive anyway: TypeScript
+  // cannot stop an adapter attaching an extra property at RUNTIME, and
+  // this asserts `computeDueAt` reads nothing off the entry regardless.
+  // Delete this only together with the assertion it protects.
+  const withListedTimestamp = (inner: Storage, lastModified: Date): Storage => ({
     get: (key, opts) => inner.get(key, opts),
     put: (key, body, opts) => inner.put(key, body, opts),
     delete: (key, opts) => inner.delete(key, opts),
     list: async function* (prefix, opts) {
       for await (const entry of inner.list(prefix, opts)) {
-        yield { ...entry, lastModified };
+        yield { ...entry, lastModified } as StorageListEntry;
       }
     },
   });
@@ -214,7 +216,7 @@ describe("runGc", () => {
     const markedAt = new Date("2026-01-08T00:00:00.000Z");
     // A month old — comfortably past the 7-day default, which is what
     // makes an age-anchored horizon land in the past at mark time.
-    const storage = withListedLastModified(inner, new Date("2025-12-08T00:00:00.000Z"));
+    const storage = withListedTimestamp(inner, new Date("2025-12-08T00:00:00.000Z"));
 
     // Default grace (no `graceMillis` override) — the production knob.
     const r = await runGc({ storage, currentJsonKey: KEY }, {

--- a/packages/server/src/gc.test.ts
+++ b/packages/server/src/gc.test.ts
@@ -12,6 +12,7 @@ import {
   type GcPending,
   type Storage,
   type StorageGetOptions,
+  GC_GRACE_PERIOD_MILLIS,
   GC_PENDING_SCHEMA_VERSION,
   MAX_PARALLEL_LOG_READS,
   MemoryStorage,
@@ -162,6 +163,74 @@ describe("runGc", () => {
     const pending = await readGcPending(s, PENDING_KEY);
     expect(pending?.json.candidates).toEqual([]);
     expect(pending?.json.last_swept_at).toBe(new Date(nowMs).toISOString());
+  });
+
+  // ── grace anchoring ──────────────────────────────────────────────
+  // `due_at` measures the writer-retry window from the MARK, never
+  // from the listed object's write time. That distinction is
+  // invisible to every backend this file runs on: `lastModified` is
+  // optional on `StorageListEntry`, and `MemoryStorage` /
+  // `LocalFsStorage` — the two the default suite covers — omit it,
+  // so they take the `now()` path and always saw the full window.
+  // The S3, GCS and R2 adapters populate it from server headers, so
+  // anchoring there would give an effective grace of
+  // `max(0, grace − object age)` — zero for anything older than the
+  // 7-day default, which stale-log and orphan candidates typically
+  // are. `pnpm test:parity` cannot see it either: the storage
+  // conformance suite projects `lastModified` out of its comparison
+  // as adapter-optional. This wrapper is the only way to reach the
+  // production shape from `MemoryStorage`.
+  const withListedLastModified = (inner: Storage, lastModified: Date): Storage => ({
+    get: (key, opts) => inner.get(key, opts),
+    put: (key, body, opts) => inner.put(key, body, opts),
+    delete: (key, opts) => inner.delete(key, opts),
+    list: async function* (prefix, opts) {
+      for await (const entry of inner.list(prefix, opts)) {
+        yield { ...entry, lastModified };
+      }
+    },
+  });
+
+  test("grants full grace from the mark even when listed objects are older than it", async () => {
+    const inner = new MemoryStorage();
+    await bootstrap(inner, KEY);
+    const writer = new Writer({ storage: inner, currentJsonKey: KEY });
+    for (let i = 0; i < 12; i++) {
+      await writer.commit({
+        op: "I",
+        collection: COLL,
+        docId: `d${i}`,
+        body: { _id: `d${i}`, n: i },
+      });
+    }
+    // Folds [0, 10) ⇒ ten stale-log candidates. The snapshot it writes
+    // is the live one and every content blob stays reachable (snapshot
+    // rows + the live tail), so stale-log is the only category marked.
+    await compact({ storage: inner, currentJsonKey: KEY }, {
+      minEntriesToCompact: 10,
+      maxEntriesPerRun: 10,
+    } as InternalCompactOptions);
+
+    const markedAt = new Date("2026-01-08T00:00:00.000Z");
+    // A month old — comfortably past the 7-day default, which is what
+    // makes an age-anchored horizon land in the past at mark time.
+    const storage = withListedLastModified(inner, new Date("2025-12-08T00:00:00.000Z"));
+
+    // Default grace (no `graceMillis` override) — the production knob.
+    const r = await runGc({ storage, currentJsonKey: KEY }, {
+      now: () => markedAt,
+    } as InternalRunGcOptions);
+    expect(r.marked.stale_log).toBe(10);
+    // The absorber must still be armed: nothing is due in the pass
+    // that marked it, however old the objects are.
+    expect(r.swept).toBe(0);
+
+    const pending = await readGcPending(inner, PENDING_KEY);
+    expect(pending?.json.candidates).toHaveLength(10);
+    const dueAts = new Set((pending?.json.candidates ?? []).map((c) => c.due_at));
+    expect(dueAts).toEqual(
+      new Set([new Date(markedAt.getTime() + GC_GRACE_PERIOD_MILLIS).toISOString()]),
+    );
   });
 
   test("marks the replaced snapshot after a second compaction run", async () => {

--- a/packages/server/src/gc.ts
+++ b/packages/server/src/gc.ts
@@ -487,12 +487,13 @@ const parseHashFromContentKey = (key: string): string | null => {
  * writer-retry window from when we judged a key dead, which is
  * unrelated to when the object was written.
  *
- * Do NOT reinstate the old `entry.lastModified ?? now()` anchor.
- * Only the S3/GCS/R2 adapters populate that field, so it made the
+ * Never anchor on the object's own timestamp. Doing so made the
  * effective grace `max(0, graceMs − object age)` — zero past the
- * 7-day default, for exactly the old objects GC marks — while the
- * backends the suite runs omit it and showed the full window.
- * `gc.test.ts` pins this against a stub that surfaces it.
+ * 7-day default, for exactly the old objects GC marks. It read a
+ * `lastModified` that only the S3/GCS/R2 adapters populated, so the
+ * suite's backends showed a full window and no test could see it.
+ * `StorageListEntry` no longer carries a timestamp; `gc.test.ts`
+ * still pins the behaviour against an entry that fakes one.
  *
  * Called per candidate, not hoisted per pass, so the local-clock
  * backends keep their exact previous horizon.

--- a/packages/server/src/gc.ts
+++ b/packages/server/src/gc.ts
@@ -124,8 +124,8 @@ export interface InternalRunGcOptions extends RunGcOptions {
   /**
    * @internal Clock injection for tests. Defaults to
    * `() => new Date()`. The function is invoked at mark time (to
-   * compute `due_at` when `lastModified` is absent) and at sweep
-   * time (to compare against candidate `due_at`).
+   * compute every candidate's `due_at`) and at sweep time (to
+   * compare against candidate `due_at`).
    */
   readonly now?: () => Date;
 }
@@ -243,7 +243,7 @@ export const runGc = async (
       }
       newCandidates.push({
         key: entry.key,
-        due_at: computeDueAt(entry, now, grace),
+        due_at: computeDueAt(now, grace),
         reason: "stale-log",
       });
       markedStaleLog++;
@@ -269,7 +269,7 @@ export const runGc = async (
     }
     newCandidates.push({
       key: entry.key,
-      due_at: computeDueAt(entry, now, grace),
+      due_at: computeDueAt(now, grace),
       reason: "orphan-snapshot",
     });
     markedOrphanSnapshot++;
@@ -322,7 +322,7 @@ export const runGc = async (
     }
     newCandidates.push({
       key: entry.key,
-      due_at: computeDueAt(entry, now, grace),
+      due_at: computeDueAt(now, grace),
       reason: "orphan-content",
     });
     markedOrphanContent++;
@@ -483,15 +483,22 @@ const parseHashFromContentKey = (key: string): string | null => {
 };
 
 /**
- * Anchor `due_at` to `lastModified` when the storage adapter
- * surfaces it; fall back to the injected `now` so a Storage impl
- * without a server clock still GCs after `grace` from the mark
- * moment.
+ * Anchor `due_at` on the MARK: `now() + graceMs`. Grace measures the
+ * writer-retry window from when we judged a key dead, which is
+ * unrelated to when the object was written.
+ *
+ * Do NOT reinstate the old `entry.lastModified ?? now()` anchor.
+ * Only the S3/GCS/R2 adapters populate that field, so it made the
+ * effective grace `max(0, graceMs − object age)` — zero past the
+ * 7-day default, for exactly the old objects GC marks — while the
+ * backends the suite runs omit it and showed the full window.
+ * `gc.test.ts` pins this against a stub that surfaces it.
+ *
+ * Called per candidate, not hoisted per pass, so the local-clock
+ * backends keep their exact previous horizon.
  */
-const computeDueAt = (entry: StorageListEntry, now: () => Date, graceMs: number): string => {
-  const base = entry.lastModified ?? now();
-  return new Date(base.getTime() + graceMs).toISOString();
-};
+const computeDueAt = (now: () => Date, graceMs: number): string =>
+  new Date(now().getTime() + graceMs).toISOString();
 
 /**
  * Build the live content-hash set. The set covers every live

--- a/tests/fixtures/collection-api-cascade.ts
+++ b/tests/fixtures/collection-api-cascade.ts
@@ -515,15 +515,16 @@ const runGcCascade = async (
     graceMillis: 0,
     maxSweepsPerRun: 50,
     maxMarksPerRun: 50,
-    // grace=0 sets each candidate's due_at to its storage `lastModified`.
-    // On S3-like backends (node-minio) `lastModified` is the *server*
-    // clock at *second* resolution, which can sit a beat ahead of the
-    // local clock (container/VM skew, worse under load). That left 1-3 of
-    // the 30 just-written entries with a due_at in the local future, so a
-    // single grace=0 pass swept 27-29 not 30 — a real flake under load
-    // (memory/local-fs use a local ms clock and never hit it). Pin `now`
-    // a day ahead so the sweep threshold dominates any plausible skew; the
-    // pass still marks + sweeps all 30, just independent of clock alignment.
+    // Pinned a day ahead, belt-and-braces. grace=0 now sets due_at to
+    // this same injected `now` on every backend, and the sweep test is
+    // `due_at <= now`, so the pass marks + sweeps all 30 regardless.
+    // The offset used to be load-bearing: `due_at` was anchored to the
+    // storage `lastModified`, which on node-minio is the *server* clock
+    // at *second* resolution and could sit a beat ahead of the local
+    // one, leaving 1-3 of the 30 just-written entries due in the local
+    // future and sweeping 27-29. `gc.ts` anchoring on the mark removed
+    // that skew coupling; keeping the offset costs nothing and holds
+    // the assertion independent of clock alignment.
     now: () => new Date(Date.now() + 24 * 60 * 60 * 1000),
   } as InternalRunGcOptions);
   expect(gcRes.marked.stale_log).toBe(30);

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -696,7 +696,22 @@ const BUDGETS: readonly Budget[] = [
   //     `casUpdateCurrentJson` guard, plus JSDoc on both. Measured 129227 raw
   //     / 39688 gz / 11471 min-gz; gz (248 B) and min-gz (817 B) both stay
   //     under, only the raw tripwire moves.
-  { entry: "maintenance.js", raw: 127 * 1024, gz: 39 * 1024, minGz: 12 * 1024 },
+  //   → gz 39→40 KiB (2026-08-01): dropping `StorageListEntry.lastModified`
+  //     replaced the field with a longer do-not-reinstate JSDoc block on the
+  //     type, and `computeDueAt` likewise. Both are `/** */` blocks, which
+  //     rolldown ships; the CODE shrank (a parameter, a `??`, and three
+  //     adapter assignments gone). Measured 129693 raw / 39898 gz / 11454
+  //     min-gz. That left gz 38 B under a hard-gated axis — a hair-trigger
+  //     for whoever edits a comment near this closure next — so the gz
+  //     tripwire moves even though it had not tripped. min-gz, the real
+  //     shipped-cost ceiling where comments are stripped, is 834 B under and
+  //     FELL 17 B on this change. Per the POLICY above: comment-dominated,
+  //     so rebaseline rather than golf the warning that keeps a
+  //     seven-day-grace bug from being reintroduced.
+  //     Same commit, no budget move needed: index.js 236837 raw (731 B
+  //     under), http.js 360265 (183 B), cloudflare.js 432978 (174 B),
+  //     dev.js unchanged.
+  { entry: "maintenance.js", raw: 127 * 1024, gz: 40 * 1024, minGz: 12 * 1024 },
   // Cloudflare Workers adapter — re-exports the kernel barrel
   // (Db, Writer, etc.) plus the R2-binding `Storage` impl
   // and the `baerlyCloudflare` helper. Aggregator: closure

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -338,7 +338,16 @@ const BUDGETS: readonly Budget[] = [
   //     (min-gz 228 B under). Deliberate doc-quality spend, not code creep —
   //     per the POLICY above, raw/gz are creep tripwires and are rebaselined
   //     rather than paid for by golfing comments.
-  { entry: "index.js", raw: 231 * 1024, gz: 73 * 1024, minGz: 20 * 1024 },
+  //   → 232 KiB raw (2026-08-01): GC grace-period anchoring fix —
+  //     `computeDueAt` drops its `entry.lastModified` anchor, plus the
+  //     do-not-reinstate rationale on it and on the `StorageListEntry`
+  //     field. Pure comment bytes: the code got SMALLER (one parameter
+  //     and one `??` gone), and min-gz — the minified hard ceiling, where
+  //     comments are stripped — measured 20239, DOWN 13 B from the 20252
+  //     recorded in the note above. Measured 236768 raw / 74313 gz (gz
+  //     still 439 B under). Rebaselined per the POLICY rather than golfing
+  //     the warning that keeps the bug from being reintroduced.
+  { entry: "index.js", raw: 232 * 1024, gz: 73 * 1024, minGz: 20 * 1024 },
   // The three auth verifier factories (bearerJwt, sharedSecret,
   // cloudflareAccess) plus the transitive jose closure pulled in by
   // bearerJwt's createRemoteJWKSet + jwtVerify. Adding a fourth


### PR DESCRIPTION
GC's grace period was silently near-zero on every production backend. This fixes the anchoring, then removes the field that caused it.

Two commits, meant to be read in order — the second is only possible because of the first.

## 1. `fix(gc): anchor the grace period on the mark, not the object's age` (patch)

`runGc` marks an orphan candidate with a `due_at` horizon and only deletes it once that horizon passes, so a writer still retrying toward an anchor we judged dead has a window to land. `computeDueAt` set that horizon to `(entry.lastModified ?? now()) + grace` — anchored, when the adapter surfaced it, to when the *object* was written rather than to when we *marked* it.

`StorageListEntry.lastModified` is optional, and which adapters populate it splits exactly along the local/production line: `MemoryStorage` and `LocalFsStorage` omit it and take the `now()` fallback, while the S3, GCS and R2 adapters populate it from server-side headers. On those three the effective grace was `max(0, grace − object age)`, so past the seven-day `GC_GRACE_PERIOD_MILLIS` default it was **zero** — a candidate was marked already-due and swept on the next pass with no absorber at all. Stale-log and orphan candidates are precisely the objects old enough to hit that. The constant's own contract warns operators not to lower the knob; the anchoring defeated it regardless of the value they set.

Anchoring on the mark is strictly more conservative on every backend, so it cannot delete anything sooner than before, and it is unchanged on the local-clock ones. Not retroactive: candidates already in `gc/pending.json` keep the `due_at` they were marked with, so the first pass after upgrading still sweeps that backlog on the old horizon.

**Why no test caught this.** The default suite runs `memory` and `local-fs`, both on the fallback path. `test:parity` could not see it either — the storage conformance suite projected `lastModified` out of its list-entry comparison as adapter-optional. The regression test therefore lists through a delegating `Storage` that surfaces a month-old `lastModified`, the only way to reach the production shape from `MemoryStorage`. Verified failing against the old anchoring: swept 10 of 10 in the marking pass.

## 2. `refactor(protocol)!: drop lastModified from StorageListEntry` (minor, breaking)

With the anchor corrected the field had no reader left, and three adapters were still minting a `Date` per listed entry on every LIST for a value nothing consumed. A listed object is now `key` + `etag` only.

Nothing else wanted it. `baerly admin usage` had already declined it, reading `commit_ts` from the `LogEntry` body instead and documenting that as the cross-backend-uniform choice. The real wall-clock need is served by `StoragePutResult.serverDate`, which drives the adaptive clock-skew loop and is untouched here.

The conformance suite now compares list entries **whole** (`toEqual` fails on extra own properties), so a backend-specific field cannot be reintroduced without a conformance failure — closing the exact hole that hid the GC bug.

Marked `!` and released `minor`: `StorageListEntry` is exported from the public barrel and `docs/contributing/extending.md` names `Storage` as an extension point, so this narrows published type surface. There are no third-party adapters and all five in-tree impls are updated (`MemoryStorage`, `LocalFsStorage`, `S3HttpStorage`, `GcsHttpStorage`, `r2BindingStorage`), so no known consumer breaks.

## Verification

Each commit is independently green — the full gate ran against the first commit's tree, not just the branch tip.

| Gate | commit 1 | commit 2 / tip |
| --- | --- | --- |
| `verify:agent` | exit 0 | exit 0 |
| `test:agent` | 2571 passed | 2571 passed |
| `test:adapter-cloudflare` (R2 under Workerd) | — | 152 passed |
| `test:adapter-node` (S3 against Minio) | — | 371 passed |
| `test:parity` | — | 113 passed |
| `test:minio` | — | 2702 passed |

The R2 and Minio suites were run specifically to back the whole-entry conformance claim against real backends rather than only the in-memory ones. R2 was the adapter that populated the field unconditionally.

## Bundle budgets

Two tripwires move, both comment-dominated, both rebaselined per the `POLICY` note in `bundle-size.test.ts` rather than paid for by golfing the do-not-reinstate warnings.

- `index.js` raw 231 → 232 KiB (commit 1). Measured 236768 raw / 74313 gz. The code got *smaller* — a parameter and a `??` gone — and min-gz, the minified hard ceiling where comments are stripped, **fell** 13 B to 20239.
- `maintenance.js` gz 39 → 40 KiB (commit 2). Measured 129693 raw / 39898 gz / 11454 min-gz. This axis had **not** tripped — it sat 38 B under a hard-gated ceiling, a hair-trigger for whoever edits a comment near this closure next. min-gz fell 17 B and stays 834 B under.

No `min-gz` axis regressed anywhere; every one of them moved down or held.
