### PR TITLE
fix(server,protocol): cap the writer's backwards pre-image scan

### DIFF
--- a/.changeset/preimage-scan-descent-budget.md
+++ b/.changeset/preimage-scan-descent-budget.md
@@ -1,0 +1,31 @@
+---
+"@gusto/baerly-storage": patch
+---
+
+Cap the writer's backwards pre-image scan.
+
+`Writer#readPreImage` walked the log backwards from the committing seq
+to 0, one sequential GET per seq, to find the index keys a doc's prior
+value produced so they can be deleted. Its docstring claimed the walk
+was bounded by `log_seq_start`; it never was. Once GC swept a doc's
+last insert/update, every later update or delete on that doc walked the
+entire history inline on the write path — the only unbounded log walk
+in the kernel.
+
+The walk is now capped at `PREIMAGE_SCAN_MAX_GETS` log GETs below the
+committing seq, sized against the Cloudflare free-tier wall of 50
+subrequests per request: an indexed `U` commit plus a co-occurring
+maintenance fold tick already spends ~41 of them.
+
+**Behaviour change.** Stale index keys are now cleaned up only for a
+doc rewritten within the budget. Colder docs keep an extra index key
+until `rebuildIndex` or `baerly admin fsck --indexes` runs. That
+residual is benign by construction — an extra key is a false positive
+the read path drops, never a missing candidate — but it is more common
+than before, and `docs/spec/sync-protocol.md` invariant 7 has been
+amended to say so. Run `fsck --indexes` if you rely on index-key counts
+directly.
+
+No new metric label: the give-up path is the common case at this
+budget, so counting it on `db.write.index_cleanup_errors_total` would
+swamp the two steps on that counter that do signal a failure.

--- a/docs/spec/sync-protocol.md
+++ b/docs/spec/sync-protocol.md
@@ -278,7 +278,8 @@ _before_ the commit, so a committed doc is always index-findable, and
 stale-key DELETEs land only _after_ the commit, so an uncommitted write
 can never remove a key a committed value depends on. The residual is
 safe: an extra key is a false-positive. It can be healed by the doc's
-next write; `rebuildIndex` is the whole-collection operator backstop. (A
+next write when the capped pre-image walk still reaches the prior image
+(see invariant 7); `rebuildIndex` is the whole-collection backstop. (A
 bounded in-tick reconcile slice was considered and deferred — see
 [ADR-004](../adr/004-single-write-commit.md#closed-paths).)
 
@@ -459,8 +460,13 @@ These are the load-bearing rules.
    index keys are emitted _before_ the commit and stale keys deleted
    _after_, so a committed value is never de-indexed by a write that did
    not commit. The only residual is a benign false-positive (an extra
-   key) dropped by `matchesWire`; it self-heals on the doc's next write,
-   with `rebuildIndex` as the operator backstop.
+   key) dropped by `matchesWire`. It self-heals on the doc's next write
+   only when that write can still read the doc's prior post-image: the
+   backwards pre-image walk is capped at `PREIMAGE_SCAN_MAX_GETS` log
+   GETs to stay inside the Cloudflare free-tier subrequest wall, so a
+   doc not rewritten within that many log entries keeps its stale key.
+   `rebuildIndex` / `baerly admin fsck --indexes` is the authoritative
+   backstop, not merely an operator convenience.
 8. **Reads are pure.** Reads load state; they never compact, GC, or
    tick maintenance. The tail forward-probe is Class B (GETs), so the
    idle-reader cost bound is untouched.

--- a/packages/protocol/src/constants.ts
+++ b/packages/protocol/src/constants.ts
@@ -140,10 +140,13 @@ export const S3_REQUEST_MAX_RETRIES: number = 8;
  * tier profile), and a contended writer multiplies that by the CAS
  * retry budget ({@link S3_REQUEST_MAX_RETRIES}).
  *
- * 16 keeps the worst-case under retry to `16 * 8 = 128` concurrent
- * GETs — comfortably under the Workers subrequest cap (50 concurrent
- * / 1000 total) and leaving headroom for the writer's content / index
- * / log / CAS PUTs sharing the same isolate.
+ * 16 bounds CONCURRENCY, not the per-request total. `16 * 8 = 128` is
+ * the whole-request worst case across the retry budget, which fits the
+ * Cloudflare PAID subrequest cap (10,000/request since 2026-02-11) but
+ * not the free cap (50/request) — see `docs/about/graduation.md`
+ * §Per-tier bounds. A free-tier reader relies on the compactor keeping
+ * the live tail short enough that the walk never approaches it. Do not
+ * cite this 128 as a per-request budget for anything else.
  *
  * @see packages/server/src/log-walk.ts (`walkLogRange`)
  */
@@ -159,6 +162,65 @@ export const MAX_PARALLEL_LOG_READS: number = 16;
  * @see packages/server/src/log-tail.ts (`probeTailFrom`)
  */
 export const LOG_FORWARD_PROBE_CAP: number = 100_000;
+
+/**
+ * Descent budget on the writer's backwards pre-image walk
+ * (`Writer#readPreImage`): max `log/<seq>` GETs below the committing
+ * seq before the walk gives up and reports "pre-image unknown".
+ *
+ * The walk MUST be 404-tolerant — a folded-and-swept entry and a peer
+ * mid-CAS are indistinguishable from a missing object — so it cannot
+ * use a hole as a stop signal, and `seq` grows monotonically forever.
+ * Without this budget the walk is O(seq): once GC sweeps a doc's last
+ * I/U past the {@link GC_GRACE_PERIOD_MILLIS} grace, every later
+ * `U` / `D` on that doc issues one SEQUENTIAL GET per seq down to 0,
+ * then returns "unknown" and deletes nothing. That is unbounded
+ * opportunistic work on the request path — the shape
+ * `docs/contributing/conventions/change-discipline.md` rules out.
+ *
+ * Deliberately NOT floored at `log_seq_start`: sub-floor entries
+ * survive the 7-day GC grace, so a post-fold `U` / `D` can still find
+ * its pre-image below the floor. The budget is anchored at the
+ * committing seq instead, which makes the cost unconditional.
+ *
+ * **Sized by the subrequest wall, not by coverage.** Cloudflare free
+ * allows 50 subrequests per request total
+ * (`docs/about/graduation.md` §Per-tier bounds); R2 binding ops count
+ * 1:1, and a `ctx.waitUntil` maintenance continuation draws on the
+ * same per-invocation budget. One `op:"U"` commit on a single-index
+ * collection already costs ~15 before this walk — 1 GET
+ * `current.json`, ~10 sequential GETs for `findLogTail`'s gallop over
+ * a one-fold-interval `tail_hint` lag, 1 content PUT, 1 index
+ * `newKey` PUT, the `log/<seq>` create, 1 stale-key DELETE — and the
+ * write-tick fold branch it may dispatch costs ~26 more (1 runner GET
+ * + `compact()`'s 3 + {@link WRITE_TICK_FOLD_ENTRIES_PER_PASS} log
+ * GETs + 2 PUTs). `50 - 15 - 26 = 9`, so 8 leaves one subrequest of
+ * slack. The walk is strictly SEQUENTIAL, so this is a hard
+ * per-request cost, not a fan-out bound like
+ * {@link MAX_PARALLEL_LOG_READS}.
+ *
+ * **What that budget actually covers.** The pre-image sits roughly
+ * one working-set of seqs back, so 8 reaches a doc rewritten within
+ * the last few log entries — a form re-save, a retry, a two-phase
+ * update — and nothing colder. On a collection with more than ~8
+ * actively-written docs the walk normally gives up. That is accepted:
+ * the residual is a benign extra index key (a false positive dropped
+ * by `matchesWire`, never a missing candidate — see
+ * `docs/spec/sync-protocol.md` invariant 7), and `rebuildIndex` /
+ * `baerly admin fsck --indexes` is the authoritative reconciler. The
+ * give-up is deliberately NOT counted: at this budget it is the
+ * common path, not an anomaly, so a counter would be noise rather
+ * than signal.
+ *
+ * A per-tier budget on `MaintenanceProfile` (free 8, Node / CF-paid
+ * far higher — the same commit leaves ~9,780 of a 10,000 subrequest
+ * budget there) would buy real coverage back on the larger tiers.
+ * Not built: it widens the profile surface for a best-effort cleanup
+ * path whose backstop already exists.
+ *
+ * @see packages/server/src/writer.ts (`Writer#readPreImage`)
+ */
+export const PREIMAGE_SCAN_MAX_GETS: number = 8;
 
 /**
  * Current major version of the `current.json` control-object schema.

--- a/packages/server/src/writer.test.ts
+++ b/packages/server/src/writer.test.ts
@@ -1,6 +1,7 @@
 import {
   CURRENT_JSON_SCHEMA_VERSION,
   type CurrentJson,
+  type DocumentData,
   type LogEntry,
   createCurrentJson,
   getOrCreateMemoryStorageForBucket,
@@ -8,6 +9,7 @@ import {
   MAINTENANCE_TAIL_HINT_REFRESH_WRITES,
   MemoryStorage,
   BaerlyError,
+  PREIMAGE_SCAN_MAX_GETS,
   resetMemoryStorage,
   str2uintDesc,
   type StoragePutOptions,
@@ -17,7 +19,7 @@ import {
 } from "@baerly/protocol";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { logStateCurrentJson, seedLogEntry } from "../../../tests/fixtures/log-state.ts";
-import type { IndexDefinition } from "./indexes.ts";
+import { allIndexKeysFor, encodeIndexValue, type IndexDefinition } from "./indexes.ts";
 import type { MaintenanceDispatch } from "./maintenance.ts";
 import {
   createObservabilityContext,
@@ -1451,5 +1453,230 @@ describe("Writer — write-tick maintenance dispatch", () => {
     await expect(
       writer.commit({ op: "I", collection: COLL, docId: badId, body: { _id: badId } }),
     ).rejects.toMatchObject({ code: "InvalidConfig" });
+  });
+});
+
+describe("Writer — pre-image scan depth", () => {
+  /**
+   * `#readPreImage` walks the log backwards from the committing seq to
+   * find the doc's prior post-image, so Step 5b can DELETE the index
+   * keys that image produced. The walk is 404-tolerant by necessity (a
+   * folded-and-swept entry and a peer mid-CAS are indistinguishable),
+   * which means it cannot use a missing object as a stop signal.
+   *
+   * Without an explicit budget that makes the walk O(seq): once GC has
+   * swept a doc's last I/U (7-day grace, `GC_GRACE_PERIOD_MILLIS`),
+   * every later `U`/`D` on that doc issues one SEQUENTIAL GET per seq
+   * all the way to 0 — then returns `undefined` and deletes nothing.
+   * That is the only unbounded log walk in the kernel and it runs
+   * inline on the write path, after the commit.
+   *
+   * These tests pin the budget from both sides: the exact GET count it
+   * spends on swept history (the cost bound is the whole point of the
+   * fix, so it is asserted as an equality — a self-referential
+   * `<= PREIMAGE_SCAN_MAX_GETS` would stay green if the constant were
+   * raised back to an unsafe value), and the depth it still reaches,
+   * including the last seq inside the budget and the first one outside.
+   */
+  const SCAN_CURRENT_KEY = `app/test/tenant/t/manifests/${COLL}/current.json`;
+  const SCAN_LOG_PREFIX = `app/test/tenant/t/manifests/${COLL}`;
+  const by_assignee: IndexDefinition = { name: "by_assignee", on: "assignee" };
+
+  /** Counts `/log/` GETs issued after the committing log create. */
+  class PostCommitLogGetCountingStorage extends MemoryStorage {
+    postCommitLogGets = 0;
+    #armed = false;
+
+    override async put(
+      key: string,
+      body: Uint8Array,
+      opts?: StoragePutOptions,
+    ): Promise<StoragePutResult> {
+      const result = await super.put(key, body, opts);
+      if (key.includes("/log/") && key.endsWith(".json") && opts?.ifNoneMatch !== undefined) {
+        this.#armed = true;
+      }
+      return result;
+    }
+
+    override async get(
+      key: string,
+      opts?: { ifNoneMatch?: string; versionId?: string; signal?: AbortSignal },
+    ): Promise<{ body: Uint8Array; etag: string; versionId?: string } | null> {
+      if (this.#armed && key.includes("/log/")) {
+        this.postCommitLogGets++;
+      }
+      return super.get(key, opts);
+    }
+  }
+
+  /**
+   * PUT the index keys a prior post-image would have left on the
+   * bucket. Without this the stale-key assertions are vacuous: seeding
+   * only a `log/<seq>` entry gives the walk something to FIND but
+   * nothing to DELETE, so "the old key is gone" passes whether or not
+   * the walk ever ran. Mirrors the writer's own emission at
+   * `writer.ts:531` (empty body, `application/json`).
+   */
+  const seedPreImageIndexKeys = async (
+    storage: MemoryStorage,
+    body: DocumentData,
+    docId: string,
+  ): Promise<void> => {
+    for (const key of allIndexKeysFor(SCAN_LOG_PREFIX, [by_assignee], body, docId)) {
+      await storage.put(key, new Uint8Array(), { contentType: "application/json" });
+    }
+  };
+
+  const listAssigneeKeys = async (storage: MemoryStorage): Promise<string[]> => {
+    const out: string[] = [];
+    for await (const entry of storage.list(`${SCAN_LOG_PREFIX}/index/${by_assignee.name}/`)) {
+      out.push(entry.key);
+    }
+    return out.toSorted();
+  };
+
+  test("bounds the backwards walk when the doc's last entry was folded and swept", async () => {
+    // Post-sweep steady state: the floor has advanced to 400 and every
+    // sub-floor `log/<seq>.json` is gone, so no entry for this doc
+    // survives anywhere on the bucket.
+    const FLOOR = 400;
+    const storage = new PostCommitLogGetCountingStorage();
+    await createCurrentJson(
+      storage,
+      SCAN_CURRENT_KEY,
+      logStateCurrentJson({ tail_hint: FLOOR, log_seq_start: FLOOR }),
+    );
+    const writer = new Writer({
+      storage,
+      currentJsonKey: SCAN_CURRENT_KEY,
+      options: { indexes: [by_assignee] },
+    });
+
+    await writer.commit({
+      op: "U",
+      collection: COLL,
+      docId: "d-old",
+      body: { _id: "d-old", assignee: "bob" },
+    });
+
+    // Asserted as a LITERAL, not against `PREIMAGE_SCAN_MAX_GETS`.
+    // The constant's value is the fix — it is sized against the
+    // Cloudflare free-tier 50-subrequest wall, most of which a `U`
+    // commit has already spent. A self-referential assertion would
+    // stay green if someone raised it back to a value that blows that
+    // wall, which is exactly the regression this test exists to catch.
+    // On `main` this walk cost 400 GETs.
+    expect(storage.postCommitLogGets).toBe(8);
+  });
+
+  test("reaches an entry at exactly the deepest seq inside the budget", async () => {
+    // The walk covers `[S - PREIMAGE_SCAN_MAX_GETS, S - 1]`, so the
+    // deepest reachable seq is `S - PREIMAGE_SCAN_MAX_GETS`. Pins the
+    // off-by-one in the `Math.max(0, currentNextSeq - N)` floor.
+    const FLOOR = 300;
+    const storage = new MemoryStorage();
+    await createCurrentJson(
+      storage,
+      SCAN_CURRENT_KEY,
+      logStateCurrentJson({ tail_hint: FLOOR, log_seq_start: FLOOR }),
+    );
+    await seedLogEntry(storage, SCAN_LOG_PREFIX, FLOOR - PREIMAGE_SCAN_MAX_GETS, {
+      op: "I",
+      collection: COLL,
+      doc_id: "d-old",
+      after: { _id: "d-old", assignee: "amy" },
+    });
+    await seedPreImageIndexKeys(storage, { _id: "d-old", assignee: "amy" }, "d-old");
+    const writer = new Writer({
+      storage,
+      currentJsonKey: SCAN_CURRENT_KEY,
+      options: { indexes: [by_assignee] },
+    });
+
+    await writer.commit({
+      op: "U",
+      collection: COLL,
+      docId: "d-old",
+      body: { _id: "d-old", assignee: "bob" },
+    });
+
+    const keys = await listAssigneeKeys(storage);
+    expect(keys.some((k) => k.includes(`/${encodeIndexValue("amy")}/`))).toBe(false);
+  });
+
+  test("leaves the stale key when the pre-image is one seq past the budget", async () => {
+    // The accepted trade, pinned so it is a deliberate choice rather
+    // than a surprise: one seq deeper than the budget and the old key
+    // survives. That is benign — an extra index key is a false
+    // positive the read path drops, never a missing candidate — and
+    // `rebuildIndex` / `fsck --indexes` is the reconciler.
+    const FLOOR = 300;
+    const storage = new MemoryStorage();
+    await createCurrentJson(
+      storage,
+      SCAN_CURRENT_KEY,
+      logStateCurrentJson({ tail_hint: FLOOR, log_seq_start: FLOOR }),
+    );
+    await seedLogEntry(storage, SCAN_LOG_PREFIX, FLOOR - PREIMAGE_SCAN_MAX_GETS - 1, {
+      op: "I",
+      collection: COLL,
+      doc_id: "d-old",
+      after: { _id: "d-old", assignee: "amy" },
+    });
+    await seedPreImageIndexKeys(storage, { _id: "d-old", assignee: "amy" }, "d-old");
+    const writer = new Writer({
+      storage,
+      currentJsonKey: SCAN_CURRENT_KEY,
+      options: { indexes: [by_assignee] },
+    });
+
+    await writer.commit({
+      op: "U",
+      collection: COLL,
+      docId: "d-old",
+      body: { _id: "d-old", assignee: "bob" },
+    });
+
+    const keys = await listAssigneeKeys(storage);
+    expect(keys.some((k) => k.includes(`/${encodeIndexValue("amy")}/`))).toBe(true);
+    expect(keys.some((k) => k.includes(`/${encodeIndexValue("bob")}/`))).toBe(true);
+  });
+
+  test("still reaches a surviving entry just below log_seq_start", async () => {
+    // Normal post-fold, pre-GC-sweep state: the floor advanced past the
+    // doc's last write, but the object is still on the bucket during the
+    // 7-day grace. The walk must reach it, or the stale index key leaks.
+    const FLOOR = 300;
+    const storage = new MemoryStorage();
+    await createCurrentJson(
+      storage,
+      SCAN_CURRENT_KEY,
+      logStateCurrentJson({ tail_hint: FLOOR, log_seq_start: FLOOR }),
+    );
+    await seedLogEntry(storage, SCAN_LOG_PREFIX, FLOOR - 5, {
+      op: "I",
+      collection: COLL,
+      doc_id: "d-old",
+      after: { _id: "d-old", assignee: "amy" },
+    });
+    await seedPreImageIndexKeys(storage, { _id: "d-old", assignee: "amy" }, "d-old");
+    const writer = new Writer({
+      storage,
+      currentJsonKey: SCAN_CURRENT_KEY,
+      options: { indexes: [by_assignee] },
+    });
+
+    await writer.commit({
+      op: "U",
+      collection: COLL,
+      docId: "d-old",
+      body: { _id: "d-old", assignee: "bob" },
+    });
+
+    const keys = await listAssigneeKeys(storage);
+    expect(keys.filter((k) => k.endsWith("/d-old.json"))).toHaveLength(1);
+    expect(keys.some((k) => k.includes(`/${encodeIndexValue("amy")}/`))).toBe(false);
+    expect(keys.some((k) => k.includes(`/${encodeIndexValue("bob")}/`))).toBe(true);
   });
 });

--- a/packages/server/src/writer.ts
+++ b/packages/server/src/writer.ts
@@ -59,6 +59,7 @@ import {
   noopMetricsRecorder,
   type Storage,
   LOG_FORWARD_PROBE_CAP,
+  PREIMAGE_SCAN_MAX_GETS,
   MAINTENANCE_PROFILE_CF_FREE,
   MAINTENANCE_TAIL_HINT_REFRESH_WRITES,
   S3_REQUEST_MAX_RETRIES,
@@ -881,27 +882,55 @@ export class Writer {
   }
 
   /**
-   * Read the pre-image content body for a doc by walking the live log
+   * Read the pre-image content body for a doc by walking the log
    * backwards from `currentNextSeq` looking for the most-recent I/U
    * entry on this `(collection, docId)`. Returns `undefined` when:
    *
    *   - the doc's most-recent op was `D` (tombstone — no live body);
-   *   - no entry for this doc lives inside the visible log range
-   *     `[log_seq_start, currentNextSeq)` (a fresh-insert race or the
-   *     doc has been folded into the snapshot but is no longer
-   *     referenced).
+   *   - no entry for this doc is found within the descent budget
+   *     (a fresh-insert race, or the doc's last write has been folded
+   *     into the snapshot and swept off the bucket).
    *
    * Used ONLY by the index-emission path's stale-key half (Step 5b, on
-   * `U` / `D`) to compute which OLD-value keys to DELETE. Bounded by
-   * `log_seq_start`: entries below have been folded into the snapshot
-   * and may already be swept off the bucket — a snapshot fold is the
-   * rebuild command's job (see `./rebuild-index.ts`), not the writer's.
+   * `U` / `D`) to compute which OLD-value keys to DELETE.
    *
-   * **Cost note:** linear walk, O(snapshot lag). For helpdesk-shape
-   * collections (100s of docs, <10k log entries) this is fine — the
-   * compactor folds the live tail every ~100 entries
-   * (`packages/server/src/compactor.ts`). A follow-up ticket caches
-   * per-doc index head in `current.json` for O(1) lookup.
+   * **Not bounded by `log_seq_start`.** GC only marks sub-floor
+   * entries and sweeps them a {@link GC_GRACE_PERIOD_MILLIS} (7-day)
+   * grace later, so a doc's last I/U often survives below the floor
+   * and is worth reading. The walk is 404-tolerant for a related
+   * reason: a swept entry and a peer mid-CAS look identical from
+   * here, so a hole cannot be a stop signal.
+   *
+   * **Cost, and what it buys.** One SEQUENTIAL GET per seq, hard-
+   * capped at {@link PREIMAGE_SCAN_MAX_GETS}. The cap is load-bearing,
+   * not a tuning knob: `seq` grows monotonically forever, so an
+   * uncapped walk is O(seq) on the write path (post-commit but inline,
+   * before the response) for any doc whose last entry GC has swept.
+   * The cap is sized against the Cloudflare free-tier 50-subrequest
+   * wall, which a `U` commit has already largely spent — the
+   * derivation is on the constant. At that size the walk reaches a doc
+   * rewritten within the last few log entries and nothing colder, so
+   * on any collection with more than a handful of active docs it
+   * normally finds nothing.
+   *
+   * That is the accepted trade, not a silent failure. Giving up is
+   * benign by construction: the caller computes no stale keys, and an
+   * extra index key is a false positive the read path drops
+   * (`matchesWire`), never a missing candidate — `docs/spec/sync-
+   * protocol.md` invariant 7. `rebuildIndex` (`./rebuild-index.ts`)
+   * and `baerly admin fsck --indexes` are the authoritative
+   * reconcilers. The give-up is deliberately NOT counted on
+   * `db.write.index_cleanup_errors_total`: at this budget it is the
+   * common path, so it would swamp the two entries on that counter
+   * that do mean something went wrong (`"pre-image-read"` — the read
+   * threw; `"delete"` — a stale-key DELETE failed).
+   *
+   * Reading below the floor cannot delete a LIVE index key: keys are
+   * docId-scoped (`./indexes.ts`), and on `U` the caller diffs
+   * `oldKeys \ newKeys`, so anything still live is in `newKeys`. The
+   * residual hazard is the pre-existing compute-then-delete-after-
+   * commit ABA (a peer may re-PUT a key between the diff and the
+   * DELETE), which the cap narrows but does not close.
    */
   async #readPreImage(
     logPrefix: string,
@@ -910,16 +939,19 @@ export class Writer {
     currentNextSeq: number,
   ): Promise<DocumentData | undefined> {
     // Walk newest-to-oldest so we hit the most-recent op first.
-    // `s = -1` is the natural empty-bucket sentinel.
-    for (let s = currentNextSeq - 1; s >= 0; s--) {
+    // `s = -1` is the natural empty-bucket sentinel; `floor` is the
+    // budget guard, NOT `log_seq_start` (see the docstring above).
+    const floor = Math.max(0, currentNextSeq - PREIMAGE_SCAN_MAX_GETS);
+    for (let s = currentNextSeq - 1; s >= floor; s--) {
       const logKey = logObjectKey(logPrefix, s);
       const got = await this.#storage.get(logKey);
       if (got === null) {
-        // A hole below the visible range — either we walked past
-        // `log_seq_start` (the entry was folded + swept) or a peer
-        // is mid-CAS on a write we don't see yet. Bail; the
-        // rebuild command (`rebuildIndex`) handles holes by
-        // re-projecting from the snapshot.
+        // A hole — either the entry was folded and swept, or a peer
+        // is mid-CAS on a write we don't see yet. Indistinguishable
+        // from here, so a hole cannot be a stop signal: keep
+        // descending until the budget runs out. The rebuild command
+        // (`rebuildIndex`) handles holes by re-projecting from the
+        // snapshot.
         continue;
       }
       let entry: LogEntry;
@@ -941,6 +973,10 @@ export class Writer {
         return entry.after;
       }
     }
+    // Fell through: either the budget stopped the walk or the doc
+    // genuinely has no prior image. Both are reported the same way and
+    // neither is counted — see the docstring on why a give-up counter
+    // would be noise at this budget.
     return undefined;
   }
 

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -355,7 +355,20 @@ const BUDGETS: readonly Budget[] = [
   //     `cursor.ts` imports only `errors.ts`, already present in every
   //     closure, so no new module was dragged in. Measured 238198 raw /
   //     74840 gz / 20304 min-gz.
-  { entry: "index.js", raw: 233 * 1024, gz: 74 * 1024, minGz: 20 * 1024 },
+  //   → 235 KiB raw (2026-08-01): the rewritten `Writer#readPreImage`
+  //     docstring (#74). The old docstring claimed a `log_seq_start` bound
+  //     the loop never had; the replacement carries the subrequest
+  //     derivation for the new descent budget and states plainly which
+  //     stale keys the walk no longer cleans up. Almost pure comment
+  //     bytes — the code delta is one `Math.max` and one loop bound.
+  //     `PREIMAGE_SCAN_MAX_GETS` itself contributes 0 B to every closure:
+  //     it is tree-shaken and the folded literal is inlined at the use
+  //     site. gz (75716, 60 B under) and min-gz (20340, 140 B under — the
+  //     hard ceiling, comments stripped) both stayed UNDER, the signature
+  //     of a comment-dominated change. Measured 240194 raw / 75716 gz /
+  //     20340 min-gz. Rebaselined per the POLICY rather than golfing the
+  //     prose that stops the false bound from being reintroduced.
+  { entry: "index.js", raw: 235 * 1024, gz: 74 * 1024, minGz: 20 * 1024 },
   // The three auth verifier factories (bearerJwt, sharedSecret,
   // cloudflareAccess) plus the transitive jose closure pulled in by
   // bearerJwt's createRemoteJWKSet + jwtVerify. Adding a fourth
@@ -552,7 +565,31 @@ const BUDGETS: readonly Budget[] = [
   //     under, but only by 43 B — the next change through this closure should
   //     expect to argue about it rather than assume headroom. Measured
   //     366541 raw / 109305 gz / 36821 min-gz.
-  { entry: "http.js", raw: 359 * 1024, gz: 107 * 1024, minGz: 36 * 1024 },
+  //   → 361 KiB raw / 108 KiB gz (2026-08-01): the rewritten
+  //     `Writer#readPreImage` docstring and its descent budget (#74).
+  //     This closure pulls in the writer via `constants.ts` + the server
+  //     barrel, so it takes the whole delta. Measured 368659 raw / 110218
+  //     gz / 36858 min-gz.
+  //     min-gz did NOT move, and that was the deciding constraint on the
+  //     change rather than an afterthought. An earlier draft counted the
+  //     walk's give-up on `db.write.index_cleanup_errors_total`; that
+  //     `if` plus its labelled `ctxMetrics().counter` call measured +15 B
+  //     min-gz, which put this closure 13 B OVER the 36 KiB hard ceiling.
+  //     Golfing was measured and does not reach — the label string, a
+  //     shorter `step` value, and hoisting the floor are all 0 B, because
+  //     the metric name already appears 3x in the chunk and deflate
+  //     absorbs the rest. The counter was dropped instead of rebaselining
+  //     min-gz, and it was the right call on its own merits: at a budget
+  //     this small the give-up path is the COMMON case, so the counter
+  //     was noise that would have swamped the two steps on that series
+  //     that do signal a failure.
+  //     ⚠️ min-gz now clears by 6 B (36858 / 36864). The 43 B note above
+  //     is now a 6 B note. This is a hair-trigger: the next change
+  //     through this closure — including one that only adds a
+  //     `console.warn` string — will trip it, and the honest fix at that
+  //     point is to shrink the closure, not to take the KiB. Do not read
+  //     the surviving 36 KiB line as headroom.
+  { entry: "http.js", raw: 361 * 1024, gz: 108 * 1024, minGz: 36 * 1024 },
   // Observability primitives — ObservabilityContext, the
   // request-scoped MetricsRecorder, LogTape config + the
   // JSON sink only (the pretty sink + picocolors now live in
@@ -919,7 +956,16 @@ const BUDGETS: readonly Budget[] = [
   //     discriminator (#73) — same change as http.js above, reaching this
   //     aggregator through the shared http + current-json chunks. min-gz
   //     stays 239 B under. Measured 439542 raw / 132296 gz / 45841 min-gz.
-  { entry: "cloudflare.js", raw: 430 * 1024, gz: 130 * 1024, minGz: 45 * 1024 },
+  //   → 432 KiB raw / 131 KiB gz (2026-08-01): the rewritten
+  //     `Writer#readPreImage` docstring and its descent budget (#74) —
+  //     same change as http.js above, reaching this aggregator through the
+  //     shared constants + server chunks. Measured 441808 raw / 133274 gz /
+  //     45878 min-gz. min-gz clears by 202 B here, so only the raw/gz creep
+  //     tripwires move. This closure has more slack than http.js because
+  //     the delta is comment-dominated and it carries more non-kernel code
+  //     to amortise it against — do not infer http.js is comfortable from
+  //     this line; see its own ⚠️ note above.
+  { entry: "cloudflare.js", raw: 432 * 1024, gz: 131 * 1024, minGz: 45 * 1024 },
   // Client surface — `BaerlyClient<TConfig>` + fetcher plumbing.
   // Browser/runtime-agnostic; no kernel modules in the closure.
   // Budget history:


### PR DESCRIPTION
Refs #74.

#74 has two halves. This PR fixes the unbounded backwards scan. It does **not** fix index-key leakage after `admin restore --force` — `restore.ts:258` builds its `Writer` with no `options.indexes`, so a restore neither emits keys for restored rows nor clears the old generation's. #74 stays open for that.

## The problem

`Writer#readPreImage` walks the log backwards from the committing seq looking for a doc's most-recent I/U, so the index-emission path can DELETE the keys that prior value produced. It walked down to 0 — one sequential GET per seq, 404-tolerating every hole — while its docstring claimed the walk was "Bounded by `log_seq_start`". That bound was never implemented: `b0d5c14d` (2026-05-12) landed the loop and the sentence in the same hunk.

The mismatch is not primarily a correctness problem. Index keys are docId-scoped and `U` diffs `oldKeys \ newKeys`, so a sub-floor pre-image cannot unlink a live key. The defect is cost. `seq` grows monotonically forever, so once GC sweeps a doc's last I/U past the 7-day grace, every later `U`/`D` on that doc walks the entire history sequentially, then returns "unknown" and deletes nothing.

This is the only unbounded log walk in the kernel — `findLogTail` caps at `LOG_FORWARD_PROBE_CAP`, `probeTailFrom` stops at the first 404, `walkLogRange` is floor-bounded — and it runs inline on the write path, post-commit but **before the response** (`writer.ts:672`, awaited).

## Why not floor at `log_seq_start`

#74 proposes flooring the loop at `log_seq_start`. This PR does not do that. Sub-floor entries survive the 7-day GC grace (`GC_GRACE_PERIOD_MILLIS`, marked at `gc.ts:229`), so after a fold a doc's last I/U is normally still on the bucket below the floor, and reaching it is worth doing. A floored walk that finds nothing computes **no** stale keys (`allIndexKeysFor` returns `[]` for `body === undefined`, `indexes.ts:392-397`) and leaks them silently.

The walk is bounded by an explicit descent budget instead, which also makes the cost unconditional rather than dependent on GC timing.

## Sizing the budget

The budget is derived from the wall it has to fit inside, not from a coverage target. Cloudflare free allows **50 subrequests per request** (`docs/about/graduation.md:292`), and R2 binding ops count 1:1. One indexed `U` commit already spends ~15:

| Step | Cost |
|---|---|
| `current.json` GET | 1 |
| `findLogTail` gallop (one fold-interval lag) | ~10 |
| content PUT | 1 |
| index `newKey` PUT | 1 |
| `log/<seq>` create | 1 |
| stale-key DELETE | 1 |

The write-tick **fold** branch it may dispatch costs ~26 more: runner GET + `compact()`'s 3 + `WRITE_TICK_FOLD_ENTRIES_PER_PASS = 20` log GETs + 2 PUTs. On Cloudflare that runs under `ctx.waitUntil`, which draws on the same per-invocation budget.

`50 − 15 − 26 = 9`, so **`PREIMAGE_SCAN_MAX_GETS = 8`**, leaving one subrequest of slack. The walk is strictly sequential, so this is a hard per-request cost, not a fan-out bound.

8 is the free-tier floor. On Node / CF-paid the same commit leaves ~9,780 of a 10,000 budget, so a per-tier budget on `MaintenanceProfile` would buy coverage back where there is room; the constant's JSDoc records that as considered-and-not-built rather than dropping it silently.

The `MAX_PARALLEL_LOG_READS` JSDoc is corrected in the same commit. Its `16 * 8 = 128` bounds **concurrency** across the retry budget (the `8` is `S3_REQUEST_MAX_RETRIES`) and fits the **paid** cap — 10,000/request since 2026-02-11 — not free's 50. Its parenthetical read "(50 concurrent / 1000 total)", stale on both figures. The note now says explicitly that this 128 is not a per-request budget, so it does not get cited as one.

The behavioral delta is two lines:

```ts
const floor = Math.max(0, currentNextSeq - PREIMAGE_SCAN_MAX_GETS);
for (let s = currentNextSeq - 1; s >= floor; s--) {
```

## The trade this makes

At a free-tier-safe budget the walk reaches a doc rewritten within the last handful of log entries — a form re-save, a retry, a two-phase update — and nothing colder. On a collection with more than ~8 actively-written docs it normally finds nothing, and the doc keeps a stale index key until `rebuildIndex` / `baerly admin fsck --indexes` runs.

That residual is benign by construction: an extra key is a false positive the read path drops (`matchesWire`), never a missing candidate. It is common enough to be worth stating in the contract, so:

- **`docs/spec/sync-protocol.md` invariant 7 is amended.** It claimed the drift "self-heals on the doc's next write, with `rebuildIndex` as the operator backstop" — unconditional before, conditional now. The companion passage at :281 is updated to match, and `rebuildIndex` / `fsck --indexes` is named as the authoritative reconciler rather than an operator convenience.
- **A changeset ships** (`.changeset/preimage-scan-descent-budget.md`) calling out the behavior change for anyone relying on index-key counts directly.

## Why the give-up is not counted

`db.write.index_cleanup_errors_total` carries two steps — `"pre-image-read"` (the read threw) and `"delete"` (a stale-key DELETE failed) — both of which mean something went wrong for that write. Budget exhaustion does not join them.

At this budget, giving up is the **common** path, not an anomaly. Any counter on it fires whenever the update touches no indexed field, whenever the pre-image had no indexed value, on a filtered-index predicate miss, and on every doc materialized from the snapshot rather than the log tail. On a collection of any size that is most `U`/`D` writes, and folding it into an `_errors_total` series would bury the two steps that carry signal.

The operator question this metric would try to answer — "are there stale index keys on the bucket?" — is answered authoritatively by `baerly admin fsck --indexes`, which walks the index prefixes directly instead of inferring from a write-path proxy.

## Bundle sizes

Raw/gz creep tripwires rebaselined on three entries, each with a dated note and measured figures.

**min-gz does not move on any entry.** `http.js` measures 36858 against its unchanged 36864 ceiling.

⚠️ That clears by **6 B**. The note in the budget table flags it as a hair-trigger: the next change through that closure will trip it, and the honest fix at that point is to shrink the closure, not take the KiB. Do not read the surviving 36 KiB line as headroom.

`PREIMAGE_SCAN_MAX_GETS` is fully tree-shaken and contributes 0 B to every closure — the folded literal is inlined at the use site — so the raw/gz movement is the rewritten docstring, which carries the subrequest derivation and states which stale keys the walk no longer cleans up.

## Verification

| Gate | Result |
|---|---|
| `pnpm test:agent` | 2617 passed, 0 failed |
| `pnpm verify:agent` | clean |
| `pnpm bundle-sizes` | 34/34, 0 axes over budget |

Four tests in `Writer — pre-image scan depth`:

- **exact GET count** on swept history — asserts the literal `8`, deliberately *not* `PREIMAGE_SCAN_MAX_GETS`, so raising the constant to a value that blows the subrequest wall is a visible test edit rather than a silently-green one. Costs 400 GETs without the budget.
- **budget edge, reached** — pre-image at exactly `S − PREIMAGE_SCAN_MAX_GETS` resolves and the old key is deleted.
- **budget edge, missed** — one seq deeper, the old key survives. Pins the trade above as a deliberate choice.
- **surviving entry below `log_seq_start`** — the post-fold, pre-sweep state the sub-floor descent exists to serve.

All four seed the pre-image's index key as well as its log entry (mirroring the writer's own emission at `writer.ts:531`); without that the stale-key assertions pass whether or not the walk ran. The boundary is mutation-checked — an off-by-one on the floor reddens two of them.
