### PR TITLE
feat(bench): measure fold-ceiling headroom, and add the storage journals and lease seam

### DIFF
--- a/bench/fold-cost.ts
+++ b/bench/fold-cost.ts
@@ -28,7 +28,13 @@
  * Storage is in-memory so I/O is ~free and the measured cost is the
  * CPU/allocation of the rebuild itself.
  *
- * MEASUREMENT METHOD
+ * The fixture builder and the per-fold CPU/heap measurement live in
+ * `bench/lib/fold-fixture.ts` so the fold-ceiling probe can reuse them
+ * verbatim — same seed, same tail, same measurement definitions — and so
+ * they are importable without running this bench. This file owns the
+ * grid, the iteration counts, and the output format.
+ *
+ * MEASUREMENT METHOD (defined in `bench/lib/fold-fixture.ts`)
  *   - **CPU**: `process.cpuUsage()` deltas (user + system µs) bracketing
  *     the fold, reported in ms. NOT wall-clock — folds are CPU-bound on
  *     Workers and wall would include I/O (which MemoryStorage makes ~free
@@ -76,51 +82,23 @@
  * portable signal.
  */
 
-/* eslint-disable no-underscore-dangle -- `_id` is the locked primary-key
-   field on document + snapshot shapes (see `@baerly/protocol`'s
-   `Collection<T>` / the snapshot body). */
-
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { MAINTENANCE_MAX_FOLD_ROWS } from "@baerly/protocol";
 import {
-  type CurrentJson,
-  type DocumentData,
-  type LogEntry,
-  MAINTENANCE_MAX_FOLD_ROWS,
-  MemoryStorage,
-  countKey,
-  encodeJsonBytes,
-  snapshotHash,
-  timestamp,
-} from "@baerly/protocol";
-import { type SnapshotBody, encodeSnapshotBody, snapshotKey } from "@baerly/server";
-import { compact } from "@baerly/server/maintenance";
-import type { InternalCompactOptions } from "@baerly/server/_internal/testing";
+  HEAP_SAMPLE_INTERVAL_MS,
+  SEED,
+  TAIL_ENTRIES,
+  buildFixture,
+  measureOneFold,
+  median,
+} from "./lib/fold-fixture.ts";
 
 // ── Bench config. Pinned constants — tweak in the source if needed. ──
-
-const SEED = 0xf01d_c057; // "fold cost"; reproduction handle.
-const SESSION = "fold000"; // 7 chars; the bench doesn't validate sessions.
-const COLLECTION = "notes";
-const CURRENT_JSON_KEY = `app/x/tenant/t/manifests/${COLLECTION}/current.json`;
-const COLLECTION_PREFIX = `app/x/tenant/t/manifests/${COLLECTION}`;
 
 /** Warmup folds (discarded) then measured folds, per grid point. */
 const WARMUP_ITERS = 5;
 const MEASURE_ITERS = 11;
-
-/** Heap-sampling interval during a fold (ms). */
-const HEAP_SAMPLE_INTERVAL_MS = 1;
-
-/**
- * Tail length folded per measured rebuild. Small + fixed so the fold's
- * cost is dominated by the snapshot rebuild (load old + serialize new +
- * hash), not by the tail walk — which mirrors the production shape (the
- * tail is SLICED, the snapshot rebuild is the unsliceable cost). The
- * tail updates existing docs so the new snapshot stays the same size /
- * row count as the old (a steady-state fold).
- */
-const TAIL_ENTRIES = 100;
 
 /**
  * BYTES axis — fixed bytes/doc, row count chosen to bracket the
@@ -154,177 +132,6 @@ const ROWS_AXIS_ROW_COUNTS: readonly number[] = [
   8192,
   16384,
 ];
-
-/**
- * Mulberry32 PRNG — small, seedable, no deps. Deterministic input so
- * two runs on the same machine produce comparable snapshot shapes.
- */
-const mulberry32 = (seed: number): (() => number) => {
-  let a = seed >>> 0;
-  return () => {
-    a = (a + 0x6d2b79f5) >>> 0;
-    let t = a;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-};
-
-/**
- * Build a document whose canonical JSON byteLength is close to
- * `targetBytes`. The doc carries a few typed fields plus a `pad` string
- * sized to hit the target; representative of a real notes-shaped record
- * (string body + scalars) rather than one giant blob.
- */
-const makeDoc = (id: string, targetBytes: number, rng: () => number): DocumentData => {
-  // Fixed scaffold the encoder always emits; the pad absorbs the rest.
-  const scaffold: DocumentData = {
-    _id: id,
-    title: `note ${id}`,
-    n: Math.floor(rng() * 1_000_000),
-    done: rng() < 0.5,
-    pad: "",
-  };
-  const scaffoldBytes = encodeJsonBytes(scaffold).byteLength;
-  const padLen = Math.max(0, targetBytes - scaffoldBytes);
-  // Printable ASCII so each char is one JSON byte (no escaping / multi-
-  // byte surprises that would throw off the target).
-  return { ...scaffold, pad: "x".repeat(padLen) };
-};
-
-interface FoldFixture {
-  readonly storage: MemoryStorage;
-  /** Actual canonical snapshot-body byteLength (measured, not target). */
-  readonly snapshotBytes: number;
-  readonly rows: number;
-}
-
-/**
- * Seed a fresh `MemoryStorage` with a `current.json` + a prior snapshot
- * of (rows × bytesPerDoc) + a `TAIL_ENTRIES`-long log tail that updates
- * existing docs. After this returns, a single `compact()` call folds the
- * whole tail into a rebuilt snapshot of the same shape.
- */
-const buildFixture = async (rows: number, bytesPerDoc: number): Promise<FoldFixture> => {
-  const storage = new MemoryStorage();
-  const rng = mulberry32(SEED ^ (rows * 0x9e37_79b1) ^ bytesPerDoc);
-
-  // 1. Prior snapshot: `rows` docs, sorted by _id (compactor invariant).
-  const docs: Array<{ _id: string; body: DocumentData }> = [];
-  for (let i = 0; i < rows; i++) {
-    const id = `doc-${i.toString().padStart(8, "0")}`;
-    docs.push({ _id: id, body: makeDoc(id, bytesPerDoc, rng) });
-  }
-  docs.sort((a, b) => byIdAsc(a._id, b._id));
-  const snapBody: SnapshotBody = {
-    schema_version: 1,
-    min_seq: 0,
-    max_seq: rows, // prior snapshot covered [0, rows)
-    collection: COLLECTION,
-    docs,
-  };
-  const snapBytes = encodeSnapshotBody(snapBody);
-  const sha = await snapshotHash(snapBytes);
-  const snapKey = snapshotKey(COLLECTION_PREFIX, 0, rows, sha);
-  await storage.put(snapKey, snapBytes, { contentType: "application/json" });
-
-  // 2. Log tail: TAIL_ENTRIES updates to existing docs at seqs
-  //    [rows, rows + TAIL_ENTRIES). U with a full post-image keeps the
-  //    rebuilt snapshot the same row count (steady-state fold).
-  for (let t = 0; t < TAIL_ENTRIES; t++) {
-    const seq = rows + t;
-    const targetIdx = Math.floor(rng() * rows);
-    const id = `doc-${targetIdx.toString().padStart(8, "0")}`;
-    const entry: LogEntry = {
-      lsn: `${timestamp(1_700_000_000_000 + seq)}_${SESSION}_${countKey(seq)}`,
-      commit_ts: new Date(1_700_000_000_000 + seq).toISOString(),
-      op: "U",
-      collection: COLLECTION,
-      doc_id: id,
-      after: makeDoc(id, bytesPerDoc, rng),
-      session: SESSION,
-      seq,
-    };
-    const entryBytes = encodeJsonBytes(entry);
-    await storage.put(`${COLLECTION_PREFIX}/log/${seq}.json`, entryBytes, {
-      contentType: "application/json",
-    });
-  }
-
-  // 3. current.json pointing at the prior snapshot with the tail live.
-  const current: CurrentJson = {
-    schema_version: 3,
-    snapshot: snapKey,
-    tail_hint: rows + TAIL_ENTRIES,
-    log_seq_start: rows,
-    writer_fence: { epoch: 1, owner: "fold-cost-bench", claimed_at: "" },
-    snapshot_bytes: snapBytes.byteLength,
-    snapshot_rows: rows,
-  };
-  await storage.put(CURRENT_JSON_KEY, encodeJsonBytes(current), {
-    ifNoneMatch: "*",
-    contentType: "application/json",
-  });
-
-  return { storage, snapshotBytes: snapBytes.byteLength, rows };
-};
-
-/** A single measured fold over an already-built fixture. */
-const measureOneFold = async (
-  storage: MemoryStorage,
-): Promise<{ cpuMs: number; peakBytes: number }> => {
-  const heapStart = process.memoryUsage().heapUsed;
-  let peak = heapStart;
-  const sampler = setInterval(() => {
-    const h = process.memoryUsage().heapUsed;
-    if (h > peak) {
-      peak = h;
-    }
-  }, HEAP_SAMPLE_INTERVAL_MS);
-  // `unref` so a stray timer can never keep the process alive.
-  sampler.unref();
-
-  const cpu0 = process.cpuUsage();
-  // Whole tail in one pass (the unsliceable rebuild); no ceiling (we are
-  // measuring the fold, not the defer path). `maxEntriesPerRun` rides on
-  // the internal options object.
-  const opts: InternalCompactOptions = {
-    minEntriesToCompact: 1,
-    maxEntriesPerRun: Number.MAX_SAFE_INTEGER,
-  };
-  const res = await compact({ storage, currentJsonKey: CURRENT_JSON_KEY }, opts);
-  const cpu1 = process.cpuUsage(cpu0);
-  clearInterval(sampler);
-
-  if (!res.written) {
-    throw new Error(`fold-cost: expected a written fold, got skippedReason=${res.skippedReason}`);
-  }
-  // One last sample in case the fold finished between ticks.
-  const heapEnd = process.memoryUsage().heapUsed;
-  if (heapEnd > peak) {
-    peak = heapEnd;
-  }
-  const cpuMs = (cpu1.user + cpu1.system) / 1000; // µs → ms
-  const peakBytes = Math.max(0, peak - heapStart);
-  return { cpuMs, peakBytes };
-};
-
-const median = (xs: readonly number[]): number => {
-  const s = [...xs].toSorted((a, b) => a - b);
-  const mid = Math.floor(s.length / 2);
-  return s.length % 2 === 0 ? (s[mid - 1]! + s[mid]!) / 2 : s[mid]!;
-};
-
-/** Lexicographic `_id` comparator — same ordering the compactor uses. */
-const byIdAsc = (a: string, b: string): number => {
-  if (a < b) {
-    return -1;
-  }
-  if (a > b) {
-    return 1;
-  }
-  return 0;
-};
 
 /** Bytes → KB / MB for the summary table. */
 const kb = (b: number): string => (b / 1024).toFixed(0);

--- a/bench/lib/fold-fixture.ts
+++ b/bench/lib/fold-fixture.ts
@@ -1,0 +1,249 @@
+/**
+ * Shared fold fixture + measurement primitives for the fold benches
+ * (bench/fold-cost.ts, bench/measurement/fold-ceiling-probe.ts).
+ *
+ * A "fold" here is ONE real `compact()` — the UNSLICEABLE snapshot
+ * rebuild — run against a fresh `MemoryStorage` seeded with a
+ * `current.json` + a prior snapshot of an exact (rows, bytesPerDoc)
+ * shape + a representative log tail. The whole tail folds in a SINGLE
+ * pass (`maxEntriesPerRun` large, `minEntriesToCompact = 1`) so what is
+ * measured is the unsliceable rebuild, not a sliced drain. The fold does
+ * the production work end to end: load + hash-verify the old snapshot,
+ * apply the tail merge, re-serialize the new snapshot body, SHA-256 it,
+ * PUT it, CAS-advance `current.json`. Storage is in-memory so I/O is
+ * ~free and the measured cost is the CPU/allocation of the rebuild
+ * itself.
+ *
+ * MEASUREMENT METHOD
+ *   - **CPU**: `process.cpuUsage()` deltas (user + system µs) bracketing
+ *     the fold, reported in ms. NOT wall-clock — folds are CPU-bound on
+ *     Workers and wall would include I/O (which MemoryStorage makes ~free
+ *     anyway).
+ *   - **Peak memory**: a tight sampler on
+ *     `process.memoryUsage().heapUsed` ({@link HEAP_SAMPLE_INTERVAL_MS}
+ *     via a `setInterval`) running for the duration of the fold; the
+ *     per-fold peak is `max(sample) - heapUsedAtStart`. The fold holds
+ *     old snapshot + new snapshot + tail resident (~2–3× snapshot).
+ *     Sampling (not `--expose-gc` deltas) so the benches run with a bare
+ *     `node` like the other no-infra benches.
+ *   - **Fixture realism** — the pad is a single repeated-char string
+ *     (`"x".repeat(n)`), so absolute byte-axis numbers are a mild lower
+ *     bound vs. heterogeneous real documents; the linear *shape* (linear
+ *     in bytes, the per-row slope) is the portable signal.
+ *
+ * This module has NO module-scope side effects, so it is safe to import
+ * from a test or from another bench. Its callers own the grid, the
+ * iteration counts, and the output format. MEASURES ONLY — it changes no
+ * production behaviour and no constant.
+ */
+
+/* eslint-disable no-underscore-dangle -- `_id` is the locked primary-key
+   field on document + snapshot shapes (see `@baerly/protocol`'s
+   `Collection<T>` / the snapshot body). */
+
+import {
+  type CurrentJson,
+  type DocumentData,
+  type LogEntry,
+  MemoryStorage,
+  countKey,
+  encodeJsonBytes,
+  snapshotHash,
+  timestamp,
+} from "@baerly/protocol";
+import { type SnapshotBody, encodeSnapshotBody, snapshotKey } from "@baerly/server";
+import { compact } from "@baerly/server/maintenance";
+import type { InternalCompactOptions } from "@baerly/server/_internal/testing";
+
+// ── Fixture config. Pinned constants — tweak in the source if needed. ──
+
+/** "fold cost"; reproduction handle. Captured in every result JSON. */
+export const SEED = 0xf01d_c057;
+const SESSION = "fold000"; // 7 chars; the bench doesn't validate sessions.
+const COLLECTION = "notes";
+const CURRENT_JSON_KEY = `app/x/tenant/t/manifests/${COLLECTION}/current.json`;
+const COLLECTION_PREFIX = `app/x/tenant/t/manifests/${COLLECTION}`;
+
+/** Heap-sampling interval during a fold (ms). */
+export const HEAP_SAMPLE_INTERVAL_MS = 1;
+
+/**
+ * Tail length folded per measured rebuild. Small + fixed so the fold's
+ * cost is dominated by the snapshot rebuild (load old + serialize new +
+ * hash), not by the tail walk — which mirrors the production shape (the
+ * tail is SLICED, the snapshot rebuild is the unsliceable cost). The
+ * tail updates existing docs so the new snapshot stays the same size /
+ * row count as the old (a steady-state fold).
+ */
+export const TAIL_ENTRIES = 100;
+
+/**
+ * Mulberry32 PRNG — small, seedable, no deps. Deterministic input so
+ * two runs on the same machine produce comparable snapshot shapes.
+ */
+const mulberry32 = (seed: number): (() => number) => {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+/**
+ * Build a document whose canonical JSON byteLength is close to
+ * `targetBytes`. The doc carries a few typed fields plus a `pad` string
+ * sized to hit the target; representative of a real notes-shaped record
+ * (string body + scalars) rather than one giant blob.
+ */
+const makeDoc = (id: string, targetBytes: number, rng: () => number): DocumentData => {
+  // Fixed scaffold the encoder always emits; the pad absorbs the rest.
+  const scaffold: DocumentData = {
+    _id: id,
+    title: `note ${id}`,
+    n: Math.floor(rng() * 1_000_000),
+    done: rng() < 0.5,
+    pad: "",
+  };
+  const scaffoldBytes = encodeJsonBytes(scaffold).byteLength;
+  const padLen = Math.max(0, targetBytes - scaffoldBytes);
+  // Printable ASCII so each char is one JSON byte (no escaping / multi-
+  // byte surprises that would throw off the target).
+  return { ...scaffold, pad: "x".repeat(padLen) };
+};
+
+/** Lexicographic `_id` comparator — same ordering the compactor uses. */
+const byIdAsc = (a: string, b: string): number => {
+  if (a < b) {
+    return -1;
+  }
+  if (a > b) {
+    return 1;
+  }
+  return 0;
+};
+
+export interface FoldFixture {
+  readonly storage: MemoryStorage;
+  /** Actual canonical snapshot-body byteLength (measured, not target). */
+  readonly snapshotBytes: number;
+  readonly rows: number;
+}
+
+/**
+ * Seed a fresh `MemoryStorage` with a `current.json` + a prior snapshot
+ * of (rows × bytesPerDoc) + a `TAIL_ENTRIES`-long log tail that updates
+ * existing docs. After this returns, a single `compact()` call folds the
+ * whole tail into a rebuilt snapshot of the same shape.
+ */
+export const buildFixture = async (rows: number, bytesPerDoc: number): Promise<FoldFixture> => {
+  const storage = new MemoryStorage();
+  const rng = mulberry32(SEED ^ (rows * 0x9e37_79b1) ^ bytesPerDoc);
+
+  // 1. Prior snapshot: `rows` docs, sorted by _id (compactor invariant).
+  const docs: Array<{ _id: string; body: DocumentData }> = [];
+  for (let i = 0; i < rows; i++) {
+    const id = `doc-${i.toString().padStart(8, "0")}`;
+    docs.push({ _id: id, body: makeDoc(id, bytesPerDoc, rng) });
+  }
+  docs.sort((a, b) => byIdAsc(a._id, b._id));
+  const snapBody: SnapshotBody = {
+    schema_version: 1,
+    min_seq: 0,
+    max_seq: rows, // prior snapshot covered [0, rows)
+    collection: COLLECTION,
+    docs,
+  };
+  const snapBytes = encodeSnapshotBody(snapBody);
+  const sha = await snapshotHash(snapBytes);
+  const snapKey = snapshotKey(COLLECTION_PREFIX, 0, rows, sha);
+  await storage.put(snapKey, snapBytes, { contentType: "application/json" });
+
+  // 2. Log tail: TAIL_ENTRIES updates to existing docs at seqs
+  //    [rows, rows + TAIL_ENTRIES). U with a full post-image keeps the
+  //    rebuilt snapshot the same row count (steady-state fold).
+  for (let t = 0; t < TAIL_ENTRIES; t++) {
+    const seq = rows + t;
+    const targetIdx = Math.floor(rng() * rows);
+    const id = `doc-${targetIdx.toString().padStart(8, "0")}`;
+    const entry: LogEntry = {
+      lsn: `${timestamp(1_700_000_000_000 + seq)}_${SESSION}_${countKey(seq)}`,
+      commit_ts: new Date(1_700_000_000_000 + seq).toISOString(),
+      op: "U",
+      collection: COLLECTION,
+      doc_id: id,
+      after: makeDoc(id, bytesPerDoc, rng),
+      session: SESSION,
+      seq,
+    };
+    const entryBytes = encodeJsonBytes(entry);
+    await storage.put(`${COLLECTION_PREFIX}/log/${seq}.json`, entryBytes, {
+      contentType: "application/json",
+    });
+  }
+
+  // 3. current.json pointing at the prior snapshot with the tail live.
+  const current: CurrentJson = {
+    schema_version: 3,
+    snapshot: snapKey,
+    tail_hint: rows + TAIL_ENTRIES,
+    log_seq_start: rows,
+    writer_fence: { epoch: 1, owner: "fold-cost-bench", claimed_at: "" },
+    snapshot_bytes: snapBytes.byteLength,
+    snapshot_rows: rows,
+  };
+  await storage.put(CURRENT_JSON_KEY, encodeJsonBytes(current), {
+    ifNoneMatch: "*",
+    contentType: "application/json",
+  });
+
+  return { storage, snapshotBytes: snapBytes.byteLength, rows };
+};
+
+/** A single measured fold over an already-built fixture. */
+export const measureOneFold = async (
+  storage: MemoryStorage,
+): Promise<{ cpuMs: number; peakBytes: number }> => {
+  const heapStart = process.memoryUsage().heapUsed;
+  let peak = heapStart;
+  const sampler = setInterval(() => {
+    const h = process.memoryUsage().heapUsed;
+    if (h > peak) {
+      peak = h;
+    }
+  }, HEAP_SAMPLE_INTERVAL_MS);
+  // `unref` so a stray timer can never keep the process alive.
+  sampler.unref();
+
+  const cpu0 = process.cpuUsage();
+  // Whole tail in one pass (the unsliceable rebuild); no ceiling (we are
+  // measuring the fold, not the defer path). `maxEntriesPerRun` rides on
+  // the internal options object.
+  const opts: InternalCompactOptions = {
+    minEntriesToCompact: 1,
+    maxEntriesPerRun: Number.MAX_SAFE_INTEGER,
+  };
+  const res = await compact({ storage, currentJsonKey: CURRENT_JSON_KEY }, opts);
+  const cpu1 = process.cpuUsage(cpu0);
+  clearInterval(sampler);
+
+  if (!res.written) {
+    throw new Error(`fold-cost: expected a written fold, got skippedReason=${res.skippedReason}`);
+  }
+  // One last sample in case the fold finished between ticks.
+  const heapEnd = process.memoryUsage().heapUsed;
+  if (heapEnd > peak) {
+    peak = heapEnd;
+  }
+  const cpuMs = (cpu1.user + cpu1.system) / 1000; // µs → ms
+  const peakBytes = Math.max(0, peak - heapStart);
+  return { cpuMs, peakBytes };
+};
+
+export const median = (xs: readonly number[]): number => {
+  const s = [...xs].toSorted((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 === 0 ? (s[mid - 1]! + s[mid]!) / 2 : s[mid]!;
+};

--- a/bench/measurement/fold-ceiling-probe-run.ts
+++ b/bench/measurement/fold-ceiling-probe-run.ts
@@ -1,0 +1,154 @@
+/**
+ * Runnable entrypoint for the fold-ceiling headroom probe.
+ *
+ * Thin by design: the grid, the verdict functions, and the record shape all
+ * live in `./fold-ceiling-probe.ts`, which the test imports and which has no
+ * module-scope side effects. This file is the only place that executes the
+ * sweep, prints, and writes to disk — the same runner/library split
+ * `bench/amortized-write-cost.ts` uses over `bench/lib/write-cost-measure.ts`.
+ *
+ *   BAERLY_SUBJECT_COMMIT=$(git rev-parse HEAD) \
+ *     node --import ./bench/register-hooks.mjs \
+ *       bench/measurement/fold-ceiling-probe-run.ts
+ *
+ * Takes minutes. Run it with nothing else competing for CPU; a parallel
+ * `pnpm test` will corrupt the medians. (Observed: a run made while the
+ * agent was writing files produced a non-monotonic CPU column — 3 MB and
+ * 5 MB equal, 4 MB above both.)
+ *
+ * Set `BAERLY_FOLD_CEILING_CELLS=<record.json>` to re-derive the record from
+ * an existing run's cells instead of re-measuring.
+ *
+ * MEASURES ONLY. Changes no constant, no profile, no production behaviour.
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import {
+  type ProbeCell,
+  buildRecommendation,
+  referenceLine,
+  renderTable,
+  runProbeGrid,
+} from "./fold-ceiling-probe.ts";
+
+/**
+ * The frozen `fold-cost` baseline. Read-only, never rewritten — manifest §7
+ * makes it byte-for-byte immutable. Five of this grid's cells also exist there,
+ * and comparing them is the only check that the fixture builder, the seed, and
+ * the measurement definitions still mean what they meant in June 2026.
+ */
+const FROZEN_BASELINE = "docs/spec/attachments/fold-cost-baseline.json";
+
+interface FrozenCell {
+  readonly axis: string;
+  readonly rows: number;
+  readonly bytes_per_doc: number;
+  readonly snapshot_bytes: number;
+  readonly cpu_ms_median: number;
+  readonly peak_bytes_median: number;
+}
+
+/** Range of a ratio series, e.g. `1.42x-2.49x`. */
+const span = (xs: readonly number[]): string =>
+  `${Math.min(...xs).toFixed(2)}x-${Math.max(...xs).toFixed(2)}x`;
+
+/**
+ * Overlap-cell divergence against the frozen baseline. Computed here rather
+ * than in the pure module because it reads a file the pure module must not.
+ *
+ * `snapshot_bytes` is seeded and MUST match exactly. `peak_bytes_median` is an
+ * allocation measurement and should track closely. `cpu_ms_median` is
+ * host-specific and is expected to differ — how much it differs is precisely
+ * what tells a reader how far to trust this run's CPU-bound verdicts.
+ */
+const overlapFindings = async (cells: readonly ProbeCell[]): Promise<readonly string[]> => {
+  let frozen: readonly FrozenCell[];
+  try {
+    const parsed: unknown = JSON.parse(await readFile(FROZEN_BASELINE, "utf8"));
+    frozen = (parsed as { cells: readonly FrozenCell[] }).cells;
+  } catch (error: unknown) {
+    return [`overlap check SKIPPED: could not read ${FROZEN_BASELINE} (${String(error)}).`];
+  }
+
+  const mismatched: string[] = [];
+  const cpuRatios: number[] = [];
+  const peakRatios: number[] = [];
+  let compared = 0;
+  for (const cell of cells) {
+    const peer = frozen.find(
+      (f) => f.axis === cell.axis && f.rows === cell.rows && f.bytes_per_doc === cell.bytes_per_doc,
+    );
+    if (peer === undefined) {
+      continue;
+    }
+    compared += 1;
+    if (peer.snapshot_bytes !== cell.snapshot_bytes) {
+      mismatched.push(
+        `${cell.axis}/${cell.label} ${cell.snapshot_bytes} != ${peer.snapshot_bytes}`,
+      );
+    }
+    cpuRatios.push(cell.cpu_ms_median / peer.cpu_ms_median);
+    peakRatios.push(cell.peak_bytes_median / peer.peak_bytes_median);
+  }
+
+  if (compared === 0) {
+    return ["overlap check SKIPPED: no cell in this grid also exists in the frozen baseline."];
+  }
+  const bytesVerdict =
+    mismatched.length === 0
+      ? "snapshot_bytes matches the frozen baseline EXACTLY on all of them (same seed, same builder)"
+      : `snapshot_bytes DIVERGES on ${mismatched.length} cell(s): ${mismatched.join("; ")} — treat this whole run as suspect`;
+  return [
+    `overlap vs the frozen fold-cost baseline (${compared} shared cells): ${bytesVerdict}. ` +
+      `peak_bytes_median ${span(peakRatios)} of frozen — allocation behaviour is unchanged. ` +
+      `cpu_ms_median ${span(cpuRatios)} of frozen, so THIS HOST IS SLOWER than the host that ` +
+      `produced the baseline. CPU-bound verdicts (the cf-free rows) are therefore conservative ` +
+      `on this hardware and are NOT portable; the memory-bound verdicts (cf-paid) are.`,
+  ];
+};
+
+const main = async (): Promise<number> => {
+  // Re-derive the record from an existing run's cells instead of re-measuring.
+  // The cells ARE the measurement; everything else in the record is a pure
+  // function of them, so this reproduces a record exactly without spending
+  // another multi-minute sweep on a possibly-contended machine.
+  const reuse = process.env["BAERLY_FOLD_CEILING_CELLS"];
+  let cells: readonly ProbeCell[];
+  if (reuse === undefined || reuse === "") {
+    // Progress as each cell lands, so a multi-minute run is not a blank screen.
+    cells = await runProbeGrid((cell) => {
+      console.error(
+        `  ${cell.axis}/${cell.label}: ${cell.cpu_ms_median.toFixed(3)} ms, ` +
+          `${(cell.peak_bytes_median / (1024 * 1024)).toFixed(2)} MB peak ` +
+          `(${cell.iterations} iters)`,
+      );
+    });
+  } else {
+    const parsed: unknown = JSON.parse(await readFile(reuse, "utf8"));
+    cells = (parsed as { cells: readonly ProbeCell[] }).cells;
+    console.error(`  re-deriving from ${cells.length} recorded cells in ${reuse} (no measurement)`);
+  }
+
+  // snake_case on purpose — it matches the serialized record shape.
+  const subject_commit = process.env["BAERLY_SUBJECT_COMMIT"] ?? "unknown";
+  const rec = buildRecommendation({
+    cells,
+    subject_commit,
+    extraFindings: await overlapFindings(cells),
+  });
+  console.log(renderTable(rec));
+  console.log("");
+  console.log(referenceLine());
+  console.log("");
+  console.log("findings");
+  for (const finding of rec.findings) {
+    console.log(`  - ${finding}`);
+  }
+
+  const outDir = "bench/results/fold-ceiling";
+  await mkdir(outDir, { recursive: true });
+  await writeFile(`${outDir}/latest.json`, JSON.stringify(rec, null, 2));
+  console.log(`\nwrote ${outDir}/latest.json`);
+  return 0;
+};
+
+process.exitCode = await main();

--- a/bench/measurement/fold-ceiling-probe.test.ts
+++ b/bench/measurement/fold-ceiling-probe.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, test } from "vitest";
+import {
+  HOST_BUDGETS,
+  type HostBudget,
+  type ProbeCell,
+  REPORTED_MARGINS,
+  buildRecommendation,
+  deriveFindings,
+  isPeakSampleUsable,
+  largestSustainable,
+  renderTable,
+  todayHeadroom,
+} from "./fold-ceiling-probe.ts";
+
+const cell = (over: Partial<ProbeCell> & Pick<ProbeCell, "axis" | "rows">): ProbeCell => ({
+  label: `${over.rows}`,
+  bytes_per_doc: 2048,
+  snapshot_bytes: over.rows * 2048,
+  tail_entries: 100,
+  iterations: 11,
+  cpu_ms_median: 1,
+  peak_bytes_median: 1_000_000,
+  peak_over_snapshot: 1,
+  peak_samples_discarded: 0,
+  ...over,
+});
+
+const budget = (over: Partial<HostBudget> = {}): HostBudget => ({
+  profile: "cf-free",
+  cpu_ms: 10,
+  memory_bytes: 128 * 1024 * 1024,
+  source: "test",
+  ...over,
+});
+
+/**
+ * `todayHeadroom` requires BOTH axes, so any fixture that reaches
+ * `buildRecommendation` must carry a rows cell as well as a bytes cell.
+ */
+const bothAxes: readonly ProbeCell[] = [
+  cell({ axis: "bytes", rows: 256, snapshot_bytes: 532_300 }),
+  cell({ axis: "rows", rows: 2048, bytes_per_doc: 64, snapshot_bytes: 232_287 }),
+];
+
+describe("largestSustainable", () => {
+  test("picks the largest cell that fits CPU at the given margin", () => {
+    const cells = [
+      cell({ axis: "bytes", rows: 256, cpu_ms_median: 1 }),
+      cell({ axis: "bytes", rows: 512, cpu_ms_median: 2 }),
+      cell({ axis: "bytes", rows: 1024, cpu_ms_median: 6 }),
+    ];
+    // margin 2 → need cpu*2 <= 10 → 1,2 fit (2,4); 6 does not (12).
+    const verdict = largestSustainable({ cells, budget: budget(), margin: 2 });
+    expect(verdict.max_c_bytes).toBe(512 * 2048);
+    expect(verdict.binding_axis).toBe("cpu");
+  });
+
+  test("memory can bind before CPU", () => {
+    const cells = [
+      cell({ axis: "bytes", rows: 256, cpu_ms_median: 0.1, peak_bytes_median: 10_000_000 }),
+      cell({ axis: "bytes", rows: 512, cpu_ms_median: 0.2, peak_bytes_median: 90_000_000 }),
+    ];
+    const verdict = largestSustainable({
+      cells,
+      budget: budget({ profile: "cf-paid", cpu_ms: 30_000 }),
+      margin: 2,
+    });
+    expect(verdict.max_c_bytes).toBe(256 * 2048);
+    expect(verdict.binding_axis).toBe("memory");
+  });
+
+  test("reports grid-exhausted when even the largest measured cell fits", () => {
+    const cells = [cell({ axis: "bytes", rows: 256, cpu_ms_median: 0.1 })];
+    const verdict = largestSustainable({
+      cells,
+      budget: budget({ profile: "cf-paid", cpu_ms: 30_000 }),
+      margin: 2,
+    });
+    expect(verdict.binding_axis).toBe("grid-exhausted");
+  });
+
+  test("reports none when not even the smallest cell fits", () => {
+    const cells = [cell({ axis: "bytes", rows: 256, cpu_ms_median: 100 })];
+    const verdict = largestSustainable({ cells, budget: budget(), margin: 2 });
+    expect(verdict.max_c_bytes).toBeNull();
+    expect(verdict.binding_axis).toBe("none");
+  });
+
+  test("the rows axis is read from rows-axis and cross cells, never bytes-axis", () => {
+    const cells = [
+      cell({ axis: "bytes", rows: 100_000, cpu_ms_median: 0.1 }),
+      cell({ axis: "rows", rows: 4096, bytes_per_doc: 64, cpu_ms_median: 0.1 }),
+      cell({ axis: "cross", rows: 8192, bytes_per_doc: 512, cpu_ms_median: 0.1 }),
+    ];
+    const verdict = largestSustainable({
+      cells,
+      budget: budget({ profile: "cf-paid", cpu_ms: 30_000 }),
+      margin: 2,
+    });
+    expect(verdict.max_e_rows).toBe(8192);
+    expect(verdict.max_c_bytes).toBe(100_000 * 2048);
+  });
+
+  test("expresses the verdict as a multiple of today's shipped ceilings", () => {
+    const cells = [cell({ axis: "rows", rows: 8192, bytes_per_doc: 64, cpu_ms_median: 0.1 })];
+    const verdict = largestSustainable({
+      cells,
+      budget: budget({ profile: "cf-paid", cpu_ms: 30_000 }),
+      margin: 2,
+    });
+    expect(verdict.e_multiple_of_today).toBe(4); // 8192 / 2048
+  });
+});
+
+describe("todayHeadroom", () => {
+  test("reports the measured margin at today's C and E", () => {
+    const cells = [
+      // C today = 512 KiB. Nearest bytes-axis cell at or below it.
+      cell({ axis: "bytes", rows: 256, snapshot_bytes: 532_300, cpu_ms_median: 1.43 }),
+      // E today = 2048 rows.
+      cell({
+        axis: "rows",
+        rows: 2048,
+        bytes_per_doc: 64,
+        snapshot_bytes: 232_287,
+        cpu_ms_median: 1.38,
+      }),
+    ];
+    const head = todayHeadroom({ cells, budget: budget() });
+    expect(head.at_c_cpu_ms).toBe(1.43);
+    expect(head.at_e_cpu_ms).toBe(1.38);
+    expect(head.cpu_margin_at_c).toBeCloseTo(10 / 1.43, 5);
+  });
+
+  test("throws rather than guessing when an axis is missing entirely", () => {
+    expect(() =>
+      todayHeadroom({ cells: [cell({ axis: "bytes", rows: 256 })], budget: budget() }),
+    ).toThrow(/both the bytes and rows axes/);
+  });
+});
+
+describe("isPeakSampleUsable", () => {
+  /**
+   * The first run of this grid reported a 0.03 MB peak for a 16.24 MB fold —
+   * `peakBytes` is `max(sample) - heapUsedAtStart`, so a `heapStart` captured at
+   * a pre-GC high-water mark floors the whole fold. That cell then passed the
+   * memory test and set `cf-paid maxC` outright. A peak below the snapshot size
+   * is physically impossible for a rebuild that must hold the snapshot resident.
+   */
+  test("rejects a peak below the snapshot size as GC-floored", () => {
+    expect(isPeakSampleUsable(30_000, 16_240_000)).toBe(false);
+  });
+
+  test("accepts a peak at or above the snapshot size", () => {
+    expect(isPeakSampleUsable(16_240_000, 16_240_000)).toBe(true);
+    expect(isPeakSampleUsable(35_000_000, 16_240_000)).toBe(true);
+  });
+});
+
+describe("deriveFindings", () => {
+  test("names a knee when cost per MB climbs, and quotes the bracketing cells", () => {
+    const cells = [
+      ...bothAxes,
+      cell({ axis: "bytes", rows: 1024, snapshot_bytes: 2 * 1024 * 1024, cpu_ms_median: 4 }),
+      cell({ axis: "bytes", rows: 2048, snapshot_bytes: 4 * 1024 * 1024, cpu_ms_median: 40 }),
+    ];
+    const knee = deriveFindings(cells).find((f) => f.startsWith("bytes axis:"));
+    expect(knee).toContain("knee is REAL");
+    expect(knee).toContain("4.00 MB");
+  });
+
+  test("says so plainly when there is no knee", () => {
+    const cells = [
+      ...bothAxes,
+      cell({ axis: "bytes", rows: 1024, snapshot_bytes: 2 * 1024 * 1024, cpu_ms_median: 2 }),
+      cell({ axis: "bytes", rows: 2048, snapshot_bytes: 4 * 1024 * 1024, cpu_ms_median: 4 }),
+    ];
+    expect(deriveFindings(cells).find((f) => f.startsWith("bytes axis:"))).toContain(
+      "no cost-per-MB knee",
+    );
+  });
+
+  test("marks a paid ceiling as a LOWER BOUND when the grid ran out first", () => {
+    const cheap = [
+      cell({ axis: "bytes", rows: 256, snapshot_bytes: 532_300, cpu_ms_median: 0.1 }),
+      cell({
+        axis: "rows",
+        rows: 2048,
+        bytes_per_doc: 64,
+        snapshot_bytes: 232_287,
+        cpu_ms_median: 0.1,
+      }),
+    ];
+    expect(
+      deriveFindings(cheap)
+        .filter((f) => f.includes("cf-paid @"))
+        .join("\n"),
+    ).toContain("LOWER BOUND (grid exhausted)");
+  });
+
+  test("compares every cross cell against its nearest bytes-axis peer", () => {
+    const cells = [
+      ...bothAxes,
+      cell({ axis: "bytes", rows: 2048, snapshot_bytes: 4 * 1024 * 1024, cpu_ms_median: 30 }),
+      cell({
+        axis: "cross",
+        label: "4k x 1KB",
+        rows: 4096,
+        bytes_per_doc: 1024,
+        snapshot_bytes: 4 * 1024 * 1024,
+        cpu_ms_median: 15,
+      }),
+    ];
+    const crossFinding = deriveFindings(cells).find((f) => f.startsWith("cross 4k x 1KB"));
+    expect(crossFinding).toContain("0.50x"); // 15 / 30
+  });
+
+  test("reports how many cells lost GC-floored peak samples", () => {
+    const cells = [...bothAxes, cell({ axis: "bytes", rows: 999, peak_samples_discarded: 4 })];
+    expect(deriveFindings(cells).find((f) => f.startsWith("peak-sample hygiene"))).toContain(
+      "worst cell dropped 4",
+    );
+  });
+
+  test("every finding lands in the record it describes", () => {
+    const rec = buildRecommendation({ cells: bothAxes, subject_commit: "deadbeef" });
+    expect(rec.findings).toEqual(deriveFindings(bothAxes));
+    expect(rec.findings.length).toBeGreaterThan(0);
+  });
+
+  test("runner-supplied findings are appended, not substituted", () => {
+    const rec = buildRecommendation({
+      cells: bothAxes,
+      subject_commit: "deadbeef",
+      extraFindings: ["overlap check: ok"],
+    });
+    expect(rec.findings.at(-1)).toBe("overlap check: ok");
+    expect(rec.findings.length).toBe(deriveFindings(bothAxes).length + 1);
+  });
+});
+
+describe("contract shape", () => {
+  test("budgets cover all three profiles and cite a source", () => {
+    expect(HOST_BUDGETS.map((b) => b.profile)).toEqual(["cf-free", "cf-paid", "node"]);
+    for (const b of HOST_BUDGETS) {
+      expect(b.source.length).toBeGreaterThan(0);
+      expect(b.cpu_ms).toBeGreaterThan(0);
+      expect(b.memory_bytes).toBeGreaterThan(0);
+    }
+  });
+
+  test("more than one margin is reported, so no single choice is baked in", () => {
+    expect(REPORTED_MARGINS.length).toBeGreaterThan(1);
+  });
+
+  test("the recommendation names an owner and a blocker for every change", () => {
+    const rec = buildRecommendation({ cells: bothAxes, subject_commit: "deadbeef" });
+    expect(rec.recommended_changes.length).toBeGreaterThan(0);
+    for (const change of rec.recommended_changes) {
+      expect(change.file.length).toBeGreaterThan(0);
+      expect(change.owner.length).toBeGreaterThan(0);
+      expect(change).toHaveProperty("blocked_by");
+    }
+    expect(rec.sustainable.length).toBe(HOST_BUDGETS.length * REPORTED_MARGINS.length);
+  });
+
+  test("renderTable emits something for every profile", () => {
+    const rec = buildRecommendation({ cells: bothAxes, subject_commit: "deadbeef" });
+    const table = renderTable(rec);
+    for (const b of HOST_BUDGETS) {
+      expect(table).toContain(b.profile);
+    }
+  });
+});

--- a/bench/measurement/fold-ceiling-probe.ts
+++ b/bench/measurement/fold-ceiling-probe.ts
@@ -1,0 +1,644 @@
+/**
+ * Fold-ceiling headroom probe.
+ *
+ * ONE QUESTION: how much larger can `C` (snapshot bytes) and `E` (snapshot rows)
+ * be, per host profile, before one unsliceable fold stops fitting inside that
+ * host's CPU and memory budget?
+ *
+ * WHY IT EXISTS. `packages/server/src/maintenance.ts` gates a fold on
+ * `snapshotBytes <= C && snapshotRows + maxFoldEntriesPerPass <= E`. Crossing it
+ * defers compaction permanently: the tail grows without bound and the collection
+ * must graduate. All three shipped profiles use identical ceilings
+ * (`C = 512 KiB`, `E = 2048`), even though `docs/about/graduation.md` gives
+ * Cloudflare paid a 30 s CPU budget against Cloudflare free's ~10 ms.
+ * `MAINTENANCE_MAX_FOLD_ROWS`'s own JSDoc says `PROVISIONAL — bench landed; paid
+ * recalibration deferred`.
+ *
+ * RELATIONSHIP TO `bench/fold-cost.ts`. That bench established the METHOD (CPU
+ * via `process.cpuUsage()` deltas, peak heap via a 1 ms `heapUsed` sampler,
+ * median over N iterations after warmup) and a 12-cell grid tied to the
+ * `graduation.md` table. This probe REUSES its fixture builder and sampler
+ * verbatim — literally the same `bench/lib/fold-fixture.ts` module, so same seed,
+ * same tail length, same measurement definitions, and the two are directly
+ * comparable — and extends the grid where the decision needs resolution. That
+ * bench's checked-in baseline is FROZEN and is never rewritten; this probe writes
+ * a separate attachment.
+ *
+ * WHAT IS NEW IN THE GRID, and why:
+ *   - **bytes axis, 2/3/4 MB** — the frozen baseline jumps 1 MB (2.59 ms) to
+ *     5 MB (45.0 ms). That is superlinear with nothing in between, and the shape
+ *     of that knee decides how far `C` can move.
+ *   - **bytes axis, 8/16/32 MB** — Cloudflare paid's wall is ~128 MB of Worker
+ *     memory, not CPU. At the frozen baseline's ~2.4x peak-over-snapshot ratio a
+ *     32 MB snapshot lands near 77 MB peak, which is where the paid answer
+ *     actually is. Nothing above 5 MB has ever been measured.
+ *   - **rows axis, 32k/64k/128k** — the frozen baseline stops at 16384 rows
+ *     (10.28 ms), just past the CF-free line. Where per-entry cost walls on PAID
+ *     is unmeasured. NOTE: at 64 B/doc, 128k rows is an ~8 MB snapshot, so byte
+ *     cost contaminates the top of this axis; the cross axis is what
+ *     disambiguates.
+ *   - **cross axis (NEW)** — the real predicate is a CONJUNCTION over both axes,
+ *     but the frozen baseline measures each axis with the other held
+ *     deliberately unloaded (2048 B/doc on bytes, 64 B/doc on rows). A workload
+ *     with many medium documents loads both. These cells are the only ones that
+ *     resemble the predicate the runtime actually evaluates.
+ *
+ * ITERATION SCALING. Big cells are slow (a 32 MB fold, warmed and measured 16
+ * times, is minutes). Cells at or above `LARGE_CELL_BYTES` drop to
+ * `LARGE_WARMUP_ITERS` / `LARGE_MEASURE_ITERS`. Per-cell `iterations` is recorded
+ * so a reader can see which cells are noisier.
+ *
+ * MARGINS, NOT A VERDICT. Today's `C` sits at a wide margin under the CF-free CPU
+ * line. Picking a new margin is a human risk decision, not a measurement, so the
+ * table is reported at 2x, 4x, and 7x and the recommendation record names an
+ * owner rather than choosing.
+ *
+ * MEASURES ONLY. Changes no constant, no profile, no production behaviour.
+ *
+ * This module has NO module-scope side effects — the test imports it. The
+ * runnable entrypoint is `bench/measurement/fold-ceiling-probe-run.ts`.
+ */
+import {
+  CF_FREE_MAX_SAFE_FOLD_BYTES,
+  MAINTENANCE_MAX_FOLD_BYTES_DEFAULT,
+  MAINTENANCE_MAX_FOLD_ROWS,
+  NODE_MAINTENANCE_FOLD_ENTRIES_PER_PASS,
+  WRITE_TICK_FOLD_ENTRIES_PER_PASS,
+} from "@baerly/protocol";
+import { TAIL_ENTRIES, buildFixture, measureOneFold, median } from "../lib/fold-fixture.ts";
+
+export const FOLD_CEILING_PROBE_VERSION = "baerly.fold-ceiling-probe/v1" as const;
+
+export interface HostBudget {
+  readonly profile: "cf-free" | "cf-paid" | "node";
+  /** Per-invocation CPU budget in ms. */
+  readonly cpu_ms: number;
+  /** Per-isolate memory budget in bytes. */
+  readonly memory_bytes: number;
+  /** Where the number comes from, so a reader can re-derive it. */
+  readonly source: string;
+}
+
+/**
+ * From `docs/about/graduation.md`. Node has no platform-imposed CPU or memory
+ * limit, so its row is a STATED ASSUMPTION about a modest container, not a
+ * platform fact — flagged as such in `source` so nobody quotes it as one.
+ */
+export const HOST_BUDGETS: readonly HostBudget[] = [
+  {
+    profile: "cf-free",
+    cpu_ms: 10,
+    memory_bytes: 128 * 1024 * 1024,
+    source: "graduation.md — ~10 ms CPU/request, 128 MB isolate",
+  },
+  {
+    profile: "cf-paid",
+    cpu_ms: 30_000,
+    memory_bytes: 128 * 1024 * 1024,
+    source: "graduation.md — 30 s CPU default, ~128 MB Worker memory (memory is the wall)",
+  },
+  {
+    profile: "node",
+    cpu_ms: 30_000,
+    memory_bytes: 512 * 1024 * 1024,
+    source: "ASSUMPTION, not a platform limit: a modest 512 MB container, 30 s request budget",
+  },
+];
+
+/** 7x is today's de facto margin at `C`; 2x and 4x bracket a loosening. */
+export const REPORTED_MARGINS: readonly number[] = [2, 4, 7];
+
+const BYTES_PER_DOC = 2048;
+const ROWS_AXIS_BYTES_PER_DOC = 64;
+
+const WARMUP_ITERS = 5;
+const MEASURE_ITERS = 11;
+const LARGE_CELL_BYTES = 8 * 1024 * 1024;
+const LARGE_WARMUP_ITERS = 2;
+/**
+ * 9, not 5. Large cells are the ones that lose peak samples to the GC floor
+ * (see {@link isPeakSampleUsable}), and a 5-sample median can be carried by
+ * floored samples outright — which is how the first run of this grid reported a
+ * 0.03 MB peak for a 16 MB fold. 9 leaves a usable median after several discards.
+ */
+const LARGE_MEASURE_ITERS = 9;
+
+/** Byte axis: extends the frozen grid through the 1-5 MB knee and up to the paid memory wall. */
+const BYTES_AXIS_TARGETS: ReadonlyArray<{ label: string; bytes: number }> = [
+  { label: "512KB", bytes: 512 * 1024 }, // = C today; overlap cell, cross-checks the frozen baseline
+  { label: "1MB", bytes: 1024 * 1024 }, // = CF_FREE_MAX_SAFE_FOLD_BYTES warn threshold
+  { label: "2MB", bytes: 2 * 1024 * 1024 }, // NEW — knee
+  { label: "3MB", bytes: 3 * 1024 * 1024 }, // NEW — knee
+  { label: "4MB", bytes: 4 * 1024 * 1024 }, // NEW — knee
+  { label: "5MB", bytes: 5 * 1024 * 1024 }, // overlap cell with the frozen baseline
+  { label: "8MB", bytes: 8 * 1024 * 1024 }, // NEW
+  { label: "16MB", bytes: 16 * 1024 * 1024 }, // NEW
+  { label: "32MB", bytes: 32 * 1024 * 1024 }, // NEW — near the ~128 MB paid memory wall
+];
+
+/** Rows axis: extends past the frozen grid's 16384 to find the paid per-entry wall. */
+const ROWS_AXIS_ROW_COUNTS: readonly number[] = [
+  MAINTENANCE_MAX_FOLD_ROWS, // 2048 — overlap cell
+  8192, // overlap cell
+  16_384, // overlap cell — the frozen grid's top
+  32_768, // NEW
+  65_536, // NEW
+  131_072, // NEW — ~8 MB at 64 B/doc; byte cost starts to contaminate
+];
+
+/**
+ * Cross axis: both axes loaded at once, which is what `foldViable` actually
+ * gates on. No cell here exists in the frozen baseline.
+ */
+const CROSS_AXIS_CELLS: ReadonlyArray<{ label: string; rows: number; bytesPerDoc: number }> = [
+  { label: "4k x 1KB", rows: 4096, bytesPerDoc: 1024 },
+  { label: "16k x 512B", rows: 16_384, bytesPerDoc: 512 },
+  { label: "65k x 256B", rows: 65_536, bytesPerDoc: 256 },
+];
+
+export interface ProbeCell {
+  readonly axis: "bytes" | "rows" | "cross";
+  readonly label: string;
+  readonly rows: number;
+  readonly bytes_per_doc: number;
+  readonly snapshot_bytes: number;
+  readonly tail_entries: number;
+  readonly iterations: number;
+  readonly cpu_ms_median: number;
+  readonly peak_bytes_median: number;
+  readonly peak_over_snapshot: number;
+  /**
+   * Peak samples discarded as GC-floored (see {@link isPeakSampleUsable}). A
+   * non-zero value means this cell's `peak_bytes_median` is a median over fewer
+   * than `iterations` samples and is correspondingly noisier.
+   */
+  readonly peak_samples_discarded: number;
+}
+
+/**
+ * A fold must hold at least one copy of the snapshot resident, so a sampled
+ * peak-heap delta BELOW the snapshot size is not a measurement — it is the
+ * GC artifact `bench/fold-cost.ts` documents: `peakBytes` is
+ * `max(sample) - heapUsedAtStart`, so a `heapStart` captured at a pre-GC
+ * high-water mark floors the whole fold to ~0.
+ *
+ * Observed on this grid: bytes/16MB reported a 0.03 MB peak against a 16.24 MB
+ * snapshot while its 8 MB and 32 MB neighbours both sat at ~2.1-2.4x. At 11
+ * iterations the median absorbs an occasional floored sample; at the large
+ * cells' lower iteration count it does not, and a floored median silently
+ * passes the memory test and inflates the reported ceiling.
+ *
+ * Discarding is deliberately conservative — only physically impossible samples
+ * go — and the count is recorded per cell rather than hidden. The measurement
+ * definition in `bench/lib/fold-fixture.ts` is untouched, so cells remain
+ * directly comparable to the frozen `fold-cost-baseline.json`.
+ */
+export const isPeakSampleUsable = (peakBytes: number, snapshotBytes: number): boolean =>
+  peakBytes >= snapshotBytes;
+
+export interface SustainableCeiling {
+  readonly profile: HostBudget["profile"];
+  readonly margin: number;
+  /** Largest measured snapshot_bytes whose cell fits cpu AND memory at margin. */
+  readonly max_c_bytes: number | null;
+  /** Largest measured row count whose cell fits cpu AND memory at margin. */
+  readonly max_e_rows: number | null;
+  readonly binding_axis: "cpu" | "memory" | "grid-exhausted" | "none";
+  /** max_c_bytes / MAINTENANCE_MAX_FOLD_BYTES_DEFAULT, or null. */
+  readonly c_multiple_of_today: number | null;
+  /** max_e_rows / MAINTENANCE_MAX_FOLD_ROWS, or null. */
+  readonly e_multiple_of_today: number | null;
+}
+
+const fits = (cell: ProbeCell, budget: HostBudget, margin: number): boolean =>
+  cell.cpu_ms_median * margin <= budget.cpu_ms &&
+  cell.peak_bytes_median * margin <= budget.memory_bytes;
+
+/**
+ * Which resource stopped us. Evaluated on the SMALLEST cell that did not fit —
+ * the first wall encountered walking up the grid, not the worst violation
+ * anywhere in it.
+ */
+const bindingFor = (cell: ProbeCell, budget: HostBudget, margin: number): "cpu" | "memory" =>
+  cell.cpu_ms_median * margin > budget.cpu_ms ? "cpu" : "memory";
+
+/**
+ * Pure. Given measured cells and one budget, the largest cell on each axis whose
+ * `cpu_ms_median * margin <= budget.cpu_ms` AND
+ * `peak_bytes_median * margin <= budget.memory_bytes`.
+ *
+ * `binding_axis` is `"grid-exhausted"` when the LARGEST measured cell still fits
+ * — the true ceiling is above the grid and the answer is a lower bound.
+ */
+export const largestSustainable = (input: {
+  readonly cells: readonly ProbeCell[];
+  readonly budget: HostBudget;
+  readonly margin: number;
+}): SustainableCeiling => {
+  const { budget, margin } = input;
+
+  // `C` is read from the bytes axis (rows deliberately unloaded); `E` from the
+  // rows and cross axes (bytes deliberately small, or both loaded). Reading `E`
+  // off a bytes-axis cell would credit a huge row count that was never
+  // per-entry-stressed.
+  const byBytes = input.cells.filter((c) => c.axis === "bytes");
+  const byRows = input.cells.filter((c) => c.axis === "rows" || c.axis === "cross");
+
+  const fittingBytes = byBytes.filter((c) => fits(c, budget, margin));
+  const fittingRows = byRows.filter((c) => fits(c, budget, margin));
+
+  const maxC =
+    fittingBytes.length === 0 ? null : Math.max(...fittingBytes.map((c) => c.snapshot_bytes));
+  const maxE = fittingRows.length === 0 ? null : Math.max(...fittingRows.map((c) => c.rows));
+
+  const all = [...input.cells].toSorted((a, b) => a.snapshot_bytes - b.snapshot_bytes);
+  const firstMiss = all.find((c) => !fits(c, budget, margin));
+
+  let binding: SustainableCeiling["binding_axis"];
+  if (firstMiss === undefined) {
+    binding = "grid-exhausted";
+  } else if (maxC === null && maxE === null) {
+    binding = "none";
+  } else {
+    binding = bindingFor(firstMiss, budget, margin);
+  }
+
+  return {
+    profile: budget.profile,
+    margin,
+    max_c_bytes: maxC,
+    max_e_rows: maxE,
+    binding_axis: binding,
+    c_multiple_of_today: maxC === null ? null : maxC / MAINTENANCE_MAX_FOLD_BYTES_DEFAULT,
+    e_multiple_of_today: maxE === null ? null : maxE / MAINTENANCE_MAX_FOLD_ROWS,
+  };
+};
+
+/** Measured cost at today's shipped ceilings, per budget. */
+export interface TodayHeadroom {
+  readonly profile: HostBudget["profile"];
+  readonly at_c_cpu_ms: number;
+  readonly at_c_peak_bytes: number;
+  readonly at_e_cpu_ms: number;
+  readonly at_e_peak_bytes: number;
+  readonly cpu_margin_at_c: number;
+  readonly cpu_margin_at_e: number;
+  readonly memory_margin_at_c: number;
+  readonly memory_margin_at_e: number;
+}
+
+/** The largest cell on `axis` at or below `limit`, or the smallest if none is. */
+const nearestAtOrBelow = (
+  cells: readonly ProbeCell[],
+  axis: ProbeCell["axis"],
+  key: (c: ProbeCell) => number,
+  limit: number,
+): ProbeCell | undefined => {
+  const on = cells.filter((c) => c.axis === axis).toSorted((a, b) => key(a) - key(b));
+  const under = on.filter((c) => key(c) <= limit);
+  return under.length > 0 ? under[under.length - 1] : on[0];
+};
+
+export const todayHeadroom = (input: {
+  readonly cells: readonly ProbeCell[];
+  readonly budget: HostBudget;
+}): TodayHeadroom => {
+  const atC = nearestAtOrBelow(
+    input.cells,
+    "bytes",
+    (c) => c.snapshot_bytes,
+    MAINTENANCE_MAX_FOLD_BYTES_DEFAULT,
+  );
+  const atE = nearestAtOrBelow(input.cells, "rows", (c) => c.rows, MAINTENANCE_MAX_FOLD_ROWS);
+  if (atC === undefined || atE === undefined) {
+    throw new Error("fold-ceiling-probe: cells must cover both the bytes and rows axes");
+  }
+  return {
+    profile: input.budget.profile,
+    at_c_cpu_ms: atC.cpu_ms_median,
+    at_c_peak_bytes: atC.peak_bytes_median,
+    at_e_cpu_ms: atE.cpu_ms_median,
+    at_e_peak_bytes: atE.peak_bytes_median,
+    cpu_margin_at_c: input.budget.cpu_ms / atC.cpu_ms_median,
+    cpu_margin_at_e: input.budget.cpu_ms / atE.cpu_ms_median,
+    memory_margin_at_c: input.budget.memory_bytes / atC.peak_bytes_median,
+    memory_margin_at_e: input.budget.memory_bytes / atE.peak_bytes_median,
+  };
+};
+
+export interface ProbeRecommendation {
+  readonly schema: typeof FOLD_CEILING_PROBE_VERSION;
+  readonly subject_commit: string;
+  readonly node_version: string;
+  readonly platform: string;
+  readonly arch: string;
+  readonly todays_ceilings: { readonly c_bytes: number; readonly e_rows: number };
+  readonly budgets: readonly HostBudget[];
+  readonly margins: readonly number[];
+  readonly cells: readonly ProbeCell[];
+  readonly today_headroom: readonly TodayHeadroom[];
+  readonly sustainable: readonly SustainableCeiling[];
+  /** Free-text findings the probe is confident enough to assert. */
+  readonly findings: readonly string[];
+  /** Changes this probe RECOMMENDS but does not make. Owner named per entry. */
+  readonly recommended_changes: readonly {
+    readonly file: string;
+    readonly change: string;
+    readonly owner: string;
+    readonly blocked_by: string | null;
+  }[];
+}
+
+const mb = (b: number): string => (b / (1024 * 1024)).toFixed(2);
+
+const msPerMb = (c: ProbeCell): number => c.cpu_ms_median / (c.snapshot_bytes / (1024 * 1024));
+
+/** Nearest cell on `axis` to `bytes`, by absolute snapshot-size distance. */
+const nearestBySize = (
+  cells: readonly ProbeCell[],
+  axis: ProbeCell["axis"],
+  bytes: number,
+): ProbeCell | undefined =>
+  cells
+    .filter((c) => c.axis === axis)
+    .toSorted((a, b) => Math.abs(a.snapshot_bytes - bytes) - Math.abs(b.snapshot_bytes - bytes))[0];
+
+/**
+ * Findings DERIVED from the cells in the same record, never hand-transcribed.
+ *
+ * The plan asks for findings that are "independently checkable against the
+ * `cells` array in the same record". Hard-coding numbers read off one run makes
+ * that false the moment the probe is re-run — the record would carry prose from
+ * one measurement and cells from another. Deriving them makes the two
+ * inseparable by construction.
+ */
+export const deriveFindings = (cells: readonly ProbeCell[]): readonly string[] => {
+  const findings: string[] = [];
+
+  // 1. Measured margin at today's shipped ceilings, per profile.
+  for (const budget of HOST_BUDGETS) {
+    const head = todayHeadroom({ cells, budget });
+    findings.push(
+      `${budget.profile}: at today's C the fold costs ${head.at_c_cpu_ms.toFixed(2)} ms and ` +
+        `${(head.at_c_peak_bytes / (1024 * 1024)).toFixed(2)} MB peak — ` +
+        `${head.cpu_margin_at_c.toFixed(1)}x CPU margin, ${head.memory_margin_at_c.toFixed(1)}x memory margin. ` +
+        `At today's E it costs ${head.at_e_cpu_ms.toFixed(2)} ms and ` +
+        `${(head.at_e_peak_bytes / (1024 * 1024)).toFixed(2)} MB peak — ` +
+        `${head.cpu_margin_at_e.toFixed(1)}x CPU, ${head.memory_margin_at_e.toFixed(1)}x memory.`,
+    );
+  }
+
+  // 2. Where the bytes-axis cost-per-MB knee starts.
+  const byBytes = cells
+    .filter((c) => c.axis === "bytes")
+    .toSorted((a, b) => a.snapshot_bytes - b.snapshot_bytes);
+  const knee = byBytes.find(
+    (c, i) => i > 0 && msPerMb(c) > 1.25 * Math.min(...byBytes.slice(0, i).map(msPerMb)),
+  );
+  if (knee === undefined) {
+    findings.push(
+      "bytes axis: no cost-per-MB knee in the measured range — CPU stays within 1.25x of its " +
+        "cheapest per-MB rate across the whole grid.",
+    );
+  } else {
+    const before = byBytes[byBytes.indexOf(knee) - 1];
+    findings.push(
+      `bytes axis: the cost-per-MB knee is REAL and starts between ` +
+        `${mb(before?.snapshot_bytes ?? 0)} MB (${msPerMb(before ?? knee).toFixed(2)} ms/MB) and ` +
+        `${mb(knee.snapshot_bytes)} MB (${msPerMb(knee).toFixed(2)} ms/MB). ` +
+        `Series, ms/MB: ${byBytes.map((c) => `${c.label}=${msPerMb(c).toFixed(1)}`).join(", ")}.`,
+    );
+  }
+
+  // 3. The paid ceiling, marked as a lower bound when the grid ran out first.
+  for (const margin of REPORTED_MARGINS) {
+    const paid = largestSustainable({
+      cells,
+      budget: HOST_BUDGETS.find((b) => b.profile === "cf-paid") ?? HOST_BUDGETS[0]!,
+      margin,
+    });
+    const bound = paid.binding_axis === "grid-exhausted" ? "LOWER BOUND (grid exhausted)" : "wall";
+    findings.push(
+      `cf-paid @${margin}x margin: C ${paid.max_c_bytes === null ? "-" : `${mb(paid.max_c_bytes)} MB`} ` +
+        `(${paid.c_multiple_of_today === null ? "-" : `${paid.c_multiple_of_today.toFixed(1)}x`} today), ` +
+        `E ${paid.max_e_rows ?? "-"} rows ` +
+        `(${paid.e_multiple_of_today === null ? "-" : `${paid.e_multiple_of_today.toFixed(1)}x`} today), ` +
+        `bound by ${paid.binding_axis} — ${bound}.`,
+    );
+  }
+
+  // 4. THE decisive one: does a two-way (C, E) ceiling describe the cost surface?
+  for (const cross of cells.filter((c) => c.axis === "cross")) {
+    const peer = nearestBySize(cells, "bytes", cross.snapshot_bytes);
+    if (peer === undefined) {
+      continue;
+    }
+    findings.push(
+      `cross ${cross.label} (${cross.rows} rows x ${cross.bytes_per_doc} B, ${mb(cross.snapshot_bytes)} MB) ` +
+        `vs the nearest bytes-axis cell ${peer.label} (${peer.rows} rows x ${peer.bytes_per_doc} B, ` +
+        `${mb(peer.snapshot_bytes)} MB): CPU ${cross.cpu_ms_median.toFixed(1)} ms vs ` +
+        `${peer.cpu_ms_median.toFixed(1)} ms (${(cross.cpu_ms_median / peer.cpu_ms_median).toFixed(2)}x), ` +
+        `peak ${mb(cross.peak_bytes_median)} MB vs ${mb(peer.peak_bytes_median)} MB ` +
+        `(${(cross.peak_bytes_median / peer.peak_bytes_median).toFixed(2)}x). ` +
+        `peak/snapshot ${cross.peak_over_snapshot.toFixed(2)} vs ${peer.peak_over_snapshot.toFixed(2)}.`,
+    );
+  }
+
+  // 5. Sample hygiene — how much of the grid needed GC-floored samples dropped.
+  const dropped = cells.filter((c) => c.peak_samples_discarded > 0);
+  findings.push(
+    `peak-sample hygiene: ${dropped.length} of ${cells.length} cells lost at least one ` +
+      `GC-floored peak sample (see isPeakSampleUsable); worst cell dropped ` +
+      `${Math.max(0, ...cells.map((c) => c.peak_samples_discarded))} of its samples. ` +
+      `CPU is unaffected — cpuUsage() deltas have no baseline to float.`,
+  );
+
+  return findings;
+};
+
+export const buildRecommendation = (input: {
+  readonly cells: readonly ProbeCell[];
+  readonly subject_commit: string;
+  /** Findings the RUNNER derives from inputs this pure module cannot read. */
+  readonly extraFindings?: readonly string[];
+}): ProbeRecommendation => {
+  const sustainable: SustainableCeiling[] = [];
+  for (const budget of HOST_BUDGETS) {
+    for (const margin of REPORTED_MARGINS) {
+      sustainable.push(largestSustainable({ cells: input.cells, budget, margin }));
+    }
+  }
+  return {
+    schema: FOLD_CEILING_PROBE_VERSION,
+    subject_commit: input.subject_commit,
+    node_version: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    todays_ceilings: {
+      c_bytes: MAINTENANCE_MAX_FOLD_BYTES_DEFAULT,
+      e_rows: MAINTENANCE_MAX_FOLD_ROWS,
+    },
+    budgets: HOST_BUDGETS,
+    margins: REPORTED_MARGINS,
+    cells: input.cells,
+    today_headroom: HOST_BUDGETS.map((budget) => todayHeadroom({ cells: input.cells, budget })),
+    sustainable,
+    findings: [...deriveFindings(input.cells), ...(input.extraFindings ?? [])],
+    // Every actionable output is a REQUEST with a named owner. This probe
+    // changes nothing; `constants.ts` is held by a locked live session and
+    // `maintenance.ts` belongs to the Protocol owner.
+    recommended_changes: [
+      {
+        file: "packages/protocol/src/constants.ts",
+        change:
+          "Give MAINTENANCE_PROFILE_CF_PAID and MAINTENANCE_PROFILE_NODE their own " +
+          "maxFoldBytes/maxFoldRows instead of sharing the CF-free values. See the " +
+          "`sustainable` table for the measured room at each margin.",
+        owner: "Protocol owner",
+        blocked_by:
+          "worktree-fix-issue-74-readpreimage-floor holds packages/protocol/src/constants.ts (locked live session)",
+      },
+      {
+        file: "packages/server/src/maintenance.ts",
+        change:
+          "`E` has no operator override: the profile read takes `args.maxFoldBytes ?? " +
+          "profile.maxFoldBytes` for C but plain `profile.maxFoldRows` for E. Add " +
+          "BAERLY_MAINTENANCE_MAX_FOLD_ROWS to mirror the C override. " +
+          "(Manifest §11 item 6.)",
+        owner: "Protocol owner",
+        blocked_by: null,
+      },
+      {
+        file: "docs/about/graduation.md",
+        change:
+          "The `≈ 11 ms CPU per MB` model and the `1 MB | ~11 ms` table row overstate " +
+          "measured cost. Restate against measurement, or mark the model as a " +
+          "deliberate upper bound and say so.",
+        owner: "Performance owner (graduation.md is a §6.2-owned product doc)",
+        blocked_by: null,
+      },
+    ],
+  };
+};
+
+export const renderTable = (rec: ProbeRecommendation): string => {
+  const lines: string[] = [];
+  lines.push("cells");
+  lines.push(
+    "axis   label        rows     snapMB   cpuMs(med)  peakMB(med)  peak/snap  iters  gcDrop",
+  );
+  for (const c of rec.cells) {
+    lines.push(
+      `${c.axis.padEnd(6)} ${c.label.padEnd(12)} ${String(c.rows).padStart(7)}  ` +
+        `${mb(c.snapshot_bytes).padStart(7)}  ${c.cpu_ms_median.toFixed(3).padStart(10)}  ` +
+        `${mb(c.peak_bytes_median).padStart(11)}  ${c.peak_over_snapshot.toFixed(2).padStart(9)}  ` +
+        `${String(c.iterations).padStart(5)}  ${String(c.peak_samples_discarded).padStart(6)}`,
+    );
+  }
+  lines.push("");
+  lines.push(
+    `today: C = ${mb(rec.todays_ceilings.c_bytes)} MB, E = ${rec.todays_ceilings.e_rows} rows`,
+  );
+  lines.push("profile   cpuMargin@C  cpuMargin@E  memMargin@C  memMargin@E");
+  for (const h of rec.today_headroom) {
+    lines.push(
+      `${h.profile.padEnd(9)} ${h.cpu_margin_at_c.toFixed(1).padStart(11)}  ` +
+        `${h.cpu_margin_at_e.toFixed(1).padStart(11)}  ` +
+        `${h.memory_margin_at_c.toFixed(1).padStart(11)}  ` +
+        `${h.memory_margin_at_e.toFixed(1).padStart(11)}`,
+    );
+  }
+  lines.push("");
+  lines.push("sustainable ceilings");
+  lines.push("profile   margin  maxC(MB)  xToday  maxE(rows)  xToday  binding");
+  for (const s of rec.sustainable) {
+    const maxC = s.max_c_bytes === null ? "-" : mb(s.max_c_bytes);
+    const xC = s.c_multiple_of_today === null ? "-" : `${s.c_multiple_of_today.toFixed(1)}x`;
+    const maxE = s.max_e_rows === null ? "-" : String(s.max_e_rows);
+    const xE = s.e_multiple_of_today === null ? "-" : `${s.e_multiple_of_today.toFixed(1)}x`;
+    lines.push(
+      `${s.profile.padEnd(9)} ${String(s.margin).padStart(6)}  ` +
+        `${maxC.padStart(8)}  ${xC.padStart(6)}  ` +
+        `${maxE.padStart(10)}  ${xE.padStart(6)}  ` +
+        s.binding_axis,
+    );
+  }
+  return lines.join("\n");
+};
+
+const runCell = async (
+  axis: ProbeCell["axis"],
+  label: string,
+  rows: number,
+  bytesPerDoc: number,
+): Promise<ProbeCell> => {
+  const probeBytes = rows * bytesPerDoc;
+  const warmup = probeBytes >= LARGE_CELL_BYTES ? LARGE_WARMUP_ITERS : WARMUP_ITERS;
+  const measure = probeBytes >= LARGE_CELL_BYTES ? LARGE_MEASURE_ITERS : MEASURE_ITERS;
+
+  for (let i = 0; i < warmup; i++) {
+    const fixture = await buildFixture(rows, bytesPerDoc);
+    await measureOneFold(fixture.storage);
+  }
+
+  const cpu: number[] = [];
+  const peak: number[] = [];
+  let snapshotBytes = 0;
+  for (let i = 0; i < measure; i++) {
+    const fixture = await buildFixture(rows, bytesPerDoc);
+    snapshotBytes = fixture.snapshotBytes;
+    const one = await measureOneFold(fixture.storage);
+    cpu.push(one.cpuMs);
+    peak.push(one.peakBytes);
+  }
+
+  // Drop GC-floored peaks before taking the median; a floored sample is not a
+  // small measurement, it is an absent one. CPU is unaffected — `cpuUsage()`
+  // deltas have no baseline to float.
+  const usablePeak = peak.filter((p) => isPeakSampleUsable(p, snapshotBytes));
+  const peakMedian = usablePeak.length > 0 ? median(usablePeak) : median(peak);
+  return {
+    axis,
+    label,
+    rows,
+    bytes_per_doc: bytesPerDoc,
+    snapshot_bytes: snapshotBytes,
+    tail_entries: TAIL_ENTRIES,
+    iterations: measure,
+    cpu_ms_median: median(cpu),
+    peak_bytes_median: peakMedian,
+    peak_over_snapshot: peakMedian / snapshotBytes,
+    peak_samples_discarded: peak.length - usablePeak.length,
+  };
+};
+
+/** Sweep the whole grid. Minutes — the 32 MB cell alone is 7 folds of 32 MB. */
+export const runProbeGrid = async (
+  onCell?: (cell: ProbeCell) => void,
+): Promise<readonly ProbeCell[]> => {
+  const cells: ProbeCell[] = [];
+  const push = (cell: ProbeCell): void => {
+    cells.push(cell);
+    onCell?.(cell);
+  };
+
+  for (const target of BYTES_AXIS_TARGETS) {
+    const rows = Math.max(1, Math.round(target.bytes / BYTES_PER_DOC));
+    push(await runCell("bytes", target.label, rows, BYTES_PER_DOC));
+  }
+  for (const rows of ROWS_AXIS_ROW_COUNTS) {
+    push(await runCell("rows", `${rows} rows`, rows, ROWS_AXIS_BYTES_PER_DOC));
+  }
+  for (const cross of CROSS_AXIS_CELLS) {
+    push(await runCell("cross", cross.label, cross.rows, cross.bytesPerDoc));
+  }
+  return cells;
+};
+
+/** One line of shipped-constant context, printed under the table by the runner. */
+export const referenceLine = (): string =>
+  `reference: C default ${mb(MAINTENANCE_MAX_FOLD_BYTES_DEFAULT)} MB, ` +
+  `CF-free warn threshold ${mb(CF_FREE_MAX_SAFE_FOLD_BYTES)} MB, ` +
+  `E ${MAINTENANCE_MAX_FOLD_ROWS} rows, fold slice ` +
+  `${WRITE_TICK_FOLD_ENTRIES_PER_PASS} (cf-free) / ` +
+  `${NODE_MAINTENANCE_FOLD_ENTRIES_PER_PASS} (node)`;

--- a/bench/measurement/storage-factory.test.ts
+++ b/bench/measurement/storage-factory.test.ts
@@ -1,0 +1,408 @@
+import { mkdir, mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import {
+  BaerlyError,
+  type Storage,
+  type StorageListEntry,
+  type StoragePutResult,
+} from "@baerly/protocol";
+import { afterAll, describe, expect, test } from "vitest";
+import { asAttemptId, wrapJournaledStorage } from "./storage-journal.ts";
+import {
+  type StorageFactory,
+  type StorageLease,
+  createExactKeyCleanup,
+  createLocalFsStorageFactory,
+  createMemoryStorageFactory,
+  isWithinCleanupAuthority,
+  withStorageLease,
+} from "./storage-factory.ts";
+
+const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
+const roots: string[] = [];
+
+afterAll(async () => {
+  for (const root of roots) {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+const makeParent = async (): Promise<string> => {
+  const parent = await mkdtemp(join(tmpdir(), "baerly-lane-a-parent-"));
+  roots.push(parent);
+  return parent;
+};
+
+/** Minimal key-addressable storage whose DELETE can be scripted to fail. */
+class DeletableStorage implements Storage {
+  readonly objects = new Map<string, Uint8Array>();
+  readonly calls: string[] = [];
+  readonly failDeletes = new Set<string>();
+
+  async get(key: string): Promise<{ body: Uint8Array; etag: string } | null> {
+    this.calls.push(`get:${key}`);
+    const body = this.objects.get(key);
+    return body === undefined ? null : { body, etag: '"e"' };
+  }
+
+  async put(key: string, body: Uint8Array): Promise<StoragePutResult> {
+    this.calls.push(`put:${key}`);
+    this.objects.set(key, body);
+    return { etag: '"e"' };
+  }
+
+  async delete(key: string): Promise<void> {
+    this.calls.push(`delete:${key}`);
+    if (this.failDeletes.has(key)) {
+      throw new BaerlyError("NetworkError", `delete ${key} failed`);
+    }
+    this.objects.delete(key);
+  }
+
+  async *list(prefix: string): AsyncIterable<StorageListEntry> {
+    this.calls.push(`list:${prefix}`);
+    for (const key of [...this.objects.keys()].toSorted()) {
+      if (key.startsWith(prefix)) {
+        yield { key, etag: '"e"' };
+      }
+    }
+  }
+}
+
+// ── REVISION 2: the authority guard, tested directly ─────────────────────────
+describe("isWithinCleanupAuthority", () => {
+  test("accepts a direct child carrying the prefix", () => {
+    expect(
+      isWithinCleanupAuthority({
+        root: "/tmp/parent/baerly-measurement-abc123",
+        parent: "/tmp/parent",
+        prefix: "baerly-measurement-",
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects a grandchild, so a nested path can never be swept", () => {
+    expect(
+      isWithinCleanupAuthority({
+        root: "/tmp/parent/nested/baerly-measurement-abc",
+        parent: "/tmp/parent",
+        prefix: "baerly-measurement-",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects the parent itself", () => {
+    expect(
+      isWithinCleanupAuthority({
+        root: "/tmp/parent",
+        parent: "/tmp/parent",
+        prefix: "baerly-measurement-",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects a sibling that does not carry the prefix", () => {
+    expect(
+      isWithinCleanupAuthority({
+        root: "/tmp/parent/someone-elses-dir",
+        parent: "/tmp/parent",
+        prefix: "baerly-measurement-",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects a path outside the parent entirely", () => {
+    expect(
+      isWithinCleanupAuthority({
+        root: "/etc/baerly-measurement-abc",
+        parent: "/tmp/parent",
+        prefix: "baerly-measurement-",
+      }),
+    ).toBe(false);
+  });
+});
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("memory factory", () => {
+  test("issues a fresh instance and a unique namespace per create", async () => {
+    const factory = createMemoryStorageFactory();
+    const first = await factory.create({ attemptId: asAttemptId("a-1") });
+    const second = await factory.create({ attemptId: asAttemptId("a-2") });
+    expect(first.status).toBe("created");
+    expect(second.status).toBe("created");
+    if (first.status !== "created" || second.status !== "created") {
+      throw new Error("expected both creates to succeed");
+    }
+    expect(first.lease.namespace_id).not.toBe(second.lease.namespace_id);
+    expect(first.lease.storage).not.toBe(second.lease.storage);
+    expect(first.lease.backend).toBe("memory");
+    await first.lease.storage.put("shared", enc("one"));
+    await expect(second.lease.storage.get("shared")).resolves.toBeNull();
+  });
+
+  test("cleanup is clean, idempotent, and flips lifecycle once", async () => {
+    const factory = createMemoryStorageFactory();
+    const created = await factory.create({ attemptId: asAttemptId("a-3") });
+    if (created.status !== "created") {
+      throw new Error("expected create to succeed");
+    }
+    const lease: StorageLease = created.lease;
+    expect(lease.lifecycle()).toBe("active");
+    expect(lease.cleanup_authority.kind).toBe("memory-instance");
+    const report = await lease.cleanup();
+    expect(report.status).toBe("clean");
+    expect(report.failures).toEqual([]);
+    expect(lease.lifecycle()).toBe("cleaned");
+    await expect(lease.cleanup()).resolves.toBe(report);
+  });
+});
+
+describe("local-fs factory", () => {
+  test("issues distinct mkdtemp roots", async () => {
+    const parent = await makeParent();
+    const factory = createLocalFsStorageFactory({ temp_parent: parent });
+    const first = await factory.create({ attemptId: asAttemptId("b-1") });
+    const second = await factory.create({ attemptId: asAttemptId("b-2") });
+    if (first.status !== "created" || second.status !== "created") {
+      throw new Error("expected both creates to succeed");
+    }
+    expect(first.lease.namespace_id).not.toBe(second.lease.namespace_id);
+    expect(dirname(first.lease.namespace_id)).toBe(parent);
+    expect(basename(first.lease.namespace_id).startsWith("baerly-measurement-")).toBe(true);
+    await first.lease.cleanup();
+    await second.lease.cleanup();
+  });
+
+  test("cleanup removes its exact root and spares a sibling", async () => {
+    const parent = await makeParent();
+    const sentinel = join(parent, "sentinel");
+    await mkdir(sentinel);
+    const factory = createLocalFsStorageFactory({ temp_parent: parent });
+    const created = await factory.create({ attemptId: asAttemptId("b-3") });
+    if (created.status !== "created") {
+      throw new Error("expected create to succeed");
+    }
+    await created.lease.storage.put("nested/doc", enc("payload"));
+    const report = await created.lease.cleanup();
+    expect(report.status).toBe("clean");
+    expect(report.authority).toEqual({
+      kind: "exact-directory",
+      absolute_path: created.lease.namespace_id,
+    });
+    await expect(stat(created.lease.namespace_id)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(sentinel)).resolves.toBeDefined();
+    await expect(stat(parent)).resolves.toBeDefined();
+  });
+
+  test("a provisioning error becomes a structured failure, not a rejection", async () => {
+    const parent = await makeParent();
+    const factory = createLocalFsStorageFactory({
+      temp_parent: join(parent, "does", "not", "exist"),
+    });
+    const created = await factory.create({ attemptId: asAttemptId("b-4") });
+    expect(created.status).toBe("failed");
+    if (created.status !== "failed") {
+      throw new Error("expected create to fail");
+    }
+    expect(created.failure).toMatchObject({
+      stage: "provision",
+      factory_id: factory.id,
+      backend: "local-fs",
+      code: "ENOENT",
+    });
+    expect(typeof created.failure.message).toBe("string");
+    expect(typeof created.failure.name).toBe("string");
+  });
+
+  test("mkdtemp on macOS appends a mixed-case suffix, which the guard tolerates", async () => {
+    // `mkdtemp` appends a base-58 mixed-case suffix on macOS. The guard checks
+    // `basename().startsWith(prefix)`, never a lowercase comparison, so a
+    // mixed-case suffix must not make cleanup refuse.
+    const parent = await makeParent();
+    const factory = createLocalFsStorageFactory({ temp_parent: parent });
+    const created = await factory.create({ attemptId: asAttemptId("b-5") });
+    if (created.status !== "created") {
+      throw new Error("expected create to succeed");
+    }
+    const report = await created.lease.cleanup();
+    expect(report.status).toBe("clean");
+    expect(report.cleaned_targets).toEqual([created.lease.namespace_id]);
+  });
+});
+
+describe("exact-key cleanup", () => {
+  test("deletes only the named keys and never lists", async () => {
+    const inner = new DeletableStorage();
+    await inner.put("a/1", enc("1"));
+    await inner.put("a/2", enc("2"));
+    await inner.put("a/3", enc("3"));
+    inner.calls.length = 0;
+    const cleanup = createExactKeyCleanup({ storage: inner, keys: ["a/2", "a/1", "a/1"] });
+    expect(cleanup.authority).toEqual({ kind: "exact-keys", keys: ["a/1", "a/2"] });
+    const report = await cleanup.cleanup();
+    expect(report.status).toBe("clean");
+    expect(report.cleaned_targets).toEqual(["a/1", "a/2"]);
+    expect(inner.calls).toEqual(["delete:a/1", "delete:a/2"]);
+    expect([...inner.objects.keys()]).toEqual(["a/3"]);
+  });
+
+  test("one failing delete yields partial and still attempts later keys", async () => {
+    const inner = new DeletableStorage();
+    await inner.put("a/1", enc("1"));
+    await inner.put("a/2", enc("2"));
+    await inner.put("a/3", enc("3"));
+    inner.failDeletes.add("a/2");
+    inner.calls.length = 0;
+    const cleanup = createExactKeyCleanup({ storage: inner, keys: ["a/1", "a/2", "a/3"] });
+    const report = await cleanup.cleanup();
+    expect(report.status).toBe("partial");
+    expect(report.attempted_targets).toEqual(["a/1", "a/2", "a/3"]);
+    expect(report.cleaned_targets).toEqual(["a/1", "a/3"]);
+    expect(report.failures).toHaveLength(1);
+    expect(report.failures[0]).toMatchObject({ target: "a/2", code: "NetworkError" });
+    expect(inner.calls).toEqual(["delete:a/1", "delete:a/2", "delete:a/3"]);
+  });
+
+  test("a repeat cleanup issues zero additional storage calls", async () => {
+    const inner = new DeletableStorage();
+    await inner.put("a/1", enc("1"));
+    inner.calls.length = 0;
+    const cleanup = createExactKeyCleanup({ storage: inner, keys: ["a/1"] });
+    const first = await cleanup.cleanup();
+    const callsAfterFirst = inner.calls.length;
+    const second = await cleanup.cleanup();
+    expect(second).toBe(first);
+    expect(inner.calls).toHaveLength(callsAfterFirst);
+  });
+});
+
+describe("withStorageLease", () => {
+  /** Factory whose cleanup always fails, so cleanup outcome can be exercised. */
+  const failingCleanupFactory = (inner: DeletableStorage): StorageFactory => ({
+    id: "test.failing-cleanup/v1",
+    backend: "test-failing",
+    create: async ({ attemptId }) => {
+      const journaled = wrapJournaledStorage({ attemptId, storage: inner });
+      const cleanup = createExactKeyCleanup({ storage: inner, keys: ["boom"] });
+      let lifecycle: "active" | "cleaned" = "active";
+      let report: Awaited<ReturnType<typeof cleanup.cleanup>> | undefined;
+      return {
+        status: "created",
+        lease: {
+          attempt_id: attemptId,
+          factory_id: "test.failing-cleanup/v1",
+          backend: "test-failing",
+          namespace_id: "test-failing-0",
+          storage: journaled.storage,
+          journal: journaled.journal,
+          cleanup_authority: cleanup.authority,
+          lifecycle: () => lifecycle,
+          cleanup: async () => {
+            lifecycle = "cleaned";
+            report ??= await cleanup.cleanup();
+            return report;
+          },
+        },
+      };
+    },
+  });
+
+  test("returns the work value plus the cleanup report", async () => {
+    const factory = createMemoryStorageFactory();
+    const outcome = await withStorageLease(factory, asAttemptId("c-1"), async (lease) => {
+      await lease.storage.put("x", enc("y"));
+      return lease.journal.snapshotOperations().length;
+    });
+    expect(outcome.status).toBe("returned");
+    if (outcome.status !== "returned") {
+      throw new Error("expected returned");
+    }
+    expect(outcome.value).toBe(1);
+    expect(outcome.cleanup.status).toBe("clean");
+    expect(outcome.pending_operations_at_cleanup).toBe(0);
+  });
+
+  test("surfaces a provisioning failure without running the work", async () => {
+    const parent = await makeParent();
+    const factory = createLocalFsStorageFactory({ temp_parent: join(parent, "absent") });
+    let ran = false;
+    const outcome = await withStorageLease(factory, asAttemptId("c-2"), async () => {
+      ran = true;
+      return 1;
+    });
+    expect(ran).toBe(false);
+    expect(outcome.status).toBe("provision_failed");
+  });
+
+  test("preserves the thrown object by identity when cleanup also fails", async () => {
+    const inner = new DeletableStorage();
+    await inner.put("boom", enc("v"));
+    inner.failDeletes.add("boom");
+    const thrown = new BaerlyError("Internal", "work exploded");
+    const outcome = await withStorageLease(
+      failingCleanupFactory(inner),
+      asAttemptId("c-3"),
+      async () => {
+        throw thrown;
+      },
+    );
+    expect(outcome.status).toBe("threw");
+    if (outcome.status !== "threw") {
+      throw new Error("expected threw");
+    }
+    expect(outcome.error).toBe(thrown);
+    expect(outcome.cleanup.status).toBe("failed");
+    expect(outcome.cleanup.failures).toHaveLength(1);
+  });
+
+  test("marks the lease cleaned even when cleanup fails", async () => {
+    const inner = new DeletableStorage();
+    await inner.put("boom", enc("v"));
+    inner.failDeletes.add("boom");
+    const created = await failingCleanupFactory(inner).create({ attemptId: asAttemptId("c-4") });
+    if (created.status !== "created") {
+      throw new Error("expected create to succeed");
+    }
+    expect(created.lease.lifecycle()).toBe("active");
+    const report = await created.lease.cleanup();
+    expect(report.status).toBe("failed");
+    expect(created.lease.lifecycle()).toBe("cleaned");
+  });
+
+  // ── REVISION 2: non-quiescence is reported, not hidden and not thrown ─────
+  test("reports in-flight operations at cleanup instead of silently tearing down", async () => {
+    const factory = createMemoryStorageFactory();
+    let leaked: Promise<unknown> | undefined;
+    const outcome = await withStorageLease(factory, asAttemptId("c-5"), async (lease) => {
+      // Deliberately abandon an operation: the work function returns without
+      // awaiting it, so the lease's storage is about to be torn out from under
+      // an in-flight call. That must be VISIBLE in the result.
+      leaked = lease.storage.put("abandoned", enc("v"));
+      return "done";
+    });
+    expect(outcome.status).toBe("returned");
+    if (outcome.status !== "returned") {
+      throw new Error("expected returned");
+    }
+    expect(outcome.pending_operations_at_cleanup).toBeGreaterThan(0);
+    await leaked;
+  });
+
+  test("does not let a non-quiescent journal mask the work's own error", async () => {
+    const factory = createMemoryStorageFactory();
+    const thrown = new BaerlyError("Internal", "work exploded");
+    let leaked: Promise<unknown> | undefined;
+    const outcome = await withStorageLease(factory, asAttemptId("c-6"), async (lease) => {
+      leaked = lease.storage.put("abandoned", enc("v"));
+      throw thrown;
+    });
+    expect(outcome.status).toBe("threw");
+    if (outcome.status !== "threw") {
+      throw new Error("expected threw");
+    }
+    expect(outcome.error).toBe(thrown);
+    await leaked;
+  });
+  // ──────────────────────────────────────────────────────────────────────────
+});

--- a/bench/measurement/storage-factory.ts
+++ b/bench/measurement/storage-factory.ts
@@ -1,0 +1,398 @@
+/**
+ * Per-attempt storage provisioning with **exact** cleanup authority.
+ *
+ * A factory hands back one fresh backend plus the narrowest possible authority
+ * to remove it: a single in-memory instance, the single `mkdtemp` directory it
+ * created, or an explicit list of known keys. Nothing here can delete a bucket,
+ * a parent directory, or a prefix — that restriction is the point of the
+ * module, not an implementation detail.
+ *
+ * Node-only: it reads `node:fs/promises`, `node:os`, and `node:path`. The
+ * journal module it composes with stays runtime-import-free.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { MemoryStorage, type Storage } from "@baerly/protocol";
+import { LocalFsStorage } from "@baerly/dev";
+import {
+  type AttemptId,
+  type StorageJournal,
+  describeThrown,
+  wrapJournaledStorage,
+} from "./storage-journal.ts";
+
+const DEFAULT_DIRECTORY_PREFIX = "baerly-measurement-";
+
+export type CleanupAuthority =
+  | { readonly kind: "memory-instance"; readonly lease_id: string }
+  | { readonly kind: "exact-directory"; readonly absolute_path: string }
+  | { readonly kind: "exact-keys"; readonly keys: readonly string[] };
+
+export interface CleanupFailure {
+  readonly target: string;
+  readonly name: string;
+  readonly code?: string;
+  readonly message: string;
+}
+
+export interface CleanupReport {
+  readonly status: "clean" | "partial" | "failed";
+  readonly authority: CleanupAuthority;
+  readonly attempted_targets: readonly string[];
+  readonly cleaned_targets: readonly string[];
+  readonly failures: readonly CleanupFailure[];
+}
+
+export interface StorageLease {
+  readonly attempt_id: AttemptId;
+  readonly factory_id: string;
+  readonly backend: string;
+  readonly namespace_id: string;
+  readonly storage: Storage;
+  readonly journal: StorageJournal;
+  readonly cleanup_authority: CleanupAuthority;
+  lifecycle(): "active" | "cleaned";
+  cleanup(): Promise<CleanupReport>;
+}
+
+export interface ProvisioningFailure {
+  readonly stage: "provision";
+  readonly factory_id: string;
+  readonly backend: string;
+  readonly name: string;
+  readonly code?: string;
+  readonly message: string;
+}
+
+export type StorageFactoryCreateResult =
+  | { readonly status: "created"; readonly lease: StorageLease }
+  | { readonly status: "failed"; readonly failure: ProvisioningFailure };
+
+export interface StorageFactory {
+  readonly id: string;
+  readonly backend: string;
+  create(input: { readonly attemptId: AttemptId }): Promise<StorageFactoryCreateResult>;
+}
+
+export interface ExactKeyCleanup {
+  readonly authority: CleanupAuthority;
+  cleanup(): Promise<CleanupReport>;
+}
+
+export type WithStorageLeaseResult<T> =
+  | { readonly status: "provision_failed"; readonly failure: ProvisioningFailure }
+  | {
+      readonly status: "returned";
+      readonly value: T;
+      readonly cleanup: CleanupReport;
+      readonly pending_operations_at_cleanup: number;
+    }
+  | {
+      readonly status: "threw";
+      readonly error: unknown;
+      readonly cleanup: CleanupReport;
+      readonly pending_operations_at_cleanup: number;
+    };
+
+/**
+ * True iff `root` is a direct child of `parent` whose basename carries
+ * `prefix`. Exported and separately tested because inside the local-fs cleanup
+ * closure the condition is unreachable by construction — `mkdtemp(join(parent,
+ * prefix))` guarantees it — so the refusal branch would otherwise ship with no
+ * coverage at all.
+ *
+ * `parent` is expected already `resolve`d and must NOT be `realpath`ed:
+ * `os.tmpdir()` is a symlink on macOS, and resolving one side of the comparison
+ * but not the other rejects every real root. `startsWith` is a case-SENSITIVE
+ * comparison on purpose — `mkdtemp` appends a mixed-case suffix on macOS, and
+ * lowercasing either side would be the bug, not the fix.
+ */
+export const isWithinCleanupAuthority = (input: {
+  readonly root: string;
+  readonly parent: string;
+  readonly prefix: string;
+}): boolean =>
+  dirname(input.root) === input.parent && basename(input.root).startsWith(input.prefix);
+
+// Process-monotone so no two leases in one process can collide, even across
+// two factory instances of the same backend.
+let leaseCounter = 0;
+const nextLeaseId = (backend: string): string => {
+  leaseCounter += 1;
+  return `${backend}-lease-${leaseCounter}`;
+};
+
+const reportStatus = (
+  cleaned: readonly string[],
+  failures: readonly CleanupFailure[],
+): CleanupReport["status"] => {
+  if (failures.length === 0) {
+    return "clean";
+  }
+  return cleaned.length === 0 ? "failed" : "partial";
+};
+
+const buildReport = (
+  authority: CleanupAuthority,
+  attempted: readonly string[],
+  cleaned: readonly string[],
+  failures: readonly CleanupFailure[],
+): CleanupReport =>
+  Object.freeze<CleanupReport>({
+    status: reportStatus(cleaned, failures),
+    authority,
+    attempted_targets: Object.freeze([...attempted]),
+    cleaned_targets: Object.freeze([...cleaned]),
+    failures: Object.freeze([...failures]),
+  });
+
+const toCleanupFailure = (target: string, error: unknown): CleanupFailure => {
+  const described = describeThrown(error);
+  return {
+    target,
+    name: described.name,
+    ...(described.code !== undefined && { code: described.code }),
+    message: described.message,
+  };
+};
+
+const toProvisioningFailure = (
+  factoryId: string,
+  backend: string,
+  error: unknown,
+): ProvisioningFailure => {
+  const described = describeThrown(error);
+  return {
+    stage: "provision",
+    factory_id: factoryId,
+    backend,
+    name: described.name,
+    ...(described.code !== undefined && { code: described.code }),
+    message: described.message,
+  };
+};
+
+/**
+ * Delete an explicit, sorted, de-duplicated key list. Never a prefix, never a
+ * LIST, and never short-circuited: a failure on one key does not skip the rest.
+ * Pass the **inner** (unwrapped) storage so teardown deletes stay out of the
+ * attempt's operation journal.
+ */
+export const createExactKeyCleanup = (input: {
+  readonly storage: Storage;
+  readonly keys: readonly string[];
+}): ExactKeyCleanup => {
+  const keys = Object.freeze([...new Set(input.keys)].toSorted());
+  const authority: CleanupAuthority = { kind: "exact-keys", keys };
+  let memoized: CleanupReport | undefined;
+  return {
+    authority,
+    cleanup: async (): Promise<CleanupReport> => {
+      if (memoized !== undefined) {
+        return memoized;
+      }
+      const cleaned: string[] = [];
+      const failures: CleanupFailure[] = [];
+      for (const key of keys) {
+        try {
+          await input.storage.delete(key);
+          cleaned.push(key);
+        } catch (error: unknown) {
+          failures.push(toCleanupFailure(key, error));
+        }
+      }
+      memoized = buildReport(authority, keys, cleaned, failures);
+      return memoized;
+    },
+  };
+};
+
+const makeLease = (input: {
+  readonly attemptId: AttemptId;
+  readonly factoryId: string;
+  readonly backend: string;
+  readonly namespaceId: string;
+  readonly storage: Storage;
+  readonly authority: CleanupAuthority;
+  readonly runCleanup: () => Promise<{
+    readonly cleaned: readonly string[];
+    readonly failures: readonly CleanupFailure[];
+    readonly attempted: readonly string[];
+  }>;
+}): StorageLease => {
+  const journaled = wrapJournaledStorage({
+    attemptId: input.attemptId,
+    storage: input.storage,
+  });
+  let lifecycle: "active" | "cleaned" = "active";
+  let memoized: CleanupReport | undefined;
+  return {
+    attempt_id: input.attemptId,
+    factory_id: input.factoryId,
+    backend: input.backend,
+    namespace_id: input.namespaceId,
+    storage: journaled.storage,
+    journal: journaled.journal,
+    cleanup_authority: input.authority,
+    lifecycle: () => lifecycle,
+    cleanup: async (): Promise<CleanupReport> => {
+      if (memoized !== undefined) {
+        return memoized;
+      }
+      lifecycle = "cleaned";
+      const outcome = await input.runCleanup();
+      memoized = buildReport(input.authority, outcome.attempted, outcome.cleaned, outcome.failures);
+      return memoized;
+    },
+  };
+};
+
+/**
+ * One isolated {@link MemoryStorage} per attempt. Cleanup drops the reference
+ * and reports `clean` without enumerating the instance.
+ */
+export const createMemoryStorageFactory = (): StorageFactory => {
+  const id = "measurement.memory/v1";
+  const backend = "memory";
+  return {
+    id,
+    backend,
+    create: async ({ attemptId }): Promise<StorageFactoryCreateResult> => {
+      try {
+        const leaseId = nextLeaseId(backend);
+        return {
+          status: "created",
+          lease: makeLease({
+            attemptId,
+            factoryId: id,
+            backend,
+            namespaceId: leaseId,
+            storage: new MemoryStorage(),
+            authority: { kind: "memory-instance", lease_id: leaseId },
+            runCleanup: async () => ({
+              attempted: [leaseId],
+              cleaned: [leaseId],
+              failures: [],
+            }),
+          }),
+        };
+      } catch (error: unknown) {
+        return { status: "failed", failure: toProvisioningFailure(id, backend, error) };
+      }
+    },
+  };
+};
+
+/**
+ * One `mkdtemp` root per attempt under the selected temp parent. Cleanup
+ * removes **only** that root, and only after {@link isWithinCleanupAuthority}
+ * re-derives that it is a direct child of the selected parent carrying the
+ * requested prefix.
+ */
+export const createLocalFsStorageFactory = (input?: {
+  readonly temp_parent?: string;
+  readonly directory_prefix?: string;
+}): StorageFactory => {
+  const id = "measurement.local-fs/v1";
+  const backend = "local-fs";
+  const parent = resolve(input?.temp_parent ?? tmpdir());
+  const prefix = input?.directory_prefix ?? DEFAULT_DIRECTORY_PREFIX;
+  return {
+    id,
+    backend,
+    create: async ({ attemptId }): Promise<StorageFactoryCreateResult> => {
+      let root: string;
+      try {
+        root = await mkdtemp(join(parent, prefix));
+      } catch (error: unknown) {
+        return { status: "failed", failure: toProvisioningFailure(id, backend, error) };
+      }
+      return {
+        status: "created",
+        lease: makeLease({
+          attemptId,
+          factoryId: id,
+          backend,
+          namespaceId: root,
+          storage: new LocalFsStorage({ root }),
+          authority: { kind: "exact-directory", absolute_path: root },
+          runCleanup: async () => {
+            if (!isWithinCleanupAuthority({ root, parent, prefix })) {
+              return {
+                attempted: [root],
+                cleaned: [],
+                failures: [
+                  {
+                    target: root,
+                    name: "CleanupAuthorityError",
+                    code: "OutOfAuthority",
+                    message:
+                      `refusing to remove ${root}: not a direct child of ${parent} ` +
+                      `with prefix ${prefix}`,
+                  },
+                ],
+              };
+            }
+            try {
+              await rm(root, { recursive: true, force: true });
+              return { attempted: [root], cleaned: [root], failures: [] };
+            } catch (error: unknown) {
+              return {
+                attempted: [root],
+                cleaned: [],
+                failures: [toCleanupFailure(root, error)],
+              };
+            }
+          },
+        }),
+      };
+    },
+  };
+};
+
+/**
+ * Provision, run, then always clean up. Provisioning failure short-circuits
+ * before `work` runs. A throw from `work` is returned **by identity** alongside
+ * the cleanup report — cleanup never replaces or masks it.
+ *
+ * `pending_operations_at_cleanup` is sampled from the journal BEFORE cleanup
+ * runs. A non-zero value means `work` returned or threw while one of its own
+ * storage operations was still in flight, so the backend may have been torn out
+ * from under it: the local-fs factory `rm -rf`s the root, and the memory factory
+ * drops the only reference. The runner does NOT throw on this — that would mask
+ * `work`'s own error, which is the one thing the caller most needs — and it does
+ * NOT wait, because there is no safe general way to wait for an operation the
+ * caller abandoned. It reports. A caller seeing a non-zero value must treat the
+ * result as invalid.
+ */
+export const withStorageLease = async <T>(
+  factory: StorageFactory,
+  attemptId: AttemptId,
+  work: (lease: StorageLease) => Promise<T>,
+): Promise<WithStorageLeaseResult<T>> => {
+  const created = await factory.create({ attemptId });
+  if (created.status === "failed") {
+    return { status: "provision_failed", failure: created.failure };
+  }
+  const { lease } = created;
+  const settled = await work(lease).then(
+    (value: T) => ({ ok: true, value }) as const,
+    (error: unknown) => ({ ok: false, error }) as const,
+  );
+  const pendingAtCleanup = lease.journal.pendingOperationCount();
+  const cleanup = await lease.cleanup();
+  return settled.ok
+    ? {
+        status: "returned",
+        value: settled.value,
+        cleanup,
+        pending_operations_at_cleanup: pendingAtCleanup,
+      }
+    : {
+        status: "threw",
+        error: settled.error,
+        cleanup,
+        pending_operations_at_cleanup: pendingAtCleanup,
+      };
+};

--- a/bench/measurement/storage-journal.test.ts
+++ b/bench/measurement/storage-journal.test.ts
@@ -1,0 +1,700 @@
+/* eslint-disable no-underscore-dangle -- `_entry` marks a deliberately unused
+   loop binding where the test only needs the iterable DRAINED (or broken out
+   of) and not the yielded value. Same convention, and same file-level opt-out,
+   as `tests/integration/maintenance-e2e.test.ts`. */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  BaerlyError,
+  type Storage,
+  type StorageGetOptions,
+  type StorageGetResult,
+  type StorageListEntry,
+  type StoragePutOptions,
+  type StoragePutResult,
+} from "@baerly/protocol";
+import { describe, expect, test, vi } from "vitest";
+import {
+  InvalidAttemptIdError,
+  JournalNotQuiescentError,
+  NAMESPACE_JOURNAL_VERSION,
+  OPERATION_JOURNAL_VERSION,
+  asAttemptId,
+  billingClassOf,
+  classifyStorageError,
+  wrapJournaledStorage,
+} from "./storage-journal.ts";
+
+const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+/**
+ * Clock-free scriptable backend. `MemoryStorage` cannot be used for the
+ * zero-clock-read assertion below because its `put` returns
+ * `serverDate: new Date()` — a real wall-clock read on every write.
+ */
+class StubStorage implements Storage {
+  readonly objects = new Map<string, { body: Uint8Array; etag: string }>();
+  readonly calls: string[] = [];
+  readonly completions: string[] = [];
+  readonly getTicks = new Map<string, number>();
+  readonly failOn = new Map<string, unknown>();
+  /** Resolve manually to hold an operation in flight. */
+  readonly gates = new Map<string, () => void>();
+  #etag = 0;
+
+  async get(key: string, _opts?: StorageGetOptions): Promise<StorageGetResult | null> {
+    this.calls.push(`get:${key}`);
+    const ticks = this.getTicks.get(key) ?? 0;
+    for (let i = 0; i < ticks; i++) {
+      await Promise.resolve();
+    }
+    if (this.gates.has(`get:${key}`)) {
+      await new Promise<void>((resolve) => this.gates.set(`get:${key}`, resolve));
+    }
+    this.completions.push(`get:${key}`);
+    const failure = this.failOn.get(`get:${key}`);
+    if (failure !== undefined) {
+      throw failure;
+    }
+    const stored = this.objects.get(key);
+    return stored === undefined ? null : { body: stored.body, etag: stored.etag };
+  }
+
+  async put(key: string, body: Uint8Array, _opts?: StoragePutOptions): Promise<StoragePutResult> {
+    this.calls.push(`put:${key}`);
+    const failure = this.failOn.get(`put:${key}`);
+    if (failure !== undefined) {
+      throw failure;
+    }
+    this.#etag += 1;
+    const etag = `"${this.#etag}"`;
+    this.objects.set(key, { body, etag });
+    return { etag };
+  }
+
+  async delete(key: string, _opts?: { signal?: AbortSignal }): Promise<void> {
+    this.calls.push(`delete:${key}`);
+    const failure = this.failOn.get(`delete:${key}`);
+    if (failure !== undefined) {
+      throw failure;
+    }
+    this.objects.delete(key);
+  }
+
+  async *list(
+    prefix: string,
+    _opts?: { startAfter?: string; maxKeys?: number; signal?: AbortSignal },
+  ): AsyncIterable<StorageListEntry> {
+    this.calls.push(`list:${prefix}`);
+    const failure = this.failOn.get(`list:${prefix}`);
+    if (failure !== undefined) {
+      throw failure;
+    }
+    for (const [key, stored] of [...this.objects].toSorted((a, b) => (a[0] < b[0] ? -1 : 1))) {
+      if (key.startsWith(prefix)) {
+        yield { key, etag: stored.etag };
+      }
+    }
+  }
+}
+
+const abortedError = (): unknown => {
+  const controller = new AbortController();
+  controller.abort();
+  try {
+    controller.signal.throwIfAborted();
+  } catch (error: unknown) {
+    return error;
+  }
+  throw new Error("unreachable: throwIfAborted did not throw");
+};
+
+describe("attempt identity", () => {
+  test("accepts a conventional id and brands it", () => {
+    expect(asAttemptId("attempt-1")).toBe("attempt-1");
+    expect(asAttemptId("study.fold:cell_07")).toBe("study.fold:cell_07");
+  });
+
+  test("rejects ids that would be unsafe as a filename or JSON key", () => {
+    for (const bad of ["", " ", "a b", "a/b", "a\\b", "a\nb", "x".repeat(129), "é"]) {
+      expect(() => asAttemptId(bad)).toThrow(InvalidAttemptIdError);
+    }
+  });
+
+  test("the thrown error carries the offending value", () => {
+    try {
+      asAttemptId("a/b");
+      throw new Error("expected a throw");
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(InvalidAttemptIdError);
+      expect((error as InvalidAttemptIdError).value).toBe("a/b");
+    }
+  });
+});
+
+describe("operation journal", () => {
+  test("records method, key, and dispatch-ordered indices", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-1"),
+      storage: stub,
+    });
+    await storage.put("a/1", enc("abc"));
+    await storage.get("a/1");
+    await storage.delete("a/1");
+    for await (const _entry of storage.list("a/")) {
+      /* drain */
+    }
+    const ops = journal.snapshotOperations();
+    expect(ops.map((o) => o.method)).toEqual(["put", "get", "delete", "list"]);
+    expect(ops.map((o) => o.operation_index)).toEqual([0, 1, 2, 3]);
+    expect(ops.every((o) => o.schema === OPERATION_JOURNAL_VERSION)).toBe(true);
+    expect(ops.every((o) => o.attempt_id === "attempt-1")).toBe(true);
+    expect(journal.pendingOperationCount()).toBe(0);
+  });
+
+  test("indices follow dispatch even when GETs settle in reverse", async () => {
+    const stub = new StubStorage();
+    stub.objects.set("k/1", { body: enc("one"), etag: '"e1"' });
+    stub.objects.set("k/2", { body: enc("two"), etag: '"e2"' });
+    stub.getTicks.set("k/1", 20);
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-2"),
+      storage: stub,
+    });
+    const first = storage.get("k/1");
+    const second = storage.get("k/2");
+    await Promise.all([first, second]);
+    expect(stub.completions).toEqual(["get:k/2", "get:k/1"]);
+    const ops = journal.snapshotOperations();
+    expect(ops.map((o) => o.key)).toEqual(["k/1", "k/2"]);
+    expect(ops.map((o) => o.operation_index)).toEqual([0, 1]);
+  });
+
+  // ── REVISION 2: quiescence is enforced, not advertised ────────────────────
+  test("snapshotOperations THROWS while an operation is in flight", async () => {
+    const stub = new StubStorage();
+    stub.gates.set("get:slow", () => {});
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-q1"),
+      storage: stub,
+    });
+    const inflight = storage.get("slow");
+    await Promise.resolve();
+    expect(journal.pendingOperationCount()).toBe(1);
+    expect(() => journal.snapshotOperations()).toThrow(JournalNotQuiescentError);
+    // The settled-only view is the explicit opt-out and never throws.
+    expect(journal.snapshotSettledOperations()).toEqual([]);
+    expect(journal.pendingOperations()).toEqual([
+      { operation_index: 0, method: "get", key: "slow" },
+    ]);
+    stub.gates.get("get:slow")?.();
+    await inflight;
+    expect(journal.snapshotOperations()).toHaveLength(1);
+  });
+
+  test("the quiescence error names every pending row", async () => {
+    const stub = new StubStorage();
+    stub.gates.set("get:a", () => {});
+    stub.gates.set("get:b", () => {});
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-q2"),
+      storage: stub,
+    });
+    const a = storage.get("a");
+    const b = storage.get("b");
+    await Promise.resolve();
+    try {
+      journal.snapshotOperations();
+      throw new Error("expected a throw");
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(JournalNotQuiescentError);
+      expect((error as JournalNotQuiescentError).pending.map((p) => p.key)).toEqual(["a", "b"]);
+    }
+    stub.gates.get("get:a")?.();
+    stub.gates.get("get:b")?.();
+    await Promise.all([a, b]);
+  });
+  // ──────────────────────────────────────────────────────────────────────────
+
+  test("records PUT byte length and the SHA-256 of the exact bytes", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-3"),
+      storage: stub,
+    });
+    await storage.put("d", enc("abc"));
+    const [op] = journal.snapshotOperations();
+    expect(op?.put).toEqual({
+      byte_length: 3,
+      sha256: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    });
+  });
+
+  test("digests the bytes as of dispatch, not as of later mutation", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-4"),
+      storage: stub,
+    });
+    const body = enc("abc");
+    const inflight = storage.put("d", body);
+    body[0] = 0x7a;
+    await inflight;
+    const [op] = journal.snapshotOperations();
+    expect(op?.put?.sha256).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+  });
+
+  test("passes the ORIGINAL array to the inner storage, not the digest copy", async () => {
+    const stub = new StubStorage();
+    const { storage } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-4b"),
+      storage: stub,
+    });
+    const body = enc("abc");
+    await storage.put("d", body);
+    // MemoryStorage-shaped backends retain the caller's array by reference;
+    // substituting the copy would change what the system under test observes.
+    expect(stub.objects.get("d")?.body).toBe(body);
+  });
+
+  test("captures only the options that were supplied", async () => {
+    const stub = new StubStorage();
+    stub.objects.set("o", { body: enc("x"), etag: '"e"' });
+    const live = new AbortController();
+    const dead = new AbortController();
+    dead.abort();
+    const signalIds = new Map<AbortSignal, string>([
+      [live.signal, "writer-signal"],
+      [dead.signal, "cancelled-signal"],
+    ]);
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-5"),
+      storage: stub,
+      signalIds,
+    });
+    await storage.get("o");
+    await storage.put("o", enc("y"), { ifMatch: '"e"', contentType: "application/json" });
+    await storage.put("o2", enc("y"), { ifNoneMatch: "*" });
+    await storage.get("o", { versionId: "v7", signal: live.signal });
+    await storage.get("o", { ifNoneMatch: '"e"', signal: dead.signal });
+    for await (const _entry of storage.list("o", { startAfter: "o", maxKeys: 5 })) {
+      /* drain */
+    }
+    const ops = journal.snapshotOperations();
+    expect(Object.keys(ops[0]?.options ?? { missing: true })).toEqual([]);
+    expect(ops[1]?.options).toEqual({ if_match: '"e"', content_type: "application/json" });
+    expect(ops[2]?.options).toEqual({ if_none_match: "*" });
+    expect(ops[3]?.options).toEqual({
+      version_id: "v7",
+      signal: { id: "writer-signal", present: true, aborted_at_dispatch: false },
+    });
+    expect(ops[4]?.options).toEqual({
+      if_none_match: '"e"',
+      signal: { id: "cancelled-signal", present: true, aborted_at_dispatch: true },
+    });
+    expect(ops[5]?.options).toEqual({ start_after: "o", max_keys: 5 });
+  });
+
+  test("names an unnamed signal deterministically and stably", async () => {
+    const stub = new StubStorage();
+    const first = new AbortController();
+    const second = new AbortController();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-5b"),
+      storage: stub,
+    });
+    await storage.get("a", { signal: first.signal });
+    await storage.get("b", { signal: second.signal });
+    await storage.get("c", { signal: first.signal });
+    const ids = journal.snapshotOperations().map((o) => o.options.signal?.id);
+    expect(ids).toEqual(["signal-1", "signal-2", "signal-1"]);
+  });
+
+  test("classifies returned results", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-6"),
+      storage: stub,
+    });
+    await storage.get("absent");
+    await storage.put("p", enc("v"));
+    await storage.get("p");
+    await storage.delete("p");
+    for await (const _entry of storage.list("")) {
+      /* drain */
+    }
+    const ops = journal.snapshotOperations();
+    expect(ops.map((o) => o.result.classification)).toEqual([
+      "not_found",
+      "put_ok",
+      "found",
+      "delete_ok",
+      "list_ok",
+    ]);
+    expect(ops[2]?.result).toMatchObject({ status: "returned", etag: '"1"' });
+    expect(ops[4]?.result).toMatchObject({ status: "returned", listed_entries: 0 });
+  });
+
+  test("classifies every error class and rethrows the same object", async () => {
+    const cases: readonly { readonly thrown: unknown; readonly expected: string }[] = [
+      { thrown: abortedError(), expected: "aborted" },
+      { thrown: new BaerlyError("Conflict", "precondition failed"), expected: "conflict" },
+      { thrown: new BaerlyError("NetworkError", "503"), expected: "network_error" },
+      { thrown: new BaerlyError("InvalidResponse", "bad xml"), expected: "invalid_response" },
+      { thrown: new BaerlyError("Internal", "bug"), expected: "internal" },
+      { thrown: new BaerlyError("InvalidConfig", "no bucket"), expected: "invalid_config" },
+      { thrown: new Error("boom"), expected: "unknown" },
+    ];
+    for (const [index, entry] of cases.entries()) {
+      const stub = new StubStorage();
+      const key = `e${index}`;
+      stub.failOn.set(`put:${key}`, entry.thrown);
+      const { storage, journal } = wrapJournaledStorage({
+        attemptId: asAttemptId(`attempt-err-${index}`),
+        storage: stub,
+      });
+      let caught: unknown;
+      try {
+        await storage.put(key, enc("v"));
+      } catch (error: unknown) {
+        caught = error;
+      }
+      expect(caught).toBe(entry.thrown);
+      const [op] = journal.snapshotOperations();
+      expect(op?.result.status).toBe("threw");
+      expect(op?.result.classification).toBe(entry.expected);
+      expect(classifyStorageError(entry.thrown)).toBe(entry.expected);
+    }
+  });
+
+  test("never writes a numeric DOMException code into the string code field", async () => {
+    const stub = new StubStorage();
+    stub.failOn.set("get:x", abortedError());
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-dom"),
+      storage: stub,
+    });
+    await expect(storage.get("x")).rejects.toThrow("aborted");
+    const result = journal.snapshotOperations()[0]?.result;
+    if (result === undefined || result.status !== "threw") {
+      throw new Error("expected a threw result");
+    }
+    expect(result.classification).toBe("aborted");
+    expect(result.name).toBe("AbortError");
+    expect(result.code).toBeUndefined();
+  });
+
+  test("allocates the LIST index at iteration start and counts yielded entries", async () => {
+    const stub = new StubStorage();
+    stub.objects.set("l/1", { body: enc("1"), etag: '"1"' });
+    stub.objects.set("l/2", { body: enc("2"), etag: '"2"' });
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-7"),
+      storage: stub,
+    });
+    const iterable = storage.list("l/");
+    expect(journal.snapshotOperations()).toEqual([]);
+    expect(stub.calls).toEqual([]);
+    let seen = 0;
+    for await (const _entry of iterable) {
+      seen += 1;
+    }
+    expect(seen).toBe(2);
+    const [op] = journal.snapshotOperations();
+    expect(op?.result).toMatchObject({ classification: "list_ok", listed_entries: 2 });
+  });
+
+  // ── REVISION 2: the list-index hazard, pinned rather than hidden ──────────
+  test("a LIST created early but iterated late sorts on the ITERATION clock", async () => {
+    const stub = new StubStorage();
+    stub.objects.set("l/1", { body: enc("1"), etag: '"1"' });
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-7b"),
+      storage: stub,
+    });
+    const deferred = storage.list("l/"); // created FIRST
+    await storage.get("later"); // dispatched second
+    for await (const _entry of deferred) {
+      /* drain */
+    }
+    const ops = journal.snapshotOperations();
+    // The GET, dispatched after `.list()` was CALLED, carries the LOWER index.
+    // This is the parent plan's "allocate when iteration begins" rule, and it
+    // means `list` is not on the same clock as the other three verbs. Any
+    // downstream journal comparator must avoid separating `.list()` from its
+    // iteration, or normalize. See Semantics §2 and Open question 6.
+    expect(ops.map((o) => `${o.method}:${o.operation_index}`)).toEqual(["get:0", "list:1"]);
+  });
+  // ──────────────────────────────────────────────────────────────────────────
+
+  test("settles a broken-out LIST with the partial count", async () => {
+    const stub = new StubStorage();
+    stub.objects.set("l/1", { body: enc("1"), etag: '"1"' });
+    stub.objects.set("l/2", { body: enc("2"), etag: '"2"' });
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-8"),
+      storage: stub,
+    });
+    for await (const _entry of storage.list("l/")) {
+      break;
+    }
+    const [op] = journal.snapshotOperations();
+    expect(op?.result).toMatchObject({ classification: "list_ok", listed_entries: 1 });
+    expect(journal.pendingOperationCount()).toBe(0);
+  });
+
+  test("a LIST that is never iterated journals nothing at all", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-8b"),
+      storage: stub,
+    });
+    void storage.list("l/");
+    await Promise.resolve();
+    expect(journal.snapshotOperations()).toEqual([]);
+    expect(journal.pendingOperationCount()).toBe(0);
+  });
+});
+
+describe("billing class", () => {
+  /**
+   * ONE definition, deliberately NOT a resolution. Manifest §11 item 1 records
+   * three live and mutually inconsistent "Class A" definitions in this repo:
+   *
+   *   D1  packages/server/src/reads-pure.test.ts   put + delete
+   *   D2  tests/integration/maintenance-e2e.test.ts put + delete + list
+   *   D3  docs/about/cost-model.md                 put + list   (DELETE is $0)
+   *       — matching bench/storage.ts's `billableClassAOps` getter and
+   *         coordination design §4.5's `billableClassAOps = puts + lists`
+   *
+   * D1 governs a CI gate; D2 backs the published "< 1 Class A op / writer /
+   * hour" claim; D3 governs the fold program's cost arguments. The journal uses
+   * D3 because that is what §4.5 binds it to. This test exists so the
+   * disagreement is discoverable evidence for the Protocol/product owner named
+   * in §11, not so this lane resolves it.
+   */
+  test("uses the cost-model definition: puts and lists bill, deletes are free", () => {
+    expect(billingClassOf("put")).toBe("A");
+    expect(billingClassOf("list")).toBe("A");
+    expect(billingClassOf("get")).toBe("B");
+    expect(billingClassOf("delete")).toBe("free");
+  });
+
+  test("billingSummary counts settled rows by class", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-bill"),
+      storage: stub,
+    });
+    await storage.put("a", enc("1"));
+    await storage.put("b", enc("2"));
+    await storage.get("a");
+    await storage.delete("b");
+    for await (const _entry of storage.list("")) {
+      /* drain */
+    }
+    expect(journal.billingSummary()).toEqual({ class_a: 3, class_b: 1, free: 1 });
+  });
+
+  test("a failed operation still counts — the request was still billed", async () => {
+    const stub = new StubStorage();
+    stub.failOn.set("put:x", new BaerlyError("Conflict", "precondition failed"));
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-bill-2"),
+      storage: stub,
+    });
+    await expect(storage.put("x", enc("v"))).rejects.toMatchObject({ code: "Conflict" });
+    expect(journal.billingSummary()).toEqual({ class_a: 1, class_b: 0, free: 0 });
+  });
+});
+
+describe("namespace journal", () => {
+  test("tracks provisioning, PUT, and DELETE without any LIST", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-ns-1"),
+      storage: stub,
+    });
+    journal.recordProvisioned([
+      { key: "seed/b", byte_length: 10 },
+      { key: "seed/a", byte_length: 4 },
+    ]);
+    await storage.put("live/1", enc("abcd"));
+    await storage.put("live/1", enc("abcdef"));
+    await storage.delete("seed/a");
+    const snapshot = journal.snapshotNamespace();
+    expect(snapshot.schema).toBe(NAMESPACE_JOURNAL_VERSION);
+    expect(snapshot.exact).toBe(true);
+    expect(snapshot.uncertain_keys).toEqual([]);
+    expect(snapshot.uncertainty).toEqual([]);
+    expect(snapshot.entries).toEqual([
+      { key: "live/1", byte_length: 6, last_operation_index: 1, source: "put" },
+      { key: "seed/b", byte_length: 10, last_operation_index: null, source: "provisioned" },
+    ]);
+    expect(stub.calls.filter((c) => c.startsWith("list:"))).toEqual([]);
+  });
+
+  test("a conflicting PUT leaves namespace truth unchanged", async () => {
+    const stub = new StubStorage();
+    stub.failOn.set("put:c", new BaerlyError("Conflict", "precondition failed"));
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-ns-2"),
+      storage: stub,
+    });
+    journal.recordProvisioned([{ key: "c", byte_length: 3 }]);
+    await expect(storage.put("c", enc("zzzz"))).rejects.toMatchObject({ code: "Conflict" });
+    const snapshot = journal.snapshotNamespace();
+    expect(snapshot.exact).toBe(true);
+    expect(snapshot.entries).toEqual([
+      { key: "c", byte_length: 3, last_operation_index: null, source: "provisioned" },
+    ]);
+  });
+
+  test("an ambiguous PUT or DELETE failure marks that exact key uncertain", async () => {
+    const stub = new StubStorage();
+    stub.failOn.set("put:u", new BaerlyError("NetworkError", "retries exhausted"));
+    stub.failOn.set("delete:d", abortedError());
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-ns-3"),
+      storage: stub,
+    });
+    journal.recordProvisioned([
+      { key: "u", byte_length: 3 },
+      { key: "d", byte_length: 5 },
+      { key: "safe", byte_length: 1 },
+    ]);
+    await expect(storage.put("u", enc("x"))).rejects.toMatchObject({ code: "NetworkError" });
+    await expect(storage.delete("d")).rejects.toThrow("aborted");
+    const snapshot = journal.snapshotNamespace();
+    expect(snapshot.exact).toBe(false);
+    expect(snapshot.uncertain_keys).toEqual(["d", "u"]);
+    expect(snapshot.entries).toEqual([
+      { key: "safe", byte_length: 1, last_operation_index: null, source: "provisioned" },
+    ]);
+  });
+
+  // ── REVISION 2: the evidence array, so a consumer can narrow ──────────────
+  test("uncertainty carries the evidence needed to narrow without guessing", async () => {
+    const stub = new StubStorage();
+    stub.failOn.set("put:net", new BaerlyError("NetworkError", "retries exhausted"));
+    stub.failOn.set("delete:pre", abortedError());
+    const dead = new AbortController();
+    dead.abort();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-ns-3b"),
+      storage: stub,
+    });
+    await expect(storage.put("net", enc("x"))).rejects.toMatchObject({ code: "NetworkError" });
+    await expect(storage.delete("pre", { signal: dead.signal })).rejects.toThrow("aborted");
+    const snapshot = journal.snapshotNamespace();
+    expect(snapshot.uncertainty).toEqual([
+      {
+        key: "net",
+        operation_index: 0,
+        method: "put",
+        classification: "network_error",
+        aborted_at_dispatch: false,
+      },
+      {
+        key: "pre",
+        operation_index: 1,
+        method: "delete",
+        classification: "aborted",
+        aborted_at_dispatch: true,
+      },
+    ]);
+    // Both are still uncertain — the journal fails CLOSED. The `pre` row simply
+    // carries enough evidence for a consumer to decide otherwise, without the
+    // journal baking in an assumption the `Storage` contract does not state.
+    expect(snapshot.uncertain_keys).toEqual(["net", "pre"]);
+    expect(snapshot.exact).toBe(false);
+  });
+
+  test("a later successful PUT clears both the key and its uncertainty row", async () => {
+    const stub = new StubStorage();
+    stub.failOn.set("put:flaky", new BaerlyError("NetworkError", "boom"));
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-ns-3c"),
+      storage: stub,
+    });
+    await expect(storage.put("flaky", enc("x"))).rejects.toMatchObject({ code: "NetworkError" });
+    expect(journal.snapshotNamespace().exact).toBe(false);
+    stub.failOn.delete("put:flaky");
+    await storage.put("flaky", enc("xy"));
+    const snapshot = journal.snapshotNamespace();
+    expect(snapshot.exact).toBe(true);
+    expect(snapshot.uncertain_keys).toEqual([]);
+    expect(snapshot.uncertainty).toEqual([]);
+    expect(snapshot.entries).toEqual([
+      { key: "flaky", byte_length: 2, last_operation_index: 1, source: "put" },
+    ]);
+  });
+  // ──────────────────────────────────────────────────────────────────────────
+
+  test("LIST is journaled but never changes namespace truth", async () => {
+    const stub = new StubStorage();
+    stub.objects.set("ghost", { body: enc("xyz"), etag: '"g"' });
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-ns-4"),
+      storage: stub,
+    });
+    for await (const _entry of storage.list("")) {
+      /* drain */
+    }
+    expect(journal.snapshotOperations()).toHaveLength(1);
+    expect(journal.snapshotNamespace().entries).toEqual([]);
+  });
+});
+
+describe("timer-free guarantee", () => {
+  const SOURCE = readFileSync(
+    fileURLToPath(new URL("./storage-journal.ts", import.meta.url)),
+    "utf8",
+  );
+
+  test("the module contains no clock or timer call site", () => {
+    expect(SOURCE).not.toMatch(/new\s+Date\b/);
+    expect(SOURCE).not.toMatch(/Date\s*\.\s*now/);
+    expect(SOURCE).not.toMatch(/performance\s*\.\s*now/);
+    expect(SOURCE).not.toMatch(/process\s*\.\s*hrtime/);
+    expect(SOURCE).not.toMatch(/set(?:Timeout|Interval|Immediate)\s*\(/);
+  });
+
+  test("the module imports nothing at runtime", () => {
+    // `import type` is erased; a bare `import ... from` is not. The probe module
+    // reads clocks by design, so importing it here would silently break the
+    // guarantee above.
+    expect(SOURCE).not.toMatch(/^import\s+(?!type\b)/m);
+  });
+
+  test("no journal operation reads a clock", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-clock"),
+      storage: stub,
+    });
+    const dateNow = vi.spyOn(Date, "now");
+    const perfNow = vi.spyOn(performance, "now");
+    try {
+      await storage.put("k", enc("abc"));
+      await storage.get("k");
+      for await (const _entry of storage.list("")) {
+        /* drain */
+      }
+      await storage.delete("k");
+      journal.recordProvisioned([{ key: "z", byte_length: 1 }]);
+      journal.snapshotOperations();
+      journal.snapshotNamespace();
+      journal.billingSummary();
+    } finally {
+      dateNow.mockRestore();
+      perfNow.mockRestore();
+    }
+    expect(dateNow).not.toHaveBeenCalled();
+    expect(perfNow).not.toHaveBeenCalled();
+  });
+});

--- a/bench/measurement/storage-journal.ts
+++ b/bench/measurement/storage-journal.ts
@@ -1,0 +1,621 @@
+/**
+ * Timer-free semantic journals over the `Storage` seam.
+ *
+ * Two journals are produced from one decorator: an ordered **operation
+ * journal** (method, key, semantically-relevant request options, PUT byte
+ * length and digest, result/error class, attempt id) and an exact **namespace
+ * journal** (known key/byte-length state from benchmark-owned provisioning plus
+ * observed PUT/DELETE outcomes).
+ *
+ * This module holds no wall-clock field and issues no wall-clock or timer call.
+ * Latency is a separate observation so a semantics comparison can ignore clock
+ * noise; `bench/storage.ts`'s latency wrapper and
+ * `bench/measurement/fold-ceiling-probe.ts` are deliberately outside this
+ * contract and must never be imported here.
+ *
+ * It also imports nothing at runtime — only types plus the global Web Crypto
+ * digest — so it stays loadable outside Node.
+ */
+import type {
+  Branded,
+  Storage,
+  StorageGetResult,
+  StorageListEntry,
+  StoragePutResult,
+} from "@baerly/protocol";
+
+/** Contract version of {@link StorageOperationRecord}. */
+export const OPERATION_JOURNAL_VERSION = "baerly.storage-operation-journal/v1" as const;
+/** Contract version of {@link NamespaceSnapshot}. */
+export const NAMESPACE_JOURNAL_VERSION = "baerly.namespace-journal/v1" as const;
+
+/** Identity of one measurement attempt. Every journal row carries it. */
+export type AttemptId = Branded<string, "AttemptId">;
+
+/**
+ * Attempt ids reach filenames, directory names, and JSON keys in downstream
+ * lanes, so the charset is narrow on purpose: ASCII alphanumerics plus `.`,
+ * `_`, `:`, and `-`, 1-128 characters. No slash, no whitespace, no non-ASCII.
+ */
+export const ATTEMPT_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+
+export class InvalidAttemptIdError extends Error {
+  readonly value: string;
+  constructor(value: string) {
+    super(`invalid attempt id ${JSON.stringify(value)}: expected ${String(ATTEMPT_ID_PATTERN)}`);
+    this.name = "InvalidAttemptIdError";
+    this.value = value;
+  }
+}
+
+/**
+ * Single deliberate boundary for minting an {@link AttemptId}. Validates rather
+ * than casting: an unchecked cast makes the brand decorative, and this repo's
+ * convention is that branded types are load-bearing.
+ */
+export const asAttemptId = (value: string): AttemptId => {
+  if (!ATTEMPT_ID_PATTERN.test(value)) {
+    throw new InvalidAttemptIdError(value);
+  }
+  return value as AttemptId;
+};
+
+export type StorageMethod = "get" | "put" | "delete" | "list";
+
+/**
+ * Billing class of one storage verb.
+ *
+ * `docs/about/cost-model.md` and coordination design §4.5 both define the
+ * billable set as `puts + lists`; DeleteObject is $0 on both S3 and R2, so
+ * `delete` is neither A nor B. `bench/storage.ts`'s `billableClassAOps` getter
+ * already agrees.
+ *
+ * This is ONE definition, not a resolution. Two other definitions are live in
+ * the tree (see the `billing class` describe block in the test file). Their
+ * owner is the Protocol/product owner named in the integration manifest's open
+ * contradictions table.
+ */
+export type BillingClass = "A" | "B" | "free";
+
+export const billingClassOf = (method: StorageMethod): BillingClass => {
+  if (method === "put" || method === "list") {
+    return "A";
+  }
+  return method === "get" ? "B" : "free";
+};
+
+export interface BillingSummary {
+  readonly class_a: number;
+  readonly class_b: number;
+  readonly free: number;
+}
+
+export type StorageErrorClass =
+  | "aborted"
+  | "conflict"
+  | "network_error"
+  | "invalid_response"
+  | "internal"
+  | "invalid_config"
+  | "unknown";
+
+export interface ThrownDescription {
+  readonly name: string;
+  readonly code?: string;
+  readonly message: string;
+}
+
+const stringField = (error: unknown, field: "name" | "message" | "code"): string | undefined => {
+  if (typeof error !== "object" || error === null || !(field in error)) {
+    return undefined;
+  }
+  const value = (error as Record<string, unknown>)[field];
+  return typeof value === "string" ? value : undefined;
+};
+
+const CODE_TO_CLASS: Readonly<Record<string, StorageErrorClass>> = {
+  Conflict: "conflict",
+  NetworkError: "network_error",
+  InvalidResponse: "invalid_response",
+  Internal: "internal",
+  InvalidConfig: "invalid_config",
+};
+
+/**
+ * Map a thrown value onto the journal's closed error vocabulary.
+ *
+ * Abort is detected by `name`, never by `code`: a `DOMException` exposes a
+ * legacy **numeric** `code` (`AbortError` is `20`), which is why
+ * {@link stringField} discards non-string values instead of forwarding them.
+ */
+export const classifyStorageError = (error: unknown): StorageErrorClass => {
+  const name = stringField(error, "name");
+  if (name === "AbortError" || name === "TimeoutError") {
+    return "aborted";
+  }
+  const code = stringField(error, "code");
+  if (code === undefined) {
+    return "unknown";
+  }
+  return CODE_TO_CLASS[code] ?? "unknown";
+};
+
+/** Structured, string-safe description of a thrown value. */
+export const describeThrown = (error: unknown): ThrownDescription => {
+  const code = stringField(error, "code");
+  return {
+    name: stringField(error, "name") ?? "UnknownError",
+    ...(code !== undefined && { code }),
+    message: stringField(error, "message") ?? String(error),
+  };
+};
+
+export interface JournalSignal {
+  readonly id: string;
+  readonly present: true;
+  readonly aborted_at_dispatch: boolean;
+}
+
+export interface JournalRequestOptions {
+  readonly if_match?: string;
+  readonly if_none_match?: string;
+  readonly content_type?: string;
+  readonly version_id?: string;
+  readonly start_after?: string;
+  readonly max_keys?: number;
+  readonly signal?: JournalSignal;
+}
+
+export type StorageOperationResult =
+  | {
+      readonly status: "returned";
+      readonly classification: "found" | "not_found" | "put_ok" | "delete_ok" | "list_ok";
+      readonly etag?: string;
+      readonly version_id?: string;
+      readonly listed_entries?: number;
+    }
+  | {
+      readonly status: "threw";
+      readonly classification: StorageErrorClass;
+      readonly name: string;
+      readonly code?: string;
+    };
+
+export interface StorageOperationRecord {
+  readonly schema: typeof OPERATION_JOURNAL_VERSION;
+  readonly attempt_id: AttemptId;
+  readonly operation_index: number;
+  readonly method: StorageMethod;
+  readonly key: string;
+  readonly options: JournalRequestOptions;
+  readonly put?: { readonly byte_length: number; readonly sha256: string };
+  readonly result: StorageOperationResult;
+}
+
+export interface NamespaceEntry {
+  readonly key: string;
+  readonly byte_length: number;
+  readonly last_operation_index: number | null;
+  readonly source: "provisioned" | "put";
+}
+
+/**
+ * Why one key is uncertain. `uncertain_keys` stays the fail-closed answer; this
+ * carries the evidence so a downstream consumer can narrow WITHOUT assuming
+ * anything about adapter behavior. In particular `aborted_at_dispatch === true`
+ * means the signal was already aborted when the wrapper was called.
+ */
+export interface NamespaceUncertainty {
+  readonly key: string;
+  readonly operation_index: number;
+  readonly method: "put" | "delete";
+  readonly classification: StorageErrorClass;
+  readonly aborted_at_dispatch: boolean;
+}
+
+export interface NamespaceSnapshot {
+  readonly schema: typeof NAMESPACE_JOURNAL_VERSION;
+  readonly exact: boolean;
+  readonly entries: readonly NamespaceEntry[];
+  readonly uncertain_keys: readonly string[];
+  readonly uncertainty: readonly NamespaceUncertainty[];
+}
+
+export interface PendingOperation {
+  readonly operation_index: number;
+  readonly method: StorageMethod;
+  readonly key: string;
+}
+
+export class JournalNotQuiescentError extends Error {
+  readonly pending: readonly PendingOperation[];
+  constructor(pending: readonly PendingOperation[]) {
+    const names = pending.map((p) => `${p.operation_index}:${p.method} ${p.key}`).join(", ");
+    super(
+      `journal is not quiescent: ${pending.length} operation(s) dispatched but unsettled ` +
+        `[${names}]. Await them, or call snapshotSettledOperations() if a mid-flight ` +
+        `view is what you actually want.`,
+    );
+    this.name = "JournalNotQuiescentError";
+    this.pending = pending;
+  }
+}
+
+export interface StorageJournal {
+  readonly attemptId: AttemptId;
+  /**
+   * THROWS `JournalNotQuiescentError` when any dispatched row is unsettled,
+   * instead of silently omitting it. Journal equality is this lane's primary
+   * consumer and a silently short list is the failure mode that passes green.
+   */
+  snapshotOperations(): readonly StorageOperationRecord[];
+  /** Settled rows only, never throws. For deliberate mid-flight inspection. */
+  snapshotSettledOperations(): readonly StorageOperationRecord[];
+  pendingOperations(): readonly PendingOperation[];
+  /** Count of rows dispatched but not yet settled. Zero means quiescent. */
+  pendingOperationCount(): number;
+  snapshotNamespace(): NamespaceSnapshot;
+  recordProvisioned(entries: readonly { key: string; byte_length: number }[]): void;
+  /** Derived from settled rows only. */
+  billingSummary(): BillingSummary;
+}
+
+export interface JournaledStorage {
+  readonly storage: Storage;
+  readonly journal: StorageJournal;
+}
+
+const HEX = "0123456789abcdef";
+
+// `Uint8Array.prototype.toHex` type-checks under `ESNext.TypedArrays` but
+// throws at run time on Node 24 and workerd (gated behind a V8 flag), so the
+// hex loop is hand-rolled on purpose.
+const toHex = (bytes: Uint8Array): string => {
+  let out = "";
+  for (const byte of bytes) {
+    out += HEX.charAt(byte >> 4);
+    out += HEX.charAt(byte & 15);
+  }
+  return out;
+};
+
+const sha256Hex = async (bytes: Uint8Array<ArrayBuffer>): Promise<string> => {
+  // `bytes` is already the dispatch-time copy, allocated over a fresh
+  // `ArrayBuffer` — tsgo narrows a bare `Uint8Array` to
+  // `Uint8Array<ArrayBufferLike>`, which `crypto.subtle.digest` rejects (it
+  // wants `ArrayBufferView<ArrayBuffer>`). Same constraint, and the same
+  // workaround, as `packages/protocol/src/sha256.ts`.
+  // See microsoft/TypeScript#61375.
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return toHex(new Uint8Array(digest));
+};
+
+interface MutableRow {
+  readonly index: number;
+  readonly method: StorageMethod;
+  readonly key: string;
+  readonly options: JournalRequestOptions;
+  put?: { readonly byte_length: number; readonly sha256: string };
+  result?: StorageOperationResult;
+}
+
+interface MutableUncertainty {
+  readonly key: string;
+  readonly operation_index: number;
+  readonly method: "put" | "delete";
+  readonly classification: StorageErrorClass;
+  readonly aborted_at_dispatch: boolean;
+}
+
+/**
+ * Record ordering for `entries` / `uncertainty` — plain string comparison on
+ * the key, NOT the S3 UTF-8 list-order contract. Written as an if/return block
+ * because `.oxlintrc.json` sets `eslint/no-nested-ternary` to `error`; do not
+ * "simplify" it back to a nested ternary.
+ */
+const byKeyAsc = (a: { key: string }, b: { key: string }): number => {
+  if (a.key < b.key) {
+    return -1;
+  }
+  return a.key > b.key ? 1 : 0;
+};
+
+interface CapturableOptions {
+  ifMatch?: string;
+  ifNoneMatch?: string;
+  contentType?: string;
+  versionId?: string;
+  startAfter?: string;
+  maxKeys?: number;
+  signal?: AbortSignal;
+}
+
+export const wrapJournaledStorage = (input: {
+  readonly attemptId: AttemptId;
+  readonly storage: Storage;
+  readonly signalIds?: ReadonlyMap<AbortSignal, string>;
+}): JournaledStorage => {
+  const inner = input.storage;
+  const rows: MutableRow[] = [];
+  const entries = new Map<
+    string,
+    { byte_length: number; last_operation_index: number | null; source: "provisioned" | "put" }
+  >();
+  const uncertain = new Map<string, MutableUncertainty>();
+  const anonymousNames = new WeakMap<AbortSignal, string>();
+  let anonymousCount = 0;
+  let nextIndex = 0;
+
+  const nameSignal = (signal: AbortSignal): string => {
+    const provided = input.signalIds?.get(signal);
+    if (provided !== undefined) {
+      return provided;
+    }
+    const known = anonymousNames.get(signal);
+    if (known !== undefined) {
+      return known;
+    }
+    anonymousCount += 1;
+    const generated = `signal-${anonymousCount}`;
+    anonymousNames.set(signal, generated);
+    return generated;
+  };
+
+  const capture = (opts?: CapturableOptions): JournalRequestOptions => ({
+    ...(opts?.ifMatch !== undefined && { if_match: opts.ifMatch }),
+    ...(opts?.ifNoneMatch !== undefined && { if_none_match: opts.ifNoneMatch }),
+    ...(opts?.contentType !== undefined && { content_type: opts.contentType }),
+    ...(opts?.versionId !== undefined && { version_id: opts.versionId }),
+    ...(opts?.startAfter !== undefined && { start_after: opts.startAfter }),
+    ...(opts?.maxKeys !== undefined && { max_keys: opts.maxKeys }),
+    ...(opts?.signal !== undefined && {
+      signal: {
+        id: nameSignal(opts.signal),
+        present: true as const,
+        aborted_at_dispatch: opts.signal.aborted,
+      },
+    }),
+  });
+
+  const openRow = (
+    method: StorageMethod,
+    key: string,
+    options: JournalRequestOptions,
+  ): MutableRow => {
+    const row: MutableRow = { index: nextIndex, method, key, options };
+    nextIndex += 1;
+    rows.push(row);
+    return row;
+  };
+
+  const threwResult = (error: unknown): StorageOperationResult => {
+    const described = describeThrown(error);
+    return {
+      status: "threw",
+      classification: classifyStorageError(error),
+      name: described.name,
+      ...(described.code !== undefined && { code: described.code }),
+    };
+  };
+
+  /**
+   * Conflict leaves prior state unchanged; any other failure class removes the
+   * key from the exactly-known set and records WHY. The evidence row is what
+   * lets a downstream consumer narrow (see `aborted_at_dispatch`) without this
+   * module assuming anything the `Storage` contract does not state.
+   */
+  const markUncertain = (row: MutableRow, method: "put" | "delete", error: unknown): void => {
+    const classification = classifyStorageError(error);
+    if (classification === "conflict") {
+      return;
+    }
+    entries.delete(row.key);
+    uncertain.set(row.key, {
+      key: row.key,
+      operation_index: row.index,
+      method,
+      classification,
+      aborted_at_dispatch: row.options.signal?.aborted_at_dispatch ?? false,
+    });
+  };
+
+  const storage: Storage = {
+    get: async (key, opts) => {
+      const row = openRow("get", key, capture(opts));
+      try {
+        const result: StorageGetResult | null = await inner.get(key, opts);
+        row.result =
+          result === null
+            ? { status: "returned", classification: "not_found" }
+            : {
+                status: "returned",
+                classification: "found",
+                etag: result.etag,
+                ...(result.versionId !== undefined && { version_id: result.versionId }),
+              };
+        return result;
+      } catch (error: unknown) {
+        row.result = threwResult(error);
+        throw error;
+      }
+    },
+
+    put: async (key, body, opts) => {
+      const row = openRow("put", key, capture(opts));
+      // Copy at dispatch so later caller mutation cannot alter the journal.
+      // The ORIGINAL `body` is handed to the inner storage: `MemoryStorage`
+      // stores the caller's array by reference, and substituting a copy would
+      // change what the system under test observes.
+      const copy = new Uint8Array(body.byteLength);
+      copy.set(body);
+      // Settle the digest to an option rather than awaiting it bare: a digest
+      // rejection must never replace the storage error, which is the outcome
+      // the caller actually needs.
+      const digest = sha256Hex(copy).then(
+        (sha256) => ({ ok: true, sha256 }) as const,
+        () => ({ ok: false }) as const,
+      );
+      const settled = await inner.put(key, body, opts).then(
+        (value: StoragePutResult) => ({ ok: true, value }) as const,
+        (error: unknown) => ({ ok: false, error }) as const,
+      );
+      const digested = await digest;
+      if (digested.ok) {
+        row.put = { byte_length: copy.byteLength, sha256: digested.sha256 };
+      }
+      if (!settled.ok) {
+        row.result = threwResult(settled.error);
+        markUncertain(row, "put", settled.error);
+        throw settled.error;
+      }
+      row.result = {
+        status: "returned",
+        classification: "put_ok",
+        etag: settled.value.etag,
+        ...(settled.value.versionId !== undefined && { version_id: settled.value.versionId }),
+      };
+      uncertain.delete(key);
+      entries.set(key, {
+        byte_length: copy.byteLength,
+        last_operation_index: row.index,
+        source: "put",
+      });
+      return settled.value;
+    },
+
+    delete: async (key, opts) => {
+      const row = openRow("delete", key, capture(opts));
+      try {
+        await inner.delete(key, opts);
+        row.result = { status: "returned", classification: "delete_ok" };
+        entries.delete(key);
+        uncertain.delete(key);
+      } catch (error: unknown) {
+        row.result = threwResult(error);
+        markUncertain(row, "delete", error);
+        throw error;
+      }
+    },
+
+    // The generator body does not run until the first `next()`, so the row is
+    // opened when ITERATION begins, per the parent plan. That is a different
+    // clock from the other three verbs — see Semantics §2 and Open question 6.
+    list: async function* (prefix, opts): AsyncIterable<StorageListEntry> {
+      const row = openRow("list", prefix, capture(opts));
+      let listed = 0;
+      try {
+        for await (const entry of inner.list(prefix, opts)) {
+          listed += 1;
+          yield entry;
+        }
+        row.result = { status: "returned", classification: "list_ok", listed_entries: listed };
+      } catch (error: unknown) {
+        row.result = threwResult(error);
+        throw error;
+      } finally {
+        // An early `break` disposes the generator without reaching either
+        // branch above; settle with the partial count so the row never leaks.
+        row.result ??= {
+          status: "returned",
+          classification: "list_ok",
+          listed_entries: listed,
+        };
+      }
+    },
+  };
+
+  const settledRows = (): (MutableRow & { result: StorageOperationResult })[] =>
+    rows
+      .filter(
+        (row): row is MutableRow & { result: StorageOperationResult } => row.result !== undefined,
+      )
+      .toSorted((a, b) => a.index - b.index);
+
+  const toRecord = (row: MutableRow & { result: StorageOperationResult }): StorageOperationRecord =>
+    Object.freeze<StorageOperationRecord>({
+      schema: OPERATION_JOURNAL_VERSION,
+      attempt_id: input.attemptId,
+      operation_index: row.index,
+      method: row.method,
+      key: row.key,
+      options: row.options,
+      ...(row.put !== undefined && { put: row.put }),
+      result: row.result,
+    });
+
+  const pending = (): PendingOperation[] =>
+    rows
+      .filter((row) => row.result === undefined)
+      .toSorted((a, b) => a.index - b.index)
+      .map((row) => ({ operation_index: row.index, method: row.method, key: row.key }));
+
+  const journal: StorageJournal = {
+    attemptId: input.attemptId,
+
+    /**
+     * Throws when the journal is not quiescent. Journal EQUALITY is this
+     * contract's primary consumer, and two silently-truncated lists compare
+     * equal to each other — the exact failure that passes green.
+     */
+    snapshotOperations: (): readonly StorageOperationRecord[] => {
+      const unsettled = pending();
+      if (unsettled.length > 0) {
+        throw new JournalNotQuiescentError(unsettled);
+      }
+      return settledRows().map(toRecord);
+    },
+
+    snapshotSettledOperations: (): readonly StorageOperationRecord[] => settledRows().map(toRecord),
+
+    pendingOperations: (): readonly PendingOperation[] => pending(),
+
+    pendingOperationCount: (): number =>
+      rows.reduce((count, row) => (row.result === undefined ? count + 1 : count), 0),
+
+    snapshotNamespace: (): NamespaceSnapshot =>
+      Object.freeze<NamespaceSnapshot>({
+        schema: NAMESPACE_JOURNAL_VERSION,
+        exact: uncertain.size === 0,
+        entries: [...entries]
+          .map(([key, value]) => ({
+            key,
+            byte_length: value.byte_length,
+            last_operation_index: value.last_operation_index,
+            source: value.source,
+          }))
+          .toSorted(byKeyAsc),
+        uncertain_keys: [...uncertain.keys()].toSorted(),
+        uncertainty: [...uncertain.values()].toSorted(byKeyAsc),
+      }),
+
+    recordProvisioned: (provisioned): void => {
+      for (const entry of provisioned) {
+        uncertain.delete(entry.key);
+        entries.set(entry.key, {
+          byte_length: entry.byte_length,
+          last_operation_index: null,
+          source: "provisioned",
+        });
+      }
+    },
+
+    billingSummary: (): BillingSummary => {
+      let classA = 0;
+      let classB = 0;
+      let free = 0;
+      for (const row of settledRows()) {
+        const cls = billingClassOf(row.method);
+        if (cls === "A") {
+          classA += 1;
+        } else if (cls === "B") {
+          classB += 1;
+        } else {
+          free += 1;
+        }
+      }
+      return { class_a: classA, class_b: classB, free };
+    },
+  };
+
+  return { storage, journal };
+};

--- a/docs/spec/attachments/fold-ceiling-headroom-baseline.json
+++ b/docs/spec/attachments/fold-ceiling-headroom-baseline.json
@@ -1,0 +1,424 @@
+{
+  "schema": "baerly.fold-ceiling-probe/v1",
+  "subject_commit": "6523ec699e26f8ad9661a878d3abe958165cea44",
+  "node_version": "v24.16.0",
+  "platform": "darwin",
+  "arch": "arm64",
+  "todays_ceilings": {
+    "c_bytes": 524288,
+    "e_rows": 2048
+  },
+  "budgets": [
+    {
+      "profile": "cf-free",
+      "cpu_ms": 10,
+      "memory_bytes": 134217728,
+      "source": "graduation.md — ~10 ms CPU/request, 128 MB isolate"
+    },
+    {
+      "profile": "cf-paid",
+      "cpu_ms": 30000,
+      "memory_bytes": 134217728,
+      "source": "graduation.md — 30 s CPU default, ~128 MB Worker memory (memory is the wall)"
+    },
+    {
+      "profile": "node",
+      "cpu_ms": 30000,
+      "memory_bytes": 536870912,
+      "source": "ASSUMPTION, not a platform limit: a modest 512 MB container, 30 s request budget"
+    }
+  ],
+  "margins": [
+    2,
+    4,
+    7
+  ],
+  "cells": [
+    {
+      "axis": "bytes",
+      "label": "512KB",
+      "rows": 256,
+      "bytes_per_doc": 2048,
+      "snapshot_bytes": 532300,
+      "tail_entries": 100,
+      "iterations": 11,
+      "cpu_ms_median": 3.523,
+      "peak_bytes_median": 2485500,
+      "peak_over_snapshot": 4.669359383806125,
+      "peak_samples_discarded": 1
+    },
+    {
+      "axis": "bytes",
+      "label": "1MB",
+      "rows": 512,
+      "bytes_per_doc": 2048,
+      "snapshot_bytes": 1064524,
+      "tail_entries": 100,
+      "iterations": 11,
+      "cpu_ms_median": 6.087,
+      "peak_bytes_median": 3167144,
+      "peak_over_snapshot": 2.9751738805325196,
+      "peak_samples_discarded": 0
+    },
+    {
+      "axis": "bytes",
+      "label": "2MB",
+      "rows": 1024,
+      "bytes_per_doc": 2048,
+      "snapshot_bytes": 2128973,
+      "tail_entries": 100,
+      "iterations": 11,
+      "cpu_ms_median": 11.024,
+      "peak_bytes_median": 5684208,
+      "peak_over_snapshot": 2.66992958576741,
+      "peak_samples_discarded": 1
+    },
+    {
+      "axis": "bytes",
+      "label": "3MB",
+      "rows": 1536,
+      "bytes_per_doc": 2048,
+      "snapshot_bytes": 3193421,
+      "tail_entries": 100,
+      "iterations": 11,
+      "cpu_ms_median": 14.499,
+      "peak_bytes_median": 8230608,
+      "peak_over_snapshot": 2.577363899091288,
+      "peak_samples_discarded": 0
+    },
+    {
+      "axis": "bytes",
+      "label": "4MB",
+      "rows": 2048,
+      "bytes_per_doc": 2048,
+      "snapshot_bytes": 4257869,
+      "tail_entries": 100,
+      "iterations": 11,
+      "cpu_ms_median": 28.356,
+      "peak_bytes_median": 10051248,
+      "peak_over_snapshot": 2.3606287558400694,
+      "peak_samples_discarded": 0
+    },
+    {
+      "axis": "bytes",
+      "label": "5MB",
+      "rows": 2560,
+      "bytes_per_doc": 2048,
+      "snapshot_bytes": 5322317,
+      "tail_entries": 100,
+      "iterations": 11,
+      "cpu_ms_median": 63.73,
+      "peak_bytes_median": 12606196,
+      "peak_over_snapshot": 2.368554146624487,
+      "peak_samples_discarded": 1
+    },
+    {
+      "axis": "bytes",
+      "label": "8MB",
+      "rows": 4096,
+      "bytes_per_doc": 2048,
+      "snapshot_bytes": 8515661,
+      "tail_entries": 100,
+      "iterations": 9,
+      "cpu_ms_median": 121.564,
+      "peak_bytes_median": 19767960,
+      "peak_over_snapshot": 2.3213653056409833,
+      "peak_samples_discarded": 3
+    },
+    {
+      "axis": "bytes",
+      "label": "16MB",
+      "rows": 8192,
+      "bytes_per_doc": 2048,
+      "snapshot_bytes": 17031245,
+      "tail_entries": 100,
+      "iterations": 9,
+      "cpu_ms_median": 285.349,
+      "peak_bytes_median": 38327800,
+      "peak_over_snapshot": 2.2504402937072423,
+      "peak_samples_discarded": 6
+    },
+    {
+      "axis": "bytes",
+      "label": "32MB",
+      "rows": 16384,
+      "bytes_per_doc": 2048,
+      "snapshot_bytes": 34062414,
+      "tail_entries": 100,
+      "iterations": 9,
+      "cpu_ms_median": 367.352,
+      "peak_bytes_median": 76763232,
+      "peak_over_snapshot": 2.2536051613957837,
+      "peak_samples_discarded": 6
+    },
+    {
+      "axis": "rows",
+      "label": "2048 rows",
+      "rows": 2048,
+      "bytes_per_doc": 64,
+      "snapshot_bytes": 232287,
+      "tail_entries": 100,
+      "iterations": 11,
+      "cpu_ms_median": 3.42,
+      "peak_bytes_median": 1786952,
+      "peak_over_snapshot": 7.692862708631994,
+      "peak_samples_discarded": 0
+    },
+    {
+      "axis": "rows",
+      "label": "8192 rows",
+      "rows": 8192,
+      "bytes_per_doc": 64,
+      "snapshot_bytes": 928947,
+      "tail_entries": 100,
+      "iterations": 11,
+      "cpu_ms_median": 9.746,
+      "peak_bytes_median": 6508296,
+      "peak_over_snapshot": 7.006100455677235,
+      "peak_samples_discarded": 3
+    },
+    {
+      "axis": "rows",
+      "label": "16384 rows",
+      "rows": 16384,
+      "bytes_per_doc": 64,
+      "snapshot_bytes": 1857834,
+      "tail_entries": 100,
+      "iterations": 11,
+      "cpu_ms_median": 18.345,
+      "peak_bytes_median": 10465112,
+      "peak_over_snapshot": 5.632963978482469,
+      "peak_samples_discarded": 0
+    },
+    {
+      "axis": "rows",
+      "label": "32768 rows",
+      "rows": 32768,
+      "bytes_per_doc": 64,
+      "snapshot_bytes": 3715572,
+      "tail_entries": 100,
+      "iterations": 11,
+      "cpu_ms_median": 29.577,
+      "peak_bytes_median": 20660040,
+      "peak_over_snapshot": 5.560392854720619,
+      "peak_samples_discarded": 4
+    },
+    {
+      "axis": "rows",
+      "label": "65536 rows",
+      "rows": 65536,
+      "bytes_per_doc": 64,
+      "snapshot_bytes": 7431356,
+      "tail_entries": 100,
+      "iterations": 11,
+      "cpu_ms_median": 80.119,
+      "peak_bytes_median": 41183200,
+      "peak_over_snapshot": 5.541814979661854,
+      "peak_samples_discarded": 6
+    },
+    {
+      "axis": "rows",
+      "label": "131072 rows",
+      "rows": 131072,
+      "bytes_per_doc": 64,
+      "snapshot_bytes": 14862044,
+      "tail_entries": 100,
+      "iterations": 9,
+      "cpu_ms_median": 451.195,
+      "peak_bytes_median": 43726064,
+      "peak_over_snapshot": 2.942129898148599,
+      "peak_samples_discarded": 3
+    },
+    {
+      "axis": "cross",
+      "label": "4k x 1KB",
+      "rows": 4096,
+      "bytes_per_doc": 1024,
+      "snapshot_bytes": 4321357,
+      "tail_entries": 100,
+      "iterations": 11,
+      "cpu_ms_median": 18.581,
+      "peak_bytes_median": 10787520,
+      "peak_over_snapshot": 2.4963269639606263,
+      "peak_samples_discarded": 3
+    },
+    {
+      "axis": "cross",
+      "label": "16k x 512B",
+      "rows": 16384,
+      "bytes_per_doc": 512,
+      "snapshot_bytes": 8896590,
+      "tail_entries": 100,
+      "iterations": 9,
+      "cpu_ms_median": 48.117,
+      "peak_bytes_median": 27213144,
+      "peak_over_snapshot": 3.0588286073652937,
+      "peak_samples_discarded": 1
+    },
+    {
+      "axis": "cross",
+      "label": "65k x 256B",
+      "rows": 65536,
+      "bytes_per_doc": 256,
+      "snapshot_bytes": 18808910,
+      "tail_entries": 100,
+      "iterations": 9,
+      "cpu_ms_median": 415.667,
+      "peak_bytes_median": 25338188,
+      "peak_over_snapshot": 1.3471375002591857,
+      "peak_samples_discarded": 7
+    }
+  ],
+  "today_headroom": [
+    {
+      "profile": "cf-free",
+      "at_c_cpu_ms": 3.523,
+      "at_c_peak_bytes": 2485500,
+      "at_e_cpu_ms": 3.42,
+      "at_e_peak_bytes": 1786952,
+      "cpu_margin_at_c": 2.838489923360772,
+      "cpu_margin_at_e": 2.9239766081871346,
+      "memory_margin_at_c": 54.000292898813115,
+      "memory_margin_at_e": 75.10986752861857
+    },
+    {
+      "profile": "cf-paid",
+      "at_c_cpu_ms": 3.523,
+      "at_c_peak_bytes": 2485500,
+      "at_e_cpu_ms": 3.42,
+      "at_e_peak_bytes": 1786952,
+      "cpu_margin_at_c": 8515.469770082316,
+      "cpu_margin_at_e": 8771.929824561405,
+      "memory_margin_at_c": 54.000292898813115,
+      "memory_margin_at_e": 75.10986752861857
+    },
+    {
+      "profile": "node",
+      "at_c_cpu_ms": 3.523,
+      "at_c_peak_bytes": 2485500,
+      "at_e_cpu_ms": 3.42,
+      "at_e_peak_bytes": 1786952,
+      "cpu_margin_at_c": 8515.469770082316,
+      "cpu_margin_at_e": 8771.929824561405,
+      "memory_margin_at_c": 216.00117159525246,
+      "memory_margin_at_e": 300.43947011447426
+    }
+  ],
+  "sustainable": [
+    {
+      "profile": "cf-free",
+      "margin": 2,
+      "max_c_bytes": 532300,
+      "max_e_rows": 2048,
+      "binding_axis": "cpu",
+      "c_multiple_of_today": 1.0152816772460938,
+      "e_multiple_of_today": 1
+    },
+    {
+      "profile": "cf-free",
+      "margin": 4,
+      "max_c_bytes": null,
+      "max_e_rows": null,
+      "binding_axis": "none",
+      "c_multiple_of_today": null,
+      "e_multiple_of_today": null
+    },
+    {
+      "profile": "cf-free",
+      "margin": 7,
+      "max_c_bytes": null,
+      "max_e_rows": null,
+      "binding_axis": "none",
+      "c_multiple_of_today": null,
+      "e_multiple_of_today": null
+    },
+    {
+      "profile": "cf-paid",
+      "margin": 2,
+      "max_c_bytes": 17031245,
+      "max_e_rows": 131072,
+      "binding_axis": "memory",
+      "c_multiple_of_today": 32.48452186584473,
+      "e_multiple_of_today": 64
+    },
+    {
+      "profile": "cf-paid",
+      "margin": 4,
+      "max_c_bytes": 8515661,
+      "max_e_rows": 65536,
+      "binding_axis": "memory",
+      "c_multiple_of_today": 16.242334365844727,
+      "e_multiple_of_today": 32
+    },
+    {
+      "profile": "cf-paid",
+      "margin": 7,
+      "max_c_bytes": 5322317,
+      "max_e_rows": 16384,
+      "binding_axis": "memory",
+      "c_multiple_of_today": 10.151514053344727,
+      "e_multiple_of_today": 8
+    },
+    {
+      "profile": "node",
+      "margin": 2,
+      "max_c_bytes": 34062414,
+      "max_e_rows": 131072,
+      "binding_axis": "grid-exhausted",
+      "c_multiple_of_today": 64.96889877319336,
+      "e_multiple_of_today": 64
+    },
+    {
+      "profile": "node",
+      "margin": 4,
+      "max_c_bytes": 34062414,
+      "max_e_rows": 131072,
+      "binding_axis": "grid-exhausted",
+      "c_multiple_of_today": 64.96889877319336,
+      "e_multiple_of_today": 64
+    },
+    {
+      "profile": "node",
+      "margin": 7,
+      "max_c_bytes": 17031245,
+      "max_e_rows": 131072,
+      "binding_axis": "memory",
+      "c_multiple_of_today": 32.48452186584473,
+      "e_multiple_of_today": 64
+    }
+  ],
+  "findings": [
+    "cf-free: at today's C the fold costs 3.52 ms and 2.37 MB peak — 2.8x CPU margin, 54.0x memory margin. At today's E it costs 3.42 ms and 1.70 MB peak — 2.9x CPU, 75.1x memory.",
+    "cf-paid: at today's C the fold costs 3.52 ms and 2.37 MB peak — 8515.5x CPU margin, 54.0x memory margin. At today's E it costs 3.42 ms and 1.70 MB peak — 8771.9x CPU, 75.1x memory.",
+    "node: at today's C the fold costs 3.52 ms and 2.37 MB peak — 8515.5x CPU margin, 216.0x memory margin. At today's E it costs 3.42 ms and 1.70 MB peak — 8771.9x CPU, 300.4x memory.",
+    "bytes axis: the cost-per-MB knee is REAL and starts between 3.05 MB (4.76 ms/MB) and 4.06 MB (6.98 ms/MB). Series, ms/MB: 512KB=6.9, 1MB=6.0, 2MB=5.4, 3MB=4.8, 4MB=7.0, 5MB=12.6, 8MB=15.0, 16MB=17.6, 32MB=11.3.",
+    "cf-paid @2x margin: C 16.24 MB (32.5x today), E 131072 rows (64.0x today), bound by memory — wall.",
+    "cf-paid @4x margin: C 8.12 MB (16.2x today), E 65536 rows (32.0x today), bound by memory — wall.",
+    "cf-paid @7x margin: C 5.08 MB (10.2x today), E 16384 rows (8.0x today), bound by memory — wall.",
+    "cross 4k x 1KB (4096 rows x 1024 B, 4.12 MB) vs the nearest bytes-axis cell 4MB (2048 rows x 2048 B, 4.06 MB): CPU 18.6 ms vs 28.4 ms (0.66x), peak 10.29 MB vs 9.59 MB (1.07x). peak/snapshot 2.50 vs 2.36.",
+    "cross 16k x 512B (16384 rows x 512 B, 8.48 MB) vs the nearest bytes-axis cell 8MB (4096 rows x 2048 B, 8.12 MB): CPU 48.1 ms vs 121.6 ms (0.40x), peak 25.95 MB vs 18.85 MB (1.38x). peak/snapshot 3.06 vs 2.32.",
+    "cross 65k x 256B (65536 rows x 256 B, 17.94 MB) vs the nearest bytes-axis cell 16MB (8192 rows x 2048 B, 16.24 MB): CPU 415.7 ms vs 285.3 ms (1.46x), peak 24.16 MB vs 36.55 MB (0.66x). peak/snapshot 1.35 vs 2.25.",
+    "peak-sample hygiene: 13 of 18 cells lost at least one GC-floored peak sample (see isPeakSampleUsable); worst cell dropped 7 of its samples. CPU is unaffected — cpuUsage() deltas have no baseline to float.",
+    "overlap vs the frozen fold-cost baseline (6 shared cells): snapshot_bytes matches the frozen baseline EXACTLY on all of them (same seed, same builder). peak_bytes_median 0.95x-1.05x of frozen — allocation behaviour is unchanged. cpu_ms_median 1.42x-2.49x of frozen, so THIS HOST IS SLOWER than the host that produced the baseline. CPU-bound verdicts (the cf-free rows) are therefore conservative on this hardware and are NOT portable; the memory-bound verdicts (cf-paid) are."
+  ],
+  "recommended_changes": [
+    {
+      "file": "packages/protocol/src/constants.ts",
+      "change": "Give MAINTENANCE_PROFILE_CF_PAID and MAINTENANCE_PROFILE_NODE their own maxFoldBytes/maxFoldRows instead of sharing the CF-free values. See the `sustainable` table for the measured room at each margin.",
+      "owner": "Protocol owner",
+      "blocked_by": "worktree-fix-issue-74-readpreimage-floor holds packages/protocol/src/constants.ts (locked live session)"
+    },
+    {
+      "file": "packages/server/src/maintenance.ts",
+      "change": "`E` has no operator override: the profile read takes `args.maxFoldBytes ?? profile.maxFoldBytes` for C but plain `profile.maxFoldRows` for E. Add BAERLY_MAINTENANCE_MAX_FOLD_ROWS to mirror the C override. (Manifest §11 item 6.)",
+      "owner": "Protocol owner",
+      "blocked_by": null
+    },
+    {
+      "file": "docs/about/graduation.md",
+      "change": "The `≈ 11 ms CPU per MB` model and the `1 MB | ~11 ms` table row overstate measured cost. Restate against measurement, or mark the model as a deliberate upper bound and say so.",
+      "owner": "Performance owner (graduation.md is a §6.2-owned product doc)",
+      "blocked_by": null
+    }
+  ]
+}


### PR DESCRIPTION
## What & why

All three maintenance profiles ship the same fold ceilings (`C = 512 KiB`, `E = 2048`) even though Cloudflare paid gets a 30 s CPU budget against free's ~10 ms, and `MAINTENANCE_MAX_FOLD_ROWS`'s JSDoc still reads `PROVISIONAL — bench landed; paid recalibration deferred`. This measures how much room actually exists: **at a conservative 7x margin cf-paid sustains 10x the byte ceiling and 8x the row ceiling, memory-bound**, while cf-free is already at its CPU line. Evidence lands at `docs/spec/attachments/fold-ceiling-headroom-baseline.json`.

It also adds the two foundation modules the rest of the fold program builds on: a timer-free `Storage` decorator producing an ordered operation journal plus an exact namespace journal, and a `StorageFactory`/`StorageLease` seam whose cleanup authority is narrowed to one in-memory instance, one `mkdtemp` root, or an explicit key list.

**Measures only — no constant, profile, or production behaviour changes.** Everything actionable is a `recommended_changes` entry in the attachment naming a file, an owner, and a blocker.

## Key points

- Extracts the fold fixture and CPU/heap sampler into `bench/lib/fold-fixture.ts` rather than exporting them in place: `bench/fold-cost.ts` ends in an unguarded `main().then(process.exit)`, so importing any symbol ran the whole 12-cell bench and killed the host process. Verified behaviour-free — all 12 deterministic columns still match the frozen `fold-cost-baseline.json` cell for cell.
- Discards peak samples below the snapshot size as GC-floored. `peakBytes` is `max(sample) - heapUsedAtStart`, so a `heapStart` caught at a pre-GC high-water mark floors a fold to ~0; the first run reported a 0.03 MB peak for a 16 MB fold and that cell then set the cf-paid ceiling outright. Discards are counted per cell, and `LARGE_MEASURE_ITERS` went 5 → 9 so a large cell keeps a usable median.
- Derives `findings` from the cells in the same record instead of transcribing them, so prose and measurement cannot drift across re-runs.
- **The cross-axis result says a two-way `(C, E)` ceiling does not describe the cost surface.** Against the nearest bytes-axis cell at equal snapshot size, cross cells ran CPU at 0.40x, 0.66x, and 1.46x — both directions — and peak/snapshot spanned 1.35–3.06 vs 2.25–2.98 on the bytes axis. Cost tracks the *(rows x bytes-per-doc)* combination, not either axis nor their conjunction.
- This host is 1.42x–2.49x slower than the one that produced the frozen baseline (six overlapping cells); memory tracked within 0.95x–1.05x. The memory-bound cf-paid verdict is portable, the CPU-bound cf-free rows are not.
- `snapshotOperations()` throws on non-quiescence rather than returning a short list — journal equality is the primary consumer, and two silently-truncated lists compare equal. `snapshotSettledOperations()` is the opt-out.
- `isWithinCleanupAuthority` is exported and tested in both polarities because inside the cleanup closure the `rm -rf` refusal branch is unreachable by construction and would otherwise ship uncovered.
- `billingClassOf` implements the `cost-model.md` definition (puts + lists bill, DELETE is \$0). One definition, not a resolution: a test records all three live disagreeing definitions as evidence for their owner.

## Verification

| `pnpm verify:agent` | clean |
| `pnpm test:agent bench/measurement/` | 72 passed |
| `oxlint bench/measurement bench/lib` | clean |
| `pnpm test:agent` (full suite) | **not run** — main has a known bundle-budget failure and several flakes being fixed separately |

Bundle budgets are unaffected structurally rather than by assertion: this branch modifies nothing under `packages/`, `tests/`, or the lockfile, and `bench/` is not an entry in `rolldown.config.ts` nor imported by any package (the one grep hit is a JSDoc reference).

## Notes for reviewers

Start at `bench/measurement/fold-ceiling-probe.ts` — the module docstring explains the grid and why each new cell exists. `isPeakSampleUsable` and `deriveFindings` are the two places where this deviates from a naive port of the plan, and both have tests.

Downstream lanes: four signatures moved. `asAttemptId` validates and throws `InvalidAttemptIdError`, `snapshotOperations()` throws `JournalNotQuiescentError`, `WithStorageLeaseResult` gained `pending_operations_at_cleanup`, and `NamespaceSnapshot` gained `uncertainty`.