### PR TITLE
fix: give /v1/since cursors a generation discriminator

### DIFF
--- a/.changeset/since-cursor-generation.md
+++ b/.changeset/since-cursor-generation.md
@@ -16,7 +16,9 @@ generation, and skipped every restored row beneath it — with no error.
 Gapped, not broken, which a sync client cannot detect for itself.
 
 `current.json` now carries an opaque `generation` nonce, and the cursor
-handed to a client is `<generation>.<lsn>` instead of a bare LSN. A
+handed to a client is `<generation>.<lsn>` once that nonce exists. A
+collection with no generation keeps handing out a bare LSN, so the
+wire-shape change is confined to collections that carry one. A
 resume whose generation no longer matches is rejected with
 `BaerlyError{code:"SchemaError"}` (HTTP 400). The nonce is re-minted by
 the writers that _replace_ a collection (both `restore` seeds, writer
@@ -39,4 +41,7 @@ re-bootstraps, which also repairs that older case.
 
 Cursors are opaque on the wire and always were; no client action is
 required. Custom `/v1/since` consumers should treat a `400 SchemaError`
-as "restart with an empty cursor" rather than retrying.
+as "back off, then restart with an empty cursor" rather than retrying.
+Backing off first matters: if a server ever hands back a cursor it then
+refuses — a mixed-version fleet mid-rolling-deploy is the reachable
+case — re-bootstrapping without a delay turns that into a hot loop.

--- a/.changeset/since-cursor-generation.md
+++ b/.changeset/since-cursor-generation.md
@@ -1,0 +1,42 @@
+---
+"@gusto/baerly-storage": patch
+---
+
+Give `/v1/since` cursors a generation discriminator, so a
+`baerly admin restore --force` truncation can no longer silently gap a
+long-poll stream.
+
+A cursor's seq identifies a `log/<seq>` slot, and slots are reused.
+`restore --force` reseeds `log_seq_start` to one past the highest
+_surviving_ log object, which lands below the old floor whenever a
+budget-bounded GC sweep has cleared the lex-first part of the old range
+(the deliberate floor exemption). A pre-restore cursor then cleared the
+`cursorSeq < log_seq_start` re-bootstrap check, resumed into the new
+generation, and skipped every restored row beneath it — with no error.
+Gapped, not broken, which a sync client cannot detect for itself.
+
+`current.json` now carries an opaque `generation` nonce, and the cursor
+handed to a client is `<generation>.<lsn>` instead of a bare LSN. A
+resume whose generation no longer matches is rejected with
+`BaerlyError{code:"SchemaError"}` (HTTP 400). The nonce is re-minted by
+the writers that _replace_ a collection (both `restore` seeds, writer
+auto-provision, `ensureTable`) and carried through by the writers that
+_advance_ one (the compactor's fold CAS, `claimWriter`, every
+`casUpdateCurrentJson` mutator).
+
+`generation` is an optional field on `schema_version: 3` — no schema
+bump, so existing buckets keep working untouched. A manifest predating
+the field and a cursor predating the composite shape both decode to a
+sentinel, so a collection that was never truncated keeps resuming
+normally through one uniform comparison, with no fail-open branch.
+
+The React client now acts on the rejection instead of hot-looping on it.
+`/v1/since`'s `SchemaError` marks a permanently dead cursor, but the
+subscription poll loop caught every error alike and retried the same
+cursor at 1 req/s forever — so the pre-existing folded-cursor rejection
+left a frozen table and a background spin. It now drops the cursor and
+re-bootstraps, which also repairs that older case.
+
+Cursors are opaque on the wire and always were; no client action is
+required. Custom `/v1/since` consumers should treat a `400 SchemaError`
+as "restart with an empty cursor" rather than retrying.

--- a/docs/guide/backups.md
+++ b/docs/guide/backups.md
@@ -167,14 +167,25 @@ restore performs only the initial `current.json` seed/reseed write.
 
 For production recovery, treat restore as a cutover to a proven copy,
 not as an overwrite of the live prefix. Do not restore over the live
-prefix while writers are still active. Drain or disconnect long-poll
-readers too, not just writers: a `--force` reseed can lower the
-collection's live log floor (`log_seq_start`), and long-poll clients
-detect a folded-away cursor by testing it against that floor, so a
-lowered floor lets a stale pre-restore cursor pass the check. Such a
-client silently resumes into the new generation instead of getting the
-re-bootstrap error, and misses restored rows below its cursor. The safe
-cutover shape is:
+prefix while writers are still active.
+
+Long-poll readers no longer need draining. A `--force` reseed re-mints
+the collection's `generation` nonce, and every `/v1/since` cursor
+carries the generation it was minted under, so a stale pre-restore
+cursor is rejected with a `SchemaError` (HTTP 400) telling the client to
+re-bootstrap. The React client (`useQuery` subscriptions) acts on that
+automatically: it drops the cursor and resumes from the collection's log
+floor. A custom `/v1/since` consumer must handle the 400 the same way —
+restart with an empty cursor rather than retrying the rejected one.
+
+This closes a real hazard rather than merely documenting it. A `--force`
+reseed can lower the live log floor (`log_seq_start`), and the older
+protocol detected a dead cursor only by testing its seq against that
+floor — so a lowered floor let a stale cursor pass, silently resume into
+the new generation, and miss every restored row beneath it. See
+invariant 13 in [the sync protocol spec](../spec/sync-protocol.md).
+
+The safe cutover shape is:
 
 1. Pause writers or put the app in read-only mode.
 2. Restore into a separate recovery bucket or tenant prefix.

--- a/docs/guide/cheatsheet.md
+++ b/docs/guide/cheatsheet.md
@@ -120,6 +120,13 @@ all optional and composable — always
 The JS SDK (`createBaerlyClient`) and the React hooks build these for
 you; reach for raw URLs only when scripting.
 
+`/v1/since`'s `cursor` is opaque — echo `next_cursor` back verbatim and
+never parse it. Start with `cursor=` (empty) to read from the
+collection's log floor. A `400 SchemaError` means the cursor is
+permanently dead (folded away, or its collection was truncated by
+`restore --force`); restart with an empty cursor rather than retrying,
+which would loop forever. The React hooks do this for you.
+
 ## Where to look next
 
 - Full API reference —

--- a/docs/spec/sync-protocol.md
+++ b/docs/spec/sync-protocol.md
@@ -498,10 +498,16 @@ These are the load-bearing rules.
 13. **A `/v1/since` cursor is valid only within the generation that
     minted it.** `current.json` carries an opaque `generation` nonce,
     and the cursor the server hands a long-poll client is
-    `<generation>.<lsn>` — not a bare LSN. On resume, a generation that
-    does not match the manifest's is rejected with
+    `<generation>.<lsn>` whenever that nonce is present. On resume, a
+    generation that does not match the manifest's is rejected with
     `BaerlyError{code:"SchemaError"}` (HTTP 400) and the client must
     re-bootstrap.
+
+    A manifest with no `generation` keeps handing out a **bare** LSN
+    rather than `-.<lsn>`. Both decode to the same sentinel, so the
+    comparison below is unaffected; emitting the bare form confines the
+    wire-shape change to collections that actually carry a nonce,
+    instead of changing every cursor in the bucket on upgrade.
 
     This exists because invariant 12's `--force` exemption makes a seq
     comparison alone unsound. A seq identifies a `log/<seq>` slot, and
@@ -526,7 +532,7 @@ These are the load-bearing rules.
     shape both decode to the sentinel `-`, so one string comparison
     covers every case with no fail-open branch:
 
-    | Manifest      | Cursor  | Result | Why                                                       |
+    | Manifest      | Cursor (decoded) | Result | Why                                            |
     | ------------- | ------- | ------ | --------------------------------------------------------- |
     | no generation | `-`     | pass   | Nothing was truncated.                                      |
     | no generation | nonce   | reject | Manifest replaced by an older build; treat as unknown.      |

--- a/docs/spec/sync-protocol.md
+++ b/docs/spec/sync-protocol.md
@@ -495,6 +495,44 @@ These are the load-bearing rules.
     place. That is sound because the reseed value is strictly greater
     than every log object still present, so the committing `log/<seq>`
     create cannot collide with the old generation.
+13. **A `/v1/since` cursor is valid only within the generation that
+    minted it.** `current.json` carries an opaque `generation` nonce,
+    and the cursor the server hands a long-poll client is
+    `<generation>.<lsn>` — not a bare LSN. On resume, a generation that
+    does not match the manifest's is rejected with
+    `BaerlyError{code:"SchemaError"}` (HTTP 400) and the client must
+    re-bootstrap.
+
+    This exists because invariant 12's `--force` exemption makes a seq
+    comparison alone unsound. A seq identifies a `log/<seq>` slot, and
+    slots are reused: after a truncating reseed that lands below the old
+    floor, a pre-restore cursor clears the `cursorSeq < log_seq_start`
+    check and resumes into the new generation, silently skipping every
+    restored row beneath it — gapped, not broken, which a sync client
+    cannot detect for itself.
+
+    The nonce is re-minted by the writers that *replace* a collection
+    (both `baerly admin restore` seeds, writer auto-provision,
+    `ensureTable`) and carried through untouched by the writers that
+    *advance* one (the compactor's fold CAS, `claimWriter`, every
+    `casUpdateCurrentJson` mutator). It is deliberately not
+    `writer_fence.epoch`: the fresh-target restore branch seeds
+    `epoch: 0`, so a truncate-to-empty would be indistinguishable from a
+    genuine epoch-0 collection. A counter that resets cannot
+    discriminate generations.
+
+    Absent is a defined state, not a degraded one. A `current.json`
+    predating the field and a bare-LSN cursor predating the composite
+    shape both decode to the sentinel `-`, so one string comparison
+    covers every case with no fail-open branch:
+
+    | Manifest      | Cursor  | Result | Why                                                       |
+    | ------------- | ------- | ------ | --------------------------------------------------------- |
+    | no generation | `-`     | pass   | Nothing was truncated.                                      |
+    | no generation | nonce   | reject | Manifest replaced by an older build; treat as unknown.      |
+    | nonce `A`     | `-`     | reject | Only a mint adds the field, and a mint means replacement.   |
+    | nonce `A`     | `A`     | pass   | Same generation.                                            |
+    | nonce `B`     | `A`     | reject | Truncated.                                                  |
 
 ## LSNs, wall clocks, and downstream consumers
 

--- a/llms.txt
+++ b/llms.txt
@@ -11,7 +11,7 @@ S3-compatible endpoints require `baerly doctor --bucket` plus owner
 validation, and GCS S3-interop is unsupported for database use today.
 Browsers and other clients talk to it over HTTP via the typed
 `@gusto/baerly-storage/client`. The change-feed is a long-poll on
-`/v1/since?cursor=<lsn>` — there is no client-side polling of the
+`/v1/since?cursor=<opaque>` — there is no client-side polling of the
 storage layer.
 
 Day-1 deploy targets, both first-class:

--- a/packages/adapter-cloudflare/src/http-conformance.test.ts
+++ b/packages/adapter-cloudflare/src/http-conformance.test.ts
@@ -64,6 +64,9 @@ describe("HTTP conformance", () => {
         writer_fence: { epoch: 0, owner: "http-conformance-test", claimed_at: "" },
         snapshot_bytes: 0,
         snapshot_rows: 0,
+        // Match the Node-side seed: exercise the composite
+        // `<generation>.<lsn>` cursor shape, not just the bare LSN.
+        generation: "0123456789ab",
       });
     },
     options: {

--- a/packages/cli/src/admin/restore.test.ts
+++ b/packages/cli/src/admin/restore.test.ts
@@ -225,6 +225,46 @@ describe("baerly admin restore", () => {
     expect(survivors).toContain(`${TABLE_PREFIX}/log/0.json`);
   });
 
+  test("both restore branches mint a generation, and --force re-mints a different one", async () => {
+    // The generation nonce is what lets `/v1/since` reject a cursor from
+    // the truncated collection. Two things have to hold: the fresh-target
+    // seed writes one at all, and `--force` writes a DIFFERENT one —
+    // re-using it would leave a pre-restore cursor looking valid and the
+    // stream silently gapped, which is issue #73.
+    //
+    // Note this is exactly what `writer_fence.epoch` cannot do: the
+    // fresh-target branch below seeds `epoch: 0`, so a truncate-to-empty
+    // is indistinguishable from a genuine epoch-0 collection.
+    await writeFile(stdinPath, CANONICAL_NDJSON, "utf8");
+    await expect(
+      runRestore(
+        [`--bucket=file://${root}`, `--app=${APP}`, `--tenant=${TENANT}`, `--collection=${COLL}`],
+        { streams: { stdin: createReadStream(stdinPath) } },
+      ),
+    ).resolves.toBe(0);
+
+    const seeded = await readCurrentJson(storage, CURRENT_JSON_KEY);
+    expect(seeded?.json.generation).toMatch(/^[0-9a-f]{12}$/);
+
+    await writeFile(stdinPath, `{"_id":"g-1","x":1}\n`, "utf8");
+    await expect(
+      runRestore(
+        [
+          `--bucket=file://${root}`,
+          `--app=${APP}`,
+          `--tenant=${TENANT}`,
+          `--collection=${COLL}`,
+          "--force",
+        ],
+        { streams: { stdin: createReadStream(stdinPath) } },
+      ),
+    ).resolves.toBe(0);
+
+    const truncated = await readCurrentJson(storage, CURRENT_JSON_KEY);
+    expect(truncated?.json.generation).toMatch(/^[0-9a-f]{12}$/);
+    expect(truncated?.json.generation).not.toBe(seeded?.json.generation);
+  });
+
   test("--force chooses old tail from log keys without decoding malformed old entries", async () => {
     await writeFile(stdinPath, CANONICAL_NDJSON, "utf8");
     const first = await runRestore(

--- a/packages/cli/src/admin/restore.ts
+++ b/packages/cli/src/admin/restore.ts
@@ -52,6 +52,7 @@ import {
   type CurrentJson,
   type DocumentData,
   encodeJsonBytes,
+  mintGeneration,
   readCurrentJson,
   type Storage,
 } from "@baerly/protocol";
@@ -211,6 +212,13 @@ const bundle = defineBaerlySubcommand({
         },
         snapshot_bytes: 0,
         snapshot_rows: 0,
+        // New generation. This is the one write in the system that
+        // lowers `log_seq_start`, so it is the one write that can leave
+        // a live `/v1/since` cursor pointing above the floor but into a
+        // dead generation. Re-minting here is what lets the next resume
+        // on that cursor fail loudly (`SchemaError` → re-bootstrap)
+        // instead of silently skipping the restored rows beneath it.
+        generation: mintGeneration(),
       };
       try {
         await bucket.storage.put(currentJsonKey, encodeJsonBytes(reseeded), {
@@ -236,6 +244,13 @@ const bundle = defineBaerlySubcommand({
         writer_fence: { epoch: 0, owner: RESTORE_OWNER, claimed_at: "" },
         snapshot_bytes: 0,
         snapshot_rows: 0,
+        // Mint here too, even though there is no old generation at this
+        // key right now. A client can still hold a cursor from a
+        // previous incarnation of this collection (dropped, then
+        // restored), and `writer_fence.epoch` resets to 0 on this branch
+        // — which is exactly why the epoch cannot serve as the
+        // discriminator and a nonce can.
+        generation: mintGeneration(),
       };
       await createCurrentJson(bucket.storage, currentJsonKey, seed);
     }

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -67,6 +67,17 @@ export interface HttpErrorEnvelope {
  * the request's `cursor` and `next_cursor`. Client passes
  * `next_cursor` back on the next call. Empty `events` + same
  * `next_cursor` means "nothing changed within the budget".
+ *
+ * `next_cursor` is **opaque**: echo it back verbatim, never parse it.
+ * `""` means "start from the collection's log floor" and is always
+ * valid.
+ *
+ * A `400 SchemaError` on resume means the cursor is permanently dead —
+ * the entry was folded into a snapshot and GC'd, or its generation was
+ * truncated by `baerly admin restore --force`. Neither clears on
+ * retry: restart with `cursor: ""`. Retrying the rejected cursor loops
+ * forever. Back off before re-bootstrapping so a cursor rejected on
+ * every lap cannot become a hot loop.
  */
 export interface SinceResponse {
   readonly events: ReadonlyArray<LogEntry>;

--- a/packages/client/src/react/subscription-pool.test.ts
+++ b/packages/client/src/react/subscription-pool.test.ts
@@ -106,4 +106,69 @@ describe("subscription-pool", () => {
     const client = makeClient(mock);
     expect(poolFor(client)).toBe(poolFor(client));
   });
+
+  test("SchemaError re-bootstraps the cursor instead of retrying it", async () => {
+    // `/v1/since` returns SchemaError (400) for two permanent cursor
+    // states: the entry was folded into a snapshot and GC'd, or the
+    // cursor was minted in a generation `restore --force` truncated.
+    // Neither clears on retry, so the pool must drop the cursor and
+    // re-bootstrap. Before this behaviour existed the loop retried the
+    // same rejected cursor at 1 req/s forever with the table frozen.
+    const cursors: (string | null)[] = [];
+    let servedEvent = false;
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", (req: Request) => {
+      const url = new URL(req.url);
+      const cursor = url.searchParams.get("cursor");
+      cursors.push(cursor);
+      if (cursor !== null && cursor.length > 0) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              error: { code: "SchemaError", message: "cursor … generation that no longer exists" },
+            }),
+            { status: 400, headers: { "content-type": "application/json" } },
+          ),
+        );
+      }
+      if (servedEvent) {
+        // Subsequent bootstraps idle. One-shot so the cursor is adopted
+        // exactly once and the count below is deterministic — otherwise
+        // the pool would legitimately re-adopt it every cycle.
+        return Promise.resolve(
+          new Response(JSON.stringify({ events: [], next_cursor: "" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      }
+      servedEvent = true;
+      // Bootstrap poll: hand back one event so the pool adopts a cursor.
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ events: [{ lsn: "aaa_bbb_ccc" }], next_cursor: "deadbeef.aaa_bbb_ccc" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    });
+    const client = makeClient(mock);
+    const pool = poolFor(client);
+    const fetcher = vi.fn<() => Promise<unknown>>().mockResolvedValue([]);
+    const unsubscribe = pool.attach(
+      "gen",
+      ["notes"],
+      new Set(["notes"]),
+      fetcher,
+      vi.fn<() => void>(),
+    );
+
+    await waitMicrotasks(40);
+    unsubscribe();
+
+    // The rejected cursor must not be retried: after the 400 the pool
+    // goes back to "" rather than sending `deadbeef.…` a second time.
+    const rejected = cursors.filter((c) => c === "deadbeef.aaa_bbb_ccc");
+    expect(rejected).toHaveLength(1);
+    expect(cursors.filter((c) => c === "" || c === null).length).toBeGreaterThan(1);
+  });
 });

--- a/packages/client/src/react/subscription-pool.test.ts
+++ b/packages/client/src/react/subscription-pool.test.ts
@@ -132,15 +132,12 @@ describe("subscription-pool", () => {
         );
       }
       if (servedEvent) {
-        // Subsequent bootstraps idle. One-shot so the cursor is adopted
-        // exactly once and the count below is deterministic — otherwise
-        // the pool would legitimately re-adopt it every cycle.
-        return Promise.resolve(
-          new Response(JSON.stringify({ events: [], next_cursor: "" }), {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          }),
-        );
+        // Subsequent bootstraps hang, like a real idle long-poll. The
+        // request is still recorded above, which is all the assertion
+        // needs. Resolving instantly instead would spin the poll loop
+        // in microtasks with no timer to yield to, and the fake-timer
+        // advance below would never return.
+        return sinceForever();
       }
       servedEvent = true;
       // Bootstrap poll: hand back one event so the pool adopts a cursor.
@@ -151,24 +148,97 @@ describe("subscription-pool", () => {
         ),
       );
     });
-    const client = makeClient(mock);
-    const pool = poolFor(client);
-    const fetcher = vi.fn<() => Promise<unknown>>().mockResolvedValue([]);
-    const unsubscribe = pool.attach(
-      "gen",
-      ["notes"],
-      new Set(["notes"]),
-      fetcher,
-      vi.fn<() => void>(),
-    );
+    vi.useFakeTimers();
+    try {
+      const client = makeClient(mock);
+      const pool = poolFor(client);
+      const fetcher = vi.fn<() => Promise<unknown>>().mockResolvedValue([]);
+      const unsubscribe = pool.attach(
+        "gen",
+        ["notes"],
+        new Set(["notes"]),
+        fetcher,
+        vi.fn<() => void>(),
+      );
 
-    await waitMicrotasks(40);
-    unsubscribe();
+      await waitMicrotasks(40);
 
-    // The rejected cursor must not be retried: after the 400 the pool
-    // goes back to "" rather than sending `deadbeef.…` a second time.
-    const rejected = cursors.filter((c) => c === "deadbeef.aaa_bbb_ccc");
-    expect(rejected).toHaveLength(1);
-    expect(cursors.filter((c) => c === "" || c === null).length).toBeGreaterThan(1);
+      // The rejected cursor must not be retried: after the 400 the pool
+      // goes back to "" rather than sending `deadbeef.…` a second time.
+      expect(cursors.filter((c) => c === "deadbeef.aaa_bbb_ccc")).toHaveLength(1);
+
+      // The re-bootstrap is deliberately behind the 1s error backoff,
+      // not immediate — see the oscillation test below for why.
+      await vi.advanceTimersByTimeAsync(1_000);
+      unsubscribe();
+      expect(cursors.filter((c) => c === "" || c === null).length).toBeGreaterThan(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("a cursor rejected on every lap backs off instead of hot-looping", async () => {
+    // The shape a mixed-version fleet produces mid-rolling-deploy: one
+    // replica hands back a cursor the other refuses. The
+    // `poll.cursor !== ""` guard bounds a same-iteration respin but NOT
+    // this two-iteration oscillation — "" succeeds, adopts a cursor,
+    // that cursor 400s, repeat. So the SchemaError path must fall
+    // through to the 1s backoff rather than `continue` past it;
+    // otherwise this runs at network speed with an invalidate storm
+    // every lap.
+    let requests = 0;
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", (req: Request) => {
+      requests += 1;
+      if (requests > 200) {
+        // Circuit breaker. On regression the loop spins at microtask
+        // speed and never yields to a timer, so `advanceTimersByTime`
+        // would pump forever and hang the runner. Parking the poll here
+        // lets the advance return and the bound below fail loudly.
+        return sinceForever();
+      }
+      const cursor = new URL(req.url).searchParams.get("cursor");
+      if (cursor !== null && cursor.length > 0) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: { code: "SchemaError", message: "dead cursor" } }), {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      }
+      // Bootstrap always succeeds, and always hands back a doomed cursor.
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ events: [{ lsn: "aaa_bbb_ccc" }], next_cursor: "deadbeef.aaa_bbb_ccc" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    });
+
+    vi.useFakeTimers();
+    try {
+      const client = makeClient(mock);
+      const pool = poolFor(client);
+      const unsubscribe = pool.attach(
+        "gen",
+        ["notes"],
+        new Set(["notes"]),
+        vi.fn<() => Promise<unknown>>().mockResolvedValue([]),
+        vi.fn<() => void>(),
+      );
+
+      await waitMicrotasks(40);
+      for (let i = 0; i < 5; i += 1) {
+        await vi.advanceTimersByTimeAsync(1_000);
+      }
+      unsubscribe();
+
+      // Two requests per backoff cycle (bootstrap + doomed resume), so
+      // ~5 simulated seconds is ~12. Without the backoff the loop is
+      // bounded only by microtask scheduling and blows past this.
+      expect(requests).toBeLessThan(20);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/client/src/react/subscription-pool.ts
+++ b/packages/client/src/react/subscription-pool.ts
@@ -189,24 +189,29 @@ const createPool = (client: BaerlyClient): SubscriptionPool => {
             // entry was folded into a snapshot and GC'd, or the cursor
             // was minted in a generation `restore --force` has since
             // truncated. Retrying the same cursor can never clear
-            // either one, so the backoff below would spin at 1 req/s
-            // forever with the table frozen.
+            // either one, so without this the loop would retry it at
+            // 1 req/s forever with the table frozen.
             //
-            // Re-bootstrap instead: `""` restarts from `log_seq_start`,
-            // which is what the server's error text asks for. The
-            // invalidate refetches the visible queries so subscribers
-            // converge on the post-restore state rather than sitting on
-            // pre-restore data.
+            // Re-bootstrap: `""` restarts from `log_seq_start`, which
+            // is what the server's error text asks for. The invalidate
+            // refetches the visible queries so subscribers converge on
+            // the post-restore state rather than sitting on pre-restore
+            // data.
             //
-            // Guarded on a non-empty cursor so this can only fire once
-            // per bootstrap. `/v1/since` short-circuits `cursor === ""`
-            // before any validation, so an empty cursor cannot produce
-            // this code — but if it ever did, `continue` skips the
-            // backoff below and we would spin. Falling through to the
-            // backoff is the safe direction.
+            // We deliberately do NOT `continue` past the backoff below.
+            // The `poll.cursor !== ""` guard bounds a same-iteration
+            // respin, but not a two-iteration oscillation: if the
+            // server rejects a cursor it just minted — a mixed-version
+            // fleet mid-rolling-deploy is the reachable case, where one
+            // replica issues a shape the other refuses — then `""`
+            // succeeds, hands back a fresh cursor, and that cursor is
+            // rejected again. Skipping the backoff would make that
+            // cycle run at network speed, with an `invalidateForTable`
+            // refetch storm on every lap. Falling through costs one
+            // second of recovery latency and bounds the pathological
+            // case at 1 cycle/s.
             poll.cursor = "";
             invalidateForTable(table);
-            continue;
           }
           // 1-second backoff on error to avoid hot-spinning on a
           // persistent failure; downstream subscribers' next fetch

--- a/packages/client/src/react/subscription-pool.ts
+++ b/packages/client/src/react/subscription-pool.ts
@@ -183,6 +183,31 @@ const createPool = (client: BaerlyClient): SubscriptionPool => {
           if (error instanceof DOMException && error.name === "AbortError") {
             return;
           }
+          if (error instanceof BaerlyError && error.code === "SchemaError" && poll.cursor !== "") {
+            // The cursor is unrecoverable, not the request. `/v1/since`
+            // returns this for exactly two states, both permanent: the
+            // entry was folded into a snapshot and GC'd, or the cursor
+            // was minted in a generation `restore --force` has since
+            // truncated. Retrying the same cursor can never clear
+            // either one, so the backoff below would spin at 1 req/s
+            // forever with the table frozen.
+            //
+            // Re-bootstrap instead: `""` restarts from `log_seq_start`,
+            // which is what the server's error text asks for. The
+            // invalidate refetches the visible queries so subscribers
+            // converge on the post-restore state rather than sitting on
+            // pre-restore data.
+            //
+            // Guarded on a non-empty cursor so this can only fire once
+            // per bootstrap. `/v1/since` short-circuits `cursor === ""`
+            // before any validation, so an empty cursor cannot produce
+            // this code — but if it ever did, `continue` skips the
+            // backoff below and we would spin. Falling through to the
+            // backoff is the safe direction.
+            poll.cursor = "";
+            invalidateForTable(table);
+            continue;
+          }
           // 1-second backoff on error to avoid hot-spinning on a
           // persistent failure; downstream subscribers' next fetch
           // sees the same error if it doesn't clear.

--- a/packages/dev/src/ensure-table.ts
+++ b/packages/dev/src/ensure-table.ts
@@ -2,6 +2,7 @@ import {
   BaerlyError,
   CURRENT_JSON_SCHEMA_VERSION,
   createCurrentJson,
+  mintGeneration,
   type Storage,
 } from "@baerly/protocol";
 
@@ -19,9 +20,12 @@ import {
  * (`app/<app>/tenant/<tenant>/manifests/<table>/current.json`) and
  * swallows `BaerlyError{code:"Conflict"}` so re-runs are safe. An
  * existing manifest is preserved verbatim — this function never
- * overwrites a populated manifest. The seed shape matches the
- * kernel's auto-create exactly, so a pre-warm and an
- * auto-provisioned bucket are byte-identical.
+ * overwrites a populated manifest. The seed shape matches the kernel's
+ * auto-create, with one deliberate exception: `generation` is a fresh
+ * nonce, so a pre-warm and an auto-provision are equivalent rather than
+ * byte-identical. Only one of them can win the `If-None-Match` create,
+ * and a generation is only ever compared against a cursor minted from
+ * it, so the difference is unobservable.
  *
  * @example
  * ```ts
@@ -47,6 +51,7 @@ export const ensureTable = async (
       writer_fence: { epoch: 0, owner: "", claimed_at: "" },
       snapshot_bytes: 0,
       snapshot_rows: 0,
+      generation: mintGeneration(),
     });
   } catch (error) {
     if (error instanceof BaerlyError && error.code === "Conflict") {

--- a/packages/protocol/src/coordination/current-json.test.ts
+++ b/packages/protocol/src/coordination/current-json.test.ts
@@ -2004,6 +2004,24 @@ describe("assertCurrentJson — generation guard", () => {
       message: expect.stringMatching(/generation/),
     });
   });
+
+  plainTest.each(["gen-1", "ABCDEF", "0123456789ab.x", "0123 456"])(
+    "rejects a non-hex generation: %j",
+    async (generation) => {
+      // The manifest validator and `/v1/since`'s `GENERATION_RE` must
+      // accept the same charset. If a manifest carrying one of these
+      // read clean, the server would mint a cursor from it and then
+      // refuse that same cursor on resume — which a client reads as a
+      // permanently dead cursor and re-bootstraps on, forever. A `.`
+      // is the worst case: it also mis-splits in `parseCursor`.
+      const s = new MemoryStorage();
+      await putRaw(s, "k", { ...rawSeed(), generation });
+      await expect(readCurrentJson(s, "k")).rejects.toMatchObject({
+        code: "InvalidResponse",
+        message: expect.stringMatching(/generation/),
+      });
+    },
+  );
 });
 
 describe("mintGeneration", () => {

--- a/packages/protocol/src/coordination/current-json.test.ts
+++ b/packages/protocol/src/coordination/current-json.test.ts
@@ -11,6 +11,7 @@ import {
   encodeJsonBytes,
   logSeqStartOf,
   MemoryStorage,
+  mintGeneration,
   readCurrentJson,
 } from "../index.ts";
 import { claimWriter } from "./current-json.ts";
@@ -1964,4 +1965,60 @@ describe("casUpdateCurrentJson — assertCurrentJson on mutated output", () => {
       expect((err as BaerlyError).message).toContain("my-key");
     },
   );
+});
+
+describe("assertCurrentJson — generation guard", () => {
+  plainTest("accepts a record with generation absent (pre-field manifest)", async () => {
+    const s = new MemoryStorage();
+    await putRaw(s, "k", rawSeed());
+    const got = await readCurrentJson(s, "k");
+    expect(got!.json.generation).toBeUndefined();
+  });
+
+  plainTest("accepts a minted generation", async () => {
+    const s = new MemoryStorage();
+    await putRaw(s, "k", { ...rawSeed(), generation: "0123456789ab" });
+    const got = await readCurrentJson(s, "k");
+    expect(got!.json.generation).toBe("0123456789ab");
+  });
+
+  plainTest("rejects generation: '' (empty string)", async () => {
+    // Not just a type guard. An empty generation formats a cursor as
+    // `.<lsn>`, which parseCursor reads as generation "" rather than as
+    // the NO_GENERATION sentinel — so the two spellings of "no
+    // generation" would stop comparing equal and every resume on this
+    // collection would be rejected.
+    const s = new MemoryStorage();
+    await putRaw(s, "k", { ...rawSeed(), generation: "" });
+    await expect(readCurrentJson(s, "k")).rejects.toMatchObject({
+      code: "InvalidResponse",
+      message: expect.stringMatching(/generation/),
+    });
+  });
+
+  plainTest("rejects generation: 7 (not a string)", async () => {
+    const s = new MemoryStorage();
+    await putRaw(s, "k", { ...rawSeed(), generation: 7 });
+    await expect(readCurrentJson(s, "k")).rejects.toMatchObject({
+      code: "InvalidResponse",
+      message: expect.stringMatching(/generation/),
+    });
+  });
+});
+
+describe("mintGeneration", () => {
+  plainTest("mints a non-empty lowercase-hex token", () => {
+    // Lowercase hex matters on the wire: `/v1/since` validates the
+    // generation half of a cursor against `[0-9a-f]+`.
+    expect(mintGeneration()).toMatch(/^[0-9a-f]{12}$/);
+    return Promise.resolve();
+  });
+
+  plainTest("mints a distinct value each call", () => {
+    // A collision would let a stale cursor resume into a truncated
+    // generation — the exact failure the field exists to prevent.
+    const minted = new Set(Array.from({ length: 200 }, () => mintGeneration()));
+    expect(minted.size).toBe(200);
+    return Promise.resolve();
+  });
 });

--- a/packages/protocol/src/coordination/current-json.ts
+++ b/packages/protocol/src/coordination/current-json.ts
@@ -133,6 +133,36 @@ export interface CurrentJson {
    * `last_warned_seq` to the observed/probed tail. Absent → 0.
    */
   last_warned_seq?: number;
+
+  /**
+   * Opaque non-empty generation nonce, re-minted by every writer that
+   * *replaces* this collection rather than advancing it — the two
+   * `baerly admin restore` seeds and the writer/dev auto-provision
+   * paths. Steady-state writers (the compactor's fold CAS,
+   * {@link claimWriter}, every {@link casUpdateCurrentJson} mutator)
+   * carry it through untouched, so it changes only on truncate or
+   * re-provision. Mint with {@link mintGeneration}.
+   *
+   * `/v1/since` pairs it with each entry's `lsn` to build the cursor it
+   * hands clients, then rejects a resume whose generation no longer
+   * matches. Without it, a `restore --force` that reseeds
+   * `log_seq_start` BELOW the old floor (the deliberate floor exemption
+   * — invariant 12 in `docs/spec/sync-protocol.md`) lets a pre-restore
+   * cursor clear the `cursorSeq < log_seq_start` gate and silently skip
+   * every restored row beneath it.
+   *
+   * Deliberately NOT `writer_fence.epoch`: the fresh-target restore
+   * branch seeds `epoch: 0`, so a truncate-to-empty is indistinguishable
+   * from a genuine epoch-0 collection. A counter that resets cannot
+   * discriminate generations; a nonce can.
+   *
+   * Optional because it postdates `schema_version: 3` and buckets
+   * written by earlier builds do not carry it. Absent is a well-defined
+   * state, not a degraded one — it decodes to `NO_GENERATION` on both
+   * sides of the comparison (see `../cursor.ts`), so a collection that
+   * was never truncated keeps resuming normally.
+   */
+  generation?: string;
 }
 
 /**
@@ -228,6 +258,24 @@ export async function readCurrentJson(
   }
   return { json: assertCurrentJson(parsed, key), etag: got.etag };
 }
+
+/**
+ * Mint a fresh {@link CurrentJson.generation} nonce.
+ *
+ * Twelve lowercase hex characters (≈2.8 × 10¹⁴ values) — sized so the
+ * birthday bound is unreachable across the truncates a bucket sees in
+ * its lifetime, while costing only twelve bytes on every `/v1/since`
+ * response. A collision would let a stale cursor resume into a
+ * truncated generation, which is the exact failure this field exists to
+ * prevent, so the margin is deliberate.
+ *
+ * `crypto.randomUUID` is universally available (Node 19+, Workerd, Bun,
+ * browsers) — the same source `uuid()` in `../types.ts` uses.
+ *
+ * Call this only where a collection is REPLACED, never where one is
+ * advanced; see {@link CurrentJson.generation} for the writer split.
+ */
+export const mintGeneration = (): string => crypto.randomUUID().replaceAll("-", "").slice(0, 12);
 
 /**
  * Create `current.json` if-and-only-if it does not exist (S3
@@ -597,6 +645,20 @@ const assertCurrentJson = (parsed: unknown, key: string): CurrentJson => {
     throw new BaerlyError(
       "InvalidResponse",
       `current.json at ${key}: mean_entry_bytes must be a non-negative integer if present`,
+    );
+  }
+  if (
+    r["generation"] !== undefined &&
+    (typeof r["generation"] !== "string" || r["generation"].length === 0)
+  ) {
+    // Non-empty matters, not just the type: `""` would format a cursor
+    // as `.<lsn>`, which `parseCursor` reads as generation `""` rather
+    // than as the `NO_GENERATION` sentinel — so the two spellings of
+    // "no generation" would stop comparing equal and every resume on
+    // this collection would be rejected.
+    throw new BaerlyError(
+      "InvalidResponse",
+      `current.json at ${key}: generation must be a non-empty string if present`,
     );
   }
   return parsed as CurrentJson;

--- a/packages/protocol/src/coordination/current-json.ts
+++ b/packages/protocol/src/coordination/current-json.ts
@@ -278,6 +278,13 @@ export async function readCurrentJson(
 export const mintGeneration = (): string => crypto.randomUUID().replaceAll("-", "").slice(0, 12);
 
 /**
+ * The charset {@link mintGeneration} emits and `/v1/since` accepts in
+ * the generation half of a cursor. Pinned so the manifest validator
+ * and the wire validator cannot drift.
+ */
+const GENERATION_RE = /^[0-9a-f]+$/;
+
+/**
  * Create `current.json` if-and-only-if it does not exist (S3
  * `If-None-Match: "*"`). Use this once per collection at provisioning
  * time; subsequent updates go through {@link casUpdateCurrentJson}.
@@ -649,16 +656,18 @@ const assertCurrentJson = (parsed: unknown, key: string): CurrentJson => {
   }
   if (
     r["generation"] !== undefined &&
-    (typeof r["generation"] !== "string" || r["generation"].length === 0)
+    (typeof r["generation"] !== "string" || !GENERATION_RE.test(r["generation"]))
   ) {
-    // Non-empty matters, not just the type: `""` would format a cursor
-    // as `.<lsn>`, which `parseCursor` reads as generation `""` rather
-    // than as the `NO_GENERATION` sentinel — so the two spellings of
-    // "no generation" would stop comparing equal and every resume on
-    // this collection would be rejected.
+    // Charset, not just type. `""` would format a cursor as `.<lsn>`,
+    // which `parseCursor` reads as generation `""` rather than as the
+    // `NO_GENERATION` sentinel. Anything outside `[0-9a-f]` (a `.`
+    // worst of all) would mint a cursor `/v1/since` then refuses on
+    // resume — the server rejecting a token it issued, which a client
+    // reads as a permanently dead cursor. Matching the wire charset
+    // means a manifest that reads clean here always round-trips.
     throw new BaerlyError(
       "InvalidResponse",
-      `current.json at ${key}: generation must be a non-empty string if present`,
+      `current.json at ${key}: generation must be a non-empty lowercase-hex string if present`,
     );
   }
   return parsed as CurrentJson;

--- a/packages/protocol/src/cursor.test.ts
+++ b/packages/protocol/src/cursor.test.ts
@@ -11,8 +11,11 @@ describe("formatCursor", () => {
     expect(formatCursor(GEN, LSN)).toBe(`${GEN}.${LSN}`);
   });
 
-  test("emits the sentinel when the manifest has no generation", () => {
-    expect(formatCursor(undefined, LSN)).toBe(`${NO_GENERATION}.${LSN}`);
+  test("emits a bare lsn when the manifest has no generation", () => {
+    // Deliberately NOT `-.<lsn>`. A collection with no generation has
+    // nothing to discriminate, so it keeps the pre-composite wire
+    // shape — which a peer still running the previous build accepts.
+    expect(formatCursor(undefined, LSN)).toBe(LSN);
   });
 });
 

--- a/packages/protocol/src/cursor.test.ts
+++ b/packages/protocol/src/cursor.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+
+import { BaerlyError } from "./errors.ts";
+import { formatCursor, NO_GENERATION, parseCursor } from "./cursor.ts";
+
+const LSN = "01j8x_a3f9c2_zzzy";
+const GEN = "7f3a9c21b4d0";
+
+describe("formatCursor", () => {
+  test("pairs a generation with an lsn", () => {
+    expect(formatCursor(GEN, LSN)).toBe(`${GEN}.${LSN}`);
+  });
+
+  test("emits the sentinel when the manifest has no generation", () => {
+    expect(formatCursor(undefined, LSN)).toBe(`${NO_GENERATION}.${LSN}`);
+  });
+});
+
+describe("parseCursor", () => {
+  test("round-trips a formatted cursor", () => {
+    expect(parseCursor(formatCursor(GEN, LSN))).toEqual({ generation: GEN, lsn: LSN });
+  });
+
+  test("decodes a bare lsn to the sentinel rather than throwing", () => {
+    // A cursor minted before the composite shape existed. Rejecting it
+    // would force every in-flight long-poll client to re-bootstrap on
+    // deploy, for a collection where nothing happened.
+    expect(parseCursor(LSN)).toEqual({ generation: NO_GENERATION, lsn: LSN });
+  });
+
+  test("a sentinel cursor and a sentinel manifest compare equal", () => {
+    // The property that lets `/v1/since` use one string comparison with
+    // no fail-open branch for pre-generation manifests.
+    expect(parseCursor(formatCursor(undefined, LSN)).generation).toBe(NO_GENERATION);
+  });
+
+  test("rejects more than one separator", () => {
+    expect(() => parseCursor(`${GEN}.${LSN}.extra`)).toThrow(BaerlyError);
+    try {
+      parseCursor(`${GEN}.${LSN}.extra`);
+      expect.unreachable("should have thrown");
+    } catch (error) {
+      // SchemaError maps to HTTP 400 — caller fault, not a storage fault.
+      expect((error as BaerlyError).code).toBe("SchemaError");
+    }
+  });
+
+  test("an empty cursor decodes to the sentinel", () => {
+    // `/v1/since` short-circuits `cursor === ""` before parsing, but the
+    // codec must not throw on it either.
+    expect(parseCursor("")).toEqual({ generation: NO_GENERATION, lsn: "" });
+  });
+});

--- a/packages/protocol/src/cursor.ts
+++ b/packages/protocol/src/cursor.ts
@@ -48,11 +48,16 @@ export const NO_GENERATION = "-";
 
 /**
  * Build the wire cursor for an entry's `lsn` under a manifest's
- * `generation`. `undefined` generation (a manifest predating the field)
- * emits {@link NO_GENERATION}.
+ * `generation`.
+ *
+ * A manifest predating the field emits the LSN **bare**, not
+ * `-.<lsn>` — {@link parseCursor} maps both to {@link NO_GENERATION},
+ * so the comparison is unchanged either way. Keeping it bare confines
+ * the wire-shape change to collections that actually carry a nonce,
+ * instead of changing every cursor in the bucket on upgrade.
  */
 export const formatCursor = (generation: string | undefined, lsn: string): string =>
-  `${generation ?? NO_GENERATION}${CURSOR_SEPARATOR}${lsn}`;
+  generation === undefined ? lsn : `${generation}${CURSOR_SEPARATOR}${lsn}`;
 
 /**
  * Split a wire cursor into its generation and LSN halves.

--- a/packages/protocol/src/cursor.ts
+++ b/packages/protocol/src/cursor.ts
@@ -1,0 +1,81 @@
+/**
+ * `/v1/since` cursor codec — the composite `<generation>.<lsn>` token a
+ * long-poll client acks and resumes from.
+ *
+ * Kept separate from `log.ts` for the same reason as `log-key.ts`:
+ * `log.ts` carries the heavier `lsn` parsing runtime, and consumers that
+ * only need to split a cursor shouldn't drag it into their bundle
+ * closure. This module imports only `BaerlyError`.
+ *
+ * ## Why the cursor is not just the LSN
+ *
+ * The seq embedded in an LSN identifies a `log/<seq>` slot, and slots
+ * are reused. `baerly admin restore --force` truncates a collection and
+ * reseeds `log_seq_start` to one past the highest *surviving* log
+ * object, which can land BELOW the old floor (the deliberate floor
+ * exemption — see invariant 12 in `docs/spec/sync-protocol.md`). A
+ * pre-restore cursor then passes `/v1/since`'s `cursorSeq <
+ * log_seq_start` gate and resumes into the new generation, silently
+ * skipping every restored row beneath it. The stream is gapped, not
+ * broken, which is the worst failure mode for a sync cursor.
+ *
+ * Pairing the LSN with the generation that minted it turns that silent
+ * gap into a `SchemaError` telling the client to re-bootstrap.
+ *
+ * The token is opaque on the wire: clients ack and echo it, never parse
+ * it. `LogEntry.lsn` is unchanged — this shape exists only at the
+ * `/v1/since` boundary.
+ */
+
+import { BaerlyError } from "./errors.ts";
+
+/**
+ * Separator between the generation and the LSN. The LSN is
+ * `_`-delimited (`<base32-time>_<session>_<seq>`) and a generation is
+ * lowercase hex, so `.` cannot occur in either half.
+ */
+const CURSOR_SEPARATOR = ".";
+
+/**
+ * Stands in for "this manifest has no `generation`". Both spellings of
+ * that state — a `current.json` predating the field, and a bare-LSN
+ * cursor minted before this build — decode to this value, so the
+ * ordinary string comparison in `/v1/since` handles them without a
+ * fail-open branch. See the truth table in
+ * `docs/spec/sync-protocol.md`.
+ */
+export const NO_GENERATION = "-";
+
+/**
+ * Build the wire cursor for an entry's `lsn` under a manifest's
+ * `generation`. `undefined` generation (a manifest predating the field)
+ * emits {@link NO_GENERATION}.
+ */
+export const formatCursor = (generation: string | undefined, lsn: string): string =>
+  `${generation ?? NO_GENERATION}${CURSOR_SEPARATOR}${lsn}`;
+
+/**
+ * Split a wire cursor into its generation and LSN halves.
+ *
+ * A cursor with no separator is a bare LSN from a build that predates
+ * the composite shape; it decodes to {@link NO_GENERATION} rather than
+ * throwing, so an in-flight client is not forced to re-bootstrap across
+ * a deploy that changed nothing about its collection.
+ *
+ * Throws `SchemaError` (→ HTTP 400) on more than one separator: that is
+ * malformed caller input, not a shape this build ever minted, and
+ * guessing which half is which would be worse than rejecting.
+ */
+export const parseCursor = (cursor: string): { generation: string; lsn: string } => {
+  const parts = cursor.split(CURSOR_SEPARATOR);
+  if (parts.length === 1) {
+    return { generation: NO_GENERATION, lsn: cursor };
+  }
+  if (parts.length !== 2) {
+    throw new BaerlyError(
+      "SchemaError",
+      `invalid cursor shape: ${JSON.stringify(cursor)} (expected "<generation>.<lsn>")`,
+    );
+  }
+  return { generation: parts[0]!, lsn: parts[1]! };
+};

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -10,6 +10,7 @@ export {
   casUpdateCurrentJson,
   createCurrentJson,
   logSeqStartOf,
+  mintGeneration,
   readCurrentJson,
 } from "./coordination/current-json.ts";
 export * from "./coordination/gc-pending.ts";
@@ -26,6 +27,7 @@ export * from "./time.ts";
 export * from "./types.ts";
 export * from "./verifier.ts";
 export * from "./hashing.ts";
+export * from "./cursor.ts";
 export * from "./log.ts";
 export * from "./log-key.ts";
 export * from "./metrics.ts";

--- a/packages/protocol/src/log.ts
+++ b/packages/protocol/src/log.ts
@@ -30,8 +30,11 @@ export interface LogEntry {
    * `<base32-time>_<session>_<seq>` — minted inside
    * `Writer.commit` (see
    * `packages/server/src/writer.ts`) from `timestamp()` +
-   * the per-commit `session` + `countKey(seq)`. Consumers ack and
-   * resume from this string.
+   * the per-commit `session` + `countKey(seq)`.
+   *
+   * This is NOT what a `/v1/since` client acks: that boundary pairs
+   * the LSN with the manifest's `generation` (see `cursor.ts`), so the
+   * token may be `<generation>.<lsn>`. Treat `next_cursor` as opaque.
    *
    * When you have a `LogEntry` in hand, prefer the structured
    * `session` / `seq` fields below over parsing this string. The

--- a/packages/server/API.md
+++ b/packages/server/API.md
@@ -518,14 +518,14 @@ interface LogEntry {
 
 **Cursor priming.** First call: pass `cursor=` (empty string). The
 server's fast path returns immediately _iff_ the log already has
-entries for this collection — you get `events: [...]` and the
-last entry's `lsn` as `next_cursor`. **If the collection is empty,
+entries for this collection — you get `events: [...]` and an opaque
+`next_cursor`. **If the collection is empty,
 the first call blocks for the full long-poll budget (~25 s) before
 returning `events: []` with `next_cursor: ''`.** Either prime by
 inserting one row first if you need an immediate response, or budget
 your client / test for the full timeout. Subsequent calls pass the
-returned cursor back — the cursor is opaque, treat it as a string,
-and `events` is empty iff the budget elapsed with no new writes
+returned cursor back — treat it as an opaque string, and
+`events` is empty iff the budget elapsed with no new writes
 (`next_cursor` unchanged).
 
 **Test-mode tuning.** Vitest's default per-test timeout is 5 s; the
@@ -548,13 +548,15 @@ factory sees `number | undefined` without runtime coercion. Don't
 shrink `sinceTimeoutMs` in production code paths — it multiplies the
 R2 class-A op count per idle long-poll connection.
 
-React applications use `@gusto/baerly-storage/client/react` (see next
-section) instead of poking `/v1/since` by hand. Hand-rolled
-subscribers in other UI frameworks `fetch` this endpoint directly:
-loop, `fetch`-ing with `cursor=` (empty) first, then threading the
-returned `next_cursor` back as `cursor` on each subsequent call (the
-cursor is opaque — treat it as a string). The wire shape above is the
-public contract; there is no exported cursor-tailing helper.
+React apps use `@gusto/baerly-storage/client/react` (see next
+section) instead of poking `/v1/since` by hand; hand-rolled
+subscribers in other frameworks `fetch` it directly. The wire shape
+above is the public contract; there is no cursor-tailing helper.
+
+**Handle `400 SchemaError` or your loop will spin.** On resume it
+means the cursor is permanently dead — folded into a snapshot and
+GC'd, or truncated by `restore --force`. It never clears on retry:
+back off, then restart with `cursor=` (empty).
 
 ## React: `createBaerlyReact`
 

--- a/packages/server/src/compactor.test.ts
+++ b/packages/server/src/compactor.test.ts
@@ -38,6 +38,35 @@ describe("compact", () => {
   const KEY = "app/t/tenant/x/manifests/c/current.json";
   const COLL = "c";
 
+  test("a fold preserves current.json's generation", async () => {
+    // `/v1/since` rejects a resume whose cursor generation no longer
+    // matches the manifest, so a fold that DROPPED the field would
+    // silently invalidate every live long-poll cursor on the next poll
+    // — and, because absent decodes to the NO_GENERATION sentinel,
+    // would do it without any read path erroring. The compactor gets
+    // this right by spreading `...current` into its CAS; this pins that
+    // it keeps doing so.
+    const s = new MemoryStorage();
+    await createCurrentJson(s, KEY, logStateCurrentJson({ generation: "0123456789ab" }));
+    const writer = new Writer({ storage: s, currentJsonKey: KEY });
+    for (let i = 0; i < 12; i++) {
+      await writer.commit({
+        op: "I",
+        collection: COLL,
+        docId: `d${i}`,
+        body: { _id: `d${i}`, n: i },
+      });
+    }
+
+    const res = await compact({ storage: s, currentJsonKey: KEY }, { minEntriesToCompact: 1 });
+    expect(res.written).toBe(true);
+    expect(res.entriesFolded).toBeGreaterThan(0);
+
+    const after = await readCurrentJson(s, KEY);
+    expect(after!.json.log_seq_start).toBeGreaterThan(0);
+    expect(after!.json.generation).toBe("0123456789ab");
+  });
+
   test("returns current-json-missing when current.json doesn't exist", async () => {
     const s = new MemoryStorage();
     const res = await compact({ storage: s, currentJsonKey: KEY });

--- a/packages/server/src/contract.ts
+++ b/packages/server/src/contract.ts
@@ -90,6 +90,19 @@ export interface HttpOkEnvelope<T> {
  * `next_cursor` back on the next call. Empty `events` + same
  * `next_cursor` means "nothing changed within the budget"
  * (default budget: ~25s).
+ *
+ * `next_cursor` is **opaque**: echo it back verbatim, never parse it.
+ * It pairs the last entry's `lsn` with the collection generation the
+ * poll read, so a cursor from a collection that `baerly admin restore
+ * --force` has since truncated can be rejected instead of silently
+ * resuming into the new generation. `""` means "start from the
+ * collection's log floor" and is always valid.
+ *
+ * A `400 SchemaError` on resume means the cursor is permanently dead —
+ * the entry was folded into a snapshot and GC'd, or its generation was
+ * truncated. Neither clears on retry: restart with `cursor: ""`.
+ * Retrying the rejected cursor loops forever. See invariant 13 in
+ * `docs/spec/sync-protocol.md`.
  */
 export interface SinceResponse {
   readonly events: ReadonlyArray<LogEntry>;

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -41,8 +41,10 @@ const physicalPrefixFor = (app: string, tenant: string): string => `app/${app}/t
  * Class A PUT on the very first write per collection and zero
  * thereafter. There is no `ensureCollection` method on this class. For
  * eager pre-warm (seed scripts, deploy-time provisioning, CI fixtures
- * that want byte-identical bytes before the first request), use
- * {@link "@gusto/baerly-storage/dev".ensureTable}.
+ * that want the manifest in place before the first request), use
+ * {@link "@gusto/baerly-storage/dev".ensureTable}. The two seeds are
+ * equivalent, not byte-identical: each mints its own `generation`
+ * nonce. Harmless — `If-None-Match` means exactly one lands.
  *
  * @example
  * ```ts

--- a/packages/server/src/http/since.test.ts
+++ b/packages/server/src/http/since.test.ts
@@ -17,9 +17,9 @@
  * so the suite stays well inside the 30 s default budget.
  */
 
-import { type CurrentJson, createCurrentJson, MemoryStorage } from "@baerly/protocol";
+import { type CurrentJson, createCurrentJson, formatCursor, MemoryStorage } from "@baerly/protocol";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { logStateCurrentJson } from "../../../../tests/fixtures/log-state.ts";
+import { LOG_STATE_GENERATION, logStateCurrentJson } from "../../../../tests/fixtures/log-state.ts";
 import { Db } from "../db.ts";
 import { listEventsSince, longPollSince } from "./since.ts";
 
@@ -115,7 +115,9 @@ describe("longPollSince — fake-timer cases", () => {
     });
 
     expect(result.events).toHaveLength(2);
-    expect(result.next_cursor).toBe(result.events[result.events.length - 1]!.lsn);
+    expect(result.next_cursor).toBe(
+      formatCursor(LOG_STATE_GENERATION, result.events[result.events.length - 1]!.lsn),
+    );
   });
 
   test("blocks then unblocks: insert lands on the next poll tick", async () => {
@@ -142,7 +144,7 @@ describe("longPollSince — fake-timer cases", () => {
     const result = await pollPromise;
     expect(result.events).toHaveLength(1);
     expect(result.events[0]!.op).toBe("I");
-    expect(result.next_cursor).toBe(result.events[0]!.lsn);
+    expect(result.next_cursor).toBe(formatCursor(LOG_STATE_GENERATION, result.events[0]!.lsn));
   });
 
   test("idle timeout: returns empty events + same cursor at deadline", async () => {
@@ -219,7 +221,11 @@ describe("listEventsSince — pre-snapshot cursor → SchemaError", () => {
       pollIntervalMs: 25,
     });
     expect(seed.events).toHaveLength(1);
-    const cursor = seed.events[0]!.lsn;
+    // The full composite cursor, NOT the bare `lsn`. A bare lsn decodes
+    // to the `NO_GENERATION` sentinel and would trip the generation
+    // check instead — leaving this test green while no longer
+    // exercising the folded-cursor path it exists to cover.
+    const cursor = seed.next_cursor;
 
     // Bump current.json.log_seq_start past the seed entry (which lands
     // at seq 0) to mark it as "folded" (the test takes the shortcut; the
@@ -245,7 +251,145 @@ describe("listEventsSince — pre-snapshot cursor → SchemaError", () => {
     await expect(listEventsSince({ db, collection: TABLE, cursor })).rejects.toMatchObject({
       name: "BaerlyError",
       code: "SchemaError",
+      // Pin WHICH rejection fired: `/v1/since` has two SchemaError
+      // paths and a bare `code` assertion cannot tell them apart.
+      message: expect.stringContaining("folded into a snapshot"),
     });
+  });
+});
+
+describe("listEventsSince — truncated generation → SchemaError", () => {
+  /**
+   * Seed one entry, take a real cursor for it, then rewrite
+   * `current.json` the way `baerly admin restore --force` does:
+   * `snapshot: null`, a new `generation`, and `log_seq_start` /
+   * `tail_hint` reseeded to one past the highest SURVIVING log object.
+   *
+   * `--force` takes the reseed from LISTed log keys, so a
+   * budget-bounded GC sweep that cleared the top of the old range
+   * leaves the floor BELOW where it was. That is the deliberate floor
+   * exemption (invariant 12) and the reason a bare seq comparison
+   * cannot detect this.
+   */
+  const truncateTo = async (
+    storage: MemoryStorage,
+    args: { floor: number; generation: string | undefined },
+  ): Promise<void> => {
+    const cjKey = currentJsonKey(TABLE);
+    const cj = await storage.get(cjKey);
+    expect(cj).not.toBeNull();
+    const parsed = JSON.parse(new TextDecoder().decode(cj!.body)) as CurrentJson;
+    const reseeded: CurrentJson = {
+      ...parsed,
+      snapshot: null,
+      tail_hint: args.floor,
+      log_seq_start: args.floor,
+      ...(args.generation === undefined
+        ? { generation: undefined }
+        : { generation: args.generation }),
+    };
+    await storage.put(cjKey, new TextEncoder().encode(JSON.stringify(reseeded)));
+  };
+
+  /**
+   * Commit one entry (it lands at the probed tail, i.e. the current
+   * floor) and return the composite cursor a client would hold for it.
+   */
+  const seedCursor = async (db: Db): Promise<string> => {
+    const { _id } = await db.collection(TABLE).insert({ title: "pre-restore" });
+    expect(_id).toBeDefined();
+    const seed = await longPollSince({
+      db,
+      collection: TABLE,
+      cursor: "",
+      timeoutMs: 500,
+      pollIntervalMs: 25,
+    });
+    expect(seed.events).toHaveLength(1);
+    return seed.next_cursor;
+  };
+
+  test("the issue #73 scenario: reseed BELOW the old floor is rejected", async () => {
+    const { db, storage } = makeDb();
+    // Old floor 12, so the cursor's entry sits at seq 12 — above the
+    // floor the truncate is about to install.
+    await createCurrentJson(
+      storage,
+      currentJsonKey(TABLE),
+      logStateCurrentJson({ tail_hint: 12, log_seq_start: 12 }),
+    );
+    const cursor = await seedCursor(db);
+
+    // GC left `log/8` and `log/9` behind (lex order `0,1,10,11,2,…`),
+    // so `--force` reseeds to 10 — BELOW the old floor of 12.
+    await truncateTo(storage, { floor: 10, generation: "ffffffffffff" });
+
+    // Before this change the cursor's seq (12) cleared `12 < 10 === false`
+    // and the stream resumed at 13, silently skipping the restored rows
+    // in [10, 13). Now it is rejected outright.
+    await expect(listEventsSince({ db, collection: TABLE, cursor })).rejects.toMatchObject({
+      name: "BaerlyError",
+      code: "SchemaError",
+      message: expect.stringContaining("generation that no longer exists"),
+    });
+  });
+
+  test("reseed landing exactly ON the old floor is still rejected", async () => {
+    const { db, storage } = makeDb();
+    await createCurrentJson(
+      storage,
+      currentJsonKey(TABLE),
+      logStateCurrentJson({ tail_hint: 12, log_seq_start: 12 }),
+    );
+    const cursor = await seedCursor(db);
+
+    // The case a floor-regression check would miss: the floor does not
+    // move, so nothing about the seq arithmetic looks wrong. Only the
+    // generation distinguishes the old collection from the new one.
+    await truncateTo(storage, { floor: 12, generation: "ffffffffffff" });
+
+    await expect(listEventsSince({ db, collection: TABLE, cursor })).rejects.toMatchObject({
+      name: "BaerlyError",
+      code: "SchemaError",
+      message: expect.stringContaining("generation that no longer exists"),
+    });
+  });
+
+  test("a manifest with no generation accepts a bare-lsn cursor", async () => {
+    const { db, storage } = makeDb();
+    // Both sides read as `NO_GENERATION`: a manifest written before the
+    // field existed, resumed with a cursor minted before the composite
+    // shape existed. Nothing was truncated, so this must NOT reject.
+    await createCurrentJson(
+      storage,
+      currentJsonKey(TABLE),
+      logStateCurrentJson({ generation: undefined }),
+    );
+    const { _id } = await db.collection(TABLE).insert({ title: "legacy" });
+    expect(_id).toBeDefined();
+
+    const seed = await longPollSince({
+      db,
+      collection: TABLE,
+      cursor: "",
+      timeoutMs: 500,
+      pollIntervalMs: 25,
+    });
+    expect(seed.events).toHaveLength(1);
+    expect(seed.next_cursor).toBe(formatCursor(undefined, seed.events[0]!.lsn));
+
+    // A pre-upgrade client echoing the bare lsn keeps working.
+    await expect(
+      listEventsSince({ db, collection: TABLE, cursor: seed.events[0]!.lsn }),
+    ).resolves.toEqual([]);
+  });
+
+  test("a cursor round-trips against an unchanged generation", async () => {
+    const { db, storage } = makeDb();
+    await provision(storage);
+    const cursor = await seedCursor(db);
+
+    await expect(listEventsSince({ db, collection: TABLE, cursor })).resolves.toEqual([]);
   });
 });
 
@@ -282,7 +426,7 @@ describe("longPollSince — cursor advances past the digit boundary", () => {
     });
     expect(first.events).toHaveLength(12);
     const cursor = first.next_cursor;
-    expect(cursor).toBe(first.events[11]!.lsn);
+    expect(cursor).toBe(formatCursor(LOG_STATE_GENERATION, first.events[11]!.lsn));
 
     // Second poll: nothing new committed, so the handler must hit
     // its deadline with an empty batch and the SAME cursor. Today's

--- a/packages/server/src/http/since.ts
+++ b/packages/server/src/http/since.ts
@@ -29,9 +29,12 @@ import {
   type BaerlyConfig,
   BaerlyError,
   COUNT_BIT_WIDTH,
+  formatCursor,
   type LogEntry,
   logSeqStartOf,
   lsnParts,
+  NO_GENERATION,
+  parseCursor,
 } from "@baerly/protocol";
 import type { Db } from "../db.ts";
 import type { SinceResponse } from "../contract.ts";
@@ -51,6 +54,33 @@ import type { SinceResponse } from "../contract.ts";
 // COUNT_BIT_WIDTH is 53; Math.ceil(53 / 5) = 11.
 const SEQ_CHARS = Math.ceil(COUNT_BIT_WIDTH / 5); // 11
 const LSN_RE = new RegExp(`^[0-9a-v]+_[0-9a-v]+_[0-9a-v]{${SEQ_CHARS}}$`);
+
+/**
+ * Generation half of a cursor: lowercase hex as minted by
+ * `mintGeneration`, or the `NO_GENERATION` sentinel for a manifest that
+ * predates the field.
+ */
+const GENERATION_RE = /^(?:[0-9a-f]+|-)$/;
+
+/**
+ * Reject a malformed cursor before it reaches storage, and return its
+ * decoded halves.
+ *
+ * Shape validation lives here rather than in the codec because the
+ * codec is a protocol leaf with no opinion about which LSN dialect a
+ * given build mints — `LSN_RE` is that opinion, and it is derived from
+ * `COUNT_BIT_WIDTH`.
+ */
+const decodeCursor = (cursor: string): { generation: string; lsn: string } => {
+  const parts = parseCursor(cursor);
+  if (!GENERATION_RE.test(parts.generation) || !LSN_RE.test(parts.lsn)) {
+    throw new BaerlyError(
+      "SchemaError",
+      `cursor: invalid shape (expected a cursor returned by a prior SinceResponse); got ${JSON.stringify(cursor)}`,
+    );
+  }
+  return parts;
+};
 
 /**
  * Hard cap on log entries returned in a single poll cycle. 1024 is
@@ -120,17 +150,14 @@ export async function longPollSince(opts: LongPollSinceOptions): Promise<SinceRe
 
   // Up-front cursor-shape validation. `listEventsSince` also checks,
   // but doing it here short-circuits the fast-path read on bad input.
-  if (cursor.length > 0 && !LSN_RE.test(cursor)) {
-    throw new BaerlyError(
-      "SchemaError",
-      `cursor: invalid shape (expected an lsn returned by a prior SinceResponse); got ${JSON.stringify(cursor)}`,
-    );
+  if (cursor.length > 0) {
+    decodeCursor(cursor);
   }
 
   // Fast path: the first poll already sees new events.
-  const initial = await listEventsSince({ db, collection, cursor, signal });
-  if (initial.length > 0) {
-    return { events: initial, next_cursor: initial[initial.length - 1]!.lsn };
+  const initial = await pollOnce({ db, collection, cursor, signal });
+  if (initial.events.length > 0) {
+    return { events: initial.events, next_cursor: nextCursor(initial) };
   }
 
   // No events yet. Race a timeout against a polling loop.
@@ -188,12 +215,12 @@ export async function longPollSince(opts: LongPollSinceOptions): Promise<SinceRe
         return;
       }
       try {
-        const events = await listEventsSince({ db, collection, cursor, signal });
+        const polled = await pollOnce({ db, collection, cursor, signal });
         if (settled) {
           return;
         }
-        if (events.length > 0) {
-          settleResolve({ events, next_cursor: events[events.length - 1]!.lsn });
+        if (polled.events.length > 0) {
+          settleResolve({ events: polled.events, next_cursor: nextCursor(polled) });
           return;
         }
         const remaining = deadline - Date.now();
@@ -236,24 +263,41 @@ export async function longPollSince(opts: LongPollSinceOptions): Promise<SinceRe
  * free — `seq` is monotonic across writer sessions.
  *
  * No `current.json` yet → `[]` (clients can poll a not-yet-existing
- * collection without erroring). Cursor inside `[0, log_seq_start)` →
- * `BaerlyError{code:"SchemaError"}`.
+ * collection without erroring). Cursor inside `[0, log_seq_start)`, or
+ * minted in a truncated generation → `BaerlyError{code:"SchemaError"}`.
  */
 export async function listEventsSince(opts: ListEventsSinceOptions): Promise<LogEntry[]> {
+  const polled = await pollOnce(opts);
+  return polled.events;
+}
+
+/**
+ * The body of {@link listEventsSince}, additionally surfacing the
+ * manifest `generation` the poll read.
+ *
+ * `longPollSince` needs that generation to mint `next_cursor`, and
+ * re-reading `current.json` to get it would add a Class A op to every
+ * poll — the idle-reader cost bound this protocol is built around.
+ * {@link listEventsSince} is public surface pinned by
+ * `tests/integration/public-surface.test.ts`, so it keeps returning a
+ * bare array and this internal variant carries the extra field.
+ *
+ * `generation` is `undefined` when the collection has no `current.json`
+ * (no events either, so it is never consumed) or when the manifest
+ * predates the field.
+ */
+async function pollOnce(
+  opts: ListEventsSinceOptions,
+): Promise<{ events: LogEntry[]; generation: string | undefined }> {
   const { db, collection, cursor, signal } = opts;
 
-  if (cursor.length > 0 && !LSN_RE.test(cursor)) {
-    throw new BaerlyError(
-      "SchemaError",
-      `cursor: invalid shape (expected an lsn returned by a prior SinceResponse); got ${JSON.stringify(cursor)}`,
-    );
-  }
+  const decoded = cursor.length > 0 ? decodeCursor(cursor) : undefined;
 
   const read = await db.getCurrentJson(collection, signalOpt(signal));
   if (read === null) {
     // No collection provisioned yet. Clients polling for a collection that
     // doesn't exist see an empty stream, NOT an error.
-    return [];
+    return { events: [], generation: undefined };
   }
   const logSeqStart = logSeqStartOf(read.json);
   // End bound is the DISCOVERED tail (probe past a stale-low hint).
@@ -269,15 +313,36 @@ export async function listEventsSince(opts: ListEventsSinceOptions): Promise<Log
 
   // Derive the seq range to scan. Empty cursor → start at
   // `log_seq_start` (the first un-snapshotted entry). Non-empty
-  // cursor → start at `cursorSeq + 1`. A cursor whose seq is below
-  // `log_seq_start` references an entry the compactor has folded
-  // into the snapshot and the GC sweep has deleted; the client must
-  // re-bootstrap from a snapshot read before resuming.
+  // cursor → start at `cursorSeq + 1`, after two rejections.
   let startSeq: number;
-  if (cursor.length === 0) {
+  if (decoded === undefined) {
     startSeq = logSeqStart;
   } else {
-    const cursorSeq = lsnParts(cursor).seq;
+    const { generation, lsn } = decoded;
+    // (1) Wrong generation. A seq identifies a `log/<seq>` slot, and
+    // slots are REUSED: `restore --force` truncates and reseeds
+    // `log_seq_start` to one past the highest surviving log object,
+    // which can land below the old floor (the floor exemption —
+    // invariant 12 in `docs/spec/sync-protocol.md`). A pre-restore
+    // cursor would then clear check (2) below and resume into the new
+    // generation, silently skipping every restored row beneath it —
+    // gapped, not broken, which is the failure mode a sync client can't
+    // detect for itself.
+    //
+    // Both spellings of "no generation" — a manifest predating the
+    // field and a bare-LSN cursor predating the composite shape —
+    // decode to `NO_GENERATION`, so this stays one comparison with no
+    // fail-open branch. See the truth table in `sync-protocol.md`.
+    const currentGeneration = read.json.generation ?? NO_GENERATION;
+    if (generation !== currentGeneration) {
+      throw new BaerlyError(
+        "SchemaError",
+        `cursor ${JSON.stringify(cursor)} was minted in a generation that no longer exists (the collection has been truncated and restored); re-bootstrap from a snapshot read before resuming`,
+      );
+    }
+    // (2) Folded away. The entry is below the floor, so the compactor
+    // folded it into the snapshot and the GC sweep deleted it.
+    const cursorSeq = lsnParts(lsn).seq;
     if (cursorSeq < logSeqStart) {
       throw new BaerlyError(
         "SchemaError",
@@ -306,8 +371,19 @@ export async function listEventsSince(opts: ListEventsSinceOptions): Promise<Log
     entries.push(entry);
   }
 
-  return entries;
+  return { events: entries, generation: read.json.generation };
 }
+
+/**
+ * Mint the `next_cursor` for a poll that produced events: the last
+ * entry's `lsn`, paired with the generation the poll read it under.
+ *
+ * Only called when `events` is non-empty, which is exactly when the
+ * poll saw a `current.json` — so the generation here is the manifest's,
+ * not a stand-in.
+ */
+const nextCursor = (polled: { events: LogEntry[]; generation: string | undefined }): string =>
+  formatCursor(polled.generation, polled.events[polled.events.length - 1]!.lsn);
 
 /** Pack an optional `signal` into the `{ signal? }` shape callers expect. */
 const signalOpt = (signal: AbortSignal | undefined): { signal?: AbortSignal } | undefined =>

--- a/packages/server/src/writer.ts
+++ b/packages/server/src/writer.ts
@@ -54,6 +54,7 @@ import {
   encodeJsonBytes,
   logObjectKey,
   logSeqStartOf,
+  mintGeneration,
   BaerlyError,
   noopMetricsRecorder,
   type Storage,
@@ -784,8 +785,11 @@ export class Writer {
    * The seed shape (`snapshot: null`, `tail_hint: 0`, `log_seq_start:
    * 0`, `writer_fence: { epoch: 0, owner: "", claimed_at: "" }`)
    * matches `ensureTable` and `baerly deploy`'s pre-warm path, so an
-   * operator who pre-provisions and a writer who auto-creates land
-   * on byte-identical bytes.
+   * operator who pre-provisions and a writer who auto-creates land on
+   * equivalent state. NOT byte-identical any more: `generation` is a
+   * fresh nonce per provisioner. That is harmless — `If-None-Match`
+   * means exactly one of them ever lands, and no reader compares a
+   * generation across provisioners, only against the cursor it minted.
    *
    * @throws BaerlyError code="InvalidResponse" — the post-recover
    *   re-read also returned null. Defensive guard; in practice
@@ -800,6 +804,7 @@ export class Writer {
       writer_fence: { epoch: 0, owner: "", claimed_at: "" },
       snapshot_bytes: 0,
       snapshot_rows: 0,
+      generation: mintGeneration(),
     };
     try {
       return await createCurrentJson(this.#storage, this.#currentJsonKey, initial);

--- a/packages/server/src/writer.ts
+++ b/packages/server/src/writer.ts
@@ -784,7 +784,7 @@ export class Writer {
    *
    * The seed shape (`snapshot: null`, `tail_hint: 0`, `log_seq_start:
    * 0`, `writer_fence: { epoch: 0, owner: "", claimed_at: "" }`)
-   * matches `ensureTable` and `baerly deploy`'s pre-warm path, so an
+   * matches `ensureTable`, so an
    * operator who pre-provisions and a writer who auto-creates land on
    * equivalent state. NOT byte-identical any more: `generation` is a
    * fresh nonce per provisioner. That is harmless — `If-None-Match`

--- a/tests/fixtures/log-state.ts
+++ b/tests/fixtures/log-state.ts
@@ -35,13 +35,25 @@ import {
 } from "@baerly/protocol";
 
 /**
+ * Fixed stand-in for the random nonce `mintGeneration()` produces at
+ * provisioning time. Pinned rather than minted so `/v1/since` cursor
+ * assertions stay deterministic; must be lowercase hex, since that is
+ * what the cursor validator accepts on the wire.
+ *
+ * Pass `{ generation: undefined }` to `logStateCurrentJson` to model a
+ * manifest written before the field existed.
+ */
+export const LOG_STATE_GENERATION = "0123456789ab";
+
+/**
  * Build a `CurrentJson` with launch defaults. Every field is
  * overridable — pass the ones a given test cares about (commonly
  * `tail_hint` / `log_seq_start` / `writer_fence.owner`) and inherit the
  * rest.
  *
  * Defaults match a freshly-provisioned collection: no snapshot, an empty
- * log tail at seq 0, and a zero-epoch fence. Pass the result to
+ * log tail at seq 0, a zero-epoch fence, and a generation nonce. Pass
+ * the result to
  * `createCurrentJson(storage, key, logStateCurrentJson(...))`.
  */
 export const logStateCurrentJson = (overrides: Partial<CurrentJson> = {}): CurrentJson => ({
@@ -52,6 +64,7 @@ export const logStateCurrentJson = (overrides: Partial<CurrentJson> = {}): Curre
   writer_fence: { epoch: 0, owner: "test", claimed_at: "" },
   snapshot_bytes: 0,
   snapshot_rows: 0,
+  generation: LOG_STATE_GENERATION,
   ...overrides,
 });
 

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -347,7 +347,15 @@ const BUDGETS: readonly Budget[] = [
   //     recorded in the note above. Measured 236768 raw / 74313 gz (gz
   //     still 439 B under). Rebaselined per the POLICY rather than golfing
   //     the warning that keeps the bug from being reintroduced.
-  { entry: "index.js", raw: 232 * 1024, gz: 73 * 1024, minGz: 20 * 1024 },
+  //   → 233 KiB raw / 74 KiB gz (2026-08-01): `/v1/since` cursor generation
+  //     discriminator (#73) — the `cursor.ts` codec, `CurrentJson.generation`
+  //     and its `assertCurrentJson` guard, and `mintGeneration`.
+  //     Comment/JSDoc dominated, as the axis split shows: raw and gz crossed
+  //     while min-gz (the hard ceiling, comments stripped) stayed 176 B under.
+  //     `cursor.ts` imports only `errors.ts`, already present in every
+  //     closure, so no new module was dragged in. Measured 238198 raw /
+  //     74840 gz / 20304 min-gz.
+  { entry: "index.js", raw: 233 * 1024, gz: 74 * 1024, minGz: 20 * 1024 },
   // The three auth verifier factories (bearerJwt, sharedSecret,
   // cloudflareAccess) plus the transitive jose closure pulled in by
   // bearerJwt's createRemoteJWKSet + jwtVerify. Adding a fourth
@@ -535,7 +543,16 @@ const BUDGETS: readonly Budget[] = [
   //     comments stripped) stays 315 B under. Measured 359799 raw / 106796 gz
   //     / 36549 min-gz. Deliberate safety + doc change; raw/gz rebaselined
   //     rather than golfing the comments.
-  { entry: "http.js", raw: 352 * 1024, gz: 105 * 1024, minGz: 36 * 1024 },
+  //   → 359 KiB raw / 107 KiB gz (2026-08-01): `/v1/since` cursor generation
+  //     discriminator (#73). This closure owns the handler, so it takes the
+  //     whole change: the `cursor.ts` codec, `decodeCursor` shape validation,
+  //     the generation comparison and its rationale comment, and the
+  //     `pollOnce` split that carries the manifest generation out to
+  //     `next_cursor` without a second `current.json` read. min-gz stays
+  //     under, but only by 43 B — the next change through this closure should
+  //     expect to argue about it rather than assume headroom. Measured
+  //     366541 raw / 109305 gz / 36821 min-gz.
+  { entry: "http.js", raw: 359 * 1024, gz: 107 * 1024, minGz: 36 * 1024 },
   // Observability primitives — ObservabilityContext, the
   // request-scoped MetricsRecorder, LogTape config + the
   // JSON sink only (the pretty sink + picocolors now live in
@@ -711,7 +728,13 @@ const BUDGETS: readonly Budget[] = [
   //     Same commit, no budget move needed: index.js 236837 raw (731 B
   //     under), http.js 360265 (183 B), cloudflare.js 432978 (174 B),
   //     dev.js unchanged.
-  { entry: "maintenance.js", raw: 127 * 1024, gz: 40 * 1024, minGz: 12 * 1024 },
+  //   → 128 KiB raw (2026-08-01): `/v1/since` cursor generation discriminator
+  //     (#73). This closure does not touch cursors; it moves only because it
+  //     shares `current-json.js`, which gained the `generation` field, its
+  //     guard, and `mintGeneration`. gz (695 B) and min-gz (776 B) both stay
+  //     under; only the raw tripwire moves. Measured 130752 raw / 40265 gz /
+  //     11512 min-gz.
+  { entry: "maintenance.js", raw: 128 * 1024, gz: 40 * 1024, minGz: 12 * 1024 },
   // Cloudflare Workers adapter — re-exports the kernel barrel
   // (Db, Writer, etc.) plus the R2-binding `Storage` impl
   // and the `baerlyCloudflare` helper. Aggregator: closure
@@ -892,7 +915,11 @@ const BUDGETS: readonly Budget[] = [
   //     chunks). Measured 432505 raw / 129632 gz / 45580 min-gz; gz (416 B)
   //     and min-gz (500 B) both stay under, only raw moves. Deliberate
   //     safety change.
-  { entry: "cloudflare.js", raw: 423 * 1024, gz: 127 * 1024, minGz: 45 * 1024 },
+  //   → 430 KiB raw / 130 KiB gz (2026-08-01): `/v1/since` cursor generation
+  //     discriminator (#73) — same change as http.js above, reaching this
+  //     aggregator through the shared http + current-json chunks. min-gz
+  //     stays 239 B under. Measured 439542 raw / 132296 gz / 45841 min-gz.
+  { entry: "cloudflare.js", raw: 430 * 1024, gz: 130 * 1024, minGz: 45 * 1024 },
   // Client surface — `BaerlyClient<TConfig>` + fetcher plumbing.
   // Browser/runtime-agnostic; no kernel modules in the closure.
   // Budget history:
@@ -1034,7 +1061,13 @@ const BUDGETS: readonly Budget[] = [
   //     guard and its expanded JSDoc. Measured 41442 raw / 14808 gz; gz stays
   //     552 B under (no min-gz axis on this entry). Comment-dominated
   //     rebaseline, not code creep.
-  { entry: "dev.js", raw: 41 * 1024, gz: 15 * 1024 },
+  //   → 42 KiB raw (2026-08-01): `/v1/since` cursor generation discriminator
+  //     (#73). This closure pulls the `current-json` chunk, so it carries the
+  //     `generation` field, its `assertCurrentJson` guard, and
+  //     `mintGeneration` (which `ensureTable` now calls). Measured 42789 raw
+  //     / 15304 gz; gz stays 56 B under — tight, so the next dev-closure
+  //     change should expect to move it. Comment-dominated rebaseline.
+  { entry: "dev.js", raw: 42 * 1024, gz: 15 * 1024 },
   // Worker-safe S3 entry — `S3HttpStorage` + `sigV4Signer` + the
   // `aws4fetch` SigV4 client + `@rgrove/parse-xml` XML parser.
   // Intended for cross-account R2 / non-R2 S3 from a Cloudflare

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -1067,7 +1067,15 @@ const BUDGETS: readonly Budget[] = [
   //     `mintGeneration` (which `ensureTable` now calls). Measured 42789 raw
   //     / 15304 gz; gz stays 56 B under — tight, so the next dev-closure
   //     change should expect to move it. Comment-dominated rebaseline.
-  { entry: "dev.js", raw: 42 * 1024, gz: 15 * 1024 },
+  //   → 43 KiB raw / 16 KiB gz (2026-08-01): review follow-up on the same
+  //     change — `assertCurrentJson`'s `generation` guard now pins the
+  //     lowercase-hex charset (matching `/v1/since`'s `GENERATION_RE`, so
+  //     the manifest validator and the wire validator cannot drift) and
+  //     carries the rationale comment for it. Measured 43032 raw /
+  //     15400 gz — the +56 B the note above predicted, plus the guard.
+  //     No min-gz axis on this entry; comment-dominated, per POLICY not
+  //     golfed to fit.
+  { entry: "dev.js", raw: 43 * 1024, gz: 16 * 1024 },
   // Worker-safe S3 entry — `S3HttpStorage` + `sigV4Signer` + the
   // `aws4fetch` SigV4 client + `@rgrove/parse-xml` XML parser.
   // Intended for cross-account R2 / non-R2 S3 from a Cloudflare

--- a/tests/integration/http-conformance.test.ts
+++ b/tests/integration/http-conformance.test.ts
@@ -296,6 +296,11 @@ for (const variant of variants) {
           writer_fence: { epoch: 0, owner: "http-conformance-test", claimed_at: "" },
           snapshot_bytes: 0,
           snapshot_rows: 0,
+          // Seed a generation so the cascade's cursor round-trips
+          // exercise the composite `<generation>.<lsn>` shape. Without
+          // it every backend would only ever see a bare LSN, and a
+          // regression in the composite path would pass on all four.
+          generation: "0123456789ab",
         });
       },
       options: {
@@ -325,6 +330,7 @@ for (const variant of variants) {
             writer_fence: { epoch: 0, owner: "http-conformance-test", claimed_at: "" },
             snapshot_bytes: 0,
             snapshot_rows: 0,
+            generation: "0123456789ab",
           });
         },
       },


### PR DESCRIPTION
Closes #73.

A `/v1/since` cursor's seq identifies a `log/<seq>` slot, and slots are reused. `baerly admin restore --force` reseeds `log_seq_start` to one past the highest *surviving* log object, which lands below the old floor whenever a budget-bounded GC sweep cleared the lex-first part of the old range — the deliberate floor exemption from #78's invariant 12. A pre-restore cursor then cleared the `cursorSeq < log_seq_start` gate, resumed into the new generation, and skipped every restored row beneath it. Rows past the cursor still arrived, so the stream was **gapped, not broken** — the failure a sync client cannot detect for itself.

## Two corrections to the issue as filed

**`writer_fence.epoch` cannot be the discriminator.** #73 suggests it, since `--force` already bumps it and nothing reads it. But `restore.ts`'s fresh-target branch (`head === null`) writes `epoch: 0`, so a truncate-to-empty is indistinguishable from a genuine epoch-0 collection. A counter that resets is not a generation. This uses a random nonce and leaves `writer_fence` dormant.

**The stated acceptance criteria would have made things worse.** #73 asks for a `SchemaError`. That maps to HTTP 400 and the client rebuilds it faithfully with its `code` — but `subscription-pool.ts` caught every error alike, backed off 1 s, and retried **the same cursor**, forever. So the folded-cursor `SchemaError` that already existed on that path was, for the React client, a permanent 1 req/s dead loop with a frozen table. Detection without recovery would only have relabelled the bug, so client recovery is included here.

## Design

`current.json` gains an optional `generation` nonce (12 lowercase hex from `crypto.randomUUID`). The cursor becomes `<generation>.<lsn>`; a mismatch on resume is rejected with `SchemaError`.

**A collection with no generation keeps handing out a bare LSN**, not `-.<lsn>`. Both spellings decode to the same sentinel, so the comparison is identical either way — but a collection with nothing to discriminate shouldn't have its wire shape changed. Emitting the composite form unconditionally would have moved every cursor in the bucket on upgrade, including against a peer still running the previous build.

**No `schema_version` bump.** `assertCurrentJson` validates field-by-field with three existing optional-field precedents, and a version bump is a hard `InvalidResponse` on every existing bucket with no migration path. Existing buckets keep working untouched.

**One charset, two validators.** `mintGeneration` emits lowercase hex, `assertCurrentJson` requires it, and `/v1/since`'s `GENERATION_RE` accepts exactly that. Pinning both ends is load-bearing: a manifest carrying a generation the validator allowed but the wire refused would make the server mint a cursor and then reject it on resume — a token it issued itself, which a client reads as permanently dead.

**Client recovery is bounded.** On `SchemaError` the pool drops the cursor and re-bootstraps from `""` — behind the existing 1 s error backoff, not ahead of it. The `poll.cursor !== ""` guard bounds a same-iteration respin but not a two-iteration oscillation: if a server ever hands back a cursor it then refuses, `""` succeeds, adopts a fresh cursor, and that cursor is rejected again. Re-bootstrapping without the delay runs that cycle at network speed with an `invalidateForTable` refetch storm every lap. One second of recovery latency buys a hard bound.

**No client changes needed for the shape.** The cursor was already opaque in practice — `poll-since-once.ts` passes it through and `subscription-pool.ts` only compares and stores. `LogEntry.lsn` is untouched, so the durable log format doesn't move.

**Four mint sites, zero carry-through edits.** The writers that *replace* a collection mint (both `restore` seeds, writer auto-provision, `ensureTable`); the writers that *advance* one already spread `...current` and carry it through (compactor fold CAS, `claimWriter`, every `casUpdateCurrentJson` mutator). I verified all seven construction sites. `compactor.test.ts` pins the preservation, because a fold that dropped the field would invalidate every live cursor with no read path erroring — a silent failure.

**The absent-generation sentinel is total, not a fallback.** A manifest predating the field and a bare-LSN cursor both decode to `-`, so one string comparison covers every case with no fail-open branch: never-truncated old bucket passes; old bucket then `--force`-restored rejects. Truth table in the spec.

## Documentation

The cursor's opacity and the `400 SchemaError` → back-off-then-re-bootstrap contract are stated everywhere a consumer might look: `API.md` (which described `next_cursor` as the last entry's `lsn`), `client/src/contract.ts`, `LogEntry.lsn`'s JSDoc, and `llms.txt`. A hand-rolled subscriber written from any of those would otherwise reproduce the dead loop this PR removes.

## Notable

- `listEventsSince` is public surface pinned by `public-surface.test.ts`, so its return type is unchanged. The body moved to an internal `pollOnce` that also surfaces the generation — `longPollSince` needs it to mint `next_cursor`, and re-reading `current.json` would add a Class A op to every poll.
- The pre-existing folded-cursor test used a bare `lsn`, which would now trip the *generation* check instead — staying green while no longer covering the path it exists for. Switched to the composite cursor and pinned which rejection fires.
- Both HTTP conformance provisioners (Node + Workerd/R2) seed a generation, so all four backends exercise the composite cursor rather than only the sentinel path.
- Seed shapes are no longer byte-identical across provisioners. Harmless (`If-None-Match` means one lands), and the three JSDoc sites claiming otherwise (`writer.ts`, `ensure-table.ts`, `db.ts`) are corrected rather than left stale.

## Deferred: seed-literal consolidation (#81)

`writer.ts` and `ensure-table.ts` build literally identical seeds, and `restore.ts`'s fresh-target branch differs only in `owner`. I built the `seedCurrentJson(owner = "")` factory in `@baerly/protocol` and measured it: every shipped bundle gets *bigger* — `index.js` +755 B raw, `maintenance.js` +895 B, `dev.js` +782 B raw / +341 B gz (gz newly crossing), `cloudflare.js` +157 B, `http.js` +137 B gz. Net source change was −1 line, so this is placement rather than volume: the factory and its JSDoc land in `current-json.ts`, which is in *every* closure, while the literals it removes only help the closures that had one — and `restore.ts` isn't bundled at all.

Not disqualifying on its own (raw/gz are creep tripwires and the policy is to rebaseline, not golf comments), but it means more baseline bumps on a PR that already carries several, for a maintainability win unrelated to this bug. #81 holds the numbers and the question worth actually deciding: where the factory belongs so it isn't in every closure — not whether to write one.

## Bundle budgets

Rebaselines raw/gz with dated notes and measured figures. The delta is comment/JSDoc-dominated and rolldown ships comments un-stripped; `min-gz` — the hard ceiling, where comments are gone — stays under on every entry: index 156 B, http 25 B, maintenance 760 B, cloudflare 222 B. `cursor.ts` imports only `errors.ts`, already in every closure, so nothing new was dragged in.

Two to flag: **http `min-gz` is 25 B under** and **index `raw` is 39 B under**. Neither is a regression, but the next change through either closure should expect to argue about the budget rather than assume headroom.

## Verification

`pnpm verify` and `pnpm test` green (2613 passed). `pnpm test:adapter-cloudflare` green (152 passed), run because `writer.ts` and the R2 conformance seed both changed. `pnpm bundle-sizes` green. Each commit ran the full pre-commit gate independently, since these land individually under rebase-merge.

The client tests are non-vacuous in an unusually strong way. Restoring the `continue` that skips the backoff makes the oscillation test spin until its circuit breaker trips and the request bound fails — and the breaker exists only because, without it, that regression hangs the runner outright rather than failing. That hang is the dead loop being removed.
