### PR TITLE
test(storage): pin the startAfter × maxKeys list contract across both first-class ports

### DIFF
--- a/docs/spec/storage-compatibility.md
+++ b/docs/spec/storage-compatibility.md
@@ -178,12 +178,24 @@ porter can cite a specific clause.
    _"keys sort by UTF-8 byte order, not UTF-16 (supplementary-plane
    divergence)"_.
 6. **`maxKeys` MUST cap the yielded count** to the first `maxKeys` keys in
-   sort order. Combined with `startAfter`, the cap MUST apply AFTER the
-   cursor filter: `list(p, { startAfter: k, maxKeys: n })` yields the first
-   `n` keys strictly greater than `k`, never a window of `n` keys from the
-   start of the prefix that is then filtered down. (Conformance: _"maxKeys
-   caps the result"_ and _"startAfter and maxKeys compose: the cap applies
-   AFTER the cursor"_.)
+   sort order. It is a hard total across the port's internal pagination, not
+   a per-page limit. Combined with `startAfter`, the cap MUST apply AFTER
+   the cursor filter: `list(p, { startAfter: k, maxKeys: n })` yields the
+   first `n` keys strictly greater than `k`, never a window of `n` keys from
+   the start of the prefix that is then filtered down. GC's wrap test —
+   _yielded fewer than `maxKeys` ⇒ reached end of keyspace_ — is unsound
+   without both halves: a port that yields one short page and stops
+   reports a false end-of-keyspace on every pass. A port MUST also
+   clamp `maxKeys` to its wire maximum (1000 on S3/R2) rather than
+   forwarding it verbatim — the kernel's unbounded path passes
+   `Number.MAX_SAFE_INTEGER`, which is `InvalidArgument` on real S3.
+   (Conformance: _"maxKeys caps the result"_ and _"startAfter and
+   maxKeys compose: the cap applies AFTER the cursor"_. **The
+   cross-adapter suite cannot reach the page boundary** — its fixtures
+   are a handful of keys and no in-tree backend pages below 1000 — so
+   the cross-page total and the clamp are pinned per-adapter instead,
+   in the `list` blocks of `s3-http.test.ts` and
+   `r2-binding-storage.test.ts`. A port MUST pin them itself.)
 7. **Body round-trip MUST be byte-exact at the size boundaries.** A `0`-byte
    body and a 1 MiB (`1048576`-byte) body MUST `put` then `get` back
    byte-for-byte. (Conformance: _"round-trip exactly 0 bytes"_ …

--- a/docs/spec/storage-compatibility.md
+++ b/docs/spec/storage-compatibility.md
@@ -157,11 +157,17 @@ porter can cite a specific clause.
    whole-bucket scan; every stored key MUST be yielded. (Used by the
    suite's own `deleteAllOnce` teardown and the _"returns the current etag
    for each entry"_ case, both listing `""`.)
-4. **`startAfter` MUST be strict-exclusive.** When `list(prefix, {
-   startAfter })` is given, the `startAfter` key itself MUST NOT be
-   returned — only keys strictly greater than it. (Conformance: _"startAfter
-   is exclusive"_ and the _"startAfter:k yields strict suffix of lex-sorted
-   keys"_ property.)
+4. **`startAfter` MUST be strict-exclusive, and MUST be a position rather
+   than a lookup.** When `list(prefix, { startAfter })` is given, the
+   `startAfter` key itself MUST NOT be returned — only keys strictly greater
+   than it. The comparison is on the key VALUE: `startAfter` MUST resolve
+   correctly for a key that was never written, or that has since been
+   deleted. GC's rotation cursors depend on this directly — a cursor names
+   the last key a pass examined, and the same pass frequently deletes it
+   before the next one resumes. (Conformance: _"startAfter is exclusive"_,
+   _"startAfter resolves against a key that does not exist"_, _"startAfter
+   still resolves after the cursor key is deleted"_, and the _"startAfter:k
+   yields strict suffix of lex-sorted keys"_ property.)
 5. **`list` results MUST be sorted by UTF-8 byte order, NOT UTF-16.** For
    BMP characters the two agree, but they diverge for supplementary-plane
    characters (surrogate pairs): a UTF-16 code-unit sort orders an emoji
@@ -172,7 +178,12 @@ porter can cite a specific clause.
    _"keys sort by UTF-8 byte order, not UTF-16 (supplementary-plane
    divergence)"_.
 6. **`maxKeys` MUST cap the yielded count** to the first `maxKeys` keys in
-   sort order. (Conformance: _"maxKeys caps the result"_.)
+   sort order. Combined with `startAfter`, the cap MUST apply AFTER the
+   cursor filter: `list(p, { startAfter: k, maxKeys: n })` yields the first
+   `n` keys strictly greater than `k`, never a window of `n` keys from the
+   start of the prefix that is then filtered down. (Conformance: _"maxKeys
+   caps the result"_ and _"startAfter and maxKeys compose: the cap applies
+   AFTER the cursor"_.)
 7. **Body round-trip MUST be byte-exact at the size boundaries.** A `0`-byte
    body and a 1 MiB (`1048576`-byte) body MUST `put` then `get` back
    byte-for-byte. (Conformance: _"round-trip exactly 0 bytes"_ …

--- a/packages/adapter-cloudflare/src/r2-binding-storage.test.ts
+++ b/packages/adapter-cloudflare/src/r2-binding-storage.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit pins for `r2BindingStorage.list`'s `maxKeys` handling.
+ *
+ * `docs/spec/storage-compatibility.md` list clause 6 makes two
+ * requirements normative: `maxKeys` is a hard TOTAL across the port's
+ * internal pagination (not a per-page limit), and a port MUST clamp it
+ * to its wire maximum rather than forwarding it verbatim. The clause
+ * also states that the cross-adapter conformance suite **cannot reach
+ * either one** — its fixtures are a handful of keys and no in-tree
+ * backend pages below 1000 — so each port must pin them itself.
+ *
+ * `s3-http.test.ts` does that for the S3 port. This file is the R2
+ * half, which was missing: `r2-binding-storage.ts` implements both
+ * correctly (`Math.min(cap - yielded, 1000)`), but nothing asserted it,
+ * so a regression would have shipped green.
+ *
+ * Both are load-bearing for GC's rotation cursors, which infer
+ * end-of-keyspace from "the LIST yielded FEWER than maxKeys". A port
+ * that stopped at a short first page would report a false wrap on every
+ * pass, clearing the cursor forever and reinstating exactly the stall
+ * the cursor exists to remove.
+ *
+ * These are plain unit tests over a fake binding — no miniflare — so
+ * they run in the DEFAULT vitest project on every `pnpm test`, not only
+ * under `pnpm test:adapter-cloudflare`.
+ */
+
+import { describe, expect, test } from "vitest";
+import { r2BindingStorage } from "./r2-binding-storage.ts";
+
+interface FakePage {
+  readonly keys: readonly string[];
+  readonly truncated: boolean;
+}
+
+/**
+ * A minimal `R2Bucket` whose `list` replays `pages` in order and
+ * records the `R2ListOptions` it was handed, so a test can assert on
+ * the `limit` that crossed the binding boundary.
+ */
+const mkBucket = (pages: readonly FakePage[]): { bucket: R2Bucket; calls: R2ListOptions[] } => {
+  const calls: R2ListOptions[] = [];
+  let i = 0;
+  const bucket = {
+    list: (opts: R2ListOptions) => {
+      calls.push(opts);
+      const page = pages[Math.min(i, pages.length - 1)]!;
+      i += 1;
+      return Promise.resolve({
+        objects: page.keys.map((key) => ({ key, etag: "deadbeef" })),
+        truncated: page.truncated,
+        cursor: page.truncated ? `tok${i}` : undefined,
+      });
+    },
+  } as unknown as R2Bucket;
+  return { bucket, calls };
+};
+
+describe("r2BindingStorage.list maxKeys", () => {
+  test("an effectively-unbounded maxKeys is clamped to the 1000-key wire maximum", async () => {
+    // GC's unbounded reconcile path passes `Number.MAX_SAFE_INTEGER`.
+    // R2 rejects anything over 1000 with `MaxKeys params must be
+    // positive integer <= 1000. (10022)`, so forwarding it verbatim
+    // would fail every unbounded LIST.
+    const { bucket, calls } = mkBucket([{ keys: ["p/a"], truncated: false }]);
+    const s = r2BindingStorage(bucket);
+    const out: string[] = [];
+    for await (const e of s.list("p/", { maxKeys: Number.MAX_SAFE_INTEGER })) {
+      out.push(e.key);
+    }
+    expect(out).toEqual(["p/a"]);
+    expect(calls[0]?.limit).toBe(1000);
+  });
+
+  test("maxKeys is a hard TOTAL across pages, not a per-page limit", async () => {
+    // The binding pages at 2; we ask for 3. Stopping at the page
+    // boundary would yield ["p/a","p/b"] and, to a rotation cursor,
+    // look like the end of the keyspace.
+    const { bucket, calls } = mkBucket([
+      { keys: ["p/a", "p/b"], truncated: true },
+      { keys: ["p/c", "p/d"], truncated: false },
+    ]);
+    const s = r2BindingStorage(bucket);
+    const out: string[] = [];
+    for await (const e of s.list("p/", { maxKeys: 3 })) {
+      out.push(e.key);
+    }
+    expect(out).toEqual(["p/a", "p/b", "p/c"]);
+    expect(calls).toHaveLength(2);
+    // The remaining budget rides on the follow-up request, so the
+    // second page asks for 1, not 3.
+    expect(calls[1]?.limit).toBe(1);
+    expect(calls[1]?.cursor).toBe("tok1");
+  });
+
+  test("startAfter rides the FIRST page only; later pages use the cursor", async () => {
+    // R2's `startAfter` is a one-shot cursor. Sending it alongside a
+    // continuation `cursor` on page 2 would re-anchor the scan.
+    const { bucket, calls } = mkBucket([
+      { keys: ["p/b"], truncated: true },
+      { keys: ["p/c"], truncated: false },
+    ]);
+    const s = r2BindingStorage(bucket);
+    const out: string[] = [];
+    for await (const e of s.list("p/", { startAfter: "p/a", maxKeys: 2 })) {
+      out.push(e.key);
+    }
+    expect(out).toEqual(["p/b", "p/c"]);
+    expect(calls[0]?.startAfter).toBe("p/a");
+    expect(calls[1]?.startAfter).toBeUndefined();
+    expect(calls[1]?.cursor).toBe("tok1");
+  });
+});

--- a/packages/adapter-node/src/s3-http.test.ts
+++ b/packages/adapter-node/src/s3-http.test.ts
@@ -352,6 +352,82 @@ describe("S3HttpStorage.list", () => {
     expect(out).toEqual(["a", "b"]);
   });
 
+  // `maxKeys` is normatively a HARD TOTAL across the port's internal
+  // pagination, not a per-page limit
+  // (docs/spec/storage-compatibility.md, list clause 6). The
+  // cross-adapter conformance suite cannot reach this: its fixtures are
+  // a handful of keys and no in-tree backend pages below 1000, so a
+  // port that yielded one page and stopped would pass conformance.
+  //
+  // It is load-bearing for GC's rotation cursors, which infer
+  // end-of-keyspace from "the LIST yielded FEWER than maxKeys". An
+  // adapter that stops at a short first page reports a false wrap on
+  // every pass, clearing the cursor forever — reinstating exactly the
+  // stall the cursor exists to remove. S3 is explicitly permitted to
+  // return fewer than `max-keys` with `IsTruncated`, so this is a real
+  // wire behaviour, not a hypothetical.
+  test("maxKeys is a hard TOTAL across pages, not a per-page limit", async () => {
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const url = urlOfFetchInput(input);
+      if (url.includes("continuation-token=tok1")) {
+        return new Response(xmlPage(["c", "d"]), { status: 200 });
+      }
+      return new Response(xmlPage(["a", "b"], "tok1"), { status: 200 });
+    });
+    const s = mkStorage(fetchFn as unknown as typeof fetch);
+    const out: string[] = [];
+    // Server pages at 2; we asked for 3. Stopping at the page boundary
+    // would yield ["a","b"] and, to a rotation cursor, look like the
+    // end of the keyspace.
+    for await (const e of s.list("p/", { maxKeys: 3 })) {
+      out.push(e.key);
+    }
+    expect(out).toEqual(["a", "b", "c"]);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    // The remaining budget rides on the follow-up request, so the
+    // second page asks for 1, not 3.
+    const second = fetchFn.mock.calls[1]![0] as Request;
+    expect(decodeURIComponent(second.url)).toContain("max-keys=1");
+  });
+
+  test("startAfter rides the FIRST page only; later pages use the continuation token", async () => {
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const url = urlOfFetchInput(input);
+      if (url.includes("continuation-token=tok1")) {
+        return new Response(xmlPage(["c"]), { status: 200 });
+      }
+      return new Response(xmlPage(["a", "b"], "tok1"), { status: 200 });
+    });
+    const s = mkStorage(fetchFn as unknown as typeof fetch);
+    const out: string[] = [];
+    for await (const e of s.list("p/", { startAfter: "p/x", maxKeys: 3 })) {
+      out.push(e.key);
+    }
+    expect(out).toEqual(["a", "b", "c"]);
+    const first = decodeURIComponent((fetchFn.mock.calls[0]![0] as Request).url);
+    const second = decodeURIComponent((fetchFn.mock.calls[1]![0] as Request).url);
+    expect(first).toContain("start-after=p/x");
+    // Sending both would be a protocol error on real S3.
+    expect(second).not.toContain("start-after");
+    expect(second).toContain("continuation-token=tok1");
+  });
+
+  test("an effectively-unbounded maxKeys is clamped to the 1000-key wire maximum", async () => {
+    // GC's unbounded reconcile path passes `Number.MAX_SAFE_INTEGER`.
+    // Forwarding that verbatim is `InvalidArgument` on real S3.
+    const fetchFn = vi.fn<typeof fetch>(
+      async (_req) => new Response(xmlPage(["a"]), { status: 200 }),
+    );
+    const s = mkStorage(fetchFn as unknown as typeof fetch);
+    const drained: string[] = [];
+    for await (const e of s.list("p/", { maxKeys: Number.MAX_SAFE_INTEGER })) {
+      drained.push(e.key);
+    }
+    expect(drained).toEqual(["a"]);
+    const req = decodeURIComponent((fetchFn.mock.calls[0]![0] as Request).url);
+    expect(req).toContain("max-keys=1000");
+  });
+
   test("startAfter sets the cursor", async () => {
     const fetchFn = vi.fn<typeof fetch>(async (_req) => new Response(xmlPage([]), { status: 200 }));
     const s = mkStorage(fetchFn as unknown as typeof fetch);

--- a/packages/protocol/src/storage/conformance.ts
+++ b/packages/protocol/src/storage/conformance.ts
@@ -697,6 +697,56 @@ export function defineStorageConformanceSuite(
         );
       });
 
+      // The two options above were each pinned alone. GC's rotation
+      // cursors (`gc/pending.json`) depend on them TOGETHER, and on a
+      // property neither test reaches: the cursor names the last key a
+      // pass examined, and that same pass routinely DELETEs it before
+      // the next one resumes. An adapter that applied `maxKeys` before
+      // the cursor filter, or that resolved `startAfter` against a key
+      // that must still exist, would pass everything above and still
+      // strand orphans.
+      test("startAfter and maxKeys compose: the cap applies AFTER the cursor", async () => {
+        await s.put("a/1", new TextEncoder().encode("a1"));
+        await s.put("a/2", new TextEncoder().encode("a2"));
+        await s.put("a/3", new TextEncoder().encode("a3"));
+        await s.put("a/4", new TextEncoder().encode("a4"));
+        // Cap-then-cursor would yield ["a/2"] (or nothing); the
+        // contract is a 2-key window starting after the cursor.
+        await expectEventuallyEqual(
+          () =>
+            collect(s.list("a/", { startAfter: "a/1", maxKeys: 2 })).then((l) =>
+              l.map((e) => e.key),
+            ),
+          ["a/2", "a/3"],
+          settle,
+        );
+      });
+
+      test("startAfter resolves against a key that does not exist", async () => {
+        await s.put("a/1", new TextEncoder().encode("a1"));
+        await s.put("a/3", new TextEncoder().encode("a3"));
+        // `a/2` was never written. `startAfter` is a strict-greater
+        // comparison on the key VALUE, not a lookup, so this is a
+        // position, not a miss.
+        await expectEventuallyEqual(
+          () => collect(s.list("a/", { startAfter: "a/2" })).then((l) => l.map((e) => e.key)),
+          ["a/3"],
+          settle,
+        );
+      });
+
+      test("startAfter still resolves after the cursor key is deleted", async () => {
+        await s.put("a/1", new TextEncoder().encode("a1"));
+        await s.put("a/2", new TextEncoder().encode("a2"));
+        await s.put("a/3", new TextEncoder().encode("a3"));
+        await s.delete("a/2");
+        await expectEventuallyEqual(
+          () => collect(s.list("a/", { startAfter: "a/2" })).then((l) => l.map((e) => e.key)),
+          ["a/3"],
+          settle,
+        );
+      });
+
       test("returns the current etag for each entry, and nothing else", async () => {
         const a = await s.put("a", new TextEncoder().encode("alpha"));
         const b = await s.put("b", new TextEncoder().encode("beta"));


### PR DESCRIPTION
Extracted from #82, which needed these `list` guarantees but bundled them with an unrelated GC fix. They stand on their own: no kernel change, no adapter change, no behaviour change.

## What this pins

GC's rotation cursors lean on three `Storage.list` properties that the conformance suite tested only in isolation, or not at all. An adapter could pass the whole suite and still strand keys.

1. **`startAfter` is a position, not a lookup.** It's a strict-greater comparison on the key VALUE, so it must resolve against a key that was never written, and against one that has since been deleted. The deleted case is load-bearing: a cursor names the last key a pass examined, and that same pass routinely deletes it before the next resumes.
2. **`maxKeys` composes with `startAfter` in the right order.** The cap applies AFTER the cursor filter — `{ startAfter: k, maxKeys: n }` is a window of `n` keys past `k`, not `n` keys from the start of the prefix filtered down to whatever survives.
3. **`maxKeys` is a hard cross-page total, and ports must clamp it.** Not a per-page limit. And a port must clamp to its wire maximum (1000 on S3/R2) rather than forwarding verbatim — the kernel's unbounded path passes `Number.MAX_SAFE_INTEGER`, which real S3 rejects as `InvalidArgument`.

(1) and (2) are cross-adapter conformance cases. (3) can't be reached by the shared suite — its fixtures are a handful of keys and no in-tree backend pages below 1000 — so both first-class ports pin it directly, with the same three cases each.

## Why both ports in one commit

A clause that says *"a port MUST pin this itself"* is only credible if every port in the tree does. Pinning S3 and leaving R2 to satisfy the clause by accident is the failure mode this avoids.

Both adapters are already correct (`Math.min(cap - yielded, 1000)` in each). Nothing asserted it, so a regression would have shipped green — and quietly: GC infers end-of-keyspace from *yielded fewer than `maxKeys`*, so a port that stopped at a short first page would report a false wrap on every pass and clear its cursor forever.

## Commits

- `test(protocol): pin startAfter as a position, not a lookup` — 3 conformance cases + `storage-compatibility.md` clauses 4 and 6
- `test(adapters): pin the maxKeys cross-page total and wire clamp per port` — `s3-http.test.ts` + `r2-binding-storage.test.ts` + clause 6's page-boundary paragraph

The R2 cases are plain unit tests over a fake binding rather than miniflare, so they run on every `pnpm test` instead of only under `pnpm test:adapter-cloudflare`.

## Verification

`pnpm verify:agent`, `pnpm test:agent` (2624 passed), `pnpm test:adapter-cloudflare` (155 passed) all green.

One pre-existing failure is present and **not** caused by this branch: `tests/integration/maintenance-profile-equivalence.test.ts` `local-fs > (A)` times out at 120s with a doubled-path `ENOENT`. Reproduced on `main` at 01bdd298 with none of these changes applied.

No changeset: `@baerly/protocol` is internal and there is no user-facing change to `@gusto/baerly-storage`.