### PR TITLE
fix(cli): remove retired follow-up references

### DIFF
--- a/packages/cli/src/admin/usage.test.ts
+++ b/packages/cli/src/admin/usage.test.ts
@@ -290,7 +290,7 @@ describe("baerly admin usage — query-cost reporting", () => {
     }
   });
 
-  test("--target=cloudflare short-circuits with an info finding", async () => {
+  test("--target=cloudflare finding names the supported Node bucket alternative", async () => {
     const stdout = captureStream(process.stdout);
     let exitCode: number;
     try {
@@ -300,11 +300,15 @@ describe("baerly admin usage — query-cost reporting", () => {
     }
     expect(exitCode).toBe(0);
     const envelope = JSON.parse(stdout.captured.join("").trim()) as {
-      result: { findings: { check: string; severity: string }[] };
+      result: { findings: { check: string; severity: string; message: string }[] };
     };
     expect(envelope.result.findings).toHaveLength(1);
-    expect(envelope.result.findings[0]?.check).toBe("usage.cloudflare");
-    expect(envelope.result.findings[0]?.severity).toBe("info");
+    const finding = envelope.result.findings[0];
+    expect(finding?.check).toBe("usage.cloudflare");
+    expect(finding?.severity).toBe("info");
+    expect(finding?.message).toBe(
+      "baerly admin usage cannot read a Workerd-side R2 binding from --target=cloudflare. Use --target=node --bucket=s3://<bucket> with your R2 S3 API credentials.",
+    );
   });
 
   test("--target=node without --bucket rejected with InvalidConfig (exit 1)", async () => {

--- a/packages/cli/src/admin/usage.ts
+++ b/packages/cli/src/admin/usage.ts
@@ -27,8 +27,8 @@
  * The CLI wrapper at the bottom of the file constructs that
  * `Storage` from `--bucket=<uri>` via `parseBucketUri`. The
  * Cloudflare target short-circuits with an info-level "not yet
- * wired" finding pending the follow-up work in
- * `docs/followups/agent-friendliness.md` entry 10.
+ * wired" finding because the Node CLI cannot consume a
+ * Workerd-side R2 binding.
  *
  * Why GET each entry instead of relying on a list-time
  * `Last-Modified`: `StorageListEntry` carries no timestamp — it is
@@ -500,13 +500,13 @@ const bundle = defineBaerlySubcommand({
 
     if (target === "cloudflare") {
       // The CLI runs in Node and can't reach a Workerd-side R2 binding
-      // from `--bucket=<uri>`; full CF wiring is a follow-up — see
-      // `docs/followups/agent-friendliness.md` entry 10.
+      // directly. Operators can instead use R2's S3-compatible API
+      // through the Node target and an explicit bucket URI.
       findings.push({
         severity: "info",
         check: "usage.cloudflare",
         message:
-          "baerly admin usage is not yet wired for --target=cloudflare. See docs/followups/agent-friendliness.md entry 10.",
+          "baerly admin usage cannot read a Workerd-side R2 binding from --target=cloudflare. Use --target=node --bucket=s3://<bucket> with your R2 S3 API credentials.",
       });
     } else {
       if (args.bucket === undefined || args.bucket.length === 0) {

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -101,10 +101,7 @@ interface Budget {
    * the result stays under this ceiling.
    */
   minGz?: number;
-  /**
-   * Skip this entry's check pending follow-up. Tracked in
-   * `docs/followups/first-touch-dx.md`.
-   */
+  /** Skip this entry's budget check. */
   skip?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- remove the four stale references to the deleted docs/followups convention
- replace the Cloudflare usage pointer with a self-contained Node/R2 alternative
- pin the actionable finding in the existing CLI test

## Verification
- pnpm verify:agent (passed)
- pnpm vitest run --project=default packages/cli/src/admin/usage.test.ts (15 passed)
- pnpm test:agent (known unrelated failures: http.js size budget and two load-harness flakes)

Closes #76