### PR TITLE
docs: add a PR template that keeps process history out of PR bodies

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,66 @@
+<!-- Write for a maintainer reading this in six months, not for a reviewer
+     watching you work. Default to short — a few sentences of framing is the
+     norm, not the exception. Match length to the change: a one-line fix needs
+     one line. A body that looks long and structured is not more valuable; it
+     usually buries the framing under scaffolding.
+
+     Delete any section that doesn't apply. Don't leave empty headings. -->
+
+## What & why
+
+<!-- The problem, then the change. Two to five sentences.
+
+     Lead with the conclusion — someone who stops reading after the first
+     sentence should still be correct about what this PR does.
+
+     Don't restate the diff, don't tour the changed files, don't explain what a
+     function does. The diff is right there. -->
+
+## Key points
+
+<!-- One line each. Tradeoffs accepted, alternatives rejected, and anything a
+     maintainer would otherwise have to guess at or rediscover.
+
+     This is the ONLY section that may mention an approach that was tried and
+     abandoned, or a plan that changed along the way. One line, stated as a
+     fact about the code — not as a story about how you got here:
+
+       - Bounds the pre-image scan by a fixed GET budget rather than flooring it
+         at `log_seq_start`: a floored walk that finds nothing computes no stale
+         keys and leaks them silently.
+
+     Not: "My original plan was to floor at log_seq_start, but after
+     investigating I realized that sub-floor entries survive GC, so I decided
+     instead to..." -->
+
+## Verification
+
+<!-- The commands you actually ran, and their results. Nothing else — no
+     test-by-test descriptions, no coverage narration, no "all green ✅".
+
+       | `pnpm verify:agent` | clean       |
+       | `pnpm test:agent`   | 2617 passed |
+       | `pnpm bundle-sizes` | 34/34       |
+
+     Never claim a gate you didn't run. If you skipped one, name it and say why
+     (missing infra, credentials, etc.). -->
+
+## Notes for reviewers
+
+<!-- Optional. Where to start reading, what's risky, what you're unsure about. -->
+
+<!-- ROUTING — this content has a home, and it isn't this body:
+
+       user-facing behavior change   → a changeset (`.changeset/*.md`)
+       design rationale, invariants  → `docs/spec/` or `docs/adr/`
+       why a constant has its value  → JSDoc at the constant
+       a bundle-size rebaseline      → the dated note in the budget table
+       work you didn't do            → an issue, linked here as one line
+
+     Never include: a changelog of your branch, ticket bookkeeping beyond
+     `Refs #N`, deferred-work inventories, file-by-file walkthroughs, sections
+     defending something you chose not to build, or AI attribution.
+
+     Proposing a maintenance, coordination, or background-work mechanism? Cite
+     [change-discipline.md](../docs/contributing/conventions/change-discipline.md#operator-burden-test-for-new-mechanisms)
+     and answer the three operator-burden questions explicitly. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -474,6 +474,26 @@ auto-load on matching edits and point at the same files.
   exist. ~10 minutes of verification up front beats hours of work
   stuck on phantom references.
 
+## Pull request bodies
+
+Follow [`.github/pull_request_template.md`](.github/pull_request_template.md).
+It applies whether or not the template was rendered into your editor —
+`gh pr create --body` bypasses it, so read the file.
+
+The body is a maintainer's reference, not a record of how the branch was
+built. Default to short and lead with the conclusion. State what the code
+does now; don't narrate how you arrived at it. A tried-and-abandoned
+approach or a changed plan gets **one line under "Key points"** and
+appears nowhere else. Deferred work is an issue link, not an inventory.
+
+Most of what wants to sprawl into a PR body belongs somewhere durable
+instead — a changeset for user-facing behavior, `docs/spec` or `docs/adr`
+for rationale and invariants, JSDoc for why a constant has its value, the
+dated baseline note for a bundle-size rebaseline. Put it there and let the
+PR point at it.
+
+No AI attribution in the title or body.
+
 ## Pointers
 
 - Doc topic map: [docs/README.md](docs/README.md) — start here if


### PR DESCRIPTION
## What & why

Agent-authored PRs here run 5–8k characters, and most of it is reasoning transcript rather than anything a maintainer would want later. This adds `.github/pull_request_template.md` and mirrors the rule into `CLAUDE.md`.

The template routes rather than bans. A tried-and-abandoned approach gets one line under "Key points"; a closing block names where everything else belongs — a changeset, `docs/spec`, a constant's JSDoc, a dated baseline note, or an issue link.

## Key points

- The rule lives in both the template and `CLAUDE.md`: `gh pr create --body` bypasses the template entirely, and root `AGENTS.md` symlinks to `CLAUDE.md`, so the second copy is what reaches non-Claude agents.
- Quarantining process narration to one bounded section beats prohibiting it — a flat ban leaves the legitimate half, rejected alternatives, with nowhere to go.
- No authorship checkboxes and no CI length check. Single approver, and a byte cap would punish the one PR that genuinely needs the words.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm verify:agent` | exit 0 |
| `pnpm verify:docs` | clean |
| `node scripts/lint-format-coverage.mjs` | 704/704 owned |

`.github/` is inside the `remark .` walk — confirmed by temporarily inserting a broken link and watching `verify:docs` fail on it — so the template's link into `change-discipline.md` is gate-validated. `pnpm test` and `pnpm bundle-sizes` not run: no `.ts` changed.

## Notes for reviewers

This body is written to the template it adds, as a check that the shape holds.