### PR TITLE
fix(cloudflare): stop shipping LocalFsStorage inside the Worker bundle

### DIFF
--- a/.changeset/worker-dev-landing-boundary.md
+++ b/.changeset/worker-dev-landing-boundary.md
@@ -1,0 +1,28 @@
+---
+"@gusto/baerly-storage": patch
+---
+
+Stop shipping the Node-only `LocalFsStorage` closure inside every deployed
+Cloudflare Worker.
+
+`packages/adapter-cloudflare/src/worker.ts` imported `renderDevLanding` from
+the `@baerly/dev` barrel. That barrel also re-exports `LocalFsStorage`, so
+rolldown chunked the whole Node-only local-fs closure — `node:crypto`,
+`node:fs/promises`, `node:os`, `node:path` — into the Worker bundle for the
+sake of one HTML string. None of it can run under Workerd; it was dead
+weight on every request.
+
+`dev-landing.ts` has no imports at all, so it now gets its own
+`@baerly/dev/dev-landing` subpath and the Worker imports the leaf module.
+`dist/cloudflare.js` drops 12705 B raw / 3614 B gz / 1765 B min-gz, and the
+budgets tighten to match rather than bank the win as headroom.
+
+Nothing stopped this returning, and nothing had caught it in the first
+place: the byte budgets all still passed with the barrel import in place,
+and `scripts/lint-package-layers.mjs` could not see it either — its
+`allowNode` gate reads a package's own source, and no `node:` specifier ever
+appeared in `packages/adapter-cloudflare/`. Two guards close that. The lint
+table gains the missing `adapter-cloudflare` row, and a new assertion checks
+the artifact where a transitive drag actually becomes observable: the
+`dist/cloudflare.js` closure may import no Node builtin but
+`node:async_hooks`, the one Workerd supports under `nodejs_compat`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 title: Architecture overview
 audience: coder
 summary: Module dependency graph and lifecycle of db.collection(...).insert().
-last-reviewed: 2026-06-30
+last-reviewed: 2026-08-02
 tags: [architecture, lifecycle, module-map]
 related: ["spec/sync-protocol.md", "contributing/extending.md", "contributing/features.md"]
 ---
@@ -200,10 +200,20 @@ kernel portable:
   compatibility is defined as "everything reachable from
   `@baerly/server`'s entry points runs under Workerd"; that holds because
   `server` depends only on `protocol`.
-- **Workerd-incompatible `node:` builtins are blocked in `protocol` and
-  `server`.** `server` allowlists `node:async_hooks` only (Workerd
-  supports it under `nodejs_compat`); `protocol` allows none. Packages
-  above this line are Node-only by design and may import any builtin.
+- **Workerd-incompatible `node:` builtins are blocked in `protocol`,
+  `server`, and `adapter-cloudflare`.** `server` and `adapter-cloudflare`
+  allowlist `node:async_hooks` only (Workerd supports it under
+  `nodejs_compat`); `protocol` allows none. The remaining packages are
+  Node-only by design and may import any builtin.
+- **That gate reads each package's own source, so it cannot see a
+  transitive drag.** Importing a barrel that re-exports Node-only code
+  pulls the whole closure into a Workerd bundle without any `node:`
+  specifier appearing in the importing package — which is how
+  `LocalFsStorage` once reached `dist/cloudflare.js` by way of the
+  `@baerly/dev` barrel, for one HTML string. Import the leaf module
+  (`@baerly/dev/dev-landing`), not the barrel. Enforced on the artifact by
+  the `dist/cloudflare.js` Workerd-builtin closure assertion in
+  `tests/integration/bundle-size.test.ts`.
 
 The production import graph (`*.test.ts` / `*.test-d.ts` excluded) is a
 hand-maintained allow list — each row names the packages that owner may

--- a/packages/adapter-cloudflare/src/worker.ts
+++ b/packages/adapter-cloudflare/src/worker.ts
@@ -1,4 +1,9 @@
-import { type DevLandingOptions, renderDevLanding } from "@baerly/dev";
+// Imported from the leaf module, NOT the `@baerly/dev` barrel. The barrel
+// re-exports `LocalFsStorage`, and pulling this through it chunks the whole
+// Node-only local-fs closure — `node:crypto`, `node:fs/promises`, `node:os`,
+// `node:path` — into the Worker bundle for the sake of one HTML string.
+// `dev-landing.ts` has no imports at all.
+import { type DevLandingOptions, renderDevLanding } from "@baerly/dev/dev-landing";
 import {
   type BaerlyAppConfig,
   CF_FREE_MAX_SAFE_FOLD_BYTES,

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -11,6 +11,10 @@
       "types": "./src/index.ts",
       "import": "./src/index.ts"
     },
+    "./dev-landing": {
+      "types": "./src/dev-landing.ts",
+      "import": "./src/dev-landing.ts"
+    },
     "./local-fs": {
       "types": "./src/local-fs.ts",
       "import": "./src/local-fs.ts"

--- a/scripts/lint-package-layers.mjs
+++ b/scripts/lint-package-layers.mjs
@@ -16,22 +16,35 @@ const ROOT = resolvePath(HERE, "..");
  * Hand-maintained import allow list (contains one accepted Node-only
  * `dev ↔ adapter-node` cycle — see docs/architecture.md
  * §Package layers), plus a per-owner `node:`-builtin
- * purity gate for `protocol` and `server`. `allows` lists every other
+ * purity gate for the Workerd-loadable packages. `allows` lists every other
  * @baerly/* package the owner is permitted to import. Self-imports always
  * allowed. Anything not listed is forbidden. The optional `allowNode` field
  * gates Node builtins: when defined, the owner may only import `node:` builtins
- * in the list (`protocol` allows none; `server` allows `node:async_hooks`,
- * which Workerd supports under `nodejs_compat`). Rows leaving `allowNode`
- * undefined are Node-only by design and may import any builtin. Source of truth
- * lives in docs/architecture.md §Package layers; this table is the
- * executable mirror. When adding a new @baerly/* package, add a row to both.
+ * in the list (`protocol` allows none; `server` and `adapter-cloudflare` allow
+ * `node:async_hooks`, which Workerd supports under `nodejs_compat`). Rows
+ * leaving `allowNode` undefined are Node-only by design and may import any
+ * builtin. Source of truth lives in docs/architecture.md §Package layers; this
+ * table is the executable mirror. When adding a new @baerly/* package, add a
+ * row to both.
+ *
+ * NOTE on scope: `allowNode` gates a package's OWN source. It says nothing
+ * about what a permitted `@baerly/*` import drags in transitively — a barrel
+ * re-export can pull a Node-only closure into a Workerd bundle without any
+ * `node:` specifier appearing in the owner's files at all. That vector is
+ * guarded at the artifact level instead, by the `dist/cloudflare.js` closure
+ * assertion in `tests/integration/bundle-size.test.ts`.
  */
 const RULES = {
   protocol: { allows: [], allowNode: [] },
   server: { allows: ["protocol"], allowNode: ["node:async_hooks"] },
   dev: { allows: ["protocol", "server", "adapter-node"] },
   "adapter-node": { allows: ["protocol", "server", "dev"] },
-  "adapter-cloudflare": { allows: ["protocol", "server", "dev"] },
+  // Workerd-loadable, so gated like `server` rather than left open: this is
+  // the one row whose runtime cannot load an arbitrary Node builtin at all.
+  "adapter-cloudflare": {
+    allows: ["protocol", "server", "dev"],
+    allowNode: ["node:async_hooks"],
+  },
   client: { allows: ["protocol", "server"] },
   cli: {
     allows: ["protocol", "server", "dev", "adapter-node", "adapter-cloudflare", "client"],

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -1012,7 +1012,38 @@ const BUDGETS: readonly Budget[] = [
   //     +4351, gz +1822, min-gz +35 and still 167 B under its unchanged
   //     budget. gz takes the full KiB rather than the 72 B that would have
   //     cleared it, for the same coin-flip reason argued on http.js.
-  { entry: "cloudflare.js", raw: 436 * 1024, gz: 133 * 1024, minGz: 45 * 1024 },
+  //   → 425 KiB raw / 129 KiB gz / 44 KiB min-gz (2026-08-02): budgets move
+  //     DOWN. `packages/adapter-cloudflare/src/worker.ts` imported
+  //     `renderDevLanding` from the `@baerly/dev` barrel, and the barrel
+  //     re-exports `LocalFsStorage`, so rolldown chunked the entire Node-only
+  //     local-fs closure — `node:crypto`, `node:fs/promises`, `node:os`,
+  //     `node:path` — into every deployed Worker for the sake of one HTML
+  //     string. `dev-landing.ts` has no imports at all, so giving it its own
+  //     `@baerly/dev/dev-landing` subpath drops the whole closure out of this
+  //     aggregator. Measured 433454 raw / 131424 gz / 44135 min-gz against a
+  //     branch base of 446159 / 135096 / 45913 — a 12705 / 3672 / 1778 B win
+  //     on all three axes. Budgets tighten to lock the win in rather than bank
+  //     it as silent headroom.
+  //
+  //     Worth noting what the base was: on the line above, raw had 305 B of
+  //     headroom and min-gz 167 B. This entry was one ordinary comment edit
+  //     from firing on two axes, and the code responsible for that pressure
+  //     could not run under Workerd in the first place.
+  //
+  //     Tightened to roughly a KiB above each measured axis, not to the
+  //     nearest boundary. Per the POLICY raw/gz are creep tripwires: one that
+  //     fires on ordinary prose reports noise, and the next author rebaselines
+  //     it reflexively, which is how a tripwire stops being read. The
+  //     regression these lock in is the ~12 KiB raw / ~3.6 KiB gz barrel drag
+  //     above, so 1746 B raw / 672 B gz of slack still catches it with margin.
+  //     min-gz keeps 921 B: that axis is the HARD ceiling and the one worth
+  //     holding tight.
+  //
+  //     The barrel drag itself is caught structurally rather than by bytes —
+  //     see the `dist/cloudflare.js` Workerd-builtin closure assertion below,
+  //     which is what lets these two axes stay diagnostic rather than
+  //     load-bearing.
+  { entry: "cloudflare.js", raw: 425 * 1024, gz: 129 * 1024, minGz: 44 * 1024 },
   // Client surface — `BaerlyClient<TConfig>` + fetcher plumbing.
   // Browser/runtime-agnostic; no kernel modules in the closure.
   // Budget history:

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -1461,6 +1461,56 @@ describe("bundle size", () => {
     ).toEqual([]);
   });
 
+  // `cloudflare.js` ships into a Worker. Workerd can load exactly one of the
+  // Node builtins this repo uses — `node:async_hooks`, under `nodejs_compat`,
+  // which `@baerly/server` needs for the per-request observability ALS. Every
+  // other `node:` specifier reaching this closure is code that cannot run
+  // there.
+  //
+  // This guard exists because nothing else could see the real thing.
+  // `worker.ts` imported `renderDevLanding` from the `@baerly/dev` barrel,
+  // the barrel re-exports `LocalFsStorage`, and rolldown chunked the whole
+  // Node-only local-fs closure — `node:crypto`, `node:fs/promises`,
+  // `node:os`, `node:path` — into the Worker bundle for the sake of one HTML
+  // string. Measured with that import reintroduced, all three byte budgets
+  // on this entry still PASSED: the drag was invisible on every axis, and
+  // only became a symptom later when unrelated growth pushed min-gz over.
+  // `scripts/lint-package-layers.mjs` cannot see it either — its `allowNode`
+  // gate reads a package's own source, and no `node:` specifier ever
+  // appeared in `packages/adapter-cloudflare/`.
+  //
+  // Asserting on the artifact is what closes that gap, because the artifact
+  // is where a transitive drag becomes observable. It also means the raw/gz
+  // creep tripwires above do not have to carry this weight — per the POLICY
+  // they are diagnostics, and a budget tight enough to catch a barrel drag
+  // would fire on an ordinary JSDoc edit instead.
+  //
+  // Matches quoted specifiers in `from "node:…"`, side-effect
+  // `import "node:…"`, and `import("node:…")` — deliberately broader than
+  // `STATIC_IMPORT_RE`, which requires `from`. Quoting is what keeps this off
+  // prose: dist ships module-level JSDoc un-stripped, and several chunks
+  // discuss `node:fs` in backticks (e.g. `current-json-*.js` documenting that
+  // it stays Worker-bundleable).
+  const NODE_SPECIFIER_RE = /["'](node:[\w/.-]+)["']/g;
+  const WORKERD_LOADABLE_BUILTINS = new Set(["node:async_hooks"]);
+  test("dist/cloudflare.js closure imports no Workerd-unloadable Node builtin", () => {
+    const distDir = resolve(__dirname, "../../dist");
+    const offenders: string[] = [];
+    for (const file of closureFiles("cloudflare.js")) {
+      for (const m of readFileSync(file, "utf8").matchAll(NODE_SPECIFIER_RE)) {
+        const spec = m[1]!;
+        if (WORKERD_LOADABLE_BUILTINS.has(spec)) {
+          continue;
+        }
+        offenders.push(`${file.replace(`${distDir}/`, "")} → ${spec}`);
+      }
+    }
+    expect(
+      offenders,
+      `dist/cloudflare.js closure may import only [${[...WORKERD_LOADABLE_BUILTINS].join(", ")}]; found: ${offenders.join(", ")}. A Node builtin here means Node-only code was dragged into the Worker bundle — usually by importing a barrel that re-exports it. Import the leaf module instead (cf. \`@baerly/dev/dev-landing\` in packages/adapter-cloudflare/src/worker.ts)`,
+    ).toEqual([]);
+  });
+
   // `node.js` and `dev-vite.js` are server-side / dev-only aggregator
   // entrypoints — they never ship to a browser and never enter a
   // consumer's app bundle. Budgeting their wire size (raw/gz) measures


### PR DESCRIPTION
## What & why

Every deployed Cloudflare Worker was carrying the entire Node-only `LocalFsStorage` closure — `node:crypto`, `node:fs/promises`, `node:os`, `node:path` — because `worker.ts` imported `renderDevLanding` from the `@baerly/dev` barrel, and the barrel re-exports `LocalFsStorage`. None of it can run under Workerd. `dev-landing.ts` has no imports at all, so it gets its own `@baerly/dev/dev-landing` subpath and the Worker imports the leaf.

`dist/cloudflare.js` drops to 433454 raw / 131424 gz / 44135 min-gz from 446159 / 135096 / 45913 — 12705 / 3672 / 1778 B off every request.

## Key points

- Budgets move DOWN rather than banking the win as headroom, landing ~1 KiB above each measured axis. The base had 305 B of raw headroom and 167 B of min-gz: one ordinary comment edit from firing on two axes, for code that could not run under Workerd at all.
- Nothing had caught this and nothing stopped it returning. Measured with the barrel import reintroduced, all three byte budgets still passed — the drag was invisible on every axis. `lint-package-layers` couldn't see it either: its `allowNode` gate reads a package's own source, and no `node:` specifier ever appeared in `packages/adapter-cloudflare/`.
- Guarded on the artifact instead, which is where a transitive drag becomes observable: the `dist/cloudflare.js` closure may import no Node builtin but `node:async_hooks`. Verified red by reintroducing the barrel import. `adapter-cloudflare` also gains the `allowNode` row it was missing — the only Workerd-loadable package without one.
- The assertion matches quoted specifiers only, because dist ships module-level JSDoc un-stripped and several chunks discuss `node:fs` in backticks.

## Verification

| `pnpm verify:agent` | clean |
| --- | --- |
| `pnpm bundle-sizes` | 35/35 |
| `node scripts/lint-package-layers.mjs` | 0 violations / 184 files |

Both commits verified green individually, not just the tip.

`pnpm test:agent` not run on this branch alone — see the stacked PR, where it is reported against a `main` control.