### PR TITLE
feat(bench): add algorithm-tagged statistics for the measurement foundation

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -1,8 +1,8 @@
 ---
 title: Bench harnesses
 audience: coder
-summary: Two bench harnesses under bench/ — r2-contention.ts and load-harness/. When to run each, how to read results, DuckDB analysis pattern, and green-light criteria.
-last-reviewed: 2026-05-12
+summary: The bench harnesses under bench/, plus the shared statistics library in bench/measurement/. When to run each, how to read results, DuckDB analysis pattern, and green-light criteria.
+last-reviewed: 2026-08-02
 tags: [bench, performance, cost-model]
 related: ["../docs/about/cost-model.md", "../tests/integration/maintenance-e2e.test.ts"]
 ---
@@ -20,6 +20,7 @@ Two harnesses live under `bench/`:
 | `bench/amortized-write-cost.ts` | Amortized BILLABLE Class A ops (PUT+LIST; DeleteObject is $0) per logical write, INCLUDING in-band maintenance (folds + GC), across workload shapes × profile (cf-free / node). Source of truth for the write-amp constants in the cost CLI + the effective-write-amp claim in docs/about/cost-model.md. No infra (MemoryStorage). MEASURES ONLY. | When revisiting the write-amplification claim or the cost-CLI projection |
 | `bench/write-amp-stress.ts` | STRESS variant of `amortized-write-cost.ts`: drives pathological churn workloads (100%-update tiny set, unbounded insert growth, 500-doc full rewrite) under aggressive in-band maintenance to find the PEAK billable Class A ops per logical write. Tracks `peak_billable_class_a_per_write` (single-writer; the route past ~4× is a CAS-retry storm, governed by the throughput ceiling, not measured here). Backs the "peaks ~4×, never reaches the retired >6 trigger" claim. No infra (MemoryStorage). MEASURES ONLY. Baseline at `docs/spec/attachments/amortized-write-cost-stress-baseline.json`. | When revisiting whether the retired `write-amp > 6` graduation trigger could ever fire |
 | `bench/collection-fanout.ts` | Storage op cost of `discoverCollections` (LIST count) + full `admin usage` scan (LIST + GET count) vs. N collections under one tenant prefix, measured via a counting Storage proxy on MemoryStorage. No infra. MEASURES ONLY — re-derives the collections/tenant fan-out limit. A checked-in baseline lives at `docs/spec/attachments/collection-fanout-baseline.json`. | When revisiting the collections/tenant fan-out limit in docs/about/graduation.md or docs/about/workload-fit.md |
+| `bench/measurement/` | Not a harness — the algorithm-tagged statistics **library** the harnesses above summarize their results with. Quantiles, MAD, three bootstraps, two binomial upper bounds, and OLS via Householder QR, each carrying its algorithm tag and every parameter that determined the number. Pure; no infra; no runnable entry point. | When a bench emits a `p95`, a confidence interval, or a regression coefficient — import from here rather than hand-rolling one |
 
 Both require `pnpm dev:storage` (Minio `:9102` + Toxiproxy `:9104`)
 for the Minio-backed variants. Neither is a per-PR CI gate. The
@@ -189,6 +190,60 @@ The key derived fields:
   (which is total bytes written / logical bytes written and is
   always `>= 1`); this is a within-compaction
   output/input ratio.
+
+## bench/measurement/
+
+The one place a bench summarizes numbers. Not runnable — a pure library
+(`statistics.ts`) with no I/O, no clock read, and one import: the
+repository's canonical Mulberry32 PRNG.
+
+Every function returns its result **tagged**: the algorithm identifier
+plus every parameter that determined the number — seed, resample count,
+confidence, inclusion unit, statistic selector, design columns. A study
+therefore cannot emit a bare `p95` or `confidence_interval` whose
+definition has to be reconstructed later from prose.
+
+`STATISTICS_ALGORITHMS` is the closed vocabulary:
+
+| Tag | Returns |
+|---|---|
+| `quantile-nearest-rank-v1` | One-indexed `ceil(q*n)` over the ascending sort |
+| `quantile-r7-v1` | Hyndman–Fan type 7 (R's `quantile` default) |
+| `mad-from-median-v1` | Median absolute deviation, **raw** — no 1.4826 normal-consistency constant |
+| `bootstrap-percentile-v1` | Percentile-interval bootstrap of a selectable statistic |
+| `paired-ratio-bootstrap-v1` | Resamples complete pairs; median of per-pair ratios |
+| `stratified-paired-difference-bootstrap-v1` | Resamples within each stratum, preserving stratum counts |
+| `clopper-pearson-zero-failure-upper-v1` | Exact one-sided upper bound at zero observed failures |
+| `wilson-one-sided-upper-v1` | Wilson score upper limit; the caller supplies `z` |
+| `ols-qr-v1` | Least squares via Householder QR, no normal equations, no pivoting |
+
+Three properties are load-bearing and easy to erode:
+
+- **Expected values live in `STATISTICS_TEST_VECTORS`, as data.** The
+  tests read their numbers from that constant and nowhere else, so a
+  changed expectation necessarily moves the hash taken over it. Do not
+  "simplify" a test back to inline literals.
+- **Every emitted number is `-0`-normalized**, echoed caller parameters
+  included. The canonical JSON these results feed rejects `-0` rather
+  than normalizing it, and `-0` clears both `Number.isInteger(v) && v >= 0`
+  and `!(v < 0)` untouched.
+- **The module supplies algorithms only.** Sample counts, thresholds,
+  retry rules, and candidate-admission policy are study-owned and
+  always arrive as caller parameters. `wilson-one-sided-upper-v1`
+  validates `(confidence, z)` against a table rather than deriving `z`,
+  because deriving it would add an untagged tenth algorithm.
+
+`ols-qr-v1` reports `condition_estimate` and never acts on it. The rank
+gate is taken on the column-equilibrated QR diagonal, so it is
+independent of column units and column order, but it still detects
+deficiency rather than degree: a merely near-collinear design passes it
+and returns coefficients that are numerically meaningless. A study that
+reads those coefficients as physics must preregister a bar on
+`condition_estimate`.
+
+```sh
+pnpm vitest run bench/measurement/statistics.test.ts
+```
 
 ## bench/fold-cost.ts
 

--- a/bench/measurement/statistics.test.ts
+++ b/bench/measurement/statistics.test.ts
@@ -672,3 +672,106 @@ describe("ols-qr-v1", () => {
     }
   });
 });
+
+describe("contract surface", () => {
+  test("every algorithm tag has exactly one pinned vector, with a well-formed id", () => {
+    expect(Object.keys(STATISTICS_TEST_VECTORS).toSorted()).toEqual(
+      [...STATISTICS_ALGORITHMS].toSorted(),
+    );
+    for (const entry of Object.values(STATISTICS_TEST_VECTORS)) {
+      expect(entry.id).toMatch(/^[a-z0-9][a-z0-9/_-]*\/v1$/);
+    }
+    expect(PRNG_TEST_VECTOR.id).toMatch(/^[a-z0-9][a-z0-9/_-]*\/v1$/);
+  });
+
+  test("every pinned id is distinct", () => {
+    const ids = [...Object.values(STATISTICS_TEST_VECTORS).map((e) => e.id), PRNG_TEST_VECTOR.id];
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("every table z is the one-sided normal quantile for its confidence", () => {
+    // Sanity, not derivation: z must increase with confidence and stay inside
+    // a range no plausible transcription error survives.
+    const rows = Object.entries(WILSON_Z_BY_CONFIDENCE)
+      .map(([c, z]) => ({ c: Number(c), z }))
+      .toSorted((a, b) => a.c - b.c);
+    for (const [i, row] of rows.entries()) {
+      expect(row.z).toBeGreaterThan(0);
+      expect(row.z).toBeLessThan(4);
+      if (i > 0) {
+        expect(row.z).toBeGreaterThan(rows[i - 1]!.z);
+      }
+    }
+  });
+});
+
+describe("canonical-JSON safety", () => {
+  /**
+   * Lane D's canonical JSON REJECTS `undefined`, `NaN`, `±Infinity`, and `-0`
+   * (`canonical-hashing.md` §"rejection contract") — it does not normalize
+   * them. Every result object here is serialized into a hashed evidence record,
+   * so a single missed `normalizeZero` becomes an opaque rejection inside
+   * Plan J. This walks every number of every result shape.
+   */
+  const assertEmittable = (value: unknown, path = "$"): void => {
+    if (typeof value === "number") {
+      expect(Number.isFinite(value), `${path} must be finite`).toBe(true);
+      expect(Object.is(value, -0), `${path} must not be negative zero`).toBe(false);
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((v, i) => assertEmittable(v, `${path}[${i}]`));
+      return;
+    }
+    if (value !== null && typeof value === "object") {
+      for (const [k, v] of Object.entries(value)) {
+        expect(v, `${path}.${k} must not be undefined`).not.toBeUndefined();
+        assertEmittable(v, `${path}.${k}`);
+      }
+      return;
+    }
+    expect(["string", "boolean"], `${path} has an unserializable type`).toContain(typeof value);
+  };
+
+  test("every result shape emits only canonical-JSON-safe values", () => {
+    const b = STATISTICS_TEST_VECTORS["bootstrap-percentile-v1"];
+    const pr = STATISTICS_TEST_VECTORS["paired-ratio-bootstrap-v1"];
+    const st = STATISTICS_TEST_VECTORS["stratified-paired-difference-bootstrap-v1"];
+    const cp = STATISTICS_TEST_VECTORS["clopper-pearson-zero-failure-upper-v1"];
+    const w = STATISTICS_TEST_VECTORS["wilson-one-sided-upper-v1"];
+    const o = STATISTICS_TEST_VECTORS["ols-qr-v1"];
+
+    assertEmittable(quantileEstimate(b.values, 0.5, "quantile-r7-v1"));
+    assertEmittable(quantileEstimate(b.values, 0, "quantile-nearest-rank-v1"));
+    assertEmittable(madEstimate(b.values));
+    assertEmittable(bootstrapPercentile(b.values, b.statistic, b.options));
+    assertEmittable(bootstrapPercentile(b.values, { algorithm: "mean-v1" }, b.options));
+    assertEmittable(pairedRatioBootstrap(pr.pairs, pr.options));
+    assertEmittable(stratifiedPairedDifferenceBootstrap(st.pairs, st.options));
+    assertEmittable(clopperPearsonZeroFailureUpper(cp.attempts, cp.confidence));
+    assertEmittable(
+      wilsonOneSidedUpper(w.failures, w.attempts, { confidence: w.confidence, z: w.z }),
+    );
+    assertEmittable(olsQr({ columns: o.columns, rows: o.rows }));
+  });
+
+  test("the zero-coefficient OLS case — the realistic -0 producer — is safe", () => {
+    // True intercept exactly 0 over a negative Householder pivot.
+    assertEmittable(
+      olsQr({
+        columns: ["intercept", "x"],
+        rows: [
+          { x: [1, 1], y: 1 },
+          { x: [1, 2], y: 3 },
+          { x: [1, 3], y: 2 },
+          { x: [1, 4], y: 5 },
+        ],
+      }),
+    );
+  });
+
+  test("a zero-dispersion sample emits +0, not -0", () => {
+    assertEmittable(madEstimate([5, 5, 5]));
+    expect(Object.is(madEstimate([5, 5, 5]).mad, -0)).toBe(false);
+  });
+});

--- a/bench/measurement/statistics.test.ts
+++ b/bench/measurement/statistics.test.ts
@@ -29,15 +29,21 @@ import {
  * errors"): assert on the `code` discriminant, never the message. Vitest's
  * `toThrowError` does not reliably accept an asymmetric matcher, so catch and
  * `toMatchObject` instead.
+ *
+ * `field` is REQUIRED. Asserting `code` alone only proves that some validation
+ * fired, not the one under test — which is how the `z` finiteness guard came
+ * to be fully deletable with this suite green: its two tests were being caught
+ * by the downstream (confidence, z) consistency gate instead, and nothing
+ * noticed. Naming the field makes each case pin the check it claims to.
  */
-const expectInputError = (fn: () => unknown): void => {
+const expectInputError = (fn: () => unknown, field: string): void => {
   let thrown: unknown;
   try {
     fn();
   } catch (error) {
     thrown = error;
   }
-  expect(thrown).toMatchObject({ code: "StatisticsInput" });
+  expect(thrown).toMatchObject({ code: "StatisticsInput", field });
 };
 
 describe("tag constants", () => {
@@ -57,6 +63,22 @@ describe("tag constants", () => {
 
   test("the PRNG tag is mulberry32-v1", () => {
     expect(BOOTSTRAP_PRNG).toBe("mulberry32-v1");
+  });
+});
+
+describe("sample ordering", () => {
+  test("the sort is numeric, not lexicographic", () => {
+    // Every other sample in this file — [1,2,3,4], [0,10,20,30], [1,2,8],
+    // [1,1,2,2,4,6,9], every replicate array — happens to sort identically as
+    // strings. So dropping the comparator from `ascending`'s `toSorted` left
+    // the entire suite green while silently corrupting every quantile, median,
+    // MAD, and bootstrap interval the module produces. This sample is the one
+    // that separates them, and it is the shape of real latency data.
+    const spread = [9, 12, 100, 250, 1500];
+    expect([...spread].toSorted()).toEqual([100, 12, 1500, 250, 9]); // what a string sort does
+    expect(quantileR7(spread, 0.5)).toBe(100);
+    expect(quantileNearestRank(spread, 0.95)).toBe(1500);
+    expect(madFromMedian(spread)).toBe(91);
   });
 });
 
@@ -83,11 +105,11 @@ describe("quantile-nearest-rank-v1", () => {
   });
 
   test("rejects an empty sample, a nonfinite value, and an out-of-range q", () => {
-    expectInputError(() => quantileNearestRank([], 0.5));
-    expectInputError(() => quantileNearestRank([1, Number.NaN], 0.5));
-    expectInputError(() => quantileNearestRank([1, Number.POSITIVE_INFINITY], 0.5));
-    expectInputError(() => quantileNearestRank([1, 2], 1.5));
-    expectInputError(() => quantileNearestRank([1, 2], -0.1));
+    expectInputError(() => quantileNearestRank([], 0.5), "values");
+    expectInputError(() => quantileNearestRank([1, Number.NaN], 0.5), "values");
+    expectInputError(() => quantileNearestRank([1, Number.POSITIVE_INFINITY], 0.5), "values");
+    expectInputError(() => quantileNearestRank([1, 2], 1.5), "q");
+    expectInputError(() => quantileNearestRank([1, 2], -0.1), "q");
   });
 });
 
@@ -239,6 +261,31 @@ describe("bootstrap-percentile-v1", () => {
     expect([...V.replicates_at_seed_1]).not.toEqual([...V.replicates]);
   });
 
+  test("the nearest-rank statistic is a distinct dispatch branch", () => {
+    // `quantile-nearest-rank-v1` is publicly admitted by BOOTSTRAP_STATISTICS
+    // but was never bootstrapped, so `applyStatistic`'s nearest-rank branch
+    // could return anything. Pinned at q=0.25, where the two quantile
+    // definitions genuinely disagree — at q=0.5 over a 3-element resample they
+    // coincide, and the assertion would hold under either dispatch.
+    const NR = V.nearest_rank;
+    expect(bootstrapPercentileReplicates(VALUES, NR.statistic, OPTIONS)).toEqual([
+      ...NR.replicates,
+    ]);
+    expect([...NR.replicates]).not.toEqual([...NR.r7_replicates_at_same_q]);
+    expect(
+      bootstrapPercentileReplicates(
+        VALUES,
+        { algorithm: "quantile-r7-v1", q: NR.statistic.q },
+        OPTIONS,
+      ),
+    ).toEqual([...NR.r7_replicates_at_same_q]);
+
+    const r = bootstrapPercentile(VALUES, NR.statistic, OPTIONS);
+    expect(r.point).toBe(NR.point);
+    expect(r.interval).toEqual({ ...NR.interval });
+    expect(r.statistic).toEqual({ ...NR.statistic });
+  });
+
   test("the mean statistic is selectable and recorded", () => {
     const r = bootstrapPercentile(VALUES, { algorithm: "mean-v1" }, OPTIONS);
     expect(r.statistic).toEqual({ algorithm: "mean-v1" });
@@ -246,23 +293,29 @@ describe("bootstrap-percentile-v1", () => {
   });
 
   test("rejects a missing q on a quantile statistic and a present q on the mean", () => {
-    expectInputError(() => bootstrapPercentile(VALUES, { algorithm: "quantile-r7-v1" }, OPTIONS));
-    expectInputError(() => bootstrapPercentile(VALUES, { algorithm: "mean-v1", q: 0.5 }, OPTIONS));
+    expectInputError(
+      () => bootstrapPercentile(VALUES, { algorithm: "quantile-r7-v1" }, OPTIONS),
+      "statistic.q",
+    );
+    expectInputError(
+      () => bootstrapPercentile(VALUES, { algorithm: "mean-v1", q: 0.5 }, OPTIONS),
+      "statistic.q",
+    );
   });
 
   test("rejects every out-of-contract bootstrap option", () => {
-    const bad: BootstrapOptions[] = [
-      { ...OPTIONS, seed: -1 },
-      { ...OPTIONS, seed: 1.5 },
-      { ...OPTIONS, seed: 4_294_967_296 },
-      { ...OPTIONS, resamples: 0 },
-      { ...OPTIONS, resamples: 2.5 },
-      { ...OPTIONS, confidence: 0 },
-      { ...OPTIONS, confidence: 1 },
-      { ...OPTIONS, inclusion_unit: "   " },
+    const bad: { options: BootstrapOptions; field: string }[] = [
+      { options: { ...OPTIONS, seed: -1 }, field: "seed" },
+      { options: { ...OPTIONS, seed: 1.5 }, field: "seed" },
+      { options: { ...OPTIONS, seed: 4_294_967_296 }, field: "seed" },
+      { options: { ...OPTIONS, resamples: 0 }, field: "resamples" },
+      { options: { ...OPTIONS, resamples: 2.5 }, field: "resamples" },
+      { options: { ...OPTIONS, confidence: 0 }, field: "confidence" },
+      { options: { ...OPTIONS, confidence: 1 }, field: "confidence" },
+      { options: { ...OPTIONS, inclusion_unit: "   " }, field: "inclusion_unit" },
     ];
-    for (const options of bad) {
-      expectInputError(() => bootstrapPercentile(VALUES, MEDIAN, options));
+    for (const { options, field } of bad) {
+      expectInputError(() => bootstrapPercentile(VALUES, MEDIAN, options), field);
     }
   });
 
@@ -303,28 +356,34 @@ describe("paired-ratio-bootstrap-v1", () => {
   });
 
   test("rejects a nonpositive baseline, a duplicate pair id, and a nonfinite arm", () => {
-    expectInputError(() =>
-      pairedRatioBootstrap([{ pair_id: "p1", baseline: 0, candidate: 1 }], OPTIONS),
+    expectInputError(
+      () => pairedRatioBootstrap([{ pair_id: "p1", baseline: 0, candidate: 1 }], OPTIONS),
+      "baseline",
     );
-    expectInputError(() =>
-      pairedRatioBootstrap([{ pair_id: "p1", baseline: -2, candidate: 1 }], OPTIONS),
+    expectInputError(
+      () => pairedRatioBootstrap([{ pair_id: "p1", baseline: -2, candidate: 1 }], OPTIONS),
+      "baseline",
     );
-    expectInputError(() =>
-      pairedRatioBootstrap(
-        [
-          { pair_id: "dup", baseline: 2, candidate: 1 },
-          { pair_id: "dup", baseline: 4, candidate: 3 },
-        ],
-        OPTIONS,
-      ),
+    expectInputError(
+      () =>
+        pairedRatioBootstrap(
+          [
+            { pair_id: "dup", baseline: 2, candidate: 1 },
+            { pair_id: "dup", baseline: 4, candidate: 3 },
+          ],
+          OPTIONS,
+        ),
+      "pair_id",
     );
-    expectInputError(() =>
-      pairedRatioBootstrap([{ pair_id: "p1", baseline: 2, candidate: Number.NaN }], OPTIONS),
+    expectInputError(
+      () => pairedRatioBootstrap([{ pair_id: "p1", baseline: 2, candidate: Number.NaN }], OPTIONS),
+      "candidate",
     );
-    expectInputError(() =>
-      pairedRatioBootstrap([{ pair_id: "  ", baseline: 2, candidate: 1 }], OPTIONS),
+    expectInputError(
+      () => pairedRatioBootstrap([{ pair_id: "  ", baseline: 2, candidate: 1 }], OPTIONS),
+      "pair_id",
     );
-    expectInputError(() => pairedRatioBootstrap([], OPTIONS));
+    expectInputError(() => pairedRatioBootstrap([], OPTIONS), "pairs");
   });
 });
 
@@ -366,18 +425,38 @@ describe("stratified-paired-difference-bootstrap-v1", () => {
   test("each stratum keeps its original count in every replicate", () => {
     // Stratum "b" alone can never contribute a value below 10, so no replicate
     // mean can fall below (1+1+10+10)/4 = 5.5 — proof strata were not pooled.
+    //
+    // The floor is RECOMPUTED from the pairs first. Asserted only with
+    // `toBeGreaterThanOrEqual`, the pinned constant was free: setting it to 0
+    // left this test green and vacuous.
+    const byStratum = new Map<string, number[]>();
+    for (const p of PAIRS) {
+      const bucket = byStratum.get(p.stratum) ?? [];
+      bucket.push(p.candidate - p.baseline);
+      byStratum.set(p.stratum, bucket);
+    }
+    const floor =
+      [...byStratum.values()].reduce((acc, d) => acc + Math.min(...d) * d.length, 0) / PAIRS.length;
+    expect(V.replicate_floor_if_strata_preserved).toBe(floor);
+
     const replicates = stratifiedPairedDifferenceBootstrapReplicates(PAIRS, OPTIONS);
     for (const r of replicates) {
       expect(r).toBeGreaterThanOrEqual(V.replicate_floor_if_strata_preserved);
     }
+    // And the floor is a real constraint on this fixture, not a number so low
+    // that pooling would satisfy it too: pooling all four differences admits
+    // replicate means as low as 1.
+    expect(floor).toBeGreaterThan(Math.min(...PAIRS.map((p) => p.candidate - p.baseline)));
   });
 
   test("rejects an empty stratum label", () => {
-    expectInputError(() =>
-      stratifiedPairedDifferenceBootstrap(
-        [{ pair_id: "x", stratum: "  ", baseline: 0, candidate: 1 }],
-        OPTIONS,
-      ),
+    expectInputError(
+      () =>
+        stratifiedPairedDifferenceBootstrap(
+          [{ pair_id: "x", stratum: "  ", baseline: 0, candidate: 1 }],
+          OPTIONS,
+        ),
+      "stratum",
     );
   });
 
@@ -430,10 +509,10 @@ describe("clopper-pearson-zero-failure-upper-v1", () => {
   });
 
   test("rejects attempts below one and confidence outside (0,1)", () => {
-    expectInputError(() => clopperPearsonZeroFailureUpper(0, 0.95));
-    expectInputError(() => clopperPearsonZeroFailureUpper(10.5, 0.95));
-    expectInputError(() => clopperPearsonZeroFailureUpper(100, 1));
-    expectInputError(() => clopperPearsonZeroFailureUpper(100, 0));
+    expectInputError(() => clopperPearsonZeroFailureUpper(0, 0.95), "attempts");
+    expectInputError(() => clopperPearsonZeroFailureUpper(10.5, 0.95), "attempts");
+    expectInputError(() => clopperPearsonZeroFailureUpper(100, 1), "confidence");
+    expectInputError(() => clopperPearsonZeroFailureUpper(100, 0), "confidence");
   });
 });
 
@@ -472,10 +551,11 @@ describe("wilson-one-sided-upper-v1", () => {
   });
 
   test("rejects a (confidence, z) pair that cannot both be true", () => {
-    expectInputError(() => wilsonOneSidedUpper(3, 100, { confidence: 0.95, z: 2 }));
+    expectInputError(() => wilsonOneSidedUpper(3, 100, { confidence: 0.95, z: 2 }), "z");
     // A confidence with no table row is rejected rather than silently trusted.
-    expectInputError(() =>
-      wilsonOneSidedUpper(3, 100, { confidence: 0.9123, z: 1.6448536269514722 }),
+    expectInputError(
+      () => wilsonOneSidedUpper(3, 100, { confidence: 0.9123, z: 1.6448536269514722 }),
+      "confidence",
     );
   });
 
@@ -499,14 +579,22 @@ describe("wilson-one-sided-upper-v1", () => {
 
   test("rejects failures outside [0, attempts], attempts below one, and a nonpositive z", () => {
     const z = WILSON_Z_BY_CONFIDENCE[0.95];
-    expectInputError(() => wilsonOneSidedUpper(-1, 100, { confidence: 0.95, z }));
-    expectInputError(() => wilsonOneSidedUpper(101, 100, { confidence: 0.95, z }));
-    expectInputError(() => wilsonOneSidedUpper(1.5, 100, { confidence: 0.95, z }));
-    expectInputError(() => wilsonOneSidedUpper(0, 0, { confidence: 0.95, z }));
-    expectInputError(() => wilsonOneSidedUpper(3, 100, { confidence: 0.95, z: 0 }));
-    expectInputError(() =>
-      wilsonOneSidedUpper(3, 100, { confidence: 0.95, z: Number.POSITIVE_INFINITY }),
+    expectInputError(() => wilsonOneSidedUpper(-1, 100, { confidence: 0.95, z }), "failures");
+    expectInputError(() => wilsonOneSidedUpper(101, 100, { confidence: 0.95, z }), "failures");
+    expectInputError(() => wilsonOneSidedUpper(1.5, 100, { confidence: 0.95, z }), "failures");
+    expectInputError(() => wilsonOneSidedUpper(0, 0, { confidence: 0.95, z }), "attempts");
+    expectInputError(() => wilsonOneSidedUpper(3, 100, { confidence: 0.95, z: 0 }), "z");
+    expectInputError(
+      () => wilsonOneSidedUpper(3, 100, { confidence: 0.95, z: Number.POSITIVE_INFINITY }),
+      "z",
     );
+    // NaN is the case that only the finiteness guard can stop. `z: 0` and
+    // `z: Infinity` above are both also caught downstream by the
+    // (confidence, z) consistency gate, so deleting the guard entirely left
+    // this suite green — while `Math.abs(NaN - expectedZ) > 1e-12` is false,
+    // letting NaN through the gate and emitting `upper: NaN` into a record
+    // the canonical serializer rejects.
+    expectInputError(() => wilsonOneSidedUpper(3, 100, { confidence: 0.95, z: Number.NaN }), "z");
   });
 });
 
@@ -775,24 +863,32 @@ describe("ols-qr-v1", () => {
   });
 
   test("rejects malformed designs", () => {
-    const bad: OlsQrInput[] = [
-      { columns: [], rows: [{ x: [], y: 1 }] },
+    const bad: { input: OlsQrInput; field: string }[] = [
+      { input: { columns: [], rows: [{ x: [], y: 1 }] }, field: "columns" },
       {
-        columns: ["a", "a"],
-        rows: [
-          { x: [1, 1], y: 1 },
-          { x: [2, 2], y: 2 },
-        ],
+        input: {
+          columns: ["a", "a"],
+          rows: [
+            { x: [1, 1], y: 1 },
+            { x: [2, 2], y: 2 },
+          ],
+        },
+        field: "columns",
       },
-      { columns: [" "], rows: [{ x: [1], y: 1 }] },
-      { columns: ["a", "b"], rows: [{ x: [1, 2], y: 1 }] }, // fewer rows than columns
-      { columns: ["a"], rows: [{ x: [1, 2], y: 1 }] }, // wrong row width
-      { columns: ["a"], rows: [{ x: [Number.POSITIVE_INFINITY], y: 1 }] },
-      { columns: ["a"], rows: [{ x: [1], y: Number.NaN }] },
-      { columns: ["a"], rows: [] },
+      { input: { columns: [" "], rows: [{ x: [1], y: 1 }] }, field: "columns" },
+      // fewer rows than columns
+      { input: { columns: ["a", "b"], rows: [{ x: [1, 2], y: 1 }] }, field: "rows" },
+      // wrong row width
+      { input: { columns: ["a"], rows: [{ x: [1, 2], y: 1 }] }, field: "rows" },
+      {
+        input: { columns: ["a"], rows: [{ x: [Number.POSITIVE_INFINITY], y: 1 }] },
+        field: "rows",
+      },
+      { input: { columns: ["a"], rows: [{ x: [1], y: Number.NaN }] }, field: "rows" },
+      { input: { columns: ["a"], rows: [] }, field: "rows" },
     ];
-    for (const input of bad) {
-      expectInputError(() => olsQr(input));
+    for (const { input, field } of bad) {
+      expectInputError(() => olsQr(input), field);
     }
   });
 });
@@ -931,9 +1027,23 @@ describe("canonical-JSON safety", () => {
     );
   });
 
-  test("a zero-dispersion sample emits +0, not -0", () => {
-    assertEmittable(madEstimate([5, 5, 5]));
-    expect(Object.is(madEstimate([5, 5, 5]).mad, -0)).toBe(false);
+  test("a single-element -0 sample is normalized on the way out", () => {
+    // Replaces a test that asserted `madEstimate([5,5,5]).mad` is not -0. That
+    // one could not fail: `madFromMedian` runs every deviation through
+    // `Math.abs`, which never returns -0. It read as a pin and pinned nothing.
+    //
+    // The reachable path is the single-element short-circuit — `quantileR7`
+    // returns `sorted[0]` verbatim when n is 1, so a sample of [-0] carries -0
+    // straight to `median`, and a q of -0 rides through untouched.
+    expect(Object.is(quantileR7([-0], 0.5), -0)).toBe(true); // the raw kernel does emit it
+    const m = madEstimate([-0]);
+    expect(Object.is(m.median, -0)).toBe(false);
+    assertEmittable(m);
+
+    const q = quantileEstimate([-0], -0, "quantile-r7-v1");
+    expect(Object.is(q.value, -0)).toBe(false);
+    expect(Object.is(q.q, -0)).toBe(false);
+    assertEmittable(q);
   });
 
   /**
@@ -963,6 +1073,17 @@ describe("canonical-JSON safety", () => {
     });
     expect(Object.is(w.failures, -0)).toBe(false);
     assertEmittable(w);
+
+    // The other two bootstraps echo `seed` through the same path.
+    const pr = STATISTICS_TEST_VECTORS["paired-ratio-bootstrap-v1"];
+    const ratio = pairedRatioBootstrap(pr.pairs, { ...pr.options, seed: -0 });
+    expect(Object.is(ratio.seed, -0)).toBe(false);
+    assertEmittable(ratio);
+
+    const st = STATISTICS_TEST_VECTORS["stratified-paired-difference-bootstrap-v1"];
+    const strat = stratifiedPairedDifferenceBootstrap(st.pairs, { ...st.options, seed: -0 });
+    expect(Object.is(strat.seed, -0)).toBe(false);
+    assertEmittable(strat);
   });
 
   test("the returned statistic selector is a copy, not the caller's object", () => {

--- a/bench/measurement/statistics.test.ts
+++ b/bench/measurement/statistics.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "vitest";
 import { mulberry32 } from "../load-harness/generators/rng.ts";
 import {
   type BootstrapOptions,
+  type BootstrapStatisticSelector,
   type OlsQrInput,
   BOOTSTRAP_PRNG,
   bootstrapPercentile,
@@ -293,13 +294,36 @@ describe("bootstrap-percentile-v1", () => {
   });
 
   test("rejects a missing q on a quantile statistic and a present q on the mean", () => {
+    // Both selectors below are now COMPILE errors — that is the point of the
+    // discriminated union. The casts are what a caller handing in a selector
+    // parsed from a study's JSON config effectively has, and the runtime guard
+    // exists for exactly them, so it still needs a test.
     expectInputError(
-      () => bootstrapPercentile(VALUES, { algorithm: "quantile-r7-v1" }, OPTIONS),
+      () =>
+        bootstrapPercentile(
+          VALUES,
+          { algorithm: "quantile-r7-v1" } as unknown as BootstrapStatisticSelector,
+          OPTIONS,
+        ),
       "statistic.q",
     );
     expectInputError(
-      () => bootstrapPercentile(VALUES, { algorithm: "mean-v1", q: 0.5 }, OPTIONS),
+      () =>
+        bootstrapPercentile(
+          VALUES,
+          { algorithm: "mean-v1", q: 0.5 } as unknown as BootstrapStatisticSelector,
+          OPTIONS,
+        ),
       "statistic.q",
+    );
+    expectInputError(
+      () =>
+        bootstrapPercentile(
+          VALUES,
+          { algorithm: "nope-v1", q: 0.5 } as unknown as BootstrapStatisticSelector,
+          OPTIONS,
+        ),
+      "statistic.algorithm",
     );
   });
 

--- a/bench/measurement/statistics.test.ts
+++ b/bench/measurement/statistics.test.ts
@@ -1,0 +1,256 @@
+import { describe, test, expect } from "vitest";
+import { mulberry32 } from "../load-harness/generators/rng.ts";
+import type { BootstrapOptions } from "./statistics.ts";
+import {
+  BOOTSTRAP_PRNG,
+  bootstrapPercentile,
+  bootstrapPercentileReplicates,
+  madEstimate,
+  madFromMedian,
+  PRNG_TEST_VECTOR,
+  quantileEstimate,
+  quantileNearestRank,
+  quantileR7,
+  STATISTICS_ALGORITHMS,
+  STATISTICS_TEST_VECTORS,
+} from "./statistics.ts";
+
+/**
+ * Repo convention (docs/contributing/conventions/tests.md §"Asserting on
+ * errors"): assert on the `code` discriminant, never the message. Vitest's
+ * `toThrowError` does not reliably accept an asymmetric matcher, so catch and
+ * `toMatchObject` instead.
+ */
+const expectInputError = (fn: () => unknown): void => {
+  let thrown: unknown;
+  try {
+    fn();
+  } catch (err) {
+    thrown = err;
+  }
+  expect(thrown).toMatchObject({ code: "StatisticsInput" });
+};
+
+describe("tag constants", () => {
+  test("the nine algorithm tags are exact and ordered", () => {
+    expect(STATISTICS_ALGORITHMS).toEqual([
+      "quantile-nearest-rank-v1",
+      "quantile-r7-v1",
+      "mad-from-median-v1",
+      "bootstrap-percentile-v1",
+      "paired-ratio-bootstrap-v1",
+      "stratified-paired-difference-bootstrap-v1",
+      "clopper-pearson-zero-failure-upper-v1",
+      "wilson-one-sided-upper-v1",
+      "ols-qr-v1",
+    ]);
+  });
+
+  test("the PRNG tag is mulberry32-v1", () => {
+    expect(BOOTSTRAP_PRNG).toBe("mulberry32-v1");
+  });
+});
+
+describe("quantile-nearest-rank-v1", () => {
+  // Nearest rank = one-indexed ceil(q*n) over the ascending sort, clamped to [1,n].
+  // n=4: q=0.25 -> ceil(1)=1 -> 1; q=0.5 -> ceil(2)=2 -> 2; q=0.95 -> ceil(3.8)=4 -> 4.
+  //
+  // The numbers come from STATISTICS_TEST_VECTORS, never inline. That is what
+  // makes the contract hash tamper-evident — changing an expected value has to
+  // change the hashed constant, because there is nowhere else to change it. Do
+  // not "simplify" this back to literals.
+  const V = STATISTICS_TEST_VECTORS["quantile-nearest-rank-v1"];
+
+  test("pinned vector [1,2,3,4]", () => {
+    for (const { q, value } of V.expected) {
+      expect(quantileNearestRank(V.values, q)).toBe(value);
+    }
+  });
+
+  test("sorts a copy and never mutates the input", () => {
+    const input = Object.freeze([4, 1, 3, 2]);
+    expect(quantileNearestRank(input, 0.5)).toBe(2);
+    expect(input).toEqual([4, 1, 3, 2]);
+  });
+
+  test("rejects an empty sample, a nonfinite value, and an out-of-range q", () => {
+    expectInputError(() => quantileNearestRank([], 0.5));
+    expectInputError(() => quantileNearestRank([1, Number.NaN], 0.5));
+    expectInputError(() => quantileNearestRank([1, Number.POSITIVE_INFINITY], 0.5));
+    expectInputError(() => quantileNearestRank([1, 2], 1.5));
+    expectInputError(() => quantileNearestRank([1, 2], -0.1));
+  });
+});
+
+describe("quantile-r7-v1", () => {
+  // R-7: h=(n-1)q, interpolate. n=4 over [0,10,20,30]:
+  // q=0.25 -> h=0.75 -> 0 + 0.75*10 = 7.5
+  // q=0.5  -> h=1.5  -> 10 + 0.5*10 = 15
+  // q=0.95 -> h=2.85 -> 20 + 0.85*10 = 28.5 (28.499999999999996 in IEEE-754)
+  const V = STATISTICS_TEST_VECTORS["quantile-r7-v1"];
+
+  test("pinned vector [0,10,20,30]", () => {
+    for (const { q, value, exact } of V.expected) {
+      const actual = quantileR7(V.values, q);
+      if (exact) {
+        expect(actual).toBe(value);
+      } else {
+        expect(actual).toBeCloseTo(value, 12);
+      }
+    }
+  });
+
+  test("a single-element sample returns that element at every q", () => {
+    expect(quantileR7([42], 0)).toBe(42);
+    expect(quantileR7([42], 0.5)).toBe(42);
+    expect(quantileR7([42], 1)).toBe(42);
+  });
+
+  test("R-7 at q=0.5 IS the ordinary median for odd and even n", () => {
+    expect(quantileR7([1, 2, 8], 0.5)).toBe(2);
+    expect(quantileR7([1, 3, 5, 7], 0.5)).toBe(4); // (3+5)/2
+  });
+});
+
+describe("mad-from-median-v1", () => {
+  // [1,1,2,2,4,6,9] -> median 2; |deviations| = [1,1,0,0,2,4,7] -> median 1.
+  const V = STATISTICS_TEST_VECTORS["mad-from-median-v1"];
+
+  test("pinned vector", () => {
+    expect(madFromMedian(V.values)).toBe(V.mad);
+  });
+
+  // [1,3,5,7] -> median 4; |deviations| = [3,1,1,3] -> median (1+3)/2 = 2.
+  test("even-length sample uses the mean of the two central values twice", () => {
+    expect(madFromMedian([1, 3, 5, 7])).toBe(2);
+  });
+
+  test("an all-identical sample has zero dispersion", () => {
+    expect(madFromMedian([5, 5, 5])).toBe(0);
+  });
+});
+
+describe("tagged summaries", () => {
+  test("quantileEstimate carries the tag, q, and sample size", () => {
+    expect(quantileEstimate([1, 2, 3, 4], 0.95, "quantile-nearest-rank-v1")).toEqual({
+      algorithm: "quantile-nearest-rank-v1",
+      q: 0.95,
+      value: 4,
+      sample_size: 4,
+    });
+    expect(quantileEstimate([0, 10, 20, 30], 0.25, "quantile-r7-v1")).toEqual({
+      algorithm: "quantile-r7-v1",
+      q: 0.25,
+      value: 7.5,
+      sample_size: 4,
+    });
+  });
+
+  test("madEstimate carries the tag, median, and sample size", () => {
+    const V = STATISTICS_TEST_VECTORS["mad-from-median-v1"];
+    expect(madEstimate(V.values)).toEqual({
+      algorithm: "mad-from-median-v1",
+      median: V.median,
+      mad: V.mad,
+      sample_size: V.values.length,
+    });
+  });
+});
+
+describe("mulberry32-v1 binding", () => {
+  test("the canonical generator still produces the pinned sequence", () => {
+    const rng = mulberry32(PRNG_TEST_VECTOR.seed);
+    expect(PRNG_TEST_VECTOR.draws.map(() => rng())).toEqual([...PRNG_TEST_VECTOR.draws]);
+  });
+
+  test("the pinned PRNG tag matches the one every bootstrap records", () => {
+    expect(PRNG_TEST_VECTOR.prng).toBe(BOOTSTRAP_PRNG);
+  });
+});
+
+describe("bootstrap-percentile-v1", () => {
+  // values [1,2,8], seed 0, 8 resamples, statistic = R-7 median.
+  // Draw index = floor(rng()*3) from ONE mulberry32(0) consumed continuously.
+  const V = STATISTICS_TEST_VECTORS["bootstrap-percentile-v1"];
+  const VALUES = V.values;
+  const OPTIONS = V.options;
+  const MEDIAN = V.statistic;
+
+  test("pinned replicate medians", () => {
+    expect(bootstrapPercentileReplicates(VALUES, MEDIAN, OPTIONS)).toEqual([...V.replicates]);
+  });
+
+  // sorted replicates = [1,1,1,1,2,2,2,8]; confidence 0.75 -> R-7 at q=0.125 and q=0.875.
+  // lower: h = 7*0.125 = 0.875 -> 1 + 0.875*(1-1) = 1
+  // upper: h = 7*0.875 = 6.125 -> 2 + 0.125*(8-2) = 2.75
+  test("pinned point, interval, and full metadata", () => {
+    expect(bootstrapPercentile(VALUES, MEDIAN, OPTIONS)).toEqual({
+      algorithm: "bootstrap-percentile-v1",
+      prng: "mulberry32-v1",
+      point: V.point,
+      interval: { ...V.interval },
+      seed: OPTIONS.seed,
+      resamples: OPTIONS.resamples,
+      inclusion_unit: OPTIONS.inclusion_unit,
+      statistic: { ...MEDIAN },
+    });
+  });
+
+  test("point is the statistic on the ORIGINAL sample, not a replicate summary", () => {
+    // The mean of the pinned replicates is 2.25; the original-sample median is 2.
+    // Asserted from the vector so the distinction cannot silently collapse.
+    const replicateMean = V.replicates.reduce((a, b) => a + b, 0) / V.replicates.length;
+    expect(replicateMean).not.toBe(V.point);
+    expect(bootstrapPercentile(VALUES, MEDIAN, OPTIONS).point).toBe(V.point);
+  });
+
+  test("same seed reproduces exactly", () => {
+    expect(bootstrapPercentile(VALUES, MEDIAN, OPTIONS)).toEqual(
+      bootstrapPercentile(VALUES, MEDIAN, OPTIONS),
+    );
+  });
+
+  test("a different seed draws a different replicate sequence", () => {
+    // Seed 1 over the same sample. NOTE: at this tiny resample count seed 1
+    // happens to produce the SAME interval [1, 2.75] as seed 0 — the seed
+    // shows up in the replicate ORDER, not the interval. Asserting interval
+    // divergence here would be a false test; assert the replicates.
+    expect(bootstrapPercentileReplicates(VALUES, MEDIAN, { ...OPTIONS, seed: 1 })).toEqual([
+      ...V.replicates_at_seed_1,
+    ]);
+    expect([...V.replicates_at_seed_1]).not.toEqual([...V.replicates]);
+  });
+
+  test("the mean statistic is selectable and recorded", () => {
+    const r = bootstrapPercentile(VALUES, { algorithm: "mean-v1" }, OPTIONS);
+    expect(r.statistic).toEqual({ algorithm: "mean-v1" });
+    expect(r.point).toBeCloseTo(11 / 3, 12);
+  });
+
+  test("rejects a missing q on a quantile statistic and a present q on the mean", () => {
+    expectInputError(() => bootstrapPercentile(VALUES, { algorithm: "quantile-r7-v1" }, OPTIONS));
+    expectInputError(() => bootstrapPercentile(VALUES, { algorithm: "mean-v1", q: 0.5 }, OPTIONS));
+  });
+
+  test("rejects every out-of-contract bootstrap option", () => {
+    const bad: BootstrapOptions[] = [
+      { ...OPTIONS, seed: -1 },
+      { ...OPTIONS, seed: 1.5 },
+      { ...OPTIONS, seed: 4_294_967_296 },
+      { ...OPTIONS, resamples: 0 },
+      { ...OPTIONS, resamples: 2.5 },
+      { ...OPTIONS, confidence: 0 },
+      { ...OPTIONS, confidence: 1 },
+      { ...OPTIONS, inclusion_unit: "   " },
+    ];
+    for (const options of bad) {
+      expectInputError(() => bootstrapPercentile(VALUES, MEDIAN, options));
+    }
+  });
+
+  test("does not mutate the caller's sample", () => {
+    const input = Object.freeze([8, 1, 2]);
+    bootstrapPercentile(input, MEDIAN, OPTIONS);
+    expect(input).toEqual([8, 1, 2]);
+  });
+});

--- a/bench/measurement/statistics.test.ts
+++ b/bench/measurement/statistics.test.ts
@@ -140,17 +140,26 @@ describe("mad-from-median-v1", () => {
 
 describe("tagged summaries", () => {
   test("quantileEstimate carries the tag, q, and sample size", () => {
-    expect(quantileEstimate([1, 2, 3, 4], 0.95, "quantile-nearest-rank-v1")).toEqual({
+    // Sourced from the vectors, not inlined. Both samples and both (q, value)
+    // pairs below have a home in STATISTICS_TEST_VECTORS, so writing them as
+    // literals here would let the tagged wrapper drift away from the constant
+    // the contract hash is taken over — one eroded test at a time.
+    const NR = STATISTICS_TEST_VECTORS["quantile-nearest-rank-v1"];
+    const nr = NR.expected[3]; // q = 0.95 -> 4
+    expect(quantileEstimate(NR.values, nr.q, "quantile-nearest-rank-v1")).toEqual({
       algorithm: "quantile-nearest-rank-v1",
-      q: 0.95,
-      value: 4,
-      sample_size: 4,
+      q: nr.q,
+      value: nr.value,
+      sample_size: NR.values.length,
     });
-    expect(quantileEstimate([0, 10, 20, 30], 0.25, "quantile-r7-v1")).toEqual({
+
+    const R7 = STATISTICS_TEST_VECTORS["quantile-r7-v1"];
+    const r7 = R7.expected[1]; // q = 0.25 -> 7.5
+    expect(quantileEstimate(R7.values, r7.q, "quantile-r7-v1")).toEqual({
       algorithm: "quantile-r7-v1",
-      q: 0.25,
-      value: 7.5,
-      sample_size: 4,
+      q: r7.q,
+      value: r7.value,
+      sample_size: R7.values.length,
     });
   });
 
@@ -689,9 +698,46 @@ describe("contract surface", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  test("every table z is the one-sided normal quantile for its confidence", () => {
-    // Sanity, not derivation: z must increase with confidence and stay inside
-    // a range no plausible transcription error survives.
+  /**
+   * Composite Simpson over the standard-normal pdf: `Φ(z) = 0.5 + ∫₀^z φ(t)dt`.
+   *
+   * This is the CDF, not its inverse. It can only ever CHECK a `(confidence, z)`
+   * row — it cannot produce a z — so it is not the untagged tenth algorithm the
+   * plan's non-goals ban. It lives in the test, never in the module.
+   */
+  const standardNormalCdf = (z: number, intervals = 20_000): number => {
+    const pdf = (t: number): number => Math.exp(-0.5 * t * t) / Math.sqrt(2 * Math.PI);
+    const h = z / intervals;
+    let sum = pdf(0) + pdf(z);
+    for (let i = 1; i < intervals; i++) {
+      sum += pdf(i * h) * (i % 2 === 0 ? 2 : 4);
+    }
+    return 0.5 + (h / 3) * sum;
+  };
+
+  test("every table z round-trips through the normal CDF to its own confidence", () => {
+    // The table is the module's one load-bearing numeric surface that is NOT in
+    // STATISTICS_TEST_VECTORS, and a wrong z ships evidence tagged with a
+    // confidence that did not determine the number — the exact failure §4.7
+    // exists to prevent. Range and monotonicity checks do not catch that: a z
+    // perturbed by 0.2 stays positive, stays under 4, and stays ordered.
+    //
+    // Every current row lands within 2.6e-15; a 0.2 perturbation lands at
+    // 4.2e-3, twelve orders away. 1e-12 separates them with enormous margin
+    // while leaving room for the quadrature's own error.
+    for (const [confidence, z] of Object.entries(WILSON_Z_BY_CONFIDENCE)) {
+      expect(Math.abs(standardNormalCdf(z) - Number(confidence))).toBeLessThan(1e-12);
+    }
+  });
+
+  test("the round-trip guard is sharp enough to reject a perturbed z", () => {
+    // Proves the guard above is not vacuous: without this, a test asserting
+    // "z is the normal quantile" could pass while checking nothing of the sort.
+    const corrupted = WILSON_Z_BY_CONFIDENCE[0.99] + 0.2;
+    expect(Math.abs(standardNormalCdf(corrupted) - 0.99)).toBeGreaterThan(1e-12);
+  });
+
+  test("table z values increase with confidence and stay in a plausible range", () => {
     const rows = Object.entries(WILSON_Z_BY_CONFIDENCE)
       .map(([c, z]) => ({ c: Number(c), z }))
       .toSorted((a, b) => a.c - b.c);
@@ -773,5 +819,44 @@ describe("canonical-JSON safety", () => {
   test("a zero-dispersion sample emits +0, not -0", () => {
     assertEmittable(madEstimate([5, 5, 5]));
     expect(Object.is(madEstimate([5, 5, 5]).mad, -0)).toBe(false);
+  });
+
+  /**
+   * The guard above walks results exhaustively, but every fixture feeding it is
+   * `-0`-free, so it could only ever catch a COMPUTED negative zero. An ECHOED
+   * one slipped straight through: `-0` clears `Number.isInteger(v) && v >= 0`
+   * and `!(v < 0)` untouched, so a caller parameter carrying `-0` was copied
+   * verbatim onto the result. These feed `-0` in deliberately.
+   */
+  test("a -0 caller parameter is normalized before it reaches the result", () => {
+    const b = STATISTICS_TEST_VECTORS["bootstrap-percentile-v1"];
+
+    // seed: -0 arises from `seed: -index` at index 0.
+    const seeded = bootstrapPercentile(b.values, b.statistic, { ...b.options, seed: -0 });
+    expect(Object.is(seeded.seed, -0)).toBe(false);
+    assertEmittable(seeded);
+
+    // statistic.q: -0 arises from `q: -x` at x = 0.
+    const q0 = bootstrapPercentile(b.values, { algorithm: "quantile-r7-v1", q: -0 }, b.options);
+    expect(Object.is(q0.statistic?.q, -0)).toBe(false);
+    assertEmittable(q0);
+
+    // failures: -0 arises from `failures: -count` at count 0.
+    const w = wilsonOneSidedUpper(-0, 100, {
+      confidence: 0.95,
+      z: WILSON_Z_BY_CONFIDENCE[0.95],
+    });
+    expect(Object.is(w.failures, -0)).toBe(false);
+    assertEmittable(w);
+  });
+
+  test("the returned statistic selector is a copy, not the caller's object", () => {
+    // Echoing by reference would let a caller mutate an already-emitted evidence
+    // record after the fact.
+    const b = STATISTICS_TEST_VECTORS["bootstrap-percentile-v1"];
+    const selector = { algorithm: "quantile-r7-v1" as const, q: 0.5 };
+    const result = bootstrapPercentile(b.values, selector, b.options);
+    expect(result.statistic).not.toBe(selector);
+    expect(result.statistic).toEqual(selector);
   });
 });

--- a/bench/measurement/statistics.test.ts
+++ b/bench/measurement/statistics.test.ts
@@ -1,18 +1,26 @@
 import { describe, test, expect } from "vitest";
 import { mulberry32 } from "../load-harness/generators/rng.ts";
-import type { BootstrapOptions } from "./statistics.ts";
+import type { BootstrapOptions, OlsQrInput } from "./statistics.ts";
 import {
   BOOTSTRAP_PRNG,
   bootstrapPercentile,
   bootstrapPercentileReplicates,
+  clopperPearsonZeroFailureUpper,
   madEstimate,
   madFromMedian,
+  olsQr,
+  pairedRatioBootstrap,
+  pairedRatioBootstrapReplicates,
   PRNG_TEST_VECTOR,
   quantileEstimate,
   quantileNearestRank,
   quantileR7,
   STATISTICS_ALGORITHMS,
   STATISTICS_TEST_VECTORS,
+  stratifiedPairedDifferenceBootstrap,
+  stratifiedPairedDifferenceBootstrapReplicates,
+  WILSON_Z_BY_CONFIDENCE,
+  wilsonOneSidedUpper,
 } from "./statistics.ts";
 
 /**
@@ -252,5 +260,415 @@ describe("bootstrap-percentile-v1", () => {
     const input = Object.freeze([8, 1, 2]);
     bootstrapPercentile(input, MEDIAN, OPTIONS);
     expect(input).toEqual([8, 1, 2]);
+  });
+});
+
+describe("paired-ratio-bootstrap-v1", () => {
+  // Pairs (baseline, candidate): (2,1), (4,3), (8,4).
+  // Per-pair ratios candidate/baseline = [0.5, 0.75, 0.5]; median = 0.5.
+  const V = STATISTICS_TEST_VECTORS["paired-ratio-bootstrap-v1"];
+  const PAIRS = V.pairs;
+  const OPTIONS = V.options;
+
+  test("pinned replicate medians", () => {
+    expect(pairedRatioBootstrapReplicates(PAIRS, OPTIONS)).toEqual([...V.replicates]);
+  });
+
+  // sorted replicates = [0.5,0.5,0.5,0.5,0.5,0.75,0.75,0.75]
+  // lower: h = 7*0.125 = 0.875 -> 0.5;  upper: h = 7*0.875 = 6.125 -> 0.75 + 0.125*(0.75-0.75) = 0.75
+  test("pinned point, interval, and full metadata", () => {
+    expect(pairedRatioBootstrap(PAIRS, OPTIONS)).toEqual({
+      algorithm: "paired-ratio-bootstrap-v1",
+      prng: "mulberry32-v1",
+      point: V.point,
+      interval: { ...V.interval },
+      seed: OPTIONS.seed,
+      resamples: OPTIONS.resamples,
+      inclusion_unit: OPTIONS.inclusion_unit,
+    });
+  });
+
+  test("same seed reproduces exactly", () => {
+    expect(pairedRatioBootstrap(PAIRS, OPTIONS)).toEqual(pairedRatioBootstrap(PAIRS, OPTIONS));
+  });
+
+  test("rejects a nonpositive baseline, a duplicate pair id, and a nonfinite arm", () => {
+    expectInputError(() =>
+      pairedRatioBootstrap([{ pair_id: "p1", baseline: 0, candidate: 1 }], OPTIONS),
+    );
+    expectInputError(() =>
+      pairedRatioBootstrap([{ pair_id: "p1", baseline: -2, candidate: 1 }], OPTIONS),
+    );
+    expectInputError(() =>
+      pairedRatioBootstrap(
+        [
+          { pair_id: "dup", baseline: 2, candidate: 1 },
+          { pair_id: "dup", baseline: 4, candidate: 3 },
+        ],
+        OPTIONS,
+      ),
+    );
+    expectInputError(() =>
+      pairedRatioBootstrap([{ pair_id: "p1", baseline: 2, candidate: Number.NaN }], OPTIONS),
+    );
+    expectInputError(() =>
+      pairedRatioBootstrap([{ pair_id: "  ", baseline: 2, candidate: 1 }], OPTIONS),
+    );
+    expectInputError(() => pairedRatioBootstrap([], OPTIONS));
+  });
+});
+
+describe("stratified-paired-difference-bootstrap-v1", () => {
+  // Stratum "a" differences [1,3]; stratum "b" differences [10,14].
+  // Point = mean over all four differences = (1+3+10+14)/4 = 7.
+  const V = STATISTICS_TEST_VECTORS["stratified-paired-difference-bootstrap-v1"];
+  const PAIRS = V.pairs;
+  const OPTIONS = V.options;
+
+  test("pinned replicate mean differences", () => {
+    expect(stratifiedPairedDifferenceBootstrapReplicates(PAIRS, OPTIONS)).toEqual([
+      ...V.replicates,
+    ]);
+  });
+
+  // sorted replicates = [6,7,7,7,7,7.5,8,8]
+  // lower: h = 7*0.125 = 0.875 -> 6 + 0.875*(7-6) = 6.875
+  // upper: h = 7*0.875 = 6.125 -> 8 + 0.125*(8-8) = 8
+  test("pinned point, interval, and full metadata", () => {
+    expect(stratifiedPairedDifferenceBootstrap(PAIRS, OPTIONS)).toEqual({
+      algorithm: "stratified-paired-difference-bootstrap-v1",
+      prng: "mulberry32-v1",
+      point: V.point,
+      interval: { ...V.interval },
+      seed: OPTIONS.seed,
+      resamples: OPTIONS.resamples,
+      inclusion_unit: OPTIONS.inclusion_unit,
+    });
+  });
+
+  test("point is the original-sample mean, not the replicate mean", () => {
+    // The mean of the pinned replicates is 7.1875; the original-sample mean is 7.
+    const replicateMean = V.replicates.reduce((a, b) => a + b, 0) / V.replicates.length;
+    expect(replicateMean).not.toBe(V.point);
+    expect(stratifiedPairedDifferenceBootstrap(PAIRS, OPTIONS).point).toBe(V.point);
+  });
+
+  test("each stratum keeps its original count in every replicate", () => {
+    // Stratum "b" alone can never contribute a value below 10, so no replicate
+    // mean can fall below (1+1+10+10)/4 = 5.5 — proof strata were not pooled.
+    const replicates = stratifiedPairedDifferenceBootstrapReplicates(PAIRS, OPTIONS);
+    for (const r of replicates) {
+      expect(r).toBeGreaterThanOrEqual(V.replicate_floor_if_strata_preserved);
+    }
+  });
+
+  test("rejects an empty stratum label", () => {
+    expectInputError(() =>
+      stratifiedPairedDifferenceBootstrap(
+        [{ pair_id: "x", stratum: "  ", baseline: 0, candidate: 1 }],
+        OPTIONS,
+      ),
+    );
+  });
+
+  test("a zero or negative baseline is allowed for differences", () => {
+    const r = stratifiedPairedDifferenceBootstrap(
+      [
+        { pair_id: "n1", stratum: "s", baseline: -5, candidate: -1 },
+        { pair_id: "n2", stratum: "s", baseline: -5, candidate: -3 },
+      ],
+      OPTIONS,
+    );
+    expect(r.point).toBe(3); // differences [4, 2] -> mean 3
+  });
+});
+
+describe("clopper-pearson-zero-failure-upper-v1", () => {
+  // 1 - (1 - 0.95)^(1/100) = 1 - 0.05^0.01. Hand-checkable against any calculator.
+  const V = STATISTICS_TEST_VECTORS["clopper-pearson-zero-failure-upper-v1"];
+
+  test("pinned vector n=100, confidence 0.95", () => {
+    const r = clopperPearsonZeroFailureUpper(V.attempts, V.confidence);
+    expect(r.algorithm).toBe("clopper-pearson-zero-failure-upper-v1");
+    expect(r.upper).toBeCloseTo(V.upper, 15);
+    expect(r.failures).toBe(0);
+    expect(r.attempts).toBe(V.attempts);
+    expect(r.confidence).toBe(V.confidence);
+  });
+
+  test("the bound tightens as attempts grow", () => {
+    expect(clopperPearsonZeroFailureUpper(1000, 0.95).upper).toBeLessThan(
+      clopperPearsonZeroFailureUpper(100, 0.95).upper,
+    );
+  });
+
+  test("rejects attempts below one and confidence outside (0,1)", () => {
+    expectInputError(() => clopperPearsonZeroFailureUpper(0, 0.95));
+    expectInputError(() => clopperPearsonZeroFailureUpper(10.5, 0.95));
+    expectInputError(() => clopperPearsonZeroFailureUpper(100, 1));
+    expectInputError(() => clopperPearsonZeroFailureUpper(100, 0));
+  });
+});
+
+describe("wilson-one-sided-upper-v1", () => {
+  // p = 3/100 = 0.03, n = 100, z = 1.6448536269514722 (the standard-normal 95th percentile).
+  // (p + z^2/(2n) + z*sqrt(p(1-p)/n + z^2/(4n^2))) / (1 + z^2/n)
+  const V = STATISTICS_TEST_VECTORS["wilson-one-sided-upper-v1"];
+
+  test("pinned vector 3 failures in 100", () => {
+    const r = wilsonOneSidedUpper(V.failures, V.attempts, {
+      confidence: V.confidence,
+      z: V.z,
+    });
+    expect(r.algorithm).toBe("wilson-one-sided-upper-v1");
+    expect(r.upper).toBeCloseTo(V.upper, 15);
+    expect(r.failures).toBe(V.failures);
+    expect(r.attempts).toBe(V.attempts);
+    expect(r.confidence).toBe(V.confidence);
+    expect(r.z).toBe(V.z);
+  });
+
+  test("the pinned z IS the table's z for the pinned confidence", () => {
+    expect(V.z).toBe(WILSON_Z_BY_CONFIDENCE[0.95]);
+  });
+
+  test("the caller's z is recorded verbatim and never derived from confidence", () => {
+    // The module does no deriving — it reads the z it was handed. Proven with a
+    // CONSISTENT pair from the table, so no lying record is minted along the way.
+    const r = wilsonOneSidedUpper(V.failures, V.attempts, {
+      confidence: 0.99,
+      z: WILSON_Z_BY_CONFIDENCE[0.99],
+    });
+    expect(r.z).toBe(WILSON_Z_BY_CONFIDENCE[0.99]);
+    expect(r.confidence).toBe(0.99);
+    expect(r.upper).toBeGreaterThan(V.upper); // a wider confidence gives a looser bound
+  });
+
+  test("rejects a (confidence, z) pair that cannot both be true", () => {
+    expectInputError(() => wilsonOneSidedUpper(3, 100, { confidence: 0.95, z: 2 }));
+    // A confidence with no table row is rejected rather than silently trusted.
+    expectInputError(() =>
+      wilsonOneSidedUpper(3, 100, { confidence: 0.9123, z: 1.6448536269514722 }),
+    );
+  });
+
+  test("a z one ulp from the table still passes — the match is toleranced, not exact", () => {
+    const nudged = WILSON_Z_BY_CONFIDENCE[0.95] * (1 + Number.EPSILON);
+    const r = wilsonOneSidedUpper(3, 100, { confidence: 0.95, z: nudged });
+    expect(r.z).toBe(nudged);
+  });
+
+  test("rejects failures outside [0, attempts], attempts below one, and a nonpositive z", () => {
+    const z = WILSON_Z_BY_CONFIDENCE[0.95];
+    expectInputError(() => wilsonOneSidedUpper(-1, 100, { confidence: 0.95, z }));
+    expectInputError(() => wilsonOneSidedUpper(101, 100, { confidence: 0.95, z }));
+    expectInputError(() => wilsonOneSidedUpper(1.5, 100, { confidence: 0.95, z }));
+    expectInputError(() => wilsonOneSidedUpper(0, 0, { confidence: 0.95, z }));
+    expectInputError(() => wilsonOneSidedUpper(3, 100, { confidence: 0.95, z: 0 }));
+    expectInputError(() =>
+      wilsonOneSidedUpper(3, 100, { confidence: 0.95, z: Number.POSITIVE_INFINITY }),
+    );
+  });
+});
+
+describe("ols-qr-v1", () => {
+  const V = STATISTICS_TEST_VECTORS["ols-qr-v1"];
+
+  test("exact-fit vector: y = 1 + 1*calls + 0.5*mib", () => {
+    const r = olsQr({ columns: V.columns, rows: V.rows });
+    expect(r.algorithm).toBe("ols-qr-v1");
+    expect(r.columns).toEqual([...V.columns]);
+    expect(r.rank).toBe(V.rank);
+    // Householder returns 0.9999999999999996 / 1.0000000000000002 / 0.5 — compare with tolerance.
+    for (const [j, expected] of V.coefficients.entries()) {
+      expect(r.coefficients[j]).toBeCloseTo(expected, 12);
+    }
+    for (const e of r.residuals) {
+      expect(Math.abs(e)).toBeLessThan(1e-12);
+    }
+    expect(r.residual_sum_squares).toBeLessThan(1e-12);
+    expect(r.root_mean_square_error).toBeLessThan(1e-12);
+    expect(r.r_squared).toBeCloseTo(V.r_squared, 12);
+    expect(r.intercept_present).toBe(V.intercept_present);
+  });
+
+  test("a well-conditioned design reports a small condition estimate", () => {
+    const r = olsQr({ columns: V.columns, rows: V.rows });
+    expect(r.condition_estimate).toBeGreaterThanOrEqual(1);
+    expect(r.condition_estimate).toBeLessThan(100);
+  });
+
+  test("a NEARLY collinear design passes the rank gate but reports a huge condition estimate", () => {
+    // This is the case the rank gate cannot see, and the reason
+    // `condition_estimate` exists. It is also the shape of Plan J's own design
+    // matrix, where rows and bytes co-vary.
+    //
+    // The perturbation ALTERNATES on purpose. Writing `bytes = calls*(1+1e-9)`
+    // would make the column exactly proportional to `calls`, so its component
+    // orthogonal to span{intercept, calls} is zero in exact arithmetic — the
+    // design would be exactly singular and `olsQr` would correctly THROW,
+    // testing the opposite of what is intended here. An alternating jitter
+    // leaves a genuine ~1e-9 orthogonal component: full rank by any tolerance
+    // (which sits near 4e-15 for this matrix), numerically hopeless in practice.
+    const r = olsQr({
+      columns: ["intercept", "calls", "bytes"],
+      rows: [
+        { x: [1, 1, 1 + 1e-9], y: 2 },
+        { x: [1, 2, 2 - 1e-9], y: 3 },
+        { x: [1, 3, 3 + 1e-9], y: 5 },
+        { x: [1, 4, 4 - 1e-9], y: 6 },
+      ],
+    });
+    expect(r.rank).toBe(3); // full rank — the gate is satisfied
+    expect(r.condition_estimate).toBeGreaterThan(1e6); // and yet
+  });
+
+  test("intercept_present is detected from the data, not from a column name", () => {
+    // Named "one", not "intercept" — still an intercept.
+    const named = olsQr({
+      columns: ["one", "x"],
+      rows: [
+        { x: [1, 1], y: 1 },
+        { x: [1, 2], y: 3 },
+      ],
+    });
+    expect(named.intercept_present).toBe(true);
+
+    // Named "intercept" but not constant — NOT an intercept.
+    const lying = olsQr({
+      columns: ["intercept", "x"],
+      rows: [
+        { x: [2, 1], y: 1 },
+        { x: [1, 2], y: 3 },
+      ],
+    });
+    expect(lying.intercept_present).toBe(false);
+  });
+
+  test("no emitted number is negative zero", () => {
+    // Lane D's canonical JSON REJECTS -0. The reachable path is an exactly zero
+    // coefficient over a negative Householder pivot — which the noisy vector
+    // below produces, since its true intercept is exactly 0.
+    const r = olsQr({
+      columns: ["intercept", "x"],
+      rows: [
+        { x: [1, 1], y: 1 },
+        { x: [1, 2], y: 3 },
+        { x: [1, 3], y: 2 },
+        { x: [1, 4], y: 5 },
+      ],
+    });
+    for (const v of [...r.coefficients, ...r.residuals]) {
+      expect(Object.is(v, -0)).toBe(false);
+    }
+  });
+
+  test("noisy vector with hand-computed simple-regression diagnostics", () => {
+    // x = [1,2,3,4], y = [1,3,2,5]. x̄ = 2.5, ȳ = 2.75.
+    // Sxy = (-1.5)(-1.75)+(-0.5)(0.25)+(0.5)(-0.75)+(1.5)(2.25) = 5.5
+    // Sxx = 2.25+0.25+0.25+2.25 = 5   -> slope = 1.1, intercept = 2.75 - 1.1*2.5 = 0
+    // fitted = [1.1, 2.2, 3.3, 4.4]   -> residuals = [-0.1, 0.8, -1.3, 0.6]
+    // RSS = 0.01+0.64+1.69+0.36 = 2.7 -> RMSE = sqrt(2.7/4) = 0.8215838362577491
+    // TSS = 3.0625+0.0625+0.5625+5.0625 = 8.75 -> R² = 1 - 2.7/8.75 = 0.6914285714285714
+    const r = olsQr({
+      columns: ["intercept", "x"],
+      rows: [
+        { x: [1, 1], y: 1 },
+        { x: [1, 2], y: 3 },
+        { x: [1, 3], y: 2 },
+        { x: [1, 4], y: 5 },
+      ],
+    });
+    expect(r.rank).toBe(2);
+    expect(r.coefficients[0]).toBeCloseTo(0, 12);
+    expect(r.coefficients[1]).toBeCloseTo(1.1, 12);
+    expect(r.residuals[0]).toBeCloseTo(-0.1, 12);
+    expect(r.residuals[1]).toBeCloseTo(0.8, 12);
+    expect(r.residuals[2]).toBeCloseTo(-1.3, 12);
+    expect(r.residuals[3]).toBeCloseTo(0.6, 12);
+    expect(r.residual_sum_squares).toBeCloseTo(2.7, 12);
+    expect(r.root_mean_square_error).toBeCloseTo(0.8215838362577491, 12);
+    expect(r.r_squared).toBeCloseTo(0.6914285714285714, 12);
+  });
+
+  test("constant response with an exact fit reports R² = 1", () => {
+    const r = olsQr({
+      columns: ["intercept"],
+      rows: [
+        { x: [1], y: 5 },
+        { x: [1], y: 5 },
+        { x: [1], y: 5 },
+      ],
+    });
+    expect(r.coefficients[0]).toBeCloseTo(5, 12);
+    expect(r.residual_sum_squares).toBeLessThan(1e-12);
+    expect(r.r_squared).toBe(1);
+  });
+
+  test("constant response with a nonzero RSS reports R² = 0", () => {
+    // No intercept column: OLS slope = (1*5 + 2*5)/(1+4) = 3.
+    // fitted = [3, 6] -> residuals = [2, -1] -> RSS = 5, RMSE = sqrt(2.5).
+    const r = olsQr({
+      columns: ["x"],
+      rows: [
+        { x: [1], y: 5 },
+        { x: [2], y: 5 },
+      ],
+    });
+    expect(r.coefficients[0]).toBeCloseTo(3, 12);
+    expect(r.residuals[0]).toBeCloseTo(2, 12);
+    expect(r.residuals[1]).toBeCloseTo(-1, 12);
+    expect(r.residual_sum_squares).toBeCloseTo(5, 12);
+    expect(r.root_mean_square_error).toBeCloseTo(1.5811388300841898, 12);
+    expect(r.r_squared).toBe(0);
+    // And the flag that tells a reader NOT to quote that 0: `r_squared` is the
+    // centered definition, which is not interpretable without a constant column.
+    expect(r.intercept_present).toBe(false);
+  });
+
+  test("a duplicated design column throws the tagged singular error", () => {
+    let thrown: unknown;
+    try {
+      olsQr({
+        columns: ["intercept", "calls", "calls_copy"],
+        rows: [
+          { x: [1, 1, 1], y: 2 },
+          { x: [1, 2, 2], y: 3 },
+          { x: [1, 3, 3], y: 5 },
+          { x: [1, 4, 4], y: 6 },
+        ],
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect(thrown).toMatchObject({
+      code: "SingularDesign",
+      algorithm: "ols-qr-v1",
+      rank: 2,
+      columns: ["intercept", "calls", "calls_copy"],
+    });
+  });
+
+  test("rejects malformed designs", () => {
+    const bad: OlsQrInput[] = [
+      { columns: [], rows: [{ x: [], y: 1 }] },
+      {
+        columns: ["a", "a"],
+        rows: [
+          { x: [1, 1], y: 1 },
+          { x: [2, 2], y: 2 },
+        ],
+      },
+      { columns: [" "], rows: [{ x: [1], y: 1 }] },
+      { columns: ["a", "b"], rows: [{ x: [1, 2], y: 1 }] }, // fewer rows than columns
+      { columns: ["a"], rows: [{ x: [1, 2], y: 1 }] }, // wrong row width
+      { columns: ["a"], rows: [{ x: [Number.POSITIVE_INFINITY], y: 1 }] },
+      { columns: ["a"], rows: [{ x: [1], y: Number.NaN }] },
+      { columns: ["a"], rows: [] },
+    ];
+    for (const input of bad) {
+      expectInputError(() => olsQr(input));
+    }
   });
 });

--- a/bench/measurement/statistics.test.ts
+++ b/bench/measurement/statistics.test.ts
@@ -651,13 +651,17 @@ describe("ols-qr-v1", () => {
   test("the rank gate catches a dependent column at ANY scale, not just 1x", () => {
     // The regression test for the gate's original defect. `bytes` is an exact
     // integer multiple of `calls`, so the design is mathematically rank 2 at
-    // every multiplier. Against a single global `max|R_kk|` tolerance, a
-    // multiplier as small as 9 was enough for the dependent column's rounding
-    // residual to clear a bar set by a different column's scale: 2737 of 4800
-    // sampled rank-2 designs were accepted as rank 3 and returned coefficients
-    // of magnitude 1e13-1e15. The suite only ever exercised multiplier 1, which
-    // is the one case that survived.
-    for (const multiplier of [1, 9, 100, 1000, 1e6, 1e9, 1e12]) {
+    // every multiplier. Against a single global `max|R_kk|` tolerance, the
+    // dependent column's rounding residual clears a bar set by a DIFFERENT
+    // column's scale: 2737 of 4800 sampled rank-2 designs were accepted as
+    // rank 3 and returned coefficients of magnitude 1e13-1e15.
+    //
+    // The `calls` values are [1,2,4,8], NOT [1,2,3,4]. Consecutive integers
+    // are one of the arrangements the old gate happened to handle correctly at
+    // every multiplier — writing the obvious row set here produced a test that
+    // passed under the broken gate too. Verified: with the original gate
+    // reinstated, [1,2,4,8] at multiplier 7 is accepted as rank 3.
+    for (const multiplier of [1, 7, 9, 100, 1000, 1e6, 1e9, 1e12]) {
       let thrown: unknown;
       try {
         olsQr({
@@ -665,8 +669,8 @@ describe("ols-qr-v1", () => {
           rows: [
             { x: [1, 1, 1 * multiplier], y: 2 },
             { x: [1, 2, 2 * multiplier], y: 3 },
-            { x: [1, 3, 3 * multiplier], y: 5 },
-            { x: [1, 4, 4 * multiplier], y: 6 },
+            { x: [1, 4, 4 * multiplier], y: 5 },
+            { x: [1, 8, 8 * multiplier], y: 6 },
           ],
         });
       } catch (error) {

--- a/bench/measurement/statistics.test.ts
+++ b/bench/measurement/statistics.test.ts
@@ -146,7 +146,7 @@ describe("tagged summaries", () => {
     // literals here would let the tagged wrapper drift away from the constant
     // the contract hash is taken over — one eroded test at a time.
     const NR = STATISTICS_TEST_VECTORS["quantile-nearest-rank-v1"];
-    const nr = NR.expected[3]; // q = 0.95 -> 4
+    const nr = NR.expected[4]; // q = 0.95 -> 4
     expect(quantileEstimate(NR.values, nr.q, "quantile-nearest-rank-v1")).toEqual({
       algorithm: "quantile-nearest-rank-v1",
       q: nr.q,
@@ -400,7 +400,10 @@ describe("clopper-pearson-zero-failure-upper-v1", () => {
   test("pinned vector n=100, confidence 0.95", () => {
     const r = clopperPearsonZeroFailureUpper(V.attempts, V.confidence);
     expect(r.algorithm).toBe("clopper-pearson-zero-failure-upper-v1");
-    expect(r.upper).toBeCloseTo(V.upper, 15);
+    // `toBe`, not `toBeCloseTo(_, 15)`: this is a deterministic double, and 15
+    // decimal places is ~36 ulps of slack at this magnitude — enough to hide a
+    // real change in how the bound is evaluated.
+    expect(r.upper).toBe(V.upper);
     expect(r.failures).toBe(0);
     expect(r.attempts).toBe(V.attempts);
     expect(r.confidence).toBe(V.confidence);
@@ -410,6 +413,20 @@ describe("clopper-pearson-zero-failure-upper-v1", () => {
     expect(clopperPearsonZeroFailureUpper(1000, 0.95).upper).toBeLessThan(
       clopperPearsonZeroFailureUpper(100, 0.95).upper,
     );
+  });
+
+  test("the bound stays accurate at large attempt counts", () => {
+    // The defining identity of the exact bound at zero failures is
+    // (1 - p_U)^n = 1 - c. Evaluated as `1 - (1-c)**(1/n)` the subtraction
+    // cancels catastrophically as the bound shrinks: 1.3e-11 relative error at
+    // n=1e6, 5.8e-6 at n=1e12. Checked against the identity rather than
+    // against a second formula, so this cannot pass by agreeing with itself.
+    for (const attempts of [1e3, 1e6, 1e9, 1e12]) {
+      const { upper } = clopperPearsonZeroFailureUpper(attempts, 0.95);
+      // log-space, because (1-p)^1e12 underflows a direct evaluation.
+      const residual = Math.abs(attempts * Math.log1p(-upper) - Math.log(0.05));
+      expect(residual, `n=${attempts}`).toBeLessThan(1e-9);
+    }
   });
 
   test("rejects attempts below one and confidence outside (0,1)", () => {
@@ -431,7 +448,7 @@ describe("wilson-one-sided-upper-v1", () => {
       z: V.z,
     });
     expect(r.algorithm).toBe("wilson-one-sided-upper-v1");
-    expect(r.upper).toBeCloseTo(V.upper, 15);
+    expect(r.upper).toBe(V.upper); // deterministic double — see the Clopper-Pearson note
     expect(r.failures).toBe(V.failures);
     expect(r.attempts).toBe(V.attempts);
     expect(r.confidence).toBe(V.confidence);
@@ -466,6 +483,18 @@ describe("wilson-one-sided-upper-v1", () => {
     const nudged = WILSON_Z_BY_CONFIDENCE[0.95] * (1 + Number.EPSILON);
     const r = wilsonOneSidedUpper(3, 100, { confidence: 0.95, z: nudged });
     expect(r.z).toBe(nudged);
+  });
+
+  test("an all-failures sample never emits a bound above 1", () => {
+    // At p̂ = 1 the Wilson upper limit is exactly 1 analytically, but the float
+    // evaluation overshoots for 501 of the first 2000 attempt counts — n = 11
+    // gives 1.0000000000000002. A probability above 1 is not a probability.
+    const z = WILSON_Z_BY_CONFIDENCE[0.95];
+    for (let attempts = 1; attempts <= 2000; attempts++) {
+      const { upper } = wilsonOneSidedUpper(attempts, attempts, { confidence: 0.95, z });
+      expect(upper, `n=${attempts}`).toBeLessThanOrEqual(1);
+    }
+    expect(wilsonOneSidedUpper(11, 11, { confidence: 0.95, z }).upper).toBe(1);
   });
 
   test("rejects failures outside [0, attempts], attempts below one, and a nonpositive z", () => {

--- a/bench/measurement/statistics.test.ts
+++ b/bench/measurement/statistics.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect } from "vitest";
 import { mulberry32 } from "../load-harness/generators/rng.ts";
-import type { BootstrapOptions, OlsQrInput } from "./statistics.ts";
 import {
+  type BootstrapOptions,
+  type OlsQrInput,
   BOOTSTRAP_PRNG,
   bootstrapPercentile,
   bootstrapPercentileReplicates,
@@ -33,8 +34,8 @@ const expectInputError = (fn: () => unknown): void => {
   let thrown: unknown;
   try {
     fn();
-  } catch (err) {
-    thrown = err;
+  } catch (error) {
+    thrown = error;
   }
   expect(thrown).toMatchObject({ code: "StatisticsInput" });
 };
@@ -501,10 +502,95 @@ describe("ols-qr-v1", () => {
     expect(r.intercept_present).toBe(V.intercept_present);
   });
 
-  test("a well-conditioned design reports a small condition estimate", () => {
+  test("a well-conditioned design reports the pinned condition estimate", () => {
     const r = olsQr({ columns: V.columns, rows: V.rows });
-    expect(r.condition_estimate).toBeGreaterThanOrEqual(1);
-    expect(r.condition_estimate).toBeLessThan(100);
+    expect(r.condition_estimate).toBe(V.condition_estimate);
+  });
+
+  test("the rank gate catches a dependent column at ANY scale, not just 1x", () => {
+    // The regression test for the gate's original defect. `bytes` is an exact
+    // integer multiple of `calls`, so the design is mathematically rank 2 at
+    // every multiplier. Against a single global `max|R_kk|` tolerance, a
+    // multiplier as small as 9 was enough for the dependent column's rounding
+    // residual to clear a bar set by a different column's scale: 2737 of 4800
+    // sampled rank-2 designs were accepted as rank 3 and returned coefficients
+    // of magnitude 1e13-1e15. The suite only ever exercised multiplier 1, which
+    // is the one case that survived.
+    for (const multiplier of [1, 9, 100, 1000, 1e6, 1e9, 1e12]) {
+      let thrown: unknown;
+      try {
+        olsQr({
+          columns: ["intercept", "calls", "bytes"],
+          rows: [
+            { x: [1, 1, 1 * multiplier], y: 2 },
+            { x: [1, 2, 2 * multiplier], y: 3 },
+            { x: [1, 3, 3 * multiplier], y: 5 },
+            { x: [1, 4, 4 * multiplier], y: 6 },
+          ],
+        });
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown, `multiplier ${multiplier} must be rejected`).toMatchObject({
+        code: "SingularDesign",
+        rank: 2,
+      });
+    }
+  });
+
+  test("the rank verdict does not depend on the order the columns were listed", () => {
+    // Same matrix, permuted. Under a global-scale tolerance this returned
+    // rank 3, rank 1, and rank 2 for three permutations of one design.
+    const base = [
+      { x: [1, 1, 1000], y: 2 },
+      { x: [1, 2, 2000], y: 3 },
+      { x: [1, 3, 3000], y: 5 },
+      { x: [1, 4, 4000], y: 6 },
+    ];
+    const names = ["intercept", "calls", "bytes"];
+    for (const p of [
+      [0, 1, 2],
+      [2, 1, 0],
+      [1, 2, 0],
+      [0, 2, 1],
+    ]) {
+      let thrown: unknown;
+      try {
+        olsQr({
+          columns: p.map((i) => names[i]!),
+          rows: base.map((row) => ({ x: p.map((i) => row.x[i]!), y: row.y })),
+        });
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown, `permutation ${p.join("")} must be rejected`).toMatchObject({
+        code: "SingularDesign",
+        rank: 2,
+      });
+    }
+  });
+
+  test("condition_estimate is invariant to the units a column is measured in", () => {
+    // The same model with its size column in bytes, KiB, MiB, GiB, and bits.
+    // Identical fit, so the diagnostic must be identical too. Over the RAW
+    // diagonal it spanned 1.6e8 to 1.3e18 and the rank verdict FLIPPED — MiB
+    // and GiB threw `SingularDesign` where bytes returned rank 3.
+    const estimates = [1, 2 ** -10, 2 ** -20, 2 ** -30, 8].map((scale) => {
+      const r = olsQr({
+        columns: ["intercept", "calls", "size"],
+        rows: [
+          { x: [1, 1, (1 + 1e-9) * scale], y: 2 },
+          { x: [1, 2, (2 - 1e-9) * scale], y: 3 },
+          { x: [1, 3, (3 + 1e-9) * scale], y: 5 },
+          { x: [1, 4, (4 - 1e-9) * scale], y: 6 },
+        ],
+      });
+      expect(r.rank).toBe(3);
+      return r.condition_estimate;
+    });
+    // Bit-identical, not merely close.
+    expect(new Set(estimates).size).toBe(1);
+    expect(estimates[0]).toBeGreaterThan(1e6);
   });
 
   test("a NEARLY collinear design passes the rank gate but reports a huge condition estimate", () => {
@@ -647,8 +733,8 @@ describe("ols-qr-v1", () => {
           { x: [1, 4, 4], y: 6 },
         ],
       });
-    } catch (err) {
-      thrown = err;
+    } catch (error) {
+      thrown = error;
     }
     expect(thrown).toBeDefined();
     expect(thrown).toMatchObject({

--- a/bench/measurement/statistics.ts
+++ b/bench/measurement/statistics.ts
@@ -322,9 +322,13 @@ export const quantileR7 = (values: readonly number[], q: number): number => {
 };
 
 /**
- * The ordinary median. Provably identical to `quantileR7(values, 0.5)` for
- * every n — for even n, `h=(n-1)/2` interpolates exactly halfway between the
- * two central values. There is deliberately no second median implementation.
+ * The ordinary median, defined as `quantileR7(values, 0.5)`. For even n,
+ * `h=(n-1)/2` interpolates exactly halfway between the two central values.
+ *
+ * The two spellings agree in exact arithmetic but NOT bit-for-bit in IEEE-754:
+ * `(a+b)/2` and `a + 0.5*(b-a)` differ in the last ulp for roughly 9% of random
+ * even-n pairs. That is precisely why there is deliberately no second median
+ * implementation here — one definition, so the question never arises.
  */
 const median = (values: readonly number[]): number => quantileR7(values, 0.5);
 
@@ -423,7 +427,7 @@ const percentileInterval = (
   return {
     lower: normalizeZero(quantileR7(replicates, alpha)),
     upper: normalizeZero(quantileR7(replicates, 1 - alpha)),
-    confidence,
+    confidence: normalizeZero(confidence),
   };
 };
 
@@ -439,6 +443,22 @@ const drawWithReplacement = <T>(source: readonly T[], rng: () => number): T[] =>
   }
   return drawn;
 };
+
+/**
+ * Copy the caller's selector, normalizing its `q`.
+ *
+ * Closes two defects at once. Echoing the caller's object BY REFERENCE lets a
+ * later mutation retroactively edit an already-emitted evidence record; and
+ * `assertProbability` accepts `-0` (`-0 < 0` is false), so a `q` of `-0` would
+ * otherwise ride into a serializer that rejects it.
+ *
+ * `q` is omitted rather than set to `undefined` when absent: canonical JSON
+ * rejects an explicit `undefined` as surely as it rejects `-0`.
+ */
+const normalizeSelector = (statistic: BootstrapStatisticSelector): BootstrapStatisticSelector =>
+  statistic.q === undefined
+    ? { algorithm: statistic.algorithm }
+    : { algorithm: statistic.algorithm, q: normalizeZero(statistic.q) };
 
 const assertStatisticSelector = (statistic: BootstrapStatisticSelector): void => {
   if (!(BOOTSTRAP_STATISTICS as readonly string[]).includes(statistic.algorithm)) {
@@ -502,10 +522,10 @@ export const bootstrapPercentile = (
     prng: BOOTSTRAP_PRNG,
     point: normalizeZero(applyStatistic(values, statistic)),
     interval: percentileInterval(replicates, options.confidence),
-    seed: options.seed,
-    resamples: options.resamples,
+    seed: normalizeZero(options.seed),
+    resamples: normalizeZero(options.resamples),
     inclusion_unit: options.inclusion_unit,
-    statistic,
+    statistic: normalizeSelector(statistic),
   };
 };
 
@@ -579,8 +599,8 @@ export const pairedRatioBootstrap = (
     prng: BOOTSTRAP_PRNG,
     point: normalizeZero(median(perPairRatios(pairs))),
     interval: percentileInterval(replicates, options.confidence),
-    seed: options.seed,
-    resamples: options.resamples,
+    seed: normalizeZero(options.seed),
+    resamples: normalizeZero(options.resamples),
     inclusion_unit: options.inclusion_unit,
   };
 };
@@ -638,8 +658,8 @@ export const stratifiedPairedDifferenceBootstrap = (
     prng: BOOTSTRAP_PRNG,
     point: normalizeZero(mean(pairs.map((p) => p.candidate - p.baseline))),
     interval: percentileInterval(replicates, options.confidence),
-    seed: options.seed,
-    resamples: options.resamples,
+    seed: normalizeZero(options.seed),
+    resamples: normalizeZero(options.resamples),
     inclusion_unit: options.inclusion_unit,
   };
 };
@@ -675,8 +695,8 @@ export const clopperPearsonZeroFailureUpper = (
     algorithm: "clopper-pearson-zero-failure-upper-v1",
     upper: normalizeZero(1 - (1 - confidence) ** (1 / attempts)),
     failures: 0,
-    attempts,
-    confidence,
+    attempts: normalizeZero(attempts),
+    confidence: normalizeZero(confidence),
   };
 };
 
@@ -743,10 +763,13 @@ export const wilsonOneSidedUpper = (
   return {
     algorithm: "wilson-one-sided-upper-v1",
     upper: normalizeZero(upper),
-    failures,
-    attempts,
-    confidence: options.confidence,
-    z,
+    // `failures` is normalized for the same reason `seed` is: `-0` clears
+    // `Number.isInteger(f) && f >= 0` untouched, and `failures: -count` at
+    // count 0 is ordinary arithmetic, not a pathological input.
+    failures: normalizeZero(failures),
+    attempts: normalizeZero(attempts),
+    confidence: normalizeZero(options.confidence),
+    z: normalizeZero(z),
   };
 };
 

--- a/bench/measurement/statistics.ts
+++ b/bench/measurement/statistics.ts
@@ -266,6 +266,11 @@ export const STATISTICS_TEST_VECTORS = {
     rank: 3,
     intercept_present: true,
     r_squared: 1,
+    // Over the COLUMN-EQUILIBRATED diagonal, so this is a pure number: rescaling
+    // any column's units leaves it bit-identical. Pinned exactly — it is the
+    // only near-collinearity signal the algorithm emits, and a study is expected
+    // to preregister a bar against it.
+    condition_estimate: 3.2008648384906406,
   },
   // The index signature is load-bearing. `satisfies` runs an excess-property
   // check against a bare `{ readonly id: string }`, which rejects every vector's
@@ -812,11 +817,21 @@ export interface OlsQrResult {
    */
   readonly r_squared: number;
   /**
-   * `max|R_kk| / min|R_kk|` over the QR diagonal — a cheap condition-number
+   * `max / min` over the COLUMN-EQUILIBRATED QR diagonal — each `|R_kk|`
+   * divided by its own column's Euclidean norm. A cheap condition-number
    * estimate, and the ONLY signal this algorithm gives about NEAR collinearity.
    *
-   * The rank gate below catches exact deficiency only. Unpivoted Householder
-   * cannot distinguish a well-conditioned design from a nearly singular one:
+   * Equilibrating is what makes the number quotable. A raw
+   * `max|R_kk| / min|R_kk|` scales with whatever units each column was measured
+   * in — the same model in bytes and in MiB reported estimates four orders
+   * apart — so no fixed bar could mean anything. Dividing each column by its
+   * own norm removes that freedom, and by van der Sluis' theorem column
+   * equilibration is within a factor of `sqrt(n)` of the best any diagonal
+   * scaling can do, so the number is also near-optimal rather than merely
+   * stable.
+   *
+   * The rank gate catches deficiency down to rounding. It still cannot
+   * distinguish a well-conditioned design from a merely NEAR-singular one:
    * both pass `rank === columns.length` and both return coefficients, but the
    * near-singular one's coefficients are noise. Plan J's design matrix is
    * near-collinear by construction (rows and bytes both grow with snapshot
@@ -882,10 +897,15 @@ const assertOlsInput = (input: OlsQrInput): void => {
  * equations, no column pivoting; back-substitution preserves the caller's
  * column order. Rank-deficient designs throw `SingularDesignError`.
  *
- * WITHOUT PIVOTING THE RANK GATE SEES EXACT DEFICIENCY ONLY. A nearly
- * collinear design passes it and returns coefficients that are numerically
- * meaningless. `condition_estimate` on the result is the only warning a caller
- * gets; a caller that interprets these coefficients as physics must check it.
+ * The rank gate is taken on the COLUMN-EQUILIBRATED diagonal, so it holds
+ * whatever units the caller measured each column in, and does not depend on
+ * the order the columns were listed in.
+ *
+ * WITHOUT PIVOTING THE GATE STILL SEES DEFICIENCY ONLY, NEVER DEGREE. A merely
+ * NEAR-collinear design passes it and returns coefficients that are
+ * numerically meaningless. `condition_estimate` on the result is the only
+ * warning a caller gets; a caller that interprets these coefficients as
+ * physics must check it.
  */
 export const olsQr = (input: OlsQrInput): OlsQrResult => {
   assertOlsInput(input);
@@ -894,6 +914,14 @@ export const olsQr = (input: OlsQrInput): OlsQrResult => {
   const n = columns.length;
   const a: number[][] = input.rows.map((r) => [...r.x]);
   const b: number[] = input.rows.map((r) => r.y);
+
+  // Euclidean norm of every ORIGINAL design column, captured before the
+  // factorization overwrites `a`. Both the rank gate and the condition estimate
+  // divide by these, which is what makes them independent of the units a caller
+  // happened to measure each column in.
+  const columnNorms = columns.map((_, k) =>
+    Math.sqrt(input.rows.reduce((acc, row) => acc + row.x[k]! * row.x[k]!, 0)),
+  );
 
   for (let k = 0; k < n; k++) {
     let norm = 0;
@@ -905,7 +933,7 @@ export const olsQr = (input: OlsQrInput): OlsQrResult => {
       continue;
     }
     const alpha = a[k]![k]! > 0 ? -norm : norm;
-    const v = new Array<number>(m).fill(0);
+    const v = Array.from<number>({ length: m }).fill(0);
     for (let i = k; i < m; i++) {
       v[i] = a[i]![k]!;
     }
@@ -937,30 +965,41 @@ export const olsQr = (input: OlsQrInput): OlsQrResult => {
     }
   }
 
-  let maxAbsDiagonal = 0;
-  let minAbsDiagonal = Number.POSITIVE_INFINITY;
-  for (let k = 0; k < n; k++) {
-    const d = Math.abs(a[k]![k]!);
-    maxAbsDiagonal = Math.max(maxAbsDiagonal, d);
-    minAbsDiagonal = Math.min(minAbsDiagonal, d);
-  }
-  const tolerance = Number.EPSILON * Math.max(m, n) * maxAbsDiagonal;
+  // Each |R_kk| divided by its own column's norm — the diagonal of the
+  // COLUMN-EQUILIBRATED factorization. `R_kk` is the part of column k
+  // orthogonal to columns 0..k-1, so this ratio is the sine of the angle
+  // between column k and the span of its predecessors: dimensionless, in
+  // [0,1], and 0 exactly when column k is a linear combination of them.
+  //
+  // Scaling by each column's OWN norm is what makes the gate correct. Against a
+  // single global `max|R_kk|`, a dependent column merely LARGER than its
+  // neighbours has a rounding residual bigger than a tolerance set by some
+  // other column's scale, and passes as full rank — at a scale ratio as small
+  // as 9, not 1e16. It also made the verdict depend on column ORDER and on the
+  // units each column was measured in (the same model in MiB threw where the
+  // one in bytes did not). A zero column has no direction, so it scores 0.
+  const scaledDiagonal = columns.map((_, k) =>
+    columnNorms[k] === 0 ? 0 : Math.abs(a[k]![k]!) / columnNorms[k]!,
+  );
+  // Dimensionless, because `scaledDiagonal` is. `max(m, n)` is the usual
+  // dimension factor on accumulated rounding error in a Householder pass.
+  const tolerance = Number.EPSILON * Math.max(m, n);
   let rank = 0;
-  for (let k = 0; k < n; k++) {
-    if (Math.abs(a[k]![k]!) > tolerance) {
+  for (const d of scaledDiagonal) {
+    if (d > tolerance) {
       rank++;
     }
   }
   if (rank < n) {
     throw new SingularDesignError(columns, rank);
   }
-  // Past the rank gate every diagonal exceeds `tolerance`, so `minAbsDiagonal`
-  // is strictly positive and this cannot divide by zero or return Infinity.
+  // Past the rank gate every entry exceeds `tolerance`, so the minimum is
+  // strictly positive and this can neither divide by zero nor return Infinity.
   // This is the ONLY near-collinearity signal `ols-qr-v1` produces: rank alone
   // cannot tell a well-conditioned design from a nearly singular one.
-  const conditionEstimate = maxAbsDiagonal / minAbsDiagonal;
+  const conditionEstimate = Math.max(...scaledDiagonal) / Math.min(...scaledDiagonal);
 
-  const coefficients = new Array<number>(n).fill(0);
+  const coefficients = Array.from<number>({ length: n }).fill(0);
   for (let k = n - 1; k >= 0; k--) {
     let sum = b[k]!;
     for (let j = k + 1; j < n; j++) {
@@ -988,9 +1027,12 @@ export const olsQr = (input: OlsQrInput): OlsQrResult => {
     return first !== 0 && input.rows.every((row) => row.x[j] === first);
   });
 
-  // oxlint's `no-nested-ternary` is repo policy. `bench/` is currently outside
-  // the lint glob (`package.json` → `"lint": "oxlint tests packages"`), so this
-  // file is UNLINTED — write it as if it were not. Const-lift the inner branch.
+  // oxlint's `no-nested-ternary` is repo policy. `bench/` is outside the
+  // `pnpm verify` lint glob (`package.json` → `"lint": "oxlint tests packages"`),
+  // so CI will not catch a violation here — but the lefthook pre-commit hook
+  // lints staged files by extension, and these two files are kept clean under
+  // `oxlint bench/`. Write it as if `verify` did cover it. Const-lift the
+  // inner branch.
   const degenerateRSquared = rss === 0 ? 1 : 0;
   const rSquared = tss === 0 ? degenerateRSquared : 1 - rss / tss;
 

--- a/bench/measurement/statistics.ts
+++ b/bench/measurement/statistics.ts
@@ -508,3 +508,479 @@ export const bootstrapPercentile = (
     statistic,
   };
 };
+
+export interface PairedValue {
+  readonly pair_id: string;
+  readonly baseline: number;
+  readonly candidate: number;
+}
+
+export interface StratifiedPair extends PairedValue {
+  readonly stratum: string;
+}
+
+const assertPairs = (pairs: readonly PairedValue[]): void => {
+  if (pairs.length === 0) {
+    throw new StatisticsInputError("pairs", "no complete pairs supplied");
+  }
+  const seen = new Set<string>();
+  for (const p of pairs) {
+    if (typeof p.pair_id !== "string" || p.pair_id.trim() === "") {
+      throw new StatisticsInputError("pair_id", "must be a nonempty string");
+    }
+    if (seen.has(p.pair_id)) {
+      throw new StatisticsInputError("pair_id", `duplicate ${p.pair_id}`);
+    }
+    seen.add(p.pair_id);
+    if (typeof p.baseline !== "number" || !Number.isFinite(p.baseline)) {
+      throw new StatisticsInputError("baseline", `pair ${p.pair_id} has no finite baseline arm`);
+    }
+    if (typeof p.candidate !== "number" || !Number.isFinite(p.candidate)) {
+      throw new StatisticsInputError("candidate", `pair ${p.pair_id} has no finite candidate arm`);
+    }
+  }
+};
+
+const perPairRatios = (pairs: readonly PairedValue[]): number[] =>
+  pairs.map((p) => {
+    if (p.baseline <= 0) {
+      throw new StatisticsInputError(
+        "baseline",
+        `pair ${p.pair_id} baseline must be > 0 for a ratio; got ${String(p.baseline)}`,
+      );
+    }
+    return p.candidate / p.baseline;
+  });
+
+/** The pinned replicate medians of `paired-ratio-bootstrap-v1`, in draw order. */
+export const pairedRatioBootstrapReplicates = (
+  pairs: readonly PairedValue[],
+  options: BootstrapOptions,
+): readonly number[] => {
+  assertPairs(pairs);
+  assertBootstrapOptions(options);
+  const ratios = perPairRatios(pairs);
+  const rng = mulberry32(options.seed);
+  const replicates: number[] = [];
+  for (let r = 0; r < options.resamples; r++) {
+    replicates.push(median(drawWithReplacement(ratios, rng)));
+  }
+  return replicates;
+};
+
+/** `paired-ratio-bootstrap-v1`: resamples complete pairs; summarizes the median of per-pair ratios. */
+export const pairedRatioBootstrap = (
+  pairs: readonly PairedValue[],
+  options: BootstrapOptions,
+): BootstrapResult<"paired-ratio-bootstrap-v1"> => {
+  const replicates = pairedRatioBootstrapReplicates(pairs, options);
+  return {
+    algorithm: "paired-ratio-bootstrap-v1",
+    prng: BOOTSTRAP_PRNG,
+    point: normalizeZero(median(perPairRatios(pairs))),
+    interval: percentileInterval(replicates, options.confidence),
+    seed: options.seed,
+    resamples: options.resamples,
+    inclusion_unit: options.inclusion_unit,
+  };
+};
+
+/** Groups differences by stratum in FIRST-APPEARANCE order — the draw order is normative. */
+const groupStrata = (pairs: readonly StratifiedPair[]): number[][] => {
+  const order: string[] = [];
+  const byStratum = new Map<string, number[]>();
+  for (const p of pairs) {
+    if (typeof p.stratum !== "string" || p.stratum.trim() === "") {
+      throw new StatisticsInputError("stratum", `pair ${p.pair_id} has no stratum label`);
+    }
+    let bucket = byStratum.get(p.stratum);
+    if (bucket === undefined) {
+      bucket = [];
+      byStratum.set(p.stratum, bucket);
+      order.push(p.stratum);
+    }
+    bucket.push(p.candidate - p.baseline);
+  }
+  return order.map((s) => byStratum.get(s)!);
+};
+
+/** The pinned replicate mean differences of the stratified bootstrap, in draw order. */
+export const stratifiedPairedDifferenceBootstrapReplicates = (
+  pairs: readonly StratifiedPair[],
+  options: BootstrapOptions,
+): readonly number[] => {
+  assertPairs(pairs);
+  assertBootstrapOptions(options);
+  const strata = groupStrata(pairs);
+  const rng = mulberry32(options.seed);
+  const replicates: number[] = [];
+  for (let r = 0; r < options.resamples; r++) {
+    const drawn: number[] = [];
+    for (const stratum of strata) {
+      drawn.push(...drawWithReplacement(stratum, rng));
+    }
+    replicates.push(mean(drawn));
+  }
+  return replicates;
+};
+
+/**
+ * `stratified-paired-difference-bootstrap-v1`: resamples complete pairs within
+ * each declared stratum, preserving every stratum's original count.
+ */
+export const stratifiedPairedDifferenceBootstrap = (
+  pairs: readonly StratifiedPair[],
+  options: BootstrapOptions,
+): BootstrapResult<"stratified-paired-difference-bootstrap-v1"> => {
+  const replicates = stratifiedPairedDifferenceBootstrapReplicates(pairs, options);
+  return {
+    algorithm: "stratified-paired-difference-bootstrap-v1",
+    prng: BOOTSTRAP_PRNG,
+    point: normalizeZero(mean(pairs.map((p) => p.candidate - p.baseline))),
+    interval: percentileInterval(replicates, options.confidence),
+    seed: options.seed,
+    resamples: options.resamples,
+    inclusion_unit: options.inclusion_unit,
+  };
+};
+
+export interface ClopperPearsonZeroFailureResult {
+  readonly algorithm: "clopper-pearson-zero-failure-upper-v1";
+  readonly upper: number;
+  readonly failures: 0;
+  readonly attempts: number;
+  readonly confidence: number;
+}
+
+const assertAttempts = (attempts: number): void => {
+  if (!Number.isInteger(attempts) || attempts < 1) {
+    throw new StatisticsInputError("attempts", `must be an integer >= 1; got ${String(attempts)}`);
+  }
+};
+
+const assertConfidence = (confidence: number): void => {
+  if (!Number.isFinite(confidence) || confidence <= 0 || confidence >= 1) {
+    throw new StatisticsInputError("confidence", `must be within (0,1); got ${String(confidence)}`);
+  }
+};
+
+/** `clopper-pearson-zero-failure-upper-v1`: the exact one-sided bound at zero observed failures. */
+export const clopperPearsonZeroFailureUpper = (
+  attempts: number,
+  confidence: number,
+): ClopperPearsonZeroFailureResult => {
+  assertAttempts(attempts);
+  assertConfidence(confidence);
+  return {
+    algorithm: "clopper-pearson-zero-failure-upper-v1",
+    upper: normalizeZero(1 - (1 - confidence) ** (1 / attempts)),
+    failures: 0,
+    attempts,
+    confidence,
+  };
+};
+
+export interface WilsonOneSidedUpperResult {
+  readonly algorithm: "wilson-one-sided-upper-v1";
+  readonly upper: number;
+  readonly failures: number;
+  readonly attempts: number;
+  readonly confidence: number;
+  readonly z: number;
+}
+
+/**
+ * `wilson-one-sided-upper-v1`. The caller supplies z; this function never
+ * DERIVES it from `confidence`, but it does REJECT a pair that cannot both be
+ * true, and records both.
+ *
+ * The three options were: derive z (an untagged tenth algorithm), record an
+ * unchecked pair (which lets a study emit `confidence: 0.95` over a number
+ * computed at z = 2 — the exact failure §4.7 exists to prevent), or validate.
+ * Only validation is neither.
+ */
+export const wilsonOneSidedUpper = (
+  failures: number,
+  attempts: number,
+  options: { readonly confidence: number; readonly z: number },
+): WilsonOneSidedUpperResult => {
+  assertAttempts(attempts);
+  assertConfidence(options.confidence);
+  if (!Number.isInteger(failures) || failures < 0 || failures > attempts) {
+    throw new StatisticsInputError(
+      "failures",
+      `must be an integer within [0, ${attempts}]; got ${String(failures)}`,
+    );
+  }
+  if (!Number.isFinite(options.z) || options.z <= 0) {
+    throw new StatisticsInputError("z", `must be finite and > 0; got ${String(options.z)}`);
+  }
+  // The (confidence, z) consistency gate. Toleranced, not exact: a study that
+  // computed its z from a different library may land an ulp away, and rejecting
+  // that would be a usability trap. 1e-12 is still four orders tighter than the
+  // gap between any two adjacent table rows, so z=2 at confidence=0.95 fails.
+  const expectedZ = (WILSON_Z_BY_CONFIDENCE as Record<number, number | undefined>)[
+    options.confidence
+  ];
+  if (expectedZ === undefined) {
+    throw new StatisticsInputError(
+      "confidence",
+      `no z is pinned for ${String(options.confidence)}; add a WILSON_Z_BY_CONFIDENCE row (a contract change) rather than passing an unchecked pair`,
+    );
+  }
+  if (Math.abs(options.z - expectedZ) > 1e-12) {
+    throw new StatisticsInputError(
+      "z",
+      `z ${String(options.z)} does not match confidence ${String(options.confidence)} (expected ~${String(expectedZ)}); recording both would emit a confidence that did not determine the number`,
+    );
+  }
+  const n = attempts;
+  const z = options.z;
+  const p = failures / n;
+  const upper =
+    (p + (z * z) / (2 * n) + z * Math.sqrt((p * (1 - p)) / n + (z * z) / (4 * n * n))) /
+    (1 + (z * z) / n);
+  return {
+    algorithm: "wilson-one-sided-upper-v1",
+    upper: normalizeZero(upper),
+    failures,
+    attempts,
+    confidence: options.confidence,
+    z,
+  };
+};
+
+/** Rank-deficient OLS design. `ols-qr-v1` records singularity as a failure, never as coefficients. */
+export class SingularDesignError extends Error {
+  readonly code = "SingularDesign" as const;
+  readonly algorithm = "ols-qr-v1" as const;
+  readonly columns: readonly string[];
+  readonly rank: number;
+  constructor(columns: readonly string[], rank: number) {
+    super(
+      `bench/measurement/statistics: singular design — rank ${rank} < ${columns.length} columns`,
+    );
+    this.name = "SingularDesignError";
+    this.columns = columns;
+    this.rank = rank;
+  }
+}
+
+export interface OlsQrInput {
+  readonly columns: readonly string[];
+  readonly rows: readonly {
+    readonly x: readonly number[];
+    readonly y: number;
+  }[];
+}
+
+export interface OlsQrResult {
+  readonly algorithm: "ols-qr-v1";
+  readonly columns: readonly string[];
+  readonly coefficients: readonly number[];
+  readonly rank: number;
+  readonly residuals: readonly number[];
+  readonly residual_sum_squares: number;
+  readonly root_mean_square_error: number;
+  /**
+   * The CENTERED R². Only interpretable when `intercept_present` is true — on a
+   * model with no constant column the centered definition can go negative and
+   * invites misreading. Check `intercept_present` before quoting it.
+   */
+  readonly r_squared: number;
+  /**
+   * `max|R_kk| / min|R_kk|` over the QR diagonal — a cheap condition-number
+   * estimate, and the ONLY signal this algorithm gives about NEAR collinearity.
+   *
+   * The rank gate below catches exact deficiency only. Unpivoted Householder
+   * cannot distinguish a well-conditioned design from a nearly singular one:
+   * both pass `rank === columns.length` and both return coefficients, but the
+   * near-singular one's coefficients are noise. Plan J's design matrix is
+   * near-collinear by construction (rows and bytes both grow with snapshot
+   * size), and it interprets these coefficients as physics, so the study MUST
+   * preregister a bar on this number rather than trusting `rank` alone.
+   *
+   * `Number.POSITIVE_INFINITY` is unreachable here: a zero min-diagonal would
+   * have thrown `SingularDesignError` first.
+   */
+  readonly condition_estimate: number;
+  /**
+   * True iff some design column is constant and nonzero across every row — i.e.
+   * the model has an intercept. Detected from the data, not from a column name,
+   * because a caller may spell it anything.
+   */
+  readonly intercept_present: boolean;
+}
+
+const assertOlsInput = (input: OlsQrInput): void => {
+  const { columns, rows } = input;
+  if (columns.length === 0) {
+    throw new StatisticsInputError("columns", "at least one design column is required");
+  }
+  const seen = new Set<string>();
+  for (const name of columns) {
+    if (typeof name !== "string" || name.trim() === "") {
+      throw new StatisticsInputError("columns", "every column name must be nonempty");
+    }
+    if (seen.has(name)) {
+      throw new StatisticsInputError("columns", `duplicate column name ${name}`);
+    }
+    seen.add(name);
+  }
+  if (rows.length === 0) {
+    throw new StatisticsInputError("rows", "at least one row is required");
+  }
+  if (rows.length < columns.length) {
+    throw new StatisticsInputError(
+      "rows",
+      `need at least ${columns.length} rows for ${columns.length} columns; got ${rows.length}`,
+    );
+  }
+  for (const [i, row] of rows.entries()) {
+    if (row.x.length !== columns.length) {
+      throw new StatisticsInputError(
+        "rows",
+        `row ${i} has width ${row.x.length}, expected ${columns.length}`,
+      );
+    }
+    for (const v of row.x) {
+      if (typeof v !== "number" || !Number.isFinite(v)) {
+        throw new StatisticsInputError("rows", `row ${i} has a nonfinite design value`);
+      }
+    }
+    if (typeof row.y !== "number" || !Number.isFinite(row.y)) {
+      throw new StatisticsInputError("rows", `row ${i} has a nonfinite response`);
+    }
+  }
+};
+
+/**
+ * `ols-qr-v1`: Householder QR on the augmented matrix [A | y]. No normal
+ * equations, no column pivoting; back-substitution preserves the caller's
+ * column order. Rank-deficient designs throw `SingularDesignError`.
+ *
+ * WITHOUT PIVOTING THE RANK GATE SEES EXACT DEFICIENCY ONLY. A nearly
+ * collinear design passes it and returns coefficients that are numerically
+ * meaningless. `condition_estimate` on the result is the only warning a caller
+ * gets; a caller that interprets these coefficients as physics must check it.
+ */
+export const olsQr = (input: OlsQrInput): OlsQrResult => {
+  assertOlsInput(input);
+  const columns = [...input.columns];
+  const m = input.rows.length;
+  const n = columns.length;
+  const a: number[][] = input.rows.map((r) => [...r.x]);
+  const b: number[] = input.rows.map((r) => r.y);
+
+  for (let k = 0; k < n; k++) {
+    let norm = 0;
+    for (let i = k; i < m; i++) {
+      norm += a[i]![k]! * a[i]![k]!;
+    }
+    norm = Math.sqrt(norm);
+    if (norm === 0) {
+      continue;
+    }
+    const alpha = a[k]![k]! > 0 ? -norm : norm;
+    const v = new Array<number>(m).fill(0);
+    for (let i = k; i < m; i++) {
+      v[i] = a[i]![k]!;
+    }
+    v[k] = v[k]! - alpha;
+    let vNorm2 = 0;
+    for (let i = k; i < m; i++) {
+      vNorm2 += v[i]! * v[i]!;
+    }
+    if (vNorm2 === 0) {
+      continue;
+    }
+    for (let j = k; j < n; j++) {
+      let dot = 0;
+      for (let i = k; i < m; i++) {
+        dot += v[i]! * a[i]![j]!;
+      }
+      const factor = (2 * dot) / vNorm2;
+      for (let i = k; i < m; i++) {
+        a[i]![j] = a[i]![j]! - factor * v[i]!;
+      }
+    }
+    let dotB = 0;
+    for (let i = k; i < m; i++) {
+      dotB += v[i]! * b[i]!;
+    }
+    const factorB = (2 * dotB) / vNorm2;
+    for (let i = k; i < m; i++) {
+      b[i] = b[i]! - factorB * v[i]!;
+    }
+  }
+
+  let maxAbsDiagonal = 0;
+  let minAbsDiagonal = Number.POSITIVE_INFINITY;
+  for (let k = 0; k < n; k++) {
+    const d = Math.abs(a[k]![k]!);
+    maxAbsDiagonal = Math.max(maxAbsDiagonal, d);
+    minAbsDiagonal = Math.min(minAbsDiagonal, d);
+  }
+  const tolerance = Number.EPSILON * Math.max(m, n) * maxAbsDiagonal;
+  let rank = 0;
+  for (let k = 0; k < n; k++) {
+    if (Math.abs(a[k]![k]!) > tolerance) {
+      rank++;
+    }
+  }
+  if (rank < n) {
+    throw new SingularDesignError(columns, rank);
+  }
+  // Past the rank gate every diagonal exceeds `tolerance`, so `minAbsDiagonal`
+  // is strictly positive and this cannot divide by zero or return Infinity.
+  // This is the ONLY near-collinearity signal `ols-qr-v1` produces: rank alone
+  // cannot tell a well-conditioned design from a nearly singular one.
+  const conditionEstimate = maxAbsDiagonal / minAbsDiagonal;
+
+  const coefficients = new Array<number>(n).fill(0);
+  for (let k = n - 1; k >= 0; k--) {
+    let sum = b[k]!;
+    for (let j = k + 1; j < n; j++) {
+      sum -= a[k]![j]! * coefficients[j]!;
+    }
+    coefficients[k] = sum / a[k]![k]!;
+  }
+
+  const residuals = input.rows.map((row) => {
+    let fitted = 0;
+    for (let j = 0; j < n; j++) {
+      fitted += row.x[j]! * coefficients[j]!;
+    }
+    return row.y - fitted;
+  });
+  const rss = residuals.reduce((acc, e) => acc + e * e, 0);
+  const yBar = mean(input.rows.map((row) => row.y));
+  const tss = input.rows.reduce((acc, row) => acc + (row.y - yBar) ** 2, 0);
+
+  // A constant, nonzero column IS an intercept, whatever the caller named it.
+  // Detected from the data because `columns` are free-form labels — Plan J
+  // spells its "intercept" and "fixed", and a third study may spell it "one".
+  const interceptPresent = columns.some((_, j) => {
+    const first = input.rows[0]!.x[j]!;
+    return first !== 0 && input.rows.every((row) => row.x[j] === first);
+  });
+
+  // oxlint's `no-nested-ternary` is repo policy. `bench/` is currently outside
+  // the lint glob (`package.json` → `"lint": "oxlint tests packages"`), so this
+  // file is UNLINTED — write it as if it were not. Const-lift the inner branch.
+  const degenerateRSquared = rss === 0 ? 1 : 0;
+  const rSquared = tss === 0 ? degenerateRSquared : 1 - rss / tss;
+
+  return {
+    algorithm: "ols-qr-v1",
+    columns,
+    coefficients: coefficients.map(normalizeZero),
+    rank,
+    residuals: residuals.map(normalizeZero),
+    residual_sum_squares: normalizeZero(rss),
+    root_mean_square_error: normalizeZero(Math.sqrt(rss / m)),
+    r_squared: normalizeZero(rSquared),
+    condition_estimate: conditionEstimate,
+    intercept_present: interceptPresent,
+  };
+};

--- a/bench/measurement/statistics.ts
+++ b/bench/measurement/statistics.ts
@@ -1,0 +1,510 @@
+/**
+ * Algorithm-tagged statistics for the fold-program measurement foundation.
+ *
+ * Every summary this module returns carries its algorithm tag and every
+ * parameter that determined the number, so a study cannot emit an untagged
+ * `p95` or `confidence_interval`.
+ *
+ * This module supplies ALGORITHMS ONLY. Sample counts, retry rules,
+ * thresholds, scenario catalogs, and candidate-admission policy are
+ * study-owned and always arrive as caller parameters.
+ *
+ * Pure: no I/O, no clock read, no dependency. The one import is the
+ * repository's single canonical PRNG. Do not add a second PRNG here.
+ */
+
+import { mulberry32 } from "../load-harness/generators/rng.ts";
+
+/** Coordination design §4.7. Order is normative: the contract descriptor hashes this array. */
+export const STATISTICS_ALGORITHMS = [
+  "quantile-nearest-rank-v1",
+  "quantile-r7-v1",
+  "mad-from-median-v1",
+  "bootstrap-percentile-v1",
+  "paired-ratio-bootstrap-v1",
+  "stratified-paired-difference-bootstrap-v1",
+  "clopper-pearson-zero-failure-upper-v1",
+  "wilson-one-sided-upper-v1",
+  "ols-qr-v1",
+] as const;
+
+export type StatisticsAlgorithm = (typeof STATISTICS_ALGORITHMS)[number];
+
+/** The one PRNG every resampling algorithm here uses. */
+export const BOOTSTRAP_PRNG = "mulberry32-v1" as const;
+
+/**
+ * Statistic selectors a caller may bootstrap. These are NOT algorithm tags —
+ * they name which summary the bootstrap resamples, and they are recorded
+ * alongside the algorithm tag in the result.
+ */
+export const BOOTSTRAP_STATISTICS = [
+  "mean-v1",
+  "quantile-nearest-rank-v1",
+  "quantile-r7-v1",
+] as const;
+
+export type BootstrapStatisticTag = (typeof BOOTSTRAP_STATISTICS)[number];
+
+/**
+ * The only `(confidence, z)` pairs `wilson-one-sided-upper-v1` accepts.
+ *
+ * The module never DERIVES z from confidence — a normal-quantile routine would
+ * be an untagged tenth algorithm. But recording a confidence that did not
+ * determine the number is exactly the untagged-summary failure §4.7 exists to
+ * prevent, so an inconsistent pair is rejected instead. This is a table of
+ * mathematical facts, not a study policy: it chooses no sample count, no
+ * threshold, and no confidence FOR the caller — it only refuses a pair that
+ * cannot both be true.
+ *
+ * Values are the one-sided standard-normal quantiles z_(1-alpha), i.e.
+ * `qnorm(confidence)`. Adding a row is a contract change; adding one is the
+ * sanctioned escape hatch if a study needs a confidence not listed here.
+ */
+export const WILSON_Z_BY_CONFIDENCE = {
+  0.9: 1.2815515655446004,
+  0.95: 1.6448536269514722,
+  0.975: 1.959963984540054,
+  0.99: 2.3263478740408408,
+  0.995: 2.5758293035489004,
+} as const;
+
+/**
+ * Invalid input to a statistics primitive. Assert on `code`, never on
+ * `message` (repo test convention:
+ * docs/contributing/conventions/tests.md §"Asserting on errors").
+ */
+export class StatisticsInputError extends Error {
+  readonly code = "StatisticsInput" as const;
+  readonly field: string;
+  constructor(field: string, detail: string) {
+    super(`bench/measurement/statistics: invalid ${field} — ${detail}`);
+    this.name = "StatisticsInputError";
+    this.field = field;
+  }
+}
+
+const MAX_UINT32 = 4_294_967_295;
+
+/**
+ * Collapse `-0` to `0` on every number this module emits.
+ *
+ * Lane D's canonical JSON REJECTS `-0` rather than normalizing it
+ * (`canonical-json.ts`: reason `negative-zero`), and these result objects are
+ * serialized into hashed evidence records. The reachable path is ordinary
+ * arithmetic, not a pathological input: an exactly zero OLS coefficient divided
+ * by a Householder pivot yields `-0` whenever that pivot is negative, which it
+ * routinely is. Normalizing here means no caller has to know.
+ *
+ * Apply at every point where a result object is CONSTRUCTED — not inside the
+ * numeric kernels, where an intermediate `-0` is harmless and stripping it
+ * would just cost cycles.
+ */
+const normalizeZero = (value: number): number => (Object.is(value, -0) ? 0 : value);
+
+const assertFiniteSample = (values: readonly number[], field: string): void => {
+  if (values.length === 0) {
+    throw new StatisticsInputError(field, "sample is empty");
+  }
+  for (const v of values) {
+    if (typeof v !== "number" || !Number.isFinite(v)) {
+      throw new StatisticsInputError(field, `nonfinite value ${String(v)}`);
+    }
+  }
+};
+
+const assertProbability = (q: number, field: string): void => {
+  if (!Number.isFinite(q) || q < 0 || q > 1) {
+    throw new StatisticsInputError(field, `must be within [0,1]; got ${String(q)}`);
+  }
+};
+
+export interface BootstrapOptions {
+  readonly seed: number;
+  readonly resamples: number;
+  readonly confidence: number;
+  readonly inclusion_unit: string;
+}
+
+const assertBootstrapOptions = (options: BootstrapOptions): void => {
+  if (!Number.isInteger(options.seed) || options.seed < 0 || options.seed > MAX_UINT32) {
+    throw new StatisticsInputError("seed", `must be a uint32; got ${String(options.seed)}`);
+  }
+  if (!Number.isInteger(options.resamples) || options.resamples < 1) {
+    throw new StatisticsInputError(
+      "resamples",
+      `must be a positive integer; got ${String(options.resamples)}`,
+    );
+  }
+  if (!Number.isFinite(options.confidence) || options.confidence <= 0 || options.confidence >= 1) {
+    throw new StatisticsInputError(
+      "confidence",
+      `must be within (0,1); got ${String(options.confidence)}`,
+    );
+  }
+  if (typeof options.inclusion_unit !== "string" || options.inclusion_unit.trim() === "") {
+    throw new StatisticsInputError("inclusion_unit", "must be a nonempty string");
+  }
+};
+
+/**
+ * The pinned numeric vectors, one per algorithm tag.
+ *
+ * The measurement contract descriptor (parent plan Task 8) hashes THIS OBJECT,
+ * not the module's source bytes: a behavior-preserving refactor must not churn
+ * `measurement_contract_hash`, while a changed expected value must — and does,
+ * because `statistics.test.ts` asserts against these values and nothing else.
+ *
+ * Changing any number here is a contract change. Bump that entry's trailing
+ * `/vN` and treat it as such; it is not a rename.
+ */
+export const STATISTICS_TEST_VECTORS = {
+  "quantile-nearest-rank-v1": {
+    id: "nearest-rank/1-2-3-4/q00-q25-q50-q95-q100/v1",
+    values: [1, 2, 3, 4],
+    // One-indexed ceil(q*n) over the ascending sort, clamped to [1,n].
+    expected: [
+      { q: 0, value: 1 },
+      { q: 0.25, value: 1 },
+      { q: 0.5, value: 2 },
+      { q: 0.95, value: 4 },
+      { q: 1, value: 4 },
+    ],
+  },
+  "quantile-r7-v1": {
+    id: "r7/0-10-20-30/q00-q25-q50-q95-q100/v1",
+    values: [0, 10, 20, 30],
+    // `exact: false` means assert with toBeCloseTo(value, 12): the true IEEE-754
+    // result at q=0.95 is 28.499999999999996, and `toBe(28.5)` would be red on a
+    // correct implementation.
+    expected: [
+      { q: 0, value: 0, exact: true },
+      { q: 0.25, value: 7.5, exact: true },
+      { q: 0.5, value: 15, exact: true },
+      { q: 0.95, value: 28.5, exact: false },
+      { q: 1, value: 30, exact: true },
+    ],
+  },
+  "mad-from-median-v1": {
+    id: "mad/1-1-2-2-4-6-9/v1",
+    values: [1, 1, 2, 2, 4, 6, 9],
+    median: 2,
+    mad: 1,
+  },
+  "bootstrap-percentile-v1": {
+    id: "bootstrap/1-2-8/median/seed0/r8/c075/v1",
+    values: [1, 2, 8],
+    statistic: { algorithm: "quantile-r7-v1", q: 0.5 },
+    options: { seed: 0, resamples: 8, confidence: 0.75, inclusion_unit: "sample" },
+    replicates: [1, 2, 2, 1, 8, 2, 1, 1],
+    point: 2,
+    interval: { lower: 1, upper: 2.75, confidence: 0.75 },
+    // Same sample and options at seed 1 — proves the seed changes the draw
+    // ORDER. At this resample count seed 1 yields the SAME interval, so
+    // asserting interval divergence would be a false test.
+    replicates_at_seed_1: [2, 8, 2, 2, 1, 1, 2, 1],
+  },
+  "paired-ratio-bootstrap-v1": {
+    id: "paired-ratio/2-1_4-3_8-4/seed7/r8/c075/v1",
+    pairs: [
+      { pair_id: "p1", baseline: 2, candidate: 1 },
+      { pair_id: "p2", baseline: 4, candidate: 3 },
+      { pair_id: "p3", baseline: 8, candidate: 4 },
+    ],
+    options: { seed: 7, resamples: 8, confidence: 0.75, inclusion_unit: "complete-pair" },
+    replicates: [0.5, 0.75, 0.75, 0.5, 0.5, 0.75, 0.5, 0.5],
+    point: 0.5,
+    interval: { lower: 0.5, upper: 0.75, confidence: 0.75 },
+  },
+  "stratified-paired-difference-bootstrap-v1": {
+    id: "stratified-diff/a_1-3_b_10-14/seed9/r8/c075/v1",
+    pairs: [
+      { pair_id: "a1", stratum: "a", baseline: 0, candidate: 1 },
+      { pair_id: "a2", stratum: "a", baseline: 0, candidate: 3 },
+      { pair_id: "b1", stratum: "b", baseline: 0, candidate: 10 },
+      { pair_id: "b2", stratum: "b", baseline: 0, candidate: 14 },
+    ],
+    options: {
+      seed: 9,
+      resamples: 8,
+      confidence: 0.75,
+      inclusion_unit: "complete-pair-within-stratum",
+    },
+    replicates: [7, 7.5, 8, 7, 8, 7, 7, 6],
+    point: 7,
+    interval: { lower: 6.875, upper: 8, confidence: 0.75 },
+    // Stratum "b" alone can never contribute below 10, so no replicate mean can
+    // fall under (1+1+10+10)/4 — proof the strata were not pooled.
+    replicate_floor_if_strata_preserved: 5.5,
+  },
+  "clopper-pearson-zero-failure-upper-v1": {
+    id: "clopper-pearson/n100/c095/v1",
+    attempts: 100,
+    confidence: 0.95,
+    upper: 0.029513049607039932,
+  },
+  "wilson-one-sided-upper-v1": {
+    id: "wilson/f3-n100/c095/z1_6448536269514722/v1",
+    failures: 3,
+    attempts: 100,
+    confidence: 0.95,
+    z: 1.6448536269514722,
+    upper: 0.07271034328690394,
+  },
+  "ols-qr-v1": {
+    id: "ols-qr/intercept-calls-mib/4x3-exact-fit/v1",
+    columns: ["intercept", "calls", "mib"],
+    rows: [
+      { x: [1, 1, 1], y: 2.5 },
+      { x: [1, 2, 2], y: 4 },
+      { x: [1, 4, 4], y: 7 },
+      { x: [1, 4, 8], y: 9 },
+    ],
+    // y = 1 + 1*calls + 0.5*mib. Householder returns 0.9999999999999996 /
+    // 1.0000000000000002 / 0.5 — every coefficient asserts with toBeCloseTo(_, 12).
+    coefficients: [1, 1, 0.5],
+    rank: 3,
+    intercept_present: true,
+    r_squared: 1,
+  },
+  // The index signature is load-bearing. `satisfies` runs an excess-property
+  // check against a bare `{ readonly id: string }`, which rejects every vector's
+  // own data. Admitting the data via `unknown` keeps both properties the clause
+  // exists for: a missing algorithm is a COMPILE error, and every entry must
+  // carry an `id`. `as const` — not `satisfies` — is what preserves the literal
+  // types, so widening the constraint here costs nothing at any use site.
+} as const satisfies Record<
+  StatisticsAlgorithm,
+  { readonly id: string; readonly [field: string]: unknown }
+>;
+
+/**
+ * The PRNG vector. Separate from `STATISTICS_TEST_VECTORS` because
+ * `mulberry32-v1` is not a `StatisticsAlgorithm`, but the descriptor must hash
+ * it too: this sequence determines every bootstrap number in the program.
+ */
+export const PRNG_TEST_VECTOR = {
+  id: "mulberry32/seed0/first-5/v1",
+  prng: BOOTSTRAP_PRNG,
+  seed: 0,
+  draws: [
+    0.26642920868471265, 0.0003297457005828619, 0.2232720274478197, 0.1462021479383111,
+    0.46732782293111086,
+  ],
+} as const;
+
+const ascending = (values: readonly number[]): number[] => [...values].toSorted((a, b) => a - b);
+
+/** `quantile-nearest-rank-v1`: one-indexed `ceil(q*n)` over the ascending sort, clamped to [1,n]. */
+export const quantileNearestRank = (values: readonly number[], q: number): number => {
+  assertFiniteSample(values, "values");
+  assertProbability(q, "q");
+  const sorted = ascending(values);
+  const n = sorted.length;
+  const rank = Math.min(n, Math.max(1, Math.ceil(q * n)));
+  return sorted[rank - 1]!;
+};
+
+/** `quantile-r7-v1`: `h=(n-1)q`, linear interpolation between `floor(h)` and `ceil(h)`. */
+export const quantileR7 = (values: readonly number[], q: number): number => {
+  assertFiniteSample(values, "values");
+  assertProbability(q, "q");
+  const sorted = ascending(values);
+  const n = sorted.length;
+  if (n === 1) {
+    return sorted[0]!;
+  }
+  const h = (n - 1) * q;
+  const lo = Math.floor(h);
+  const hi = Math.ceil(h);
+  const loValue = sorted[lo]!;
+  return loValue + (h - lo) * (sorted[hi]! - loValue);
+};
+
+/**
+ * The ordinary median. Provably identical to `quantileR7(values, 0.5)` for
+ * every n — for even n, `h=(n-1)/2` interpolates exactly halfway between the
+ * two central values. There is deliberately no second median implementation.
+ */
+const median = (values: readonly number[]): number => quantileR7(values, 0.5);
+
+const mean = (values: readonly number[]): number => {
+  let total = 0;
+  for (const v of values) {
+    total += v;
+  }
+  return total / values.length;
+};
+
+/** `mad-from-median-v1`: the ordinary median of absolute deviations from the ordinary median. */
+export const madFromMedian = (values: readonly number[]): number => {
+  assertFiniteSample(values, "values");
+  const centre = median(values);
+  return median(values.map((v) => Math.abs(v - centre)));
+};
+
+export interface QuantileEstimate {
+  readonly algorithm: "quantile-nearest-rank-v1" | "quantile-r7-v1";
+  readonly q: number;
+  readonly value: number;
+  readonly sample_size: number;
+}
+
+/** Tagged wrapper. Use this — not the bare quantile functions — when emitting evidence. */
+export const quantileEstimate = (
+  values: readonly number[],
+  q: number,
+  algorithm: "quantile-nearest-rank-v1" | "quantile-r7-v1",
+): QuantileEstimate => ({
+  algorithm,
+  q: normalizeZero(q),
+  value: normalizeZero(
+    algorithm === "quantile-nearest-rank-v1"
+      ? quantileNearestRank(values, q)
+      : quantileR7(values, q),
+  ),
+  sample_size: values.length,
+});
+
+export interface DispersionEstimate {
+  readonly algorithm: "mad-from-median-v1";
+  readonly median: number;
+  readonly mad: number;
+  readonly sample_size: number;
+}
+
+/** Tagged wrapper. Use this — not `madFromMedian` — when emitting evidence. */
+export const madEstimate = (values: readonly number[]): DispersionEstimate => {
+  assertFiniteSample(values, "values");
+  return {
+    algorithm: "mad-from-median-v1",
+    median: normalizeZero(median(values)),
+    mad: normalizeZero(madFromMedian(values)),
+    sample_size: values.length,
+  };
+};
+
+export interface IntervalEstimate {
+  readonly lower: number;
+  readonly upper: number;
+  readonly confidence: number;
+}
+
+export interface BootstrapStatisticSelector {
+  readonly algorithm: BootstrapStatisticTag;
+  /** Required for a quantile algorithm; must be absent for `mean-v1`. */
+  readonly q?: number;
+}
+
+export interface BootstrapResult<
+  Algorithm extends
+    | "bootstrap-percentile-v1"
+    | "paired-ratio-bootstrap-v1"
+    | "stratified-paired-difference-bootstrap-v1",
+> {
+  readonly algorithm: Algorithm;
+  readonly prng: "mulberry32-v1";
+  /** The statistic applied to the ORIGINAL sample, not a replicate summary. */
+  readonly point: number;
+  readonly interval: IntervalEstimate;
+  readonly seed: number;
+  readonly resamples: number;
+  readonly inclusion_unit: string;
+  /** Which summary was resampled. Present only for `bootstrap-percentile-v1`. */
+  readonly statistic?: BootstrapStatisticSelector;
+}
+
+/** The one percentile-interval rule every bootstrap here uses: R-7 over replicate statistics. */
+const percentileInterval = (
+  replicates: readonly number[],
+  confidence: number,
+): IntervalEstimate => {
+  const alpha = (1 - confidence) / 2;
+  return {
+    lower: normalizeZero(quantileR7(replicates, alpha)),
+    upper: normalizeZero(quantileR7(replicates, 1 - alpha)),
+    confidence,
+  };
+};
+
+/**
+ * The one resample-draw rule. `rng` is a single `mulberry32(seed)` generator
+ * consumed continuously across every replicate, in replicate order.
+ */
+const drawWithReplacement = <T>(source: readonly T[], rng: () => number): T[] => {
+  const n = source.length;
+  const drawn: T[] = [];
+  for (let i = 0; i < n; i++) {
+    drawn.push(source[Math.floor(rng() * n)]!);
+  }
+  return drawn;
+};
+
+const assertStatisticSelector = (statistic: BootstrapStatisticSelector): void => {
+  if (!(BOOTSTRAP_STATISTICS as readonly string[]).includes(statistic.algorithm)) {
+    throw new StatisticsInputError("statistic.algorithm", `unknown ${statistic.algorithm}`);
+  }
+  if (statistic.algorithm === "mean-v1") {
+    if (statistic.q !== undefined) {
+      throw new StatisticsInputError("statistic.q", "must be absent for mean-v1");
+    }
+    return;
+  }
+  if (statistic.q === undefined) {
+    throw new StatisticsInputError("statistic.q", `required for ${statistic.algorithm}`);
+  }
+  assertProbability(statistic.q, "statistic.q");
+};
+
+const applyStatistic = (
+  values: readonly number[],
+  statistic: BootstrapStatisticSelector,
+): number => {
+  if (statistic.algorithm === "mean-v1") {
+    return mean(values);
+  }
+  if (statistic.algorithm === "quantile-nearest-rank-v1") {
+    return quantileNearestRank(values, statistic.q!);
+  }
+  return quantileR7(values, statistic.q!);
+};
+
+/** The pinned replicate statistics of `bootstrap-percentile-v1`, in draw order. */
+export const bootstrapPercentileReplicates = (
+  values: readonly number[],
+  statistic: BootstrapStatisticSelector,
+  options: BootstrapOptions,
+): readonly number[] => {
+  assertFiniteSample(values, "values");
+  assertStatisticSelector(statistic);
+  assertBootstrapOptions(options);
+  const rng = mulberry32(options.seed);
+  const replicates: number[] = [];
+  for (let r = 0; r < options.resamples; r++) {
+    replicates.push(applyStatistic(drawWithReplacement(values, rng), statistic));
+  }
+  return replicates;
+};
+
+/**
+ * `bootstrap-percentile-v1` with `mulberry32-v1`. `point` is the statistic on
+ * the ORIGINAL sample; the interval is the R-7 percentile interval over the
+ * replicate statistics.
+ */
+export const bootstrapPercentile = (
+  values: readonly number[],
+  statistic: BootstrapStatisticSelector,
+  options: BootstrapOptions,
+): BootstrapResult<"bootstrap-percentile-v1"> => {
+  const replicates = bootstrapPercentileReplicates(values, statistic, options);
+  return {
+    algorithm: "bootstrap-percentile-v1",
+    prng: BOOTSTRAP_PRNG,
+    point: normalizeZero(applyStatistic(values, statistic)),
+    interval: percentileInterval(replicates, options.confidence),
+    seed: options.seed,
+    resamples: options.resamples,
+    inclusion_unit: options.inclusion_unit,
+    statistic,
+  };
+};

--- a/bench/measurement/statistics.ts
+++ b/bench/measurement/statistics.ts
@@ -160,12 +160,19 @@ const assertBootstrapOptions = (options: BootstrapOptions): void => {
  */
 export const STATISTICS_TEST_VECTORS = {
   "quantile-nearest-rank-v1": {
-    id: "nearest-rank/1-2-3-4/q00-q25-q50-q95-q100/v1",
+    id: "nearest-rank/1-2-3-4/q00-q25-q30-q50-q95-q100/v1",
     values: [1, 2, 3, 4],
     // One-indexed ceil(q*n) over the ascending sort, clamped to [1,n].
+    //
+    // q=0.3 is the row that pins CEIL specifically. At every other q here
+    // `q*n` is already an integer or rounds up anyway (0, 1, 2, 3.8, 4), so
+    // `Math.round` computes the same five answers and the defining operation
+    // went unpinned. At q=0.3, `q*n` is 1.2: ceil gives rank 2 (value 2),
+    // round gives rank 1 (value 1).
     expected: [
       { q: 0, value: 1 },
       { q: 0.25, value: 1 },
+      { q: 0.3, value: 2 },
       { q: 0.5, value: 2 },
       { q: 0.95, value: 4 },
       { q: 1, value: 4 },
@@ -241,7 +248,7 @@ export const STATISTICS_TEST_VECTORS = {
     id: "clopper-pearson/n100/c095/v1",
     attempts: 100,
     confidence: 0.95,
-    upper: 0.029513049607039932,
+    upper: 0.029513049607039925,
   },
   "wilson-one-sided-upper-v1": {
     id: "wilson/f3-n100/c095/z1_6448536269514722/v1",
@@ -698,7 +705,12 @@ export const clopperPearsonZeroFailureUpper = (
   assertConfidence(confidence);
   return {
     algorithm: "clopper-pearson-zero-failure-upper-v1",
-    upper: normalizeZero(1 - (1 - confidence) ** (1 / attempts)),
+    // `-expm1(log1p(-c)/n)`, not the algebraically equal
+    // `1 - (1-c)**(1/n)`. The latter subtracts two nearly equal numbers: the
+    // bound falls as 1/n, so at n=1e6 it loses 1.3e-11 relative and at n=1e12
+    // it loses 5.8e-6 — while `expm1`/`log1p` are exactly the pair built for
+    // this regime. Below n≈1e4 the two agree to within an ulp.
+    upper: normalizeZero(-Math.expm1(Math.log1p(-confidence) / attempts)),
     failures: 0,
     attempts: normalizeZero(attempts),
     confidence: normalizeZero(confidence),
@@ -767,7 +779,12 @@ export const wilsonOneSidedUpper = (
     (1 + (z * z) / n);
   return {
     algorithm: "wilson-one-sided-upper-v1",
-    upper: normalizeZero(upper),
+    // Clamped because this is a probability. At p̂ = 1 the limit is exactly 1
+    // analytically — numerator and denominator both collapse to 1 + z²/n — but
+    // the float evaluation overshoots for 501 of the first 2000 attempt counts
+    // (n = 11 gives 1.0000000000000002). An all-failures scenario is ordinary
+    // in a bench study, and a bound above 1 is not a probability.
+    upper: normalizeZero(Math.min(1, upper)),
     // `failures` is normalized for the same reason `seed` is: `-0` clears
     // `Number.isInteger(f) && f >= 0` untouched, and `failures: -count` at
     // count 0 is ordinary arithmetic, not a pathological input.

--- a/bench/measurement/statistics.ts
+++ b/bench/measurement/statistics.ts
@@ -210,6 +210,21 @@ export const STATISTICS_TEST_VECTORS = {
     // ORDER. At this resample count seed 1 yields the SAME interval, so
     // asserting interval divergence would be a false test.
     replicates_at_seed_1: [2, 8, 2, 2, 1, 1, 2, 1],
+    // The nearest-rank selector is a legal `BOOTSTRAP_STATISTICS` member and a
+    // distinct dispatch branch, and it had no test.
+    //
+    // q=0.25, NOT q=0.5. Over a 3-element resample the two quantile
+    // definitions coincide at the median — `ceil(0.5*3)=2` and `h=(3-1)*0.5=1`
+    // both select `sorted[1]` — so a q=0.5 vector is satisfied by either
+    // dispatch and would pin nothing. At q=0.25 they genuinely diverge, and
+    // the R-7 replicates are carried alongside so the test can assert that.
+    nearest_rank: {
+      statistic: { algorithm: "quantile-nearest-rank-v1", q: 0.25 },
+      replicates: [1, 1, 2, 1, 2, 2, 1, 1],
+      r7_replicates_at_same_q: [1, 1.5, 2, 1, 5, 2, 1, 1],
+      point: 1,
+      interval: { lower: 1, upper: 2, confidence: 0.75 },
+    },
   },
   "paired-ratio-bootstrap-v1": {
     id: "paired-ratio/2-1_4-3_8-4/seed7/r8/c075/v1",

--- a/bench/measurement/statistics.ts
+++ b/bench/measurement/statistics.ts
@@ -421,18 +421,32 @@ export interface IntervalEstimate {
   readonly confidence: number;
 }
 
-export interface BootstrapStatisticSelector {
-  readonly algorithm: BootstrapStatisticTag;
-  /** Required for a quantile algorithm; must be absent for `mean-v1`. */
-  readonly q?: number;
-}
+/**
+ * Which summary a bootstrap resamples.
+ *
+ * A union, not one interface with an optional `q`, because `q` is required for
+ * a quantile algorithm and forbidden for `mean-v1` — a state-dependent shape.
+ * As a single interface the invariant lived only in `assertStatisticSelector`,
+ * and every read of `q` downstream needed a non-null assertion the compiler
+ * could not check.
+ *
+ * The runtime validation stays regardless: a study may hand this straight in
+ * from parsed JSON, where the union is only a compile-time promise.
+ */
+export type BootstrapStatisticSelector =
+  | { readonly algorithm: "mean-v1"; readonly q?: undefined }
+  | {
+      readonly algorithm: Exclude<BootstrapStatisticTag, "mean-v1">;
+      readonly q: number;
+    };
 
-export interface BootstrapResult<
-  Algorithm extends
-    | "bootstrap-percentile-v1"
-    | "paired-ratio-bootstrap-v1"
-    | "stratified-paired-difference-bootstrap-v1",
-> {
+/** The three algorithms that return a `BootstrapResult`. */
+export type BootstrapAlgorithm =
+  | "bootstrap-percentile-v1"
+  | "paired-ratio-bootstrap-v1"
+  | "stratified-paired-difference-bootstrap-v1";
+
+export interface BootstrapResult<Algorithm extends BootstrapAlgorithm> {
   readonly algorithm: Algorithm;
   readonly prng: "mulberry32-v1";
   /** The statistic applied to the ORIGINAL sample, not a replicate summary. */
@@ -483,24 +497,30 @@ const drawWithReplacement = <T>(source: readonly T[], rng: () => number): T[] =>
  * rejects an explicit `undefined` as surely as it rejects `-0`.
  */
 const normalizeSelector = (statistic: BootstrapStatisticSelector): BootstrapStatisticSelector =>
-  statistic.q === undefined
-    ? { algorithm: statistic.algorithm }
+  statistic.algorithm === "mean-v1"
+    ? { algorithm: "mean-v1" }
     : { algorithm: statistic.algorithm, q: normalizeZero(statistic.q) };
 
 const assertStatisticSelector = (statistic: BootstrapStatisticSelector): void => {
-  if (!(BOOTSTRAP_STATISTICS as readonly string[]).includes(statistic.algorithm)) {
-    throw new StatisticsInputError("statistic.algorithm", `unknown ${statistic.algorithm}`);
+  // Read through an untyped view on purpose. The union above is a
+  // compile-time promise; this function exists for the caller who does not
+  // have one — a selector parsed from a study's JSON config. Narrowing the
+  // union here would make the checks unreachable to the compiler and
+  // therefore untestable.
+  const { algorithm, q } = statistic as { algorithm: string; q?: number };
+  if (!(BOOTSTRAP_STATISTICS as readonly string[]).includes(algorithm)) {
+    throw new StatisticsInputError("statistic.algorithm", `unknown ${algorithm}`);
   }
-  if (statistic.algorithm === "mean-v1") {
-    if (statistic.q !== undefined) {
+  if (algorithm === "mean-v1") {
+    if (q !== undefined) {
       throw new StatisticsInputError("statistic.q", "must be absent for mean-v1");
     }
     return;
   }
-  if (statistic.q === undefined) {
-    throw new StatisticsInputError("statistic.q", `required for ${statistic.algorithm}`);
+  if (q === undefined) {
+    throw new StatisticsInputError("statistic.q", `required for ${algorithm}`);
   }
-  assertProbability(statistic.q, "statistic.q");
+  assertProbability(q, "statistic.q");
 };
 
 const applyStatistic = (
@@ -511,9 +531,39 @@ const applyStatistic = (
     return mean(values);
   }
   if (statistic.algorithm === "quantile-nearest-rank-v1") {
-    return quantileNearestRank(values, statistic.q!);
+    return quantileNearestRank(values, statistic.q);
   }
-  return quantileR7(values, statistic.q!);
+  return quantileR7(values, statistic.q);
+};
+
+/**
+ * The shared result envelope for all three bootstraps.
+ *
+ * Collapsed into one place because it already drifted: normalization of the
+ * echoed `seed` had to be fixed at three call sites that had been written out
+ * separately, and one of them was missed. Everything that varies between the
+ * three algorithms is a parameter here; everything that does not is written
+ * once.
+ */
+const finalizeBootstrap = <Algorithm extends BootstrapAlgorithm>(
+  algorithm: Algorithm,
+  point: number,
+  replicates: readonly number[],
+  options: BootstrapOptions,
+  statistic?: BootstrapStatisticSelector,
+): BootstrapResult<Algorithm> => {
+  const base = {
+    algorithm,
+    prng: BOOTSTRAP_PRNG,
+    point: normalizeZero(point),
+    interval: percentileInterval(replicates, options.confidence),
+    seed: normalizeZero(options.seed),
+    resamples: normalizeZero(options.resamples),
+    inclusion_unit: options.inclusion_unit,
+  };
+  // `statistic` is OMITTED, never set to undefined — canonical JSON rejects an
+  // explicit undefined as surely as it rejects -0.
+  return statistic === undefined ? base : { ...base, statistic: normalizeSelector(statistic) };
 };
 
 /** The pinned replicate statistics of `bootstrap-percentile-v1`, in draw order. */
@@ -544,16 +594,13 @@ export const bootstrapPercentile = (
   options: BootstrapOptions,
 ): BootstrapResult<"bootstrap-percentile-v1"> => {
   const replicates = bootstrapPercentileReplicates(values, statistic, options);
-  return {
-    algorithm: "bootstrap-percentile-v1",
-    prng: BOOTSTRAP_PRNG,
-    point: normalizeZero(applyStatistic(values, statistic)),
-    interval: percentileInterval(replicates, options.confidence),
-    seed: normalizeZero(options.seed),
-    resamples: normalizeZero(options.resamples),
-    inclusion_unit: options.inclusion_unit,
-    statistic: normalizeSelector(statistic),
-  };
+  return finalizeBootstrap(
+    "bootstrap-percentile-v1",
+    applyStatistic(values, statistic),
+    replicates,
+    options,
+    statistic,
+  );
 };
 
 export interface PairedValue {
@@ -621,15 +668,12 @@ export const pairedRatioBootstrap = (
   options: BootstrapOptions,
 ): BootstrapResult<"paired-ratio-bootstrap-v1"> => {
   const replicates = pairedRatioBootstrapReplicates(pairs, options);
-  return {
-    algorithm: "paired-ratio-bootstrap-v1",
-    prng: BOOTSTRAP_PRNG,
-    point: normalizeZero(median(perPairRatios(pairs))),
-    interval: percentileInterval(replicates, options.confidence),
-    seed: normalizeZero(options.seed),
-    resamples: normalizeZero(options.resamples),
-    inclusion_unit: options.inclusion_unit,
-  };
+  return finalizeBootstrap(
+    "paired-ratio-bootstrap-v1",
+    median(perPairRatios(pairs)),
+    replicates,
+    options,
+  );
 };
 
 /** Groups differences by stratum in FIRST-APPEARANCE order — the draw order is normative. */
@@ -680,15 +724,12 @@ export const stratifiedPairedDifferenceBootstrap = (
   options: BootstrapOptions,
 ): BootstrapResult<"stratified-paired-difference-bootstrap-v1"> => {
   const replicates = stratifiedPairedDifferenceBootstrapReplicates(pairs, options);
-  return {
-    algorithm: "stratified-paired-difference-bootstrap-v1",
-    prng: BOOTSTRAP_PRNG,
-    point: normalizeZero(mean(pairs.map((p) => p.candidate - p.baseline))),
-    interval: percentileInterval(replicates, options.confidence),
-    seed: normalizeZero(options.seed),
-    resamples: normalizeZero(options.resamples),
-    inclusion_unit: options.inclusion_unit,
-  };
+  return finalizeBootstrap(
+    "stratified-paired-difference-bootstrap-v1",
+    mean(pairs.map((p) => p.candidate - p.baseline)),
+    replicates,
+    options,
+  );
 };
 
 export interface ClopperPearsonZeroFailureResult {


### PR DESCRIPTION
## What & why

`bench/measurement/statistics.ts` implements the ten algorithm/PRNG tags that coordination design §4.7 requires, so a fold-program study cannot emit an untagged `p95` or `confidence_interval`. Every summary carries its algorithm tag and every parameter that determined the number — seed, resample count, confidence, inclusion unit, statistic selector, design columns — and echoes them back on the result.

Two new files under `bench/measurement/`, plus a catalog entry in `bench/README.md`. No production change, no new dependency, no npm script. The module is pure and imports the repository's one canonical Mulberry32 rather than defining a second.

## Key points

- Pinned vectors are held as **data** in `STATISTICS_TEST_VECTORS`, and the tests assert against that constant rather than inline literals — so a changed expectation necessarily moves the measurement contract hash. A tag→description map would leave the hash green over changed evidence semantics.
- `ols-qr-v1` takes its rank gate on the **column-equilibrated** QR diagonal (`|R_kk| / ‖A e_k‖`), so the verdict is independent of the units each column was measured in and of the order the columns were listed. A single global `max|R_kk|` tolerance is not sufficient: a dependent column merely larger in scale clears a bar set by a different column, and 2737 of 4800 sampled exactly-rank-2 designs were accepted as full rank, returning coefficients of magnitude 1e13–1e15. The equilibrated gate accepts 0 of those, and also wrongly rejects 0 of 6000 full-rank designs with column scales spanning 1e-6…1e9, where the global-scale gate rejected 500.
- `condition_estimate` is reported and never acted on: no pivoting, no ridge term, no refusal. The gate detects deficiency, not degree, so a merely near-collinear design still passes it and still returns numerically meaningless coefficients. A consumer that reads these coefficients as physics must preregister a bar on this number; choosing the bar is study policy, not this module's. Equilibration is what makes such a bar expressible at all.
- `wilson-one-sided-upper-v1` validates `(confidence, z)` against a five-row table instead of deriving z. Deriving would add an untagged tenth algorithm; recording an unchecked pair would let a study stamp `confidence: 0.95` on a number computed at z = 2. Its result is clamped to 1 — at p̂ = 1 the limit is exactly 1 analytically, but the float evaluation overshoots for 501 of the first 2000 attempt counts.
- `clopper-pearson-zero-failure-upper-v1` evaluates `-expm1(log1p(-c)/n)` rather than the algebraically equal `1 - (1-c)**(1/n)`, which cancels catastrophically as the bound falls with 1/n (5.8e-6 relative error at n = 1e12).
- Every emitted number is `-0`-normalized, including echoed caller parameters: `-0` clears both `Number.isInteger(v) && v >= 0` and `!(v < 0)`, and the canonical JSON these results feed rejects `-0` rather than normalizing it.
- The tag strings and pinned numbers are frozen identity; result *diagnostics* (`condition_estimate`, `intercept_present`) are additive surface, since this contract is hashed before its consumer has run once.

## Verification

| Command | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` (full default suite) | 2715 passed, 0 failed |
| `pnpm vitest run bench/measurement/statistics.test.ts` | 70 passed |
| `oxlint bench/measurement/` | clean |
| `git diff main...HEAD -- bench/load-harness/` | empty (canonical PRNG byte-unchanged) |

## Notes for reviewers

Start at `STATISTICS_TEST_VECTORS` — the tests read their numbers from it and nowhere else, which is the property that makes the contract hash tamper-evident.

The suite is written against hand-mutation rather than line coverage: for each behaviour, the question was which single edit to the module would keep every test green. Several would have. The sort comparator was the worst — every other sample in the file sorts identically as strings, so a bare `.toSorted()` left the whole suite green while turning `quantileR7([9,12,100,250,1500], 0.5)` from 100 into 1500. `expectInputError` now requires the field name, because asserting `code` alone proved only that *some* validation fired: the `z` finiteness guard was fully deletable, its two cases being caught downstream by the `(confidence, z)` gate instead.

The `WILSON_Z_BY_CONFIDENCE` guard uses a Simpson-quadrature normal **CDF** to round-trip each row back to its own confidence. That is a check, not a derivation: it can only reject a `(confidence, z)` pair, never produce a z, so it is not a tenth algorithm.

Two adjacent defects were found and deliberately not touched here, both recorded in the fold-program deferred-defects backlog: `bench/metrics.ts:39` and `bench/storage.ts:91` compute a floor index while their comments call it "nearest-rank", so existing `bench/results/` percentiles are not `quantile-nearest-rank-v1`; and `bench/` sits outside the `verify` lint glob, so oxlint findings there reach only the pre-commit hook and never CI.

**Suggested merge: squash.** The branch carries its own corrections as separate commits, which is useful while reviewing and noise on `main`.
