### PR TITLE
fix(dev): two atomicity defects in LocalFsStorage.put

### DIFF
--- a/.changeset/local-fs-put-temp-inside-root.md
+++ b/.changeset/local-fs-put-temp-inside-root.md
@@ -1,0 +1,33 @@
+---
+"@gusto/baerly-storage": patch
+---
+
+Fix `LocalFsStorage.put` failing with `EXDEV` whenever the bucket root and
+`os.tmpdir()` are on different filesystems.
+
+The write path that serves unconditional and `ifMatch` puts staged its temp
+file in `os.tmpdir()` and then `rename`d it onto the destination under the
+bucket root. `rename(2)` refuses to cross filesystems, so on any host where
+those are separate volumes *every* such put failed with
+`BaerlyError{code:"InvalidResponse"}` wrapping `EXDEV`, with no fallback.
+
+That is the ordinary self-hosted shape, not an exotic one. The default root
+is `<cwd>/.baerly-data`, which in a container is a mounted data volume while
+`/tmp` is a tmpfs or the image layer, and the same split is routine on
+systemd hosts (`/tmp` on tmpfs), for `$BAERLY_DATA_DIR` pointed at a network
+mount, and for `baerly export` / `admin restore` against a `file:///…` URI on
+another disk. It made the documented zero-credential path —
+`baerlyNode({ config, storage: localFsStorage() })`, from that factory's own
+`@example` — dead on arrival there.
+
+Both write paths now stage their temp as a sibling of the destination, which
+is what the `ifNoneMatch:"*"` branch already did (its `link(2)` create has
+the same cross-device constraint). The temp is named with the reserved
+`TEMP_PREFIX` that `walk` filters at every depth, so a crash between staging
+and publishing leaves a file invisible to `list` rather than a bogus key —
+that filter is what makes staging inside the bucket safe. Cleanup moved to a
+`try/finally`, so a failed write no longer strands the partial body.
+
+A temp-write failure also now surfaces as `BaerlyError{code:"InvalidResponse"}`
+like every other error from this adapter; previously the `writeFile` sat
+outside the `try` and escaped as a raw Node `ErrnoException`.

--- a/.changeset/local-fs-serialize-ifmatch.md
+++ b/.changeset/local-fs-serialize-ifmatch.md
@@ -1,0 +1,61 @@
+---
+"@gusto/baerly-storage": patch
+---
+
+Fix `LocalFsStorage` admitting multiple winners for a concurrent `ifMatch`
+CAS on the same base etag.
+
+The `ifMatch` path read the stored body, compared etags, and only then
+staged and published the new one — with awaited filesystem operations in
+between, and no lock. Because `node:fs/promises` yields the event loop at
+each of those, concurrent callers all read the same base etag, all passed
+the comparison, and all published. Measured on the pre-fix code, 16 racers
+against one base etag produced **16 winners and zero `Conflict`s**; the
+same held across 16 separate `LocalFsStorage` instances over one directory.
+Every update but the last was silently lost.
+
+That is reachable in the default test suite today: the `local-fs` variant of
+`randomized.test.ts` runs three writers over one directory whose write-tick
+maintenance CAS-updates a shared `gc/pending.json` via `casUpdateGcPending`.
+It went unnoticed because no test asserted the property — the storage
+conformance suite's `ifMatch` block was three sequential cases, and its only
+concurrency test covered `ifNoneMatch:"*"`.
+
+`LocalFsStorage` now serializes every mutation of a key — `ifMatch`,
+unconditional, create-if-absent, and `delete` — behind a per-key async
+mutex held across the whole read-compare-write. The lock is module-level,
+not per instance, because instances sharing a directory are the normal
+case (`localFsStorage()` returns a new one per call); a per-instance lock
+would have left the multi-writer harness broken. It is keyed on the
+canonical filesystem path — `realpath`'d, case-folded, NFC-normalized —
+because several spellings can name one file, and giving an alias its own
+lock reinstates the race: case variants on macOS, and any symlinked root
+such as `/tmp` versus `/private/tmp`. Entries are evicted when their last
+contender drains, so the map is bounded by in-flight writers rather than
+by the keyspace.
+
+Two smaller defects in the same file are fixed alongside, both the same
+shape as the main one. `list()` walks names and then reads each file to
+hash its etag; a `delete` landing in that window escaped as a raw Node
+`ENOENT` instead of a `BaerlyError` — reachable whenever GC deletes while
+the compactor walks the same prefixes. A key that vanishes mid-listing is
+legal on a real object store, so it is now skipped. And the
+`.baerly-tmp-` prefix that `list` filters is now *reserved*: a user key
+inside it used to be writable and readable but invisible to `list`,
+silently violating put-then-list.
+
+One trade-off is worth stating because the EXDEV change created it: a
+temp stranded by a hard crash now sits inside the bucket, and since every
+enumerator goes through `list`, nothing reclaims it. Staging in
+`os.tmpdir()` at least let the OS reap it. Non-crash failures are still
+cleaned up.
+
+The conformance suite gains the missing contract — "admits exactly one
+winner under concurrent `ifMatch` on the same etag", plus an error-code
+parity row — so it now binds every backend rather than just this one.
+`MemoryStorage` and the miniflare R2 binding already satisfied it.
+
+The guarantee is explicitly single-process, and the adapter's docs now say
+so precisely: within a process, concurrent CAS on a key admits exactly one
+winner across any number of instances; across processes nothing is
+guaranteed, which is why horizontally-scaled deploys need S3 / R2.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 title: Architecture overview
 audience: coder
 summary: Module dependency graph and lifecycle of db.collection(...).insert().
-last-reviewed: 2026-06-30
+last-reviewed: 2026-08-02
 tags: [architecture, lifecycle, module-map]
 related: ["spec/sync-protocol.md", "contributing/extending.md", "contributing/features.md"]
 ---
@@ -200,10 +200,20 @@ kernel portable:
   compatibility is defined as "everything reachable from
   `@baerly/server`'s entry points runs under Workerd"; that holds because
   `server` depends only on `protocol`.
-- **Workerd-incompatible `node:` builtins are blocked in `protocol` and
-  `server`.** `server` allowlists `node:async_hooks` only (Workerd
-  supports it under `nodejs_compat`); `protocol` allows none. Packages
-  above this line are Node-only by design and may import any builtin.
+- **Workerd-incompatible `node:` builtins are blocked in `protocol`,
+  `server`, and `adapter-cloudflare`.** `server` and `adapter-cloudflare`
+  allowlist `node:async_hooks` only (Workerd supports it under
+  `nodejs_compat`); `protocol` allows none. The remaining packages are
+  Node-only by design and may import any builtin.
+- **That gate reads each package's own source, so it cannot see a
+  transitive drag.** Importing a barrel that re-exports Node-only code
+  pulls the whole closure into a Workerd bundle without any `node:`
+  specifier appearing in the importing package — which is how
+  `LocalFsStorage` once reached `dist/cloudflare.js` by way of the
+  `@baerly/dev` barrel, for one HTML string. Import the leaf module
+  (`@baerly/dev/dev-landing`), not the barrel. Enforced on the artifact by
+  the `dist/cloudflare.js` Workerd-builtin closure assertion in
+  `tests/integration/bundle-size.test.ts`.
 
 The production import graph (`*.test.ts` / `*.test-d.ts` excluded) is a
 hand-maintained allow list — each row names the packages that owner may

--- a/docs/contributing/conventions/tests.md
+++ b/docs/contributing/conventions/tests.md
@@ -2,7 +2,7 @@
 title: Conventions for tests
 audience: coder
 summary: Test file layout, vitest imports, colocation rules, property-based testing patterns.
-last-reviewed: 2026-06-13
+last-reviewed: 2026-08-01
 tags: [conventions, tests, vitest]
 related: [docs.md, "../development.md"]
 ---
@@ -108,9 +108,10 @@ Run it:
 - CAS **fairness is not a parity property** ([ADR-002](../../adr/002-ephemeral-coordination.md)
   "No fairness"); only exactly-one-winner + code-on-loss are asserted, never
   ordering/FIFO.
-- `LocalFsStorage` `ifMatch` is **in-process TOCTOU only** — the suite exercises
-  single-process CAS, so parity holds for what is tested; it does not claim cross-process
-  parity for local-fs.
+- `LocalFsStorage` `ifMatch` is **serialized in-process only** — it holds a per-key
+  lock across the whole read-compare-write, so single-process CAS (which is what the
+  suite exercises) has parity with the real backends, including exactly-one-winner
+  under concurrency. The gate does not claim cross-process parity for local-fs.
 - **HTTP-wire CAS parity is a known hole** (`tests/fixtures/http-conformance-cascade.ts`
   defaults `supportsCAS` false — the router does not yet plumb `If-Match`). The gate does
   not cover the HTTP `If-Match` round-trip.

--- a/docs/spec/capabilities.md
+++ b/docs/spec/capabilities.md
@@ -3,7 +3,7 @@ title: Storage capabilities — required vs optional
 audience: spec
 doc_type: current-contract
 summary: What a backend MUST support to certify as full Storage (CAS, exactly-one-winner), and what is optional.
-last-reviewed: 2026-07-16
+last-reviewed: 2026-08-01
 tags: [storage, conformance, capabilities, cas, contract]
 related: ["sync-protocol.md", "storage-compatibility.md"]
 ---
@@ -43,11 +43,14 @@ failure fails certification — full stop.
 
 The in-tree dev adapters run the same suite under their documented
 topology. `LocalFsStorage` is a local/single-process development
-adapter: its `ifMatch` behavior is in-process TOCTOU only, so a green
-dev conformance run does **not** certify it for multi-process production
-use. Production certification means the required capabilities hold
-across the backend's real concurrency boundary (processes, isolates, or
-regions as applicable).
+adapter: it satisfies the CAS blocks — including the two
+exactly-one-winner races — by serializing mutations of a key within the
+process, across however many instances address the directory. That
+guarantee stops at the process boundary, where its read-compare-write
+`ifMatch` is unsynchronized, so a green dev conformance run does **not**
+certify it for multi-process production use. Production certification
+means the required capabilities hold across the backend's real
+concurrency boundary (processes, isolates, or regions as applicable).
 
 ## Optional
 

--- a/packages/adapter-cloudflare/src/worker.ts
+++ b/packages/adapter-cloudflare/src/worker.ts
@@ -1,4 +1,9 @@
-import { type DevLandingOptions, renderDevLanding } from "@baerly/dev";
+// Imported from the leaf module, NOT the `@baerly/dev` barrel. The barrel
+// re-exports `LocalFsStorage`, and pulling this through it chunks the
+// whole Node-only local-fs closure — `node:fs`, `node:crypto`,
+// `node:path` and the per-key write lock — into the Worker bundle for
+// the sake of one HTML string. `dev-landing.ts` has no imports at all.
+import { type DevLandingOptions, renderDevLanding } from "@baerly/dev/dev-landing";
 import {
   type BaerlyAppConfig,
   CF_FREE_MAX_SAFE_FOLD_BYTES,

--- a/packages/adapter-node/src/local-fs-storage.ts
+++ b/packages/adapter-node/src/local-fs-storage.ts
@@ -17,10 +17,12 @@ export interface LocalFsStorageFactoryOptions {
  * and lost on exit.
  *
  * NOT for multi-instance production: `LocalFsStorage`'s `ifMatch` CAS is
- * in-process TOCTOU only (cross-process `current.json` CAS-advance is not
- * atomic — see its class JSDoc). For horizontally-scaled deploys use
- * `s3Storage` / `r2Storage`, whose cross-process guarantee the no-lease
- * maintenance fold relies on.
+ * serialized within one process only, so a `current.json` CAS-advance is
+ * not atomic against a second process on the same directory (see its class
+ * JSDoc). Every call here returns a fresh instance, which is fine — the
+ * lock is keyed by resolved root, so instances sharing a directory share
+ * it. For horizontally-scaled deploys use `s3Storage` / `r2Storage`, whose
+ * cross-process guarantee the no-lease maintenance fold relies on.
  *
  * @example
  * ```ts

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -11,6 +11,10 @@
       "types": "./src/index.ts",
       "import": "./src/index.ts"
     },
+    "./dev-landing": {
+      "types": "./src/dev-landing.ts",
+      "import": "./src/dev-landing.ts"
+    },
     "./local-fs": {
       "types": "./src/local-fs.ts",
       "import": "./src/local-fs.ts"

--- a/packages/dev/src/current-json.test.ts
+++ b/packages/dev/src/current-json.test.ts
@@ -14,12 +14,12 @@ import { LocalFsStorage } from "./local-fs.ts";
 
 /**
  * Single-process smoke for the current.json CAS protocol against the
- * directory-tree storage adapter. `LocalFsStorage` documents that
- * `ifMatch`/`ifNoneMatch` are NOT cross-process safe (see
- * `local-fs.ts` class JSDoc) — this file only covers the
- * single-process case where the in-process TOCTOU window is narrow
- * enough that the CAS protocol is observably correct. Multi-process
- * safety is delegated to S3 / R2 / Minio.
+ * directory-tree storage adapter. `LocalFsStorage` serializes mutations
+ * of a key within a process, so the CAS protocol is correct here — but
+ * it documents no cross-process guarantee for `ifMatch`/`ifNoneMatch`
+ * (see `local-fs.ts` class JSDoc), so this file covers only the
+ * single-process case. Multi-process safety is delegated to S3 / R2 /
+ * Minio.
  */
 describe("current.json on LocalFsStorage", () => {
   let root: string;
@@ -62,14 +62,15 @@ describe("current.json on LocalFsStorage", () => {
   });
 
   test("stale-etag update surfaces as Conflict", async () => {
-    // True multi-writer races on LocalFsStorage have a TOCTOU window
-    // even within a single process — two `casUpdateCurrentJson`
-    // calls that read the same etag can both pass the ifMatch guard
-    // because the content-addressed etag depends only on the body
-    // written. Cross-process CAS is delegated to S3/R2 (see
-    // `local-fs.ts` class JSDoc). What we DO verify here is that
-    // when the storage layer observes a stale etag, it surfaces
-    // `Conflict` directly — no string-sentinel translation needed.
+    // In-process multi-writer races are covered directly in
+    // `local-fs.test.ts` ("concurrent ifMatch … exactly one winner") and
+    // by the shared storage conformance suite; `LocalFsStorage`
+    // serializes mutations of a key, so two `casUpdateCurrentJson` calls
+    // reading the same etag cannot both pass the ifMatch guard. Across
+    // processes there is still no such guarantee — that is delegated to
+    // S3/R2 (see `local-fs.ts` class JSDoc). What we verify HERE is
+    // narrower: when the storage layer observes a stale etag, it
+    // surfaces `Conflict` directly — no string-sentinel translation.
     await createCurrentJson(storage, "k", seed);
     // Stage a stale read by snapshotting etag, then landing a
     // separate update that bumps it.

--- a/packages/dev/src/key-lock.test.ts
+++ b/packages/dev/src/key-lock.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "vitest";
+import { keyLockCount, withKeyLock } from "./key-lock.ts";
+
+/** A promise plus its resolver, so a test can hold a section open. */
+const deferred = (): { promise: Promise<void>; resolve: () => void } => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+};
+
+describe("withKeyLock", () => {
+  test("serializes sections sharing a key", async () => {
+    // Each section records enter/exit. If they overlap, an "enter" lands
+    // between another section's enter and exit.
+    const trace: string[] = [];
+    const section = async (id: number): Promise<void> => {
+      trace.push(`enter${id}`);
+      await Promise.resolve();
+      await Promise.resolve();
+      trace.push(`exit${id}`);
+    };
+    await Promise.all([0, 1, 2, 3].map((i) => withKeyLock("k", () => section(i))));
+    expect(trace).toEqual([
+      "enter0",
+      "exit0",
+      "enter1",
+      "exit1",
+      "enter2",
+      "exit2",
+      "enter3",
+      "exit3",
+    ]);
+  });
+
+  test("admits only one holder at a time", async () => {
+    let live = 0;
+    let peak = 0;
+    await Promise.all(
+      Array.from({ length: 16 }, () =>
+        withKeyLock("k", async () => {
+          live += 1;
+          peak = Math.max(peak, live);
+          await Promise.resolve();
+          live -= 1;
+        }),
+      ),
+    );
+    expect(peak).toBe(1);
+  });
+
+  test("different keys are not serialized against each other", async () => {
+    // Both sections block until the other has entered. Under a global lock
+    // this deadlocks; under a per-key lock it completes.
+    const aEntered = deferred();
+    const bEntered = deferred();
+    await Promise.all([
+      withKeyLock("a", async () => {
+        aEntered.resolve();
+        await bEntered.promise;
+      }),
+      withKeyLock("b", async () => {
+        bEntered.resolve();
+        await aEntered.promise;
+      }),
+    ]);
+    expect(keyLockCount()).toBe(0);
+  });
+
+  test("a throwing section releases the lock and does not poison the next", async () => {
+    const outcomes = await Promise.allSettled([
+      withKeyLock("k", async () => {
+        throw new Error("boom");
+      }),
+      withKeyLock("k", async () => "ok"),
+    ]);
+    expect(outcomes[0]).toMatchObject({ status: "rejected" });
+    expect(outcomes[1]).toMatchObject({ status: "fulfilled", value: "ok" });
+    expect(keyLockCount()).toBe(0);
+  });
+
+  test("entries are evicted once contenders drain", async () => {
+    // Without eviction the map grows with the keyspace, which on a
+    // long-lived dev server means one retained entry per key ever written.
+    expect(keyLockCount()).toBe(0);
+    const held = deferred();
+    const inSection = deferred();
+    const running = withKeyLock("k", async () => {
+      inSection.resolve();
+      await held.promise;
+    });
+    await inSection.promise;
+    expect(keyLockCount()).toBe(1);
+    held.resolve();
+    await running;
+    expect(keyLockCount()).toBe(0);
+
+    await Promise.all(Array.from({ length: 50 }, (_, i) => withKeyLock(`key-${i}`, async () => i)));
+    expect(keyLockCount()).toBe(0);
+  });
+
+  test("returns the section's value", async () => {
+    await expect(withKeyLock("k", async () => 42)).resolves.toBe(42);
+  });
+});

--- a/packages/dev/src/key-lock.ts
+++ b/packages/dev/src/key-lock.ts
@@ -1,0 +1,84 @@
+/**
+ * A keyed async mutex: serializes async critical sections that share a
+ * lock key, while letting different keys run concurrently.
+ *
+ * Deliberately NOT re-exported from `./index.ts` — this is an internal
+ * implementation detail of `LocalFsStorage`, not part of the published
+ * `@gusto/baerly-storage/dev` surface.
+ */
+
+interface KeyLock {
+  /** Resolves when the currently-running holder releases. */
+  tail: Promise<void>;
+  /** Holders currently running or queued; the entry is evicted at zero. */
+  waiters: number;
+}
+
+/**
+ * Live locks, keyed by caller-supplied string.
+ *
+ * Module-level rather than per-owner on purpose. `LocalFsStorage` is
+ * constructed freely — `localFsStorage()` mints a fresh instance on every
+ * call over the same default root, and the randomized cascade builds N
+ * instances over one directory specifically to make them contend — so a
+ * lock map hanging off the instance would serialize nothing in exactly the
+ * cases that need it. Callers key on the resolved root plus the storage
+ * key, which is the real identity of the thing being mutated.
+ */
+const locks = new Map<string, KeyLock>();
+
+/**
+ * Run `fn` with exclusive access to `lockKey`, in FIFO order among
+ * contenders. Concurrent calls on *different* keys are unaffected.
+ *
+ * A rejecting `fn` releases the lock like any other completion and the
+ * rejection propagates to its own caller only — one failed critical
+ * section must not wedge the key or poison the next holder.
+ *
+ * Scope: one loaded copy of this module, since `locks` is module-level.
+ * That is one process in every normal setup. It says nothing about other
+ * processes, which need a lock file, a lease, or server-side CAS.
+ *
+ * `fn` must not itself call `withKeyLock` on the same key — the inner
+ * call would wait on the outer call's release and self-deadlock. Nothing
+ * in this package does; only one lock is ever held at a time, so there is
+ * no lock-ordering cycle either.
+ */
+export const withKeyLock = async <T>(lockKey: string, fn: () => Promise<T>): Promise<T> => {
+  let lock = locks.get(lockKey);
+  if (lock === undefined) {
+    lock = { tail: Promise.resolve(), waiters: 0 };
+    locks.set(lockKey, lock);
+  }
+  lock.waiters += 1;
+
+  // Take a ticket: wait on the previous holder's release, and publish our
+  // own release as what the next arrival waits on. Both happen before any
+  // `await`, so tickets are handed out in call order with no interleaving.
+  const predecessor = lock.tail;
+  let release!: () => void;
+  lock.tail = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await predecessor;
+  try {
+    return await fn();
+  } finally {
+    release();
+    lock.waiters -= 1;
+    // Evict once the last contender drains, so the map is bounded by
+    // in-flight writers rather than growing with the keyspace — a
+    // long-lived dev server would otherwise retain an entry per key ever
+    // written. `waiters` is incremented synchronously at registration and
+    // decremented only here, so zero really does mean nobody is left. The
+    // identity check is belt-and-braces: there is no `await` between the
+    // release above and this line, so it cannot currently be false.
+    if (lock.waiters === 0 && locks.get(lockKey) === lock) {
+      locks.delete(lockKey);
+    }
+  }
+};
+
+/** Test-only: number of live lock entries. Pins the eviction path. */
+export const keyLockCount = (): number => locks.size;

--- a/packages/dev/src/local-fs.test.ts
+++ b/packages/dev/src/local-fs.test.ts
@@ -480,4 +480,54 @@ describe("LocalFsStorage — impl-specific", () => {
     expect(fromBytes((await s.get("key-a"))!.body)).toBe("a");
     expect(fromBytes((await s.get("key-b"))!.body)).toBe("b");
   });
+
+  // --- AbortSignal must be re-checked inside the critical section ---
+  //
+  // `put` / `delete` check the signal on entry and then take the key's lock,
+  // which is an unbounded wait behind other writers to the same key. A signal
+  // aborted during that wait has already cleared the entry guard, so without
+  // the re-check inside the critical section the write lands anyway. Measured
+  // before the fix: an aborted queued put and an aborted queued delete both
+  // completed, and the key was gone.
+  //
+  // Aborting AFTER the call returns its promise is what makes these
+  // deterministic rather than timing-dependent. The entry guard is a
+  // synchronous `throwIfAborted()` at the top of the method, so by the time
+  // `abort()` runs it has provably already passed — leaving the
+  // in-critical-section re-check as the only guard that can still reject. No
+  // reliance on queue depth or on who wins the ticket.
+  //
+  // This is the gap the shared conformance suite cannot cover: its abort
+  // tests use a pre-aborted controller, which trips the entry guard and never
+  // reaches the lock at all.
+
+  test("put aborted while queued behind another writer rejects and does not land", async () => {
+    const holder = s.put("k", utf8("holder"));
+    const ac = new AbortController();
+    const queued = s.put("k", utf8("queued"), { signal: ac.signal });
+    ac.abort();
+    const [held, aborted] = await Promise.allSettled([holder, queued]);
+    expect(held.status).toBe("fulfilled");
+    expect(aborted.status).toBe("rejected");
+    expect((aborted as PromiseRejectedResult).reason).toMatchObject({ name: "AbortError" });
+    // Whichever racer took the ticket first, the aborted body must never be
+    // the one on disk.
+    expect(fromBytes((await s.get("k"))!.body)).toBe("holder");
+  });
+
+  test("delete aborted while queued behind another writer rejects and keeps the key", async () => {
+    await s.put("k", utf8("v0"));
+    const holder = s.put("k", utf8("holder"));
+    const ac = new AbortController();
+    const queued = s.delete("k", { signal: ac.signal });
+    ac.abort();
+    const [held, aborted] = await Promise.allSettled([holder, queued]);
+    expect(held.status).toBe("fulfilled");
+    expect(aborted.status).toBe("rejected");
+    expect((aborted as PromiseRejectedResult).reason).toMatchObject({ name: "AbortError" });
+    // Order-independent: if the delete had taken the ticket first it would
+    // still have to reject before its `rm`, so the key survives either way.
+    await expect(s.get("k")).resolves.not.toBeNull();
+    expect(fromBytes((await s.get("k"))!.body)).toBe("holder");
+  });
 });

--- a/packages/dev/src/local-fs.test.ts
+++ b/packages/dev/src/local-fs.test.ts
@@ -1,13 +1,15 @@
 import {
   accessSync,
   constants,
+  existsSync,
+  mkdirSync,
   mkdtempSync,
   readdirSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fc } from "@fast-check/vitest";
@@ -65,6 +67,22 @@ const findForeignFilesystem = (): string | null => {
 };
 
 const FOREIGN_FS = findForeignFilesystem();
+
+/**
+ * Whether the filesystem backing `os.tmpdir()` folds case — true on a
+ * stock macOS (APFS, case-insensitive by default), false on Linux ext4.
+ * Probed rather than assumed from `process.platform`, since either OS can
+ * be configured the other way.
+ */
+const CASE_INSENSITIVE_FS = ((): boolean => {
+  const probe = mkdtempSync(join(tmpdir(), "baerly-case-probe-"));
+  try {
+    writeFileSync(join(probe, "probe"), "x");
+    return existsSync(join(probe, "PROBE"));
+  } finally {
+    rmSync(probe, { recursive: true, force: true });
+  }
+})();
 
 // LocalFsStorage-specific key arbitrary:
 //   - Lowercase only. Case-insensitive filesystems (default macOS
@@ -165,6 +183,12 @@ describe("LocalFsStorage — impl-specific", () => {
     await s.put("nested/real", utf8("v"));
     writeFileSync(join(root, ".baerly-tmp-99999-0-deadbeef"), "leftover");
     writeFileSync(join(root, "nested", ".baerly-tmp-99999-0-cafebabe"), "leftover");
+    // A *directory* in the reserved namespace is skipped wholesale rather
+    // than descended into. Nothing here creates one, but were its children
+    // yielded they would be keys that `#pathFor` rejects, and `list` would
+    // throw part-way through iteration instead of returning.
+    mkdirSync(join(root, ".baerly-tmp-99999-0-straydir"));
+    writeFileSync(join(root, ".baerly-tmp-99999-0-straydir", "child"), "leftover");
     const listed = await collect(s.list(""));
     expect(listed.map((e) => e.key)).toEqual(["nested/real", "real"]);
   });
@@ -184,6 +208,39 @@ describe("LocalFsStorage — impl-specific", () => {
         code: "InvalidConfig",
       });
     }
+  });
+
+  test("keys in the reserved temp namespace are rejected", async () => {
+    // `walk` skips TEMP_PREFIX so staging temps never surface as keys —
+    // which means a real key there would be writable and readable but
+    // invisible to list(), silently violating put-then-list. The namespace
+    // is reserved rather than left as a hole for `tempPathFor` alone to
+    // avoid.
+    for (const bad of [".baerly-tmp-mine", "nested/.baerly-tmp-mine", ".baerly-tmp-"]) {
+      await expect(s.put(bad, utf8("v"))).rejects.toMatchObject({ code: "InvalidConfig" });
+      await expect(s.get(bad)).rejects.toMatchObject({ code: "InvalidConfig" });
+      await expect(s.delete(bad)).rejects.toMatchObject({ code: "InvalidConfig" });
+    }
+  });
+
+  test("list() tolerates a key deleted mid-iteration", async () => {
+    // `list` walks names, then reads each file to hash its etag. A delete
+    // landing in that window used to escape as a raw Node ENOENT rather
+    // than a BaerlyError — reachable in the maintenance fold, where runGc
+    // deletes while the compactor walks the same prefixes. A key vanishing
+    // mid-listing is legal on a real object store, so it is skipped.
+    for (const k of ["a", "b", "c", "d"]) {
+      await s.put(k, utf8("v"));
+    }
+    const seen: string[] = [];
+    for await (const entry of s.list("")) {
+      seen.push(entry.key);
+      if (entry.key === "a") {
+        await s.delete("b");
+        await s.delete("c");
+      }
+    }
+    expect(seen).toEqual(["a", "d"]);
   });
 
   // --- The write path must never leave the bucket root (EXDEV) ---
@@ -276,5 +333,151 @@ describe("LocalFsStorage — impl-specific", () => {
     } finally {
       await rm(concRoot, { recursive: true, force: true });
     }
+  });
+
+  // --- ifMatch CAS is read-compare-write and must be serialized ---
+  //
+  // The compare reads the on-disk etag, but the write that follows is two
+  // more awaited fs ops away, and `node:fs/promises` yields the event loop
+  // at each one. Without a lock, every racer reads the same base etag,
+  // every racer passes the compare, and every racer renames — N "successful"
+  // CAS writes against one base version, which is the one thing CAS exists
+  // to prevent. `Storage`'s contract (and every caller: the compactor's
+  // fold, `casUpdateCurrentJson`, `casUpdateGcPending`) requires exactly one.
+
+  test("concurrent ifMatch on the same etag has exactly one winner", async () => {
+    const base = await s.put("k", utf8("v0"));
+    const RACERS = 16;
+    const outcomes = await Promise.allSettled(
+      Array.from({ length: RACERS }, (_, i) => s.put("k", utf8(`r${i}`), { ifMatch: base.etag })),
+    );
+    const winners = outcomes.filter((o) => o.status === "fulfilled").length;
+    const conflicts = outcomes.filter(
+      (o) => o.status === "rejected" && (o.reason as { code?: string }).code === "Conflict",
+    ).length;
+    expect(winners).toBe(1);
+    expect(conflicts).toBe(RACERS - 1);
+  });
+
+  test("concurrent ifMatch across separate instances on one root has exactly one winner", async () => {
+    // The load-bearing arm. `localFsStorage()` mints a fresh instance per
+    // call over the same default root, and the randomized cascade builds N
+    // instances over one `mkdtemp` root specifically to make them contend
+    // (`tests/integration/randomized.test.ts` → `makeStorages`). A lock
+    // scoped to the instance would serialize nothing in exactly the harness
+    // built to catch this, so the lock is keyed by resolved root + key.
+    const RACERS = 16;
+    const instances = Array.from({ length: RACERS }, () => new LocalFsStorage({ root }));
+    const base = await instances[0]!.put("k", utf8("v0"));
+    const outcomes = await Promise.allSettled(
+      instances.map((inst, i) => inst.put("k", utf8(`r${i}`), { ifMatch: base.etag })),
+    );
+    const winners = outcomes.filter((o) => o.status === "fulfilled").length;
+    const conflicts = outcomes.filter(
+      (o) => o.status === "rejected" && (o.reason as { code?: string }).code === "Conflict",
+    ).length;
+    expect(winners).toBe(1);
+    expect(conflicts).toBe(RACERS - 1);
+    // The survivor must be one of the racers' bodies, not a torn mix.
+    const body = fromBytes((await s.get("k"))!.body);
+    expect(body).toMatch(/^r\d+$/);
+  });
+
+  test("concurrent ifMatch through a symlinked root has exactly one winner", async () => {
+    // Two instances over ONE directory reached by two different path
+    // spellings. `resolve()` collapses `.`/`..` but not symlinks, so
+    // before the lock keyed on `realpath` these took separate locks and
+    // both published over the same base etag — measured, 2 winners.
+    //
+    // This is the portable arm of the aliasing guard: it needs no
+    // case-insensitive filesystem, so unlike the case variant below it
+    // actually runs on Linux CI, which is the only platform gating merges.
+    // `/tmp` -> `/private/tmp` on macOS makes this an ordinary
+    // misconfiguration, not a contrived one.
+    const base = await mkdtemp(join(tmpdir(), "baerly-localfs-symlink-"));
+    try {
+      await mkdir(join(base, "real"));
+      await symlink(join(base, "real"), join(base, "link"));
+      const viaReal = new LocalFsStorage({ root: join(base, "real") });
+      const viaLink = new LocalFsStorage({ root: join(base, "link") });
+      const seed = await viaReal.put("k", utf8("v0"));
+      const outcomes = await Promise.allSettled([
+        ...Array.from({ length: 8 }, (_, i) =>
+          viaReal.put("k", utf8(`real-${i}`), { ifMatch: seed.etag }),
+        ),
+        ...Array.from({ length: 8 }, (_, i) =>
+          viaLink.put("k", utf8(`link-${i}`), { ifMatch: seed.etag }),
+        ),
+      ]);
+      const winners = outcomes.filter((o) => o.status === "fulfilled").length;
+      const nonConflict = outcomes.filter(
+        (o) => o.status === "rejected" && (o.reason as { code?: string }).code !== "Conflict",
+      );
+      expect(nonConflict).toEqual([]);
+      expect(winners).toBe(1);
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  test.skipIf(!CASE_INSENSITIVE_FS)(
+    "concurrent ifMatch on case-variant keys has exactly one winner",
+    async () => {
+      // The case/normalization arm. It only means anything where the
+      // filesystem folds case — on a case-sensitive one these spellings
+      // are genuinely different objects and the assertion would hold
+      // trivially — so it skips honestly rather than passing for free and
+      // looking like coverage it is not providing. The symlink arm above
+      // is what guards the same mechanism on Linux CI.
+      const seed = await s.put("alias", utf8("v0"));
+      const spellings = ["alias", "ALIAS", "Alias", "aLiAs"];
+      const outcomes = await Promise.allSettled(
+        spellings.flatMap((spelling) =>
+          Array.from({ length: 4 }, (_, j) =>
+            s.put(spelling, utf8(`w-${spelling}-${j}`), { ifMatch: seed.etag }),
+          ),
+        ),
+      );
+      const winners = outcomes.filter((o) => o.status === "fulfilled").length;
+      const nonConflict = outcomes.filter(
+        (o) => o.status === "rejected" && (o.reason as { code?: string }).code !== "Conflict",
+      );
+      expect(nonConflict).toEqual([]);
+      expect(winners).toBe(1);
+    },
+  );
+
+  test("distinct keys are not serialized against each other", async () => {
+    // The lock must be per key, not global — serializing the whole adapter
+    // would be a "correctness fix" that quietly turns the dev server
+    // single-file. Asserting that N distinct puts all landed would NOT
+    // catch that (they land either way); this deadlocks under a global
+    // lock, because neither put can finish until the other has started.
+    let releaseA!: () => void;
+    let releaseB!: () => void;
+    const aStarted = new Promise<void>((r) => {
+      releaseA = r;
+    });
+    const bStarted = new Promise<void>((r) => {
+      releaseB = r;
+    });
+    const bodyA = utf8("a");
+    const bodyB = utf8("b");
+    await Promise.all([
+      (async () => {
+        const p = s.put("key-a", bodyA);
+        releaseA();
+        await bStarted;
+        await p;
+      })(),
+      (async () => {
+        const p = s.put("key-b", bodyB);
+        releaseB();
+        await aStarted;
+        await p;
+      })(),
+    ]);
+    expect(fromBytes((await s.get("key-a"))!.body)).toBe("a");
+    expect(fromBytes((await s.get("key-b"))!.body)).toBe("b");
   });
 });

--- a/packages/dev/src/local-fs.test.ts
+++ b/packages/dev/src/local-fs.test.ts
@@ -4,7 +4,6 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
-  readdirSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -36,23 +35,24 @@ const ETAG_HELLO = `"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938
  * `null` when the host has only one. Identified by a differing `st_dev`,
  * which is exactly the condition `rename(2)` rejects with `EXDEV`.
  *
- * `/dev/shm` is a separate tmpfs mount on essentially every Linux distro,
- * so the cross-device arm runs for real in CI. macOS has no equivalent
- * (`/Volumes` holds only removable/network mounts, usually absent or
- * read-only), so it typically skips there — hence the always-runs
- * `TMPDIR` proxy alongside it.
+ * Deliberately limited to the shared-memory tmpfs mounts. `/dev/shm` is a
+ * separate mount on essentially every Linux distro, so the cross-device arm
+ * runs for real on CI — the only platform gating merges. macOS has no
+ * equivalent and skips, which the always-runs `TMPDIR` proxy alongside this
+ * covers.
+ *
+ * An earlier version also enumerated `/Volumes` to find a second filesystem
+ * on macOS. Removed: at module load that stats a developer's mounted
+ * volumes and `mkdtemp`s into the first writable one, so an external SSD or
+ * a mounted DMG collects temp directories from a unit test, and a stale
+ * network mount blocks the import. It bought coverage only on the platform
+ * that does not gate merges, and only when the machine happens to have a
+ * spare volume — i.e. non-deterministically. A fixed allowlist skips
+ * honestly instead.
  */
 const findForeignFilesystem = (): string | null => {
   const tmpDev = statSync(tmpdir()).dev;
-  const candidates = ["/dev/shm", "/run/shm"];
-  try {
-    for (const volume of readdirSync("/Volumes")) {
-      candidates.push(join("/Volumes", volume));
-    }
-  } catch {
-    // No /Volumes (non-darwin) — the Linux candidates above are enough.
-  }
-  for (const candidate of candidates) {
+  for (const candidate of ["/dev/shm", "/run/shm"]) {
     try {
       if (statSync(candidate).dev === tmpDev) {
         continue;

--- a/packages/dev/src/local-fs.test.ts
+++ b/packages/dev/src/local-fs.test.ts
@@ -1,4 +1,12 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  accessSync,
+  constants,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -20,6 +28,43 @@ const collect = async <T>(iter: AsyncIterable<T>): Promise<T[]> => {
 
 // sha-256("hello") — quoted to match the wire ETag format.
 const ETAG_HELLO = `"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"`;
+
+/**
+ * A writable directory on a filesystem *other* than `os.tmpdir()`'s, or
+ * `null` when the host has only one. Identified by a differing `st_dev`,
+ * which is exactly the condition `rename(2)` rejects with `EXDEV`.
+ *
+ * `/dev/shm` is a separate tmpfs mount on essentially every Linux distro,
+ * so the cross-device arm runs for real in CI. macOS has no equivalent
+ * (`/Volumes` holds only removable/network mounts, usually absent or
+ * read-only), so it typically skips there — hence the always-runs
+ * `TMPDIR` proxy alongside it.
+ */
+const findForeignFilesystem = (): string | null => {
+  const tmpDev = statSync(tmpdir()).dev;
+  const candidates = ["/dev/shm", "/run/shm"];
+  try {
+    for (const volume of readdirSync("/Volumes")) {
+      candidates.push(join("/Volumes", volume));
+    }
+  } catch {
+    // No /Volumes (non-darwin) — the Linux candidates above are enough.
+  }
+  for (const candidate of candidates) {
+    try {
+      if (statSync(candidate).dev === tmpDev) {
+        continue;
+      }
+      accessSync(candidate, constants.W_OK);
+      return candidate;
+    } catch {
+      // Missing, unreadable, or read-only — not usable as a foreign root.
+    }
+  }
+  return null;
+};
+
+const FOREIGN_FS = findForeignFilesystem();
 
 // LocalFsStorage-specific key arbitrary:
 //   - Lowercase only. Case-insensitive filesystems (default macOS
@@ -109,14 +154,19 @@ describe("LocalFsStorage — impl-specific", () => {
     expect(entries).toEqual(["x/y/z"]);
   });
 
-  test("list() excludes internal create-if-absent temp files", async () => {
-    // The link(2)-based create-if-absent writes a `.baerly-tmp-*` file under
-    // the bucket root; a crash mid-create (or a concurrent list during a
-    // create) can leave one behind. It must never surface as a key.
+  test("list() excludes internal temp files at every depth", async () => {
+    // BOTH write paths stage a `.baerly-tmp-*` file next to their
+    // destination — the link(2) create-if-absent and the write+rename that
+    // serves unconditional and `ifMatch` puts. A crash between staging and
+    // publishing (or a concurrent list during one) can leave one behind at
+    // any depth, and it must never surface as a key. This is what makes
+    // staging inside the bucket root safe; see `tempPathFor`.
     await s.put("real", utf8("v"));
+    await s.put("nested/real", utf8("v"));
     writeFileSync(join(root, ".baerly-tmp-99999-0-deadbeef"), "leftover");
+    writeFileSync(join(root, "nested", ".baerly-tmp-99999-0-cafebabe"), "leftover");
     const listed = await collect(s.list(""));
-    expect(listed.map((e) => e.key)).toEqual(["real"]);
+    expect(listed.map((e) => e.key)).toEqual(["nested/real", "real"]);
   });
 
   test("path-traversal keys are rejected", async () => {
@@ -135,6 +185,76 @@ describe("LocalFsStorage — impl-specific", () => {
       });
     }
   });
+
+  // --- The write path must never leave the bucket root (EXDEV) ---
+  //
+  // `rename(2)` and `link(2)` fail with `EXDEV` across filesystems, so a
+  // temp staged outside the root breaks every write whenever the root and
+  // `os.tmpdir()` are on different volumes. That is the *normal* production
+  // shape, not an exotic one: the default root is `<cwd>/.baerly-data`
+  // (`packages/adapter-node/src/local-fs-storage.ts`), which in a container
+  // is a mounted data volume while `/tmp` is a tmpfs or the image layer.
+  //
+  // A genuine EXDEV needs a second filesystem, which no test can assume, so
+  // the guard is split: the first test always runs and pins the invariant
+  // that actually matters (the write path does not depend on `os.tmpdir()`),
+  // and the second exercises real EXDEV wherever a second volume exists.
+
+  test("put does not depend on os.tmpdir() being usable", async () => {
+    // The portable proxy for EXDEV. If `put` stages its temp outside the
+    // bucket root, it inherits every failure mode of that other directory —
+    // a different volume (EXDEV), a read-only `/tmp`, a tmpfs too small for
+    // the body, or, as here, a `TMPDIR` that does not resolve. A `put` that
+    // stages same-dir is immune to all of them, so pointing `TMPDIR` at a
+    // missing directory is a deterministic, dependency-free stand-in for
+    // "the temp escaped the root". `os.tmpdir()` re-reads `TMPDIR` on every
+    // call, so this takes effect without reloading the module.
+    const original = process.env["TMPDIR"];
+    process.env["TMPDIR"] = join(root, "..", "baerly-tmpdir-does-not-exist");
+    try {
+      await expect(s.put("unconditional", utf8("v1"))).resolves.toMatchObject({
+        etag: expect.any(String),
+      });
+      const created = await s.put("cas", utf8("v1"), { ifNoneMatch: "*" });
+      await expect(s.put("cas", utf8("v2"), { ifMatch: created.etag })).resolves.toMatchObject({
+        etag: expect.any(String),
+      });
+      expect(fromBytes((await s.get("unconditional"))!.body)).toBe("v1");
+      expect(fromBytes((await s.get("cas"))!.body)).toBe("v2");
+    } finally {
+      if (original === undefined) {
+        delete process.env["TMPDIR"];
+      } else {
+        process.env["TMPDIR"] = original;
+      }
+    }
+  });
+
+  test.skipIf(FOREIGN_FS === null)(
+    "put succeeds when the bucket root is on a different filesystem",
+    async () => {
+      // The real thing. Skips rather than lies when the host has only one
+      // writable filesystem — on Linux CI `/dev/shm` is a separate tmpfs mount
+      // (hence a distinct `st_dev`, hence a genuine EXDEV against `/tmp`), so
+      // this arm does run where it counts.
+      const foreignRoot = mkdtempSync(join(FOREIGN_FS!, "baerly-localfs-exdev-"));
+      try {
+        const storage = new LocalFsStorage({ root: foreignRoot });
+        expect(statSync(foreignRoot).dev).not.toBe(statSync(tmpdir()).dev);
+        await expect(storage.put("k", utf8("v1"))).resolves.toMatchObject({
+          etag: expect.any(String),
+        });
+        const created = await storage.put("cas", utf8("v1"), { ifNoneMatch: "*" });
+        await expect(
+          storage.put("cas", utf8("v2"), { ifMatch: created.etag }),
+        ).resolves.toMatchObject({ etag: expect.any(String) });
+        expect(fromBytes((await storage.get("k"))!.body)).toBe("v1");
+        expect(fromBytes((await storage.get("cas"))!.body)).toBe("v2");
+      } finally {
+        rmSync(foreignRoot, { recursive: true, force: true });
+      }
+    },
+  );
 
   test("concurrent create-if-absent on a fresh key has exactly one winner", async () => {
     const concRoot = await mkdtemp(join(tmpdir(), "baerly-localfs-race-"));

--- a/packages/dev/src/local-fs.ts
+++ b/packages/dev/src/local-fs.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 import { link, mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { dirname, join, posix, relative, resolve, sep } from "node:path";
 import {
   BaerlyError,
@@ -14,10 +13,24 @@ import {
 } from "@baerly/protocol";
 
 /**
- * Reserved prefix for the in-directory create-if-absent temp (see `put`).
+ * Reserved prefix for the in-directory staging temps (see `put`).
  * `walk`/`list` skip it; it is internal/transient and never a real key.
  */
 const TEMP_PREFIX = ".baerly-tmp-";
+
+/**
+ * Staging path for a two-phase (write → publish) `put`. Always a sibling
+ * of the destination: `rename(2)`/`link(2)` refuse to cross filesystems
+ * (`EXDEV`), and the bucket root is routinely on a different volume from
+ * `os.tmpdir()`. `TEMP_PREFIX` is what makes staging in-bucket safe —
+ * `walk` filters it at every depth, so a crash before the publish leaves
+ * a file invisible to `list` rather than a bogus key.
+ */
+const tempPathFor = (finalPath: string): string =>
+  join(
+    dirname(finalPath),
+    `${TEMP_PREFIX}${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
 
 export interface LocalFsStorageOptions {
   /** Root directory; treated as "the bucket". */
@@ -56,14 +69,17 @@ const compareKeysUtf8 = (a: string, b: string): number => {
  * makes this adapter useful for fixture-based tests.
  *
  * Writes are atomic via `writeFile(temp) + rename(final)`; readers
- * never see a partially-written file.
+ * never see a partially-written file. The temp is always a sibling of
+ * its destination — `rename(2)`/`link(2)` fail with `EXDEV` across
+ * filesystems, and the bucket root is routinely on a different volume
+ * from `os.tmpdir()` (see `tempPathFor`).
  *
- * `ifNoneMatch:"*"` uses a same-dir temp + `link(2)` (atomic exclusive
- * create; `EEXIST` ⇒ key exists) so concurrent creates have exactly one
- * winner. Same-dir avoids `EXDEV`; temp+`link` over `open(…,"wx")` keeps
- * a partially-written new key invisible to a concurrent reader. `ifMatch`
- * keeps the `rename` path (in-process TOCTOU only; cross-process
- * contention uses the S3 / Minio `If-Match` path).
+ * `ifNoneMatch:"*"` uses `link(2)` (atomic exclusive create; `EEXIST` ⇒
+ * key exists) so concurrent creates have exactly one winner. temp+`link`
+ * over `open(…,"wx")` keeps a partially-written new key invisible to a
+ * concurrent reader. `ifMatch` keeps the `rename` path (in-process
+ * TOCTOU only; cross-process contention uses the S3 / Minio `If-Match`
+ * path).
  *
  * Node-only — imports `node:fs`, `node:path`, `node:crypto`. Lives in
  * `@baerly/dev` because the protocol kernel is pure-modules / no I/O
@@ -109,10 +125,7 @@ export class LocalFsStorage implements Storage {
 
     if (opts?.ifNoneMatch === "*") {
       // Atomic exclusive create via link(2) — see class JSDoc.
-      const tmp = join(
-        dirname(path),
-        `${TEMP_PREFIX}${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-      );
+      const tmp = tempPathFor(path);
       try {
         await writeFile(tmp, body);
         await link(tmp, path);
@@ -155,28 +168,27 @@ export class LocalFsStorage implements Storage {
       }
     }
 
-    // Unconditional PUT (or ifMatch already verified above).
-    // Write to a unique temp path then rename for atomicity. Temp lives
-    // in `os.tmpdir()` so a half-written file never appears under the
-    // bucket root where `list` might see it. PID + timestamp + random
-    // tail makes the name unique across concurrent writers in the same
-    // process.
-    const tmp = join(
-      tmpdir(),
-      `baerly-localfs-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-    );
-    await writeFile(tmp, body);
+    // Unconditional PUT (or `ifMatch` already verified above). Stage to a
+    // sibling temp, then `rename` to publish — the rename is atomic, so a
+    // reader sees either the old body or the new one, never a partial
+    // write. See `tempPathFor` for why the temp must be a sibling.
+    const tmp = tempPathFor(path);
     try {
+      await writeFile(tmp, body);
       await rename(tmp, path);
     } catch (error) {
-      // Best-effort cleanup of the temp file; swallow any error there
-      // so the original failure surfaces unchanged.
-      await rm(tmp, { force: true }).catch(() => {});
       throw new BaerlyError(
         "InvalidResponse",
         `LocalFsStorage.put(${key}): ${(error as Error).message}`,
         error,
       );
+    } finally {
+      // Best-effort cleanup, mirroring the create-if-absent branch. On
+      // success the rename already consumed the temp and this is a no-op;
+      // on failure it keeps a half-written body from lingering under the
+      // bucket root, where only the `TEMP_PREFIX` filter hides it. A
+      // cleanup failure must not mask the error thrown above.
+      await rm(tmp, { force: true }).catch(() => {});
     }
     return { etag: newEtag, serverDate: new Date() };
   }

--- a/packages/dev/src/local-fs.ts
+++ b/packages/dev/src/local-fs.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { link, mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { link, mkdir, readdir, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join, posix, relative, resolve, sep } from "node:path";
 import {
   BaerlyError,
@@ -11,6 +11,7 @@ import {
   type StoragePutOptions,
   type StoragePutResult,
 } from "@baerly/protocol";
+import { withKeyLock } from "./key-lock.ts";
 
 /**
  * Reserved prefix for the in-directory staging temps (see `put`).
@@ -25,6 +26,14 @@ const TEMP_PREFIX = ".baerly-tmp-";
  * `os.tmpdir()`. `TEMP_PREFIX` is what makes staging in-bucket safe —
  * `walk` filters it at every depth, so a crash before the publish leaves
  * a file invisible to `list` rather than a bogus key.
+ *
+ * The trade-off that invisibility buys: a temp stranded by a hard crash
+ * now sits inside the bucket, and because every enumerator goes through
+ * `list`, nothing — not `runGc`, not `admin fsck` — will ever reclaim it.
+ * Staging in `os.tmpdir()` at least let the OS reap it. Repeated crashes
+ * therefore grow the data directory, and clearing that is a manual
+ * `find . -name '.baerly-tmp-*' -delete`. Non-crash failures are cleaned
+ * up by `put`'s `finally`.
  */
 const tempPathFor = (finalPath: string): string =>
   join(
@@ -77,9 +86,25 @@ const compareKeysUtf8 = (a: string, b: string): number => {
  * `ifNoneMatch:"*"` uses `link(2)` (atomic exclusive create; `EEXIST` ⇒
  * key exists) so concurrent creates have exactly one winner. temp+`link`
  * over `open(…,"wx")` keeps a partially-written new key invisible to a
- * concurrent reader. `ifMatch` keeps the `rename` path (in-process
- * TOCTOU only; cross-process contention uses the S3 / Minio `If-Match`
- * path).
+ * concurrent reader.
+ *
+ * `ifMatch` is a read-compare-write, so it is made atomic by serializing
+ * every mutation of a key against every other — see `#lockKey`.
+ *
+ * Scope of that guarantee, precisely: **one loaded copy of this module**.
+ * Within it, concurrent CAS on one key admits exactly one winner and the
+ * losers get `Conflict`, across any number of `LocalFsStorage` instances
+ * whose roots resolve — through symlinks — to the same directory. That is
+ * one process in every normal setup, but the lock lives in a module-level
+ * map, so a process that somehow loads both this source and the bundled
+ * copy has two of them.
+ *
+ * Across processes it guarantees nothing: two `baerly` CLI runs, or two
+ * servers, sharing a directory can both win, because nothing in POSIX
+ * makes read-compare-write atomic without a lock file or a lease. That is
+ * why this adapter is for single-process dev and self-hosting;
+ * horizontally-scaled deploys need S3 / R2, whose server-side conditional
+ * write is what the no-lease maintenance fold actually relies on.
  *
  * Node-only — imports `node:fs`, `node:path`, `node:crypto`. Lives in
  * `@baerly/dev` because the protocol kernel is pure-modules / no I/O
@@ -87,6 +112,8 @@ const compareKeysUtf8 = (a: string, b: string): number => {
  */
 export class LocalFsStorage implements Storage {
   readonly #root: string;
+  /** Memoized `realpath` of {@link #root} — see {@link #canonicalRoot}. */
+  #realRoot: string | undefined;
 
   constructor(opts: LocalFsStorageOptions) {
     this.#root = resolve(opts.root);
@@ -119,9 +146,32 @@ export class LocalFsStorage implements Storage {
   async put(key: string, body: Uint8Array, opts?: StoragePutOptions): Promise<StoragePutResult> {
     opts?.signal?.throwIfAborted();
     const path = this.#pathFor(key);
-    const newEtag = etagOf(body);
-
+    // Create the parent before taking the lock, so the `realpath` behind
+    // `#lockKey` has a directory to canonicalize.
     await mkdir(dirname(path), { recursive: true });
+    // Every mutation of a key is serialized against every other. `ifMatch`
+    // is the reason: it reads the current body, compares etags, and only
+    // then publishes, with awaited fs ops in between — so unguarded, two
+    // callers both read the base etag, both pass the compare, and both
+    // publish, yielding N winners for one base version. Guarding the
+    // unconditional and create-if-absent paths too is not incidental: an
+    // unconditional put landing inside another caller's compare→publish
+    // window is the same lost update reached from the other side.
+    return withKeyLock(await this.#lockKey(path), () => this.#putSerialized(key, path, body, opts));
+  }
+
+  async #putSerialized(
+    key: string,
+    path: string,
+    body: Uint8Array,
+    opts?: StoragePutOptions,
+  ): Promise<StoragePutResult> {
+    // Re-check inside the critical section. The pre-lock check happens
+    // before an unbounded queue wait, so a signal aborted while this call
+    // sat behind other writers to the same key would otherwise be ignored
+    // and the write would land anyway.
+    opts?.signal?.throwIfAborted();
+    const newEtag = etagOf(body);
 
     if (opts?.ifNoneMatch === "*") {
       // Atomic exclusive create via link(2) — see class JSDoc.
@@ -150,8 +200,9 @@ export class LocalFsStorage implements Storage {
     }
 
     if (opts?.ifMatch !== undefined) {
-      // TOCTOU within a process — fine. Cross-process callers should
-      // not rely on these guards (see class JSDoc).
+      // Read-compare-write. Atomic only because `put` holds this key's
+      // lock for the whole of it, publish included — see the class JSDoc
+      // for what that does and does not guarantee.
       const existing = await readExisting(path);
       if (existing === null) {
         throw new BaerlyError(
@@ -196,17 +247,76 @@ export class LocalFsStorage implements Storage {
   async delete(key: string, opts?: { signal?: AbortSignal }): Promise<void> {
     opts?.signal?.throwIfAborted();
     const path = this.#pathFor(key);
+    // Same lock as `put`: a delete slipping between an `ifMatch` compare
+    // and its publish would resurrect the key from a version the caller
+    // was told no longer existed.
+    return withKeyLock(await this.#lockKey(path), async () => {
+      // Re-check after the queue wait — see `#putSerialized`.
+      opts?.signal?.throwIfAborted();
+      try {
+        await rm(path);
+      } catch (error) {
+        if (isErrnoException(error) && error.code === "ENOENT") {
+          return;
+        } // idempotent
+        throw new BaerlyError(
+          "InvalidResponse",
+          `LocalFsStorage.delete(${key}): ${(error as Error).message}`,
+          error,
+        );
+      }
+    });
+  }
+
+  /**
+   * Identity of the thing being mutated, for {@link withKeyLock}.
+   *
+   * Keyed on the *canonical filesystem path*, not on the key and not on
+   * `this`. Not on `this` because separate instances over one directory
+   * are the common case (`localFsStorage()` mints a fresh one per call),
+   * so an instance-scoped lock would serialize nothing where it matters.
+   * Not on the key because several distinct spellings can name one file,
+   * and handing an alias its own lock lets the race straight back in —
+   * each of the three below was measured at 2 winners before it was
+   * closed:
+   *
+   * - Case. The default macOS filesystem folds it, so `k` and `K` are one
+   *   object.
+   * - Unicode. macOS normalizes filenames, so NFC and NFD spellings of
+   *   one string are one object.
+   * - Symlinks. `resolve()` collapses `.`/`..` but not links, so
+   *   `/tmp/data` and `/private/tmp/data` — the same directory on every
+   *   Mac — look like two. Hence `realpath`, memoized per instance and
+   *   only cached once it succeeds, so a root that does not exist yet
+   *   cannot poison the entry.
+   *
+   * Case-folding and NFC-normalizing deliberately over-approximate: on a
+   * case-sensitive filesystem `a` and `A` are genuinely different objects
+   * and will share a lock. That costs a little concurrency between keys
+   * differing only in case, and never costs correctness — whereas
+   * under-approximating does, which is exactly how the symlink class got
+   * missed the first time. This adapter is not the throughput path.
+   */
+  async #lockKey(path: string): Promise<string> {
+    const root = await this.#canonicalRoot();
+    return (root + path.slice(this.#root.length)).normalize("NFC").toLowerCase();
+  }
+
+  /**
+   * {@link #root} with symlinks resolved. Cached only on success: `delete`
+   * against a bucket that was never created would otherwise memoize the
+   * un-canonicalized spelling and defeat the aliasing guard for every
+   * later `put`.
+   */
+  async #canonicalRoot(): Promise<string> {
+    if (this.#realRoot !== undefined) {
+      return this.#realRoot;
+    }
     try {
-      await rm(path);
-    } catch (error) {
-      if (isErrnoException(error) && error.code === "ENOENT") {
-        return;
-      } // idempotent
-      throw new BaerlyError(
-        "InvalidResponse",
-        `LocalFsStorage.delete(${key}): ${(error as Error).message}`,
-        error,
-      );
+      this.#realRoot = await realpath(this.#root);
+      return this.#realRoot;
+    } catch {
+      return this.#root;
     }
   }
 
@@ -236,7 +346,25 @@ export class LocalFsStorage implements Storage {
         return;
       }
       opts?.signal?.throwIfAborted();
-      const buf = await readFile(this.#pathFor(key));
+      let buf: Buffer;
+      try {
+        buf = await readFile(this.#pathFor(key));
+      } catch (error) {
+        if (isErrnoException(error) && error.code === "ENOENT") {
+          // Deleted between `walk` and this read. A key vanishing
+          // mid-listing is a legal outcome on a real object store, so skip
+          // it rather than failing the whole iteration — and skip it
+          // rather than locking, since `list` is a snapshot iterator, not
+          // a critical section. Reachable in the maintenance fold, where
+          // `runGc` deletes while the compactor walks the same prefixes.
+          continue;
+        }
+        throw new BaerlyError(
+          "InvalidResponse",
+          `LocalFsStorage.list(${key}): ${(error as Error).message}`,
+          error,
+        );
+      }
       yield { key, etag: etagOf(buf) };
       yielded += 1;
     }
@@ -261,6 +389,17 @@ export class LocalFsStorage implements Storage {
     const segments = key.split("/");
     if (segments.some((s) => s === "" || s === "." || s === "..")) {
       throw new BaerlyError("InvalidConfig", `LocalFsStorage: illegal segment in key: ${key}`);
+    }
+    if (segments.some((s) => s.startsWith(TEMP_PREFIX))) {
+      // `walk` skips this prefix so in-flight staging temps never surface
+      // as keys, which means a *real* key here would be writable and
+      // readable but invisible to `list` — a silent violation of the
+      // put-then-list contract. Reserve the namespace rather than leave
+      // the hole open; `tempPathFor` is the only legitimate producer.
+      throw new BaerlyError(
+        "InvalidConfig",
+        `LocalFsStorage: key uses the reserved "${TEMP_PREFIX}" prefix: ${key}`,
+      );
     }
     const path = join(this.#root, ...segments);
     if (path !== this.#root && !path.startsWith(this.#root + sep)) {
@@ -312,11 +451,19 @@ const walk = async (root: string, out: string[]): Promise<void> => {
     }
     for (const entry of entries) {
       const full = join(dir, entry.name);
+      // Skip the reserved staging namespace (see TEMP_PREFIX) so a
+      // concurrent list during a write never surfaces a half-published
+      // key. Applied to directories as well as files: `#pathFor` rejects
+      // the prefix in ANY segment, so yielding `.baerly-tmp-d/child` here
+      // would produce a key that `list` then throws on when it maps that
+      // key back to a path. Nothing in this adapter creates such a
+      // directory, but a stray one must not break iteration.
+      if (entry.name.startsWith(TEMP_PREFIX)) {
+        continue;
+      }
       if (entry.isDirectory()) {
         stack.push(full);
-      } else if (entry.isFile() && !entry.name.startsWith(TEMP_PREFIX)) {
-        // Skip the transient create-if-absent temps (see TEMP_PREFIX) so a
-        // concurrent list during a create never surfaces a half-linked key.
+      } else if (entry.isFile()) {
         out.push(relative(root, full).split(sep).join(posix.sep));
       }
     }

--- a/packages/dev/src/local-fs.ts
+++ b/packages/dev/src/local-fs.ts
@@ -296,6 +296,11 @@ export class LocalFsStorage implements Storage {
    * differing only in case, and never costs correctness — whereas
    * under-approximating does, which is exactly how the symlink class got
    * missed the first time. This adapter is not the throughput path.
+   *
+   * Strong approximation, not exact: `toLowerCase()` is not Unicode case
+   * folding (JS has no `toCaseFold()`), so APFS folds `Σ`/`σ`/`ς` onto one
+   * file where this yields two lock keys. Unreached — protocol keys are
+   * ASCII — and not worth a folding table here.
    */
   async #lockKey(path: string): Promise<string> {
     const root = await this.#canonicalRoot();
@@ -307,6 +312,22 @@ export class LocalFsStorage implements Storage {
    * against a bucket that was never created would otherwise memoize the
    * un-canonicalized spelling and defeat the aliasing guard for every
    * later `put`.
+   *
+   * Not caching failure bounds that to one call but does not erase it.
+   * `put` mkdirs before locking so it always canonicalizes; `delete` does
+   * not, so against a not-yet-created symlinked root it locks the
+   * unresolved spelling while a concurrent `put` locks the resolved one —
+   * two locks, no serialization. That needs only ONE spelling in play, not
+   * two: the split is resolved-vs-unresolved form of the same path.
+   *
+   * Known and kept (Fresh Eyes, PR #84, Info). The hazard `delete` locks
+   * against is slipping inside an `ifMatch` compare→publish, which needs
+   * the key to exist, hence the root to exist, hence `realpath` to have
+   * succeeded — so both conditions hold only if the root appears between
+   * this call and the `rm`, and the next call self-heals. Fixes cost more
+   * than that: mkdir-to-get-a-lock-key makes deleting from an absent
+   * bucket create it, and walking to the deepest existing ancestor adds
+   * real complexity for an unreachable window.
    */
   async #canonicalRoot(): Promise<string> {
     if (this.#realRoot !== undefined) {

--- a/packages/protocol/src/storage/conformance.ts
+++ b/packages/protocol/src/storage/conformance.ts
@@ -19,10 +19,12 @@ export interface ConformanceOptions {
   // `ifMatch` under the no-lease maintenance fold — so a `Storage` that
   // doesn't honor them isn't a valid baerly backend. The CAS blocks
   // below always run; a backend that can't pass them must not ship.
-  // CAVEAT: these blocks exercise single-process semantics. `LocalFsStorage`
-  // is a dev/single-process adapter whose `ifMatch` is in-process TOCTOU
-  // only (cross-process `current.json` CAS-advance is NOT atomic there) —
-  // see its class JSDoc in `packages/dev/src/local-fs.ts`. Real S3 / Minio
+  // CAVEAT: these blocks exercise single-process semantics, including the
+  // two exactly-one-winner races. `LocalFsStorage` passes them by
+  // serializing mutations of a key in-process, which is a real guarantee
+  // but only that one: a green run here does NOT certify it across
+  // processes, where its read-compare-write `ifMatch` has no lock at all.
+  // See its class JSDoc in `packages/dev/src/local-fs.ts`. Real S3 / Minio
   // / R2 provide the cross-process guarantee the no-lease fold relies on.
   /**
    * When false, generated key arbitraries must yield case-insensitively
@@ -492,6 +494,49 @@ export function defineStorageConformanceSuite(
           s.put("k", new TextEncoder().encode("v2"), { ifMatch: opts.staleEtag }),
         ).rejects.toMatchObject({ code: "Conflict" });
       });
+
+      test("admits exactly one winner under concurrent ifMatch on the same etag", async () => {
+        // The mirror of the `ifNoneMatch:"*"` exactly-one-winner test below,
+        // and the reason it matters: `ifNoneMatch` guards the log-append
+        // commit, while `ifMatch` guards every *advance* of an existing
+        // coordination object — `current.json` under the no-lease fold
+        // (`compactor.ts`), `gc/pending.json` (`casUpdateGcPending`). A
+        // backend that lets two racers both win an `ifMatch` on one base
+        // etag silently loses one of those updates, which is exactly the
+        // read-compare-write hazard CAS is supposed to close.
+        //
+        // The three tests above are all sequential, so this contract went
+        // unstated — and an in-tree adapter violated it undetected.
+        const RACERS = 16;
+        const enc = new TextEncoder();
+        const first = await s.put("k", enc.encode("v0"));
+        // Same guard as "succeeds and rotates etag": on an eventually-
+        // consistent backend a racer can otherwise hit a replica that has
+        // not seen the seed write and 412 for the wrong reason.
+        await pollUntil(
+          () => s.get("k"),
+          (g) => g !== null && g.etag === first.etag,
+          settle,
+        );
+        const outcomes = await Promise.allSettled(
+          Array.from({ length: RACERS }, (_u, i) =>
+            s.put("k", enc.encode(`r${i}`), { ifMatch: first.etag }),
+          ),
+        );
+        const winners = outcomes.filter((o) => o.status === "fulfilled").length;
+        // Loser codes are a SET for the same reason as the create race: real
+        // AWS S3 surfaces a contended conditional write as 409
+        // ConditionalRequestConflict (retryable `NetworkError`) rather than
+        // 412. Asserting a single code would manufacture false parity.
+        const losers = outcomes.filter(
+          (o) =>
+            o.status === "rejected" &&
+            o.reason instanceof BaerlyError &&
+            (o.reason.code === "Conflict" || o.reason.code === "NetworkError"),
+        ).length;
+        expect(winners).toBe(1);
+        expect(losers).toBe(RACERS - 1);
+      });
     });
 
     describe('CAS — ifNoneMatch="*"', () => {
@@ -589,6 +634,35 @@ export function defineStorageConformanceSuite(
           const outcomes = await Promise.allSettled(
             Array.from({ length: 16 }, (_u, i) =>
               store.put("k", ENC.encode(`r${i}`), { ifNoneMatch: "*" }),
+            ),
+          );
+          const loser = outcomes.find((o) => o.status === "rejected");
+          if (loser === undefined) {
+            throw new Error("expected at least one contended loser");
+          }
+          throw (loser as PromiseRejectedResult).reason;
+        },
+        expectedCodes: ["Conflict", "NetworkError"],
+      },
+      {
+        label: "concurrent ifMatch loser",
+        act: async (store) => {
+          const first = await store.put("k", ENC.encode("v0"));
+          // Settle guard, for the same reason as the block test above: on
+          // an eventually-consistent backend a racer can otherwise hit a
+          // replica that has not seen the seed and lose for the wrong
+          // reason, which would still pass this row but would stop
+          // exercising contention. Four racers, not sixteen — this row
+          // only samples a loser's code, and the exactly-one-winner
+          // property is already asserted above.
+          await pollUntil(
+            () => store.get("k"),
+            (g) => g !== null && g.etag === first.etag,
+            settle,
+          );
+          const outcomes = await Promise.allSettled(
+            Array.from({ length: 4 }, (_u, i) =>
+              store.put("k", ENC.encode(`r${i}`), { ifMatch: first.etag }),
             ),
           );
           const loser = outcomes.find((o) => o.status === "rejected");

--- a/scripts/lint-package-layers.mjs
+++ b/scripts/lint-package-layers.mjs
@@ -16,22 +16,35 @@ const ROOT = resolvePath(HERE, "..");
  * Hand-maintained import allow list (contains one accepted Node-only
  * `dev ↔ adapter-node` cycle — see docs/architecture.md
  * §Package layers), plus a per-owner `node:`-builtin
- * purity gate for `protocol` and `server`. `allows` lists every other
+ * purity gate for the Workerd-loadable packages. `allows` lists every other
  * @baerly/* package the owner is permitted to import. Self-imports always
  * allowed. Anything not listed is forbidden. The optional `allowNode` field
  * gates Node builtins: when defined, the owner may only import `node:` builtins
- * in the list (`protocol` allows none; `server` allows `node:async_hooks`,
- * which Workerd supports under `nodejs_compat`). Rows leaving `allowNode`
- * undefined are Node-only by design and may import any builtin. Source of truth
- * lives in docs/architecture.md §Package layers; this table is the
- * executable mirror. When adding a new @baerly/* package, add a row to both.
+ * in the list (`protocol` allows none; `server` and `adapter-cloudflare` allow
+ * `node:async_hooks`, which Workerd supports under `nodejs_compat`). Rows
+ * leaving `allowNode` undefined are Node-only by design and may import any
+ * builtin. Source of truth lives in docs/architecture.md §Package layers; this
+ * table is the executable mirror. When adding a new @baerly/* package, add a
+ * row to both.
+ *
+ * NOTE on scope: `allowNode` gates a package's OWN source. It says nothing
+ * about what a permitted `@baerly/*` import drags in transitively — a barrel
+ * re-export can pull a Node-only closure into a Workerd bundle without any
+ * `node:` specifier appearing in the owner's files at all. That vector is
+ * guarded at the artifact level instead, by the `dist/cloudflare.js` closure
+ * assertion in `tests/integration/bundle-size.test.ts`.
  */
 const RULES = {
   protocol: { allows: [], allowNode: [] },
   server: { allows: ["protocol"], allowNode: ["node:async_hooks"] },
   dev: { allows: ["protocol", "server", "adapter-node"] },
   "adapter-node": { allows: ["protocol", "server", "dev"] },
-  "adapter-cloudflare": { allows: ["protocol", "server", "dev"] },
+  // Workerd-loadable, so gated like `server` rather than left open: this is
+  // the one row whose runtime cannot load an arbitrary Node builtin at all.
+  "adapter-cloudflare": {
+    allows: ["protocol", "server", "dev"],
+    allowNode: ["node:async_hooks"],
+  },
   client: { allows: ["protocol", "server"] },
   cli: {
     allows: ["protocol", "server", "dev", "adapter-node", "adapter-cloudflare", "client"],

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -929,7 +929,7 @@ const BUDGETS: readonly Budget[] = [
   //     `dev.js` under its own line, and cutting further would delete the
   //     reason the code is shaped this way. Measured 440712 raw; gz (132345,
   //     −775) and min-gz (45839, −241) both stay under.
-  //   → 418 KiB raw / 126 KiB gz / 44 KiB min-gz (2026-08-01): budgets move
+  //   → 419 KiB raw / 127 KiB gz / 44 KiB min-gz (2026-08-01): budgets move
   //     DOWN. `packages/adapter-cloudflare/src/worker.ts` imported
   //     `renderDevLanding` from the `@baerly/dev` barrel, and the barrel
   //     re-exports `LocalFsStorage`, so rolldown chunked the entire
@@ -947,7 +947,21 @@ const BUDGETS: readonly Budget[] = [
   //     min-gz, i.e. below the pre-branch 439542 / 132296 / 45841 on every
   //     axis. Budgets tighten to lock the win in rather than bank it as
   //     silent headroom.
-  { entry: "cloudflare.js", raw: 418 * 1024, gz: 126 * 1024, minGz: 44 * 1024 },
+  //
+  //     Tightened to one KiB above each measured axis, not to the nearest
+  //     boundary. Landing gz at 126 KiB left 105 B — less than a single
+  //     JSDoc line, on the entry that just took +392 B of raw comment prose
+  //     from a `packages/dev/` edit that never mentions Cloudflare. Per the
+  //     POLICY raw/gz are creep tripwires: a tripwire that fires on ordinary
+  //     prose reports noise, and the next author rebaselines it reflexively,
+  //     which is how a tripwire stops being read. The regression this locks
+  //     in is ~12 KiB raw / ~3.4 KiB gz (the barrel drag above), so ~1 KiB
+  //     of slack still catches it with 3× margin. min-gz stays at 44 KiB
+  //     with 963 B: that axis is the HARD ceiling and the one worth holding
+  //     tight. The barrel drag itself is now caught structurally, by the
+  //     `dist/cloudflare.js` Workerd-builtin closure assertion below, which
+  //     is what lets these two axes stay diagnostic rather than load-bearing.
+  { entry: "cloudflare.js", raw: 419 * 1024, gz: 127 * 1024, minGz: 44 * 1024 },
   // Client surface — `BaerlyClient<TConfig>` + fetcher plumbing.
   // Browser/runtime-agnostic; no kernel modules in the closure.
   // Budget history:
@@ -1112,9 +1126,28 @@ const BUDGETS: readonly Budget[] = [
   //     single-process guarantee. Unlike most rebaselines above this is NOT
   //     comment-dominated: it is real shipped control flow. This closure is
   //     the right place for it to land — the same change REMOVED it from
-  //     `cloudflare.js` (see that entry). Measured 49869 raw / 17866 gz; no
+  //     `cloudflare.js` (see that entry). Measured 49883 raw / 17872 gz; no
   //     min-gz axis on this entry.
-  { entry: "dev.js", raw: 49 * 1024, gz: 18 * 1024 },
+  //   → 51 KiB raw / 19 KiB gz (2026-08-02): JSDoc only. `#canonicalRoot`
+  //     now records why the `delete`-vs-`put` lock-key divergence against a
+  //     not-yet-created symlinked root is a known, bounded gap rather than a
+  //     fix (Fresh Eyes, PR #84, Info), and `#lockKey` notes that
+  //     `toLowerCase()` approximates Unicode case folding rather than
+  //     implementing it. Both were condensed once before rebaselining — the
+  //     first drafts cost 1842 B raw, these cost 1253 B — but per the POLICY
+  //     comments are not golfed to fit a tripwire, and a recorded decision
+  //     on a reviewer finding is what keeps the next reader from
+  //     re-deriving it. This entry has NO min-gz axis precisely because it
+  //     never reaches a browser, so both axes here are pure creep
+  //     diagnostics on a dev/self-host surface.
+  //
+  //     gz is rebaselined even though 18396 still cleared 18 KiB — by 36 B.
+  //     Same reasoning as the `cloudflare.js` recalibration above: a
+  //     tripwire with less than one comment line of slack reports noise, and
+  //     leaving it there just defers the rebaseline to whoever next edits a
+  //     docstring in `packages/dev/`. Measured 51136 raw / 18396 gz, landing
+  //     both axes ~1 KiB clear.
+  { entry: "dev.js", raw: 51 * 1024, gz: 19 * 1024 },
   // Worker-safe S3 entry — `S3HttpStorage` + `sigV4Signer` + the
   // `aws4fetch` SigV4 client + `@rgrove/parse-xml` XML parser.
   // Intended for cross-account R2 / non-R2 S3 from a Cloudflare
@@ -1373,6 +1406,54 @@ describe("bundle size", () => {
     expect(
       observabilityChunks,
       `kernel barrel must not pull the observability subgraph; found: ${observabilityChunks.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  // `cloudflare.js` ships into a Worker. Workerd can load exactly one of the
+  // Node builtins this repo uses — `node:async_hooks`, under `nodejs_compat`,
+  // which `@baerly/server` needs for the per-request observability ALS. Every
+  // other `node:` specifier reaching this closure is code that cannot run
+  // there.
+  //
+  // This guard exists because the byte budgets alone did not catch the real
+  // thing. `worker.ts` imported `renderDevLanding` from the `@baerly/dev`
+  // barrel, the barrel re-exports `LocalFsStorage`, and rolldown chunked the
+  // whole Node-only local-fs closure — `node:fs`, `node:crypto`, `node:path`
+  // — into the Worker bundle for the sake of one HTML string. It surfaced
+  // only as a min-gz overrun, i.e. as a size symptom, several changes after
+  // it landed. `scripts/lint-package-layers.mjs` cannot see it either: its
+  // `allowNode` gate reads a package's own source, and no `node:` specifier
+  // ever appeared in `packages/adapter-cloudflare/`.
+  //
+  // Asserting on the artifact is what closes that gap, because the artifact
+  // is where a transitive drag becomes observable. It also means the raw/gz
+  // creep tripwires above do not have to carry this weight — per the POLICY
+  // they are diagnostics, and a budget tight enough to catch a barrel drag
+  // would fire on an ordinary JSDoc edit instead.
+  //
+  // Matches quoted specifiers in `from "node:…"`, side-effect
+  // `import "node:…"`, and `import("node:…")` — deliberately broader than
+  // `STATIC_IMPORT_RE`, which requires `from`. Quoting is what keeps this off
+  // prose: dist ships module-level JSDoc un-stripped, and several chunks
+  // discuss `node:fs` in backticks (e.g. `current-json-*.js` documenting that
+  // it stays Worker-bundleable).
+  const NODE_SPECIFIER_RE = /["'](node:[\w/.-]+)["']/g;
+  const WORKERD_LOADABLE_BUILTINS = new Set(["node:async_hooks"]);
+  test("dist/cloudflare.js closure imports no Workerd-unloadable Node builtin", () => {
+    const distDir = resolve(__dirname, "../../dist");
+    const offenders: string[] = [];
+    for (const file of closureFiles("cloudflare.js")) {
+      for (const m of readFileSync(file, "utf8").matchAll(NODE_SPECIFIER_RE)) {
+        const spec = m[1]!;
+        if (WORKERD_LOADABLE_BUILTINS.has(spec)) {
+          continue;
+        }
+        offenders.push(`${file.replace(`${distDir}/`, "")} → ${spec}`);
+      }
+    }
+    expect(
+      offenders,
+      `dist/cloudflare.js closure may import only [${[...WORKERD_LOADABLE_BUILTINS].join(", ")}]; found: ${offenders.join(", ")}. A Node builtin here means Node-only code was dragged into the Worker bundle — usually by importing a barrel that re-exports it. Import the leaf module instead (cf. \`@baerly/dev/dev-landing\` in packages/adapter-cloudflare/src/worker.ts)`,
     ).toEqual([]);
   });
 

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -919,7 +919,17 @@ const BUDGETS: readonly Budget[] = [
   //     discriminator (#73) — same change as http.js above, reaching this
   //     aggregator through the shared http + current-json chunks. min-gz
   //     stays 239 B under. Measured 439542 raw / 132296 gz / 45841 min-gz.
-  { entry: "cloudflare.js", raw: 430 * 1024, gz: 130 * 1024, minGz: 45 * 1024 },
+  //   → 431 KiB raw (2026-08-01): `LocalFsStorage`'s EXDEV fix — the shared
+  //     `tempPathFor` helper and the rewritten staging comments in
+  //     `packages/dev/src/local-fs.ts`, which reaches this aggregator via the
+  //     same `src-*` chunk `dev.js` uses. Comments ship un-stripped, so the
+  //     +392 B is almost entirely the corrected prose explaining why the temp
+  //     must be a sibling of its destination. Per the POLICY that is a
+  //     rebaseline, not a trim — the JSDoc was already tightened once to keep
+  //     `dev.js` under its own line, and cutting further would delete the
+  //     reason the code is shaped this way. Measured 440712 raw; gz (132345,
+  //     −775) and min-gz (45839, −241) both stay under.
+  { entry: "cloudflare.js", raw: 431 * 1024, gz: 130 * 1024, minGz: 45 * 1024 },
   // Client surface — `BaerlyClient<TConfig>` + fetcher plumbing.
   // Browser/runtime-agnostic; no kernel modules in the closure.
   // Budget history:

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -929,7 +929,25 @@ const BUDGETS: readonly Budget[] = [
   //     `dev.js` under its own line, and cutting further would delete the
   //     reason the code is shaped this way. Measured 440712 raw; gz (132345,
   //     −775) and min-gz (45839, −241) both stay under.
-  { entry: "cloudflare.js", raw: 431 * 1024, gz: 130 * 1024, minGz: 45 * 1024 },
+  //   → 418 KiB raw / 126 KiB gz / 44 KiB min-gz (2026-08-01): budgets move
+  //     DOWN. `packages/adapter-cloudflare/src/worker.ts` imported
+  //     `renderDevLanding` from the `@baerly/dev` barrel, and the barrel
+  //     re-exports `LocalFsStorage`, so rolldown chunked the entire
+  //     Node-only local-fs closure — `node:fs`, `node:crypto`, `node:path`,
+  //     and now the per-key write lock — into the Worker bundle for one
+  //     HTML string. `dev-landing.ts` has no imports at all, so giving it
+  //     its own `@baerly/dev/dev-landing` subpath drops the whole closure
+  //     out of this aggregator.
+  //
+  //     Found because `LocalFsStorage`'s atomicity fixes pushed min-gz
+  //     46150 past the 45 KiB HARD ceiling. Per the POLICY that is a
+  //     regression to shrink, not a line to raise — and shrinking it
+  //     correctly turned out to mean removing code that was never supposed
+  //     to ship to a Worker. Measured 427462 raw / 128919 gz / 44093
+  //     min-gz, i.e. below the pre-branch 439542 / 132296 / 45841 on every
+  //     axis. Budgets tighten to lock the win in rather than bank it as
+  //     silent headroom.
+  { entry: "cloudflare.js", raw: 418 * 1024, gz: 126 * 1024, minGz: 44 * 1024 },
   // Client surface — `BaerlyClient<TConfig>` + fetcher plumbing.
   // Browser/runtime-agnostic; no kernel modules in the closure.
   // Budget history:
@@ -1085,7 +1103,18 @@ const BUDGETS: readonly Budget[] = [
   //     15400 gz — the +56 B the note above predicted, plus the guard.
   //     No min-gz axis on this entry; comment-dominated, per POLICY not
   //     golfed to fit.
-  { entry: "dev.js", raw: 43 * 1024, gz: 16 * 1024 },
+  //   → 49 KiB raw / 18 KiB gz (2026-08-01): `LocalFsStorage`'s two `put`
+  //     atomicity fixes — the shared `tempPathFor` staging helper (EXDEV),
+  //     the `key-lock.ts` per-key async mutex that makes the `ifMatch`
+  //     read-compare-write atomic, `realpath` canonicalization of the lock
+  //     key, the reserved-prefix guard in `#pathFor`, and `list`'s
+  //     deleted-mid-iteration tolerance — plus the JSDoc scoping the
+  //     single-process guarantee. Unlike most rebaselines above this is NOT
+  //     comment-dominated: it is real shipped control flow. This closure is
+  //     the right place for it to land — the same change REMOVED it from
+  //     `cloudflare.js` (see that entry). Measured 49869 raw / 17866 gz; no
+  //     min-gz axis on this entry.
+  { entry: "dev.js", raw: 49 * 1024, gz: 18 * 1024 },
   // Worker-safe S3 entry — `S3HttpStorage` + `sigV4Signer` + the
   // `aws4fetch` SigV4 client + `@rgrove/parse-xml` XML parser.
   // Intended for cross-account R2 / non-R2 S3 from a Cloudflare

--- a/tests/integration/maintenance-profile-equivalence.test.ts
+++ b/tests/integration/maintenance-profile-equivalence.test.ts
@@ -198,7 +198,7 @@ describe("MaintenanceProfile cross-profile correctness", () => {
 
       test(
         "(A) materialized state is byte-for-byte identical across every profile (and the no-maintenance reference)",
-        // 120s locally: under single-write commit each commit forward-probes
+        // 180s locally: under single-write commit each commit forward-probes
         // the log tail (galloping, O(log gap) GETs). The no-maintenance
         // reference seed never advances tail_hint, so its gap grows to the
         // full stream length — over LocalFs (real file I/O) under
@@ -206,7 +206,17 @@ describe("MaintenanceProfile cross-profile correctness", () => {
         // ciTimeout gives the 2-vCPU CI core extra headroom (the higher
         // ceiling only bites if the replay is genuinely that slow; locally
         // the tighter bound stands).
-        { timeout: ciTimeout(120_000) },
+        //
+        // 120s → 180s (2026-08-01): the local-fs arm measures ~87s in
+        // isolation (80s before `LocalFsStorage`'s two `put` atomicity
+        // fixes; the per-key write lock is ~5% of that and the same-dir
+        // staging is within noise). 87s of work against a 120s ceiling
+        // left under 33s for fork-pool contention, which the full suite
+        // exhausts — the timeout was load, not a hang, and the arm passes
+        // in isolation. This is the next turn of the rotating-cast
+        // problem `tests/setup/ci.ts` describes, so the base moves rather
+        // than the work shrinking.
+        { timeout: ciTimeout(180_000) },
         async () => {
           const ops = buildOps();
 


### PR DESCRIPTION
`LocalFsStorage.put` had two independent atomicity defects. One made every write fail on an ordinary self-hosted layout; the other let concurrent CAS admit as many winners as there were racers. Both were verified by measurement before being fixed, and the conformance suite gains the contract whose absence let the second one live.

Two commits, meant to be read in order.

## 1. `fix(dev): keep the put temp file inside the bucket root` (patch)

The write path serving unconditional and `ifMatch` puts staged its temp in `os.tmpdir()` and then `rename`d it onto a destination under the bucket root. `rename(2)` refuses to cross filesystems, so wherever those are separate volumes **every such put failed** with `InvalidResponse` wrapping `EXDEV`, and nothing fell back.

That is the ordinary self-hosted shape, not an exotic one. The default root is `<cwd>/.baerly-data` — in a container a mounted data volume while `/tmp` is a tmpfs or the image layer. Same split for `$BAERLY_DATA_DIR` on a network mount, for `baerly export` / `admin restore` against a `file:///…` URI on another disk, and on any systemd host with `/tmp` on tmpfs. The documented zero-credential path `baerlyNode({ config, storage: localFsStorage() })` — from that factory's own `@example` — was dead on arrival there.

Verified against a real second filesystem (a 20 MB HFS+ RAM disk) before changing anything. The result is a clean natural experiment, because one branch of the same function already survived:

```
unconditional PUT : InvalidResponse -- EXDEV: cross-device link not permitted, rename ...
ifNoneMatch:"*"   : OK                        <-- already staged same-dir
ifMatch PUT       : InvalidResponse -- EXDEV: cross-device link not permitted, rename ...
```

So the fix generalizes what the `ifNoneMatch:"*"` branch already did — `link(2)` has the same cross-device constraint — rather than adding a second mechanism. Both paths now stage through one `tempPathFor`.

**One correction to the obvious version of this fix.** Moving the temp same-dir is only safe because `walk` filters `TEMP_PREFIX`, and the old name (`baerly-localfs-…`) did **not** carry that prefix. Moving it without also renaming it would have leaked a visible bogus key on a crash. The name changes too.

Cleanup moves to a `try/finally` so a failed write no longer strands the partial body, and `writeFile` moves inside the `try` — previously it sat outside, so a temp-write failure escaped as a raw Node `ErrnoException` rather than a `BaerlyError`.

**Why no test caught this.** Every local-fs root in the suite is `mkdtemp(tmpdir())`, so root and temp are always on one volume and `rename` never crosses a boundary.

**What the guard is, and why that one.** A genuine EXDEV needs a second filesystem, which no test can assume, so the guard is split:

- **Always runs, portable:** point `TMPDIR` at a missing directory and `put`. A `put` that stages same-dir is immune; one that stages outside the root inherits every failure mode of that other directory. It pins the invariant that actually matters — *the write path does not depend on `os.tmpdir()`* — rather than asserting an implementation detail. Confirmed red pre-fix.
- **Real EXDEV, where available:** finds a second writable filesystem by comparing `st_dev` against `os.tmpdir()`'s. That picks up `/dev/shm` on Linux CI, so the genuine path is exercised where merges are gated; it `skipIf`-skips visibly elsewhere rather than passing for free.

The temp-filter test now also covers nested depth and a stray temp *directory*.

## 2. `fix(dev): serialize the ifMatch read-compare-write window` (patch)

The `ifMatch` path read the stored body, compared etags, then staged and published — awaited filesystem work in between, no lock. `node:fs/promises` yields the event loop at each of those, so every racer read the same base etag, every racer passed the comparison, and every racer published:

```
16 concurrent put(k, …, {ifMatch: E})   ->  winners=16  losers=0
same, across 16 separate instances      ->  winners=16  losers=0
```

Not a narrow window — concurrent CAS was entirely unserialized. Every update but the last was silently lost.

**It is reachable in today's default `pnpm test`.** The `local-fs` variant of `randomized.test.ts` runs three writers over one directory whose write-tick maintenance CAS-updates a shared `gc/pending.json` through `casUpdateGcPending`. Note this is *not* the compactor's `current.json` CAS: that gate needs ~512 log entries at cold-start `mean_entry_bytes`, and the cascade commits ~100, so `compact()` is never reached there. Nothing failed only because nothing asserted the property.

Every mutation of a key — `ifMatch`, unconditional, create-if-absent, `delete` — now serializes behind a per-key async mutex held across the whole read-compare-write. Guarding the other verbs is not incidental: an unconditional put or a delete landing inside another caller's compare→publish window is the same lost update from the other side.

**Choosing the lock's identity took three tries, each found by measuring rather than reading, and each reproducing the original defect.** This is the part worth reviewing:

- **Module-level, not per instance.** `localFsStorage()` mints a fresh instance per call, and the randomized cascade builds N over one root deliberately — an instance-scoped map serializes nothing in the harness built to catch this.
- **Keyed on the path, not the storage key.** The default macOS filesystem folds case and normalizes filenames, so `k`/`K` and NFC/NFD are one file but were two locks. **2 winners.**
- **`realpath`'d, not just `resolve()`d.** `resolve` collapses `.`/`..` but not symlinks, so `/tmp/data` and `/private/tmp/data` — the same directory on every Mac — were two locks. **2 winners.** Memoized, and cached only on success so a not-yet-created root cannot poison it.

Case-folding over-approximates: on a case-sensitive filesystem `a` and `A` share a lock. That costs a little concurrency and never costs correctness, which is precisely the trade the symlink miss argues for.

`AbortSignal` needed re-checking inside the critical section. The pre-lock check now fronts an unbounded queue, so a call aborted while queued behind other writers to its key would otherwise still land — measured: an aborted put and an aborted delete both completed and the key was gone.

`key-lock.ts` is deliberately **not** re-exported from the package barrel, so the published `@gusto/baerly-storage/dev` surface is unchanged. Entries evict when their last contender drains, so the map is bounded by in-flight writers rather than by the keyspace.

**Two adjacent defects of the same shape**, both pre-existing, both fixed here because leaving them would have been inconsistent with the error handling this branch already touched:

- `list()` walks names then reads each file to hash its etag; a `delete` in that window escaped as a raw Node `ENOENT` rather than a `BaerlyError`. Reachable whenever GC deletes while the compactor walks the same prefixes. A key that vanishes mid-listing is legal on a real object store, so it is now skipped.
- The `.baerly-tmp-` prefix `list` filters was never *reserved*, so a key inside it was writable and readable but invisible — a silent put-then-list violation. `#pathFor` now rejects it in any segment, and `walk` skips the prefix on directories too, or a stray `.baerly-tmp-d/child` would list as a key that `#pathFor` immediately rejects.

### The conformance gap that let this live

`conformance.ts` had **no concurrency contract for `ifMatch`** — its block was three sequential tests, and the only concurrency test covered `ifNoneMatch:"*"`. Added the mirror, *"admits exactly one winner under concurrent `ifMatch` on the same etag"*, plus an error-code parity row. Loser codes are a set (`Conflict | NetworkError`) for the same reason as the create race: real AWS S3 surfaces a contended conditional write as 409 `ConditionalRequestConflict`.

Because there is no `supportsCAS` opt-out, this binds every backend with no call-site changes. **Verified green on Memory, LocalFs, the miniflare R2 binding, and real Minio over the S3 path** — the belief that they already satisfied it was checked, not assumed.

### Prose

The guarantee is now scoped precisely — one loaded copy of this module, any number of instances whose roots resolve to the same directory, nothing across processes — rather than the old "in-process TOCTOU only". Updated in the class JSDoc, the `localFsStorage` factory, the conformance CAVEAT, `docs/spec/capabilities.md`, `docs/contributing/conventions/tests.md`, and `packages/dev/src/current-json.test.ts`, whose comment had documented the defect **as intended behavior**.

## Verification

Each commit is independently green — the full gate ran against the first commit's tree, not just the branch tip.

| Gate | commit 1 | tip |
| --- | --- | --- |
| `verify:agent` | exit 0 | exit 0 |
| `test:agent` | 2615 passed | 2631 passed |
| `test:parity` | — | 125 passed |
| `test:adapter-cloudflare` (R2 under Workerd) | — | 154 passed |
| `test:adapter-node` (S3 against Minio) | — | 375 passed |
| `test:minio` | — | 2766 passed |
| `verify:examples` | — | exit 0 |
| `pnpm bundle-sizes` | exit 0 | exit 0 |

R2 and Minio were run specifically to back the new conformance contract against real backends rather than only the in-memory ones.

Two caveats, stated rather than omitted:

- **`pnpm test:randomize` does not pass on this machine, on this branch or on `main`.** Pristine `main` @ `01bdd298`: 3 failed / 2610 passed. This branch: 2 failed / 2629 passed. All five are per-test **timeouts**, never `AssertionError`s, and the failing sets barely overlap — CPU saturation with a rotating cast. It cranks `FC_NUM_RUNS=10000` across the whole project while per-test ceilings are sized for a file running alone (`maintenance-crash-fuzz`'s own docstring says as much). The branch is the better of the two here: its 120s → 180s raise fixes one of main's three.
- **`node-minio` suites flake once the dev stack has been up for hours**, with a rotating cast including a `gc/pending.json … does not exist` error that reads like a real bootstrap race. After `pnpm dev:storage:stop && pnpm dev:storage`, `test:minio` was green at 2766 passed. The numbers above are from the fresh stack.

`maintenance-profile-equivalence`'s local-fs arm moves 120s → 180s. It measures ~87s in isolation (80s before this branch; the lock is ~5% of that, the same-dir staging within noise), which left under 33s for fork-pool contention — the timeout was load, not a hang, and it passes in isolation. Next turn of the rotating-cast problem `tests/setup/ci.ts` describes.

## Bundle budgets

**`cloudflare.js` moves DOWN on all three axes.** Adding the lock pushed its `min-gz` to 46150, past the 45 KiB **hard** ceiling — which POLICY says to shrink, not raise. The right shrink turned out to be to stop shipping the code at all: `worker.ts` imported `renderDevLanding` from the `@baerly/dev` barrel, and the barrel re-exports `LocalFsStorage`, so rolldown chunked the entire Node-only closure — `node:fs`, `node:crypto`, `node:path` — into the Worker bundle for one HTML string. `dev-landing.ts` has no imports at all, so it gets its own subpath.

| `cloudflare.js` | main | this branch |
| --- | --- | --- |
| raw | 439542 | **427462** |
| gz | 132296 | **128919** |
| min-gz (hard ceiling) | 45841 | **44093** |

Budgets tighten to 418 KiB / 126 KiB / 44 KiB to lock the win in rather than bank it as silent headroom.

`dev.js` rebaselines 43 → 49 KiB raw and 16 → 18 KiB gz. Unlike most rebaselines in that file this is **not** comment-dominated — `key-lock.ts` is real shipped control flow — and this closure is the right place for it to land, given the same change removed it from `cloudflare.js`. No min-gz axis on that entry.

## Known, not fixed

A temp stranded by a **hard** crash (SIGKILL, OOM, power loss) between staging and publishing now sits inside the bucket, and since every enumerator goes through `Storage.list` → the `TEMP_PREFIX` filter, nothing — not `runGc`, not `admin fsck` — can reclaim it. Staging in `os.tmpdir()` at least let the OS reap it. Ordinary failures are still cleaned by the `finally`.

Not a correctness bug: the file is inert, never surfaces as a key, never affects reads, CAS, or GC. It is a space leak and an observability gap (`du` disagrees with `admin usage`). It is also **widened rather than introduced** — the `ifNoneMatch:"*"` path already staged in-bucket; this extends that shape to every write.

Left for its own change because a reaper is a cleanup mechanism and CLAUDE.md's operator-burden test governs it — that gate does not belong bolted onto a bugfix under review. The trade-off is stated in `tempPathFor`'s JSDoc and in the changeset so nobody inherits it as a surprise.

Two changesets, both patch: no public API change.
