### PR TITLE
feat(bench): probe per-profile fold-ceiling headroom above C and E

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -16,11 +16,12 @@ Two harnesses live under `bench/`:
 | `bench/r2-contention.ts` | CAS-storm 412/429 rates on one `current.json`; validates the idle-reader bound on the wire | When changing `packages/server/src/writer.ts`, coordination primitives, or retry policy |
 | `bench/load-harness/` | Object-storage ops + bytes per logical `Db` operation across seven workload presets; validates the workload cost model. `--variant=node-gcs` (gated on `GCS=1` + `credentials/gcs.json`) is the source of the measured GCS write-amp behind the GCS row in [docs/about/cost-model.md](../docs/about/cost-model.md#cost-vs-scale-table) | When changing storage layout, manifest cache TTLs, or compaction profile — run before/after a perf-shaped PR |
 | `bench/fold-cost.ts` | CPU + peak-heap cost of ONE compaction fold (the unsliceable snapshot rebuild) vs. snapshot bytes and snapshot row count; Phase 2 evidence for raising the snapshot ceilings `C` / `E` on a more capable host. No infra (MemoryStorage). MEASURES ONLY — changes no constant. | When validating / revisiting the snapshot-rebuild cost model in [docs/about/graduation.md](../docs/about/graduation.md) |
+| `bench/measurement/fold-ceiling-probe-run.ts` | How far above today's `C` / `E` a fold still fits each host profile's CPU + memory budget, at 2× / 4× / 7× safety margins. Reuses the `fold-cost.ts` fixture verbatim so cells stay comparable to its frozen baseline. No infra (MemoryStorage). MEASURES ONLY. **No checked-in baseline yet** — its sampling and axis-aggregation methodology is unresolved; read the caveats in the section below before promoting any output. | When revisiting whether `C` / `E` can be raised on a more capable host |
 | `bench/maintenance-backlog.ts` | Maintenance backlog (live log-tail entries + bucket object count + snapshot-over-ceiling minutes) vs. write rate, per trigger (in-band write-tick / scheduled cron) and profile (cf-free / node); Phase 2 evidence for whether FREE-RATE maintenance keeps up within the ~30 writes/min M-size envelope. Verdict is per-axis (tail + objects) then combined. No infra (MemoryStorage). MEASURES ONLY — changes no constant. | When validating / revisiting whether the per-host maintenance profile (`MAINTENANCE_PROFILE_CF_FREE` vs `MAINTENANCE_PROFILE_NODE`) is justified |
 | `bench/amortized-write-cost.ts` | Amortized BILLABLE Class A ops (PUT+LIST; DeleteObject is $0) per logical write, INCLUDING in-band maintenance (folds + GC), across workload shapes × profile (cf-free / node). Source of truth for the write-amp constants in the cost CLI + the effective-write-amp claim in docs/about/cost-model.md. No infra (MemoryStorage). MEASURES ONLY. | When revisiting the write-amplification claim or the cost-CLI projection |
 | `bench/write-amp-stress.ts` | STRESS variant of `amortized-write-cost.ts`: drives pathological churn workloads (100%-update tiny set, unbounded insert growth, 500-doc full rewrite) under aggressive in-band maintenance to find the PEAK billable Class A ops per logical write. Tracks `peak_billable_class_a_per_write` (single-writer; the route past ~4× is a CAS-retry storm, governed by the throughput ceiling, not measured here). Backs the "peaks ~4×, never reaches the retired >6 trigger" claim. No infra (MemoryStorage). MEASURES ONLY. Baseline at `docs/spec/attachments/amortized-write-cost-stress-baseline.json`. | When revisiting whether the retired `write-amp > 6` graduation trigger could ever fire |
 | `bench/collection-fanout.ts` | Storage op cost of `discoverCollections` (LIST count) + full `admin usage` scan (LIST + GET count) vs. N collections under one tenant prefix, measured via a counting Storage proxy on MemoryStorage. No infra. MEASURES ONLY — re-derives the collections/tenant fan-out limit. A checked-in baseline lives at `docs/spec/attachments/collection-fanout-baseline.json`. | When revisiting the collections/tenant fan-out limit in docs/about/graduation.md or docs/about/workload-fit.md |
-| `bench/measurement/` | Not a harness — the shared measurement **library** the harnesses above build on. `statistics.ts` holds the algorithm-tagged summaries (quantiles, MAD, three bootstraps, two binomial upper bounds, OLS via Householder QR), each carrying its algorithm tag and every parameter that determined the number. `storage-journal.ts` and `storage-factory.ts` hold the recording and isolation seam: a timer-free `Storage` decorator producing an ordered operation journal plus an exact namespace journal, and a per-attempt backend lease whose cleanup authority is one in-memory instance, one `mkdtemp` root, or an explicit key list. Pure; no infra. | When a bench emits a `p95`, a confidence interval, or a regression coefficient; or when it needs a recorded, disposable backend rather than a shared one |
+| `bench/measurement/` | Not a harness — the shared measurement **library** the harnesses above build on. `statistics.ts` holds the algorithm-tagged summaries (quantiles, MAD, three bootstraps, two binomial upper bounds, OLS via Householder QR), each carrying its algorithm tag and every parameter that determined the number. `storage-journal.ts` and `storage-factory.ts` hold the recording and isolation seam: a timer-free `Storage` decorator producing an ordered operation journal plus an exact namespace journal, and a per-attempt backend lease whose cleanup authority is one in-memory instance, one `mkdtemp` root, or an explicit key list. `fold-ceiling-probe.ts` is the pure half of the fold-ceiling probe. All pure; no infra — the directory's one script is `fold-ceiling-probe-run.ts` (`pnpm bench:fold-ceiling`). | When a bench emits a `p95`, a confidence interval, or a regression coefficient; or when it needs a recorded, disposable backend rather than a shared one |
 
 Both require `pnpm dev:storage` (Minio `:9102` + Toxiproxy `:9104`)
 for the Minio-backed variants. Neither is a per-PR CI gate. The
@@ -193,9 +194,14 @@ The key derived fields:
 
 ## bench/measurement/
 
-The one place a bench summarizes numbers. Not runnable — a pure library
-(`statistics.ts`) with no I/O, no clock read, and one import: the
+The one place a bench summarizes numbers. `statistics.ts` is a pure
+library — not runnable, no I/O, no clock read, and one import: the
 repository's canonical Mulberry32 PRNG.
+
+`fold-ceiling-probe.ts` sits alongside it and splits the same way: the
+module itself is pure and has no module-scope side effects, and
+`fold-ceiling-probe-run.ts` is the runnable half wired to
+`pnpm bench:fold-ceiling`. Its own section is below.
 
 Every function returns its result **tagged**: the algorithm identifier
 plus every parameter that determined the number — seed, resample count,
@@ -371,6 +377,54 @@ find where the CPU / memory budget of a target host intersects the grid
 This bench **measures only**: it never moves `C`, `E`, or any constant.
 Re-sizing the ceilings off these numbers is an explicitly deferred later
 phase.
+
+## bench/measurement/fold-ceiling-probe.ts
+
+Extends `fold-cost.ts` past today's ceilings: for each host profile
+(cf-free / cf-paid / node) and each safety margin (2× / 4× / 7×), how
+large could `C` and `E` be before the fold stops fitting the profile's
+CPU and memory budget? Reuses `bench/lib/fold-fixture.ts` verbatim —
+same seed, same tail, same measurement definitions — so its cells are
+directly comparable to the frozen `fold-cost` baseline, and the runner
+prints an overlap check against that baseline as a calibration signal.
+
+```sh
+BAERLY_SUBJECT_COMMIT=$(git rev-parse HEAD) pnpm bench:fold-ceiling
+```
+
+Takes minutes. **Run it on an otherwise-idle machine** — a contended run
+produces a non-monotonic CPU column, and the large cells discard a high
+fraction of peak samples to GC (see the flooring note under `fold-cost.ts`
+above). Set `BAERLY_FOLD_CEILING_CELLS=<record.json>` to re-derive a
+record from an existing run's cells without re-measuring; everything in
+the record except `cells` is a pure function of them.
+
+One timestamped JSON per run lands in `bench/results/fold-ceiling/`
+(gitignored). **There is deliberately no checked-in baseline yet.** Three
+methodology issues have to be resolved, and the grid re-run on a quiesced
+machine, before any output of this probe is promoted to
+`docs/spec/attachments/` or cited anywhere:
+
+- **No minimum usable-sample floor.** `runCell` keeps the filtered median
+  whenever _any_ sample survives `isPeakSampleUsable`, so a cell that
+  discarded 7 of its 9 iterations reports a median over 2 samples with
+  nothing in the record marking it as thin. The filter is also one-sided:
+  it drops fully-floored samples and keeps partially-floored ones.
+- **`largestSustainable` aggregates with `Math.max`.** That answers "the
+  largest row count for which _some_ tested configuration fits", where a
+  safety ceiling wants "…for which _all_ tested configurations fit". A
+  cross-axis cell can credit a row count whose own rows-axis cell fails
+  the same budget.
+- **`binding_axis` is derived from an axis-mixed sort.** Rows-axis cells
+  are byte-small but allocation-expensive, so they sort early and win
+  `firstMiss`, letting one scalar annotate two independent verdicts.
+
+Also read `todayHeadroom` with care: `nearestAtOrBelow` falls back to the
+lowest cell when none is at or below the limit, and no bytes-axis cell
+currently lands under `C` (the smallest measures 532300 against a 524288
+ceiling), so "at today's `C`" is reported from a cell ~1.5% above it.
+
+This probe **measures only**: it never moves `C`, `E`, or any constant.
 
 ## bench/maintenance-backlog.ts
 

--- a/bench/fold-cost.ts
+++ b/bench/fold-cost.ts
@@ -28,7 +28,13 @@
  * Storage is in-memory so I/O is ~free and the measured cost is the
  * CPU/allocation of the rebuild itself.
  *
- * MEASUREMENT METHOD
+ * The fixture builder and the per-fold CPU/heap measurement live in
+ * `bench/lib/fold-fixture.ts` so the fold-ceiling probe can reuse them
+ * verbatim — same seed, same tail, same measurement definitions — and so
+ * they are importable without running this bench. This file owns the
+ * grid, the iteration counts, and the output format.
+ *
+ * MEASUREMENT METHOD (defined in `bench/lib/fold-fixture.ts`)
  *   - **CPU**: `process.cpuUsage()` deltas (user + system µs) bracketing
  *     the fold, reported in ms. NOT wall-clock — folds are CPU-bound on
  *     Workers and wall would include I/O (which MemoryStorage makes ~free
@@ -76,51 +82,23 @@
  * portable signal.
  */
 
-/* eslint-disable no-underscore-dangle -- `_id` is the locked primary-key
-   field on document + snapshot shapes (see `@baerly/protocol`'s
-   `Collection<T>` / the snapshot body). */
-
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { MAINTENANCE_MAX_FOLD_ROWS } from "@baerly/protocol";
 import {
-  type CurrentJson,
-  type DocumentData,
-  type LogEntry,
-  MAINTENANCE_MAX_FOLD_ROWS,
-  MemoryStorage,
-  countKey,
-  encodeJsonBytes,
-  snapshotHash,
-  timestamp,
-} from "@baerly/protocol";
-import { type SnapshotBody, encodeSnapshotBody, snapshotKey } from "@baerly/server";
-import { compact } from "@baerly/server/maintenance";
-import type { InternalCompactOptions } from "@baerly/server/_internal/testing";
+  HEAP_SAMPLE_INTERVAL_MS,
+  SEED,
+  TAIL_ENTRIES,
+  buildFixture,
+  measureOneFold,
+  median,
+} from "./lib/fold-fixture.ts";
 
 // ── Bench config. Pinned constants — tweak in the source if needed. ──
-
-const SEED = 0xf01d_c057; // "fold cost"; reproduction handle.
-const SESSION = "fold000"; // 7 chars; the bench doesn't validate sessions.
-const COLLECTION = "notes";
-const CURRENT_JSON_KEY = `app/x/tenant/t/manifests/${COLLECTION}/current.json`;
-const COLLECTION_PREFIX = `app/x/tenant/t/manifests/${COLLECTION}`;
 
 /** Warmup folds (discarded) then measured folds, per grid point. */
 const WARMUP_ITERS = 5;
 const MEASURE_ITERS = 11;
-
-/** Heap-sampling interval during a fold (ms). */
-const HEAP_SAMPLE_INTERVAL_MS = 1;
-
-/**
- * Tail length folded per measured rebuild. Small + fixed so the fold's
- * cost is dominated by the snapshot rebuild (load old + serialize new +
- * hash), not by the tail walk — which mirrors the production shape (the
- * tail is SLICED, the snapshot rebuild is the unsliceable cost). The
- * tail updates existing docs so the new snapshot stays the same size /
- * row count as the old (a steady-state fold).
- */
-const TAIL_ENTRIES = 100;
 
 /**
  * BYTES axis — fixed bytes/doc, row count chosen to bracket the
@@ -154,177 +132,6 @@ const ROWS_AXIS_ROW_COUNTS: readonly number[] = [
   8192,
   16384,
 ];
-
-/**
- * Mulberry32 PRNG — small, seedable, no deps. Deterministic input so
- * two runs on the same machine produce comparable snapshot shapes.
- */
-const mulberry32 = (seed: number): (() => number) => {
-  let a = seed >>> 0;
-  return () => {
-    a = (a + 0x6d2b79f5) >>> 0;
-    let t = a;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-};
-
-/**
- * Build a document whose canonical JSON byteLength is close to
- * `targetBytes`. The doc carries a few typed fields plus a `pad` string
- * sized to hit the target; representative of a real notes-shaped record
- * (string body + scalars) rather than one giant blob.
- */
-const makeDoc = (id: string, targetBytes: number, rng: () => number): DocumentData => {
-  // Fixed scaffold the encoder always emits; the pad absorbs the rest.
-  const scaffold: DocumentData = {
-    _id: id,
-    title: `note ${id}`,
-    n: Math.floor(rng() * 1_000_000),
-    done: rng() < 0.5,
-    pad: "",
-  };
-  const scaffoldBytes = encodeJsonBytes(scaffold).byteLength;
-  const padLen = Math.max(0, targetBytes - scaffoldBytes);
-  // Printable ASCII so each char is one JSON byte (no escaping / multi-
-  // byte surprises that would throw off the target).
-  return { ...scaffold, pad: "x".repeat(padLen) };
-};
-
-interface FoldFixture {
-  readonly storage: MemoryStorage;
-  /** Actual canonical snapshot-body byteLength (measured, not target). */
-  readonly snapshotBytes: number;
-  readonly rows: number;
-}
-
-/**
- * Seed a fresh `MemoryStorage` with a `current.json` + a prior snapshot
- * of (rows × bytesPerDoc) + a `TAIL_ENTRIES`-long log tail that updates
- * existing docs. After this returns, a single `compact()` call folds the
- * whole tail into a rebuilt snapshot of the same shape.
- */
-const buildFixture = async (rows: number, bytesPerDoc: number): Promise<FoldFixture> => {
-  const storage = new MemoryStorage();
-  const rng = mulberry32(SEED ^ (rows * 0x9e37_79b1) ^ bytesPerDoc);
-
-  // 1. Prior snapshot: `rows` docs, sorted by _id (compactor invariant).
-  const docs: Array<{ _id: string; body: DocumentData }> = [];
-  for (let i = 0; i < rows; i++) {
-    const id = `doc-${i.toString().padStart(8, "0")}`;
-    docs.push({ _id: id, body: makeDoc(id, bytesPerDoc, rng) });
-  }
-  docs.sort((a, b) => byIdAsc(a._id, b._id));
-  const snapBody: SnapshotBody = {
-    schema_version: 1,
-    min_seq: 0,
-    max_seq: rows, // prior snapshot covered [0, rows)
-    collection: COLLECTION,
-    docs,
-  };
-  const snapBytes = encodeSnapshotBody(snapBody);
-  const sha = await snapshotHash(snapBytes);
-  const snapKey = snapshotKey(COLLECTION_PREFIX, 0, rows, sha);
-  await storage.put(snapKey, snapBytes, { contentType: "application/json" });
-
-  // 2. Log tail: TAIL_ENTRIES updates to existing docs at seqs
-  //    [rows, rows + TAIL_ENTRIES). U with a full post-image keeps the
-  //    rebuilt snapshot the same row count (steady-state fold).
-  for (let t = 0; t < TAIL_ENTRIES; t++) {
-    const seq = rows + t;
-    const targetIdx = Math.floor(rng() * rows);
-    const id = `doc-${targetIdx.toString().padStart(8, "0")}`;
-    const entry: LogEntry = {
-      lsn: `${timestamp(1_700_000_000_000 + seq)}_${SESSION}_${countKey(seq)}`,
-      commit_ts: new Date(1_700_000_000_000 + seq).toISOString(),
-      op: "U",
-      collection: COLLECTION,
-      doc_id: id,
-      after: makeDoc(id, bytesPerDoc, rng),
-      session: SESSION,
-      seq,
-    };
-    const entryBytes = encodeJsonBytes(entry);
-    await storage.put(`${COLLECTION_PREFIX}/log/${seq}.json`, entryBytes, {
-      contentType: "application/json",
-    });
-  }
-
-  // 3. current.json pointing at the prior snapshot with the tail live.
-  const current: CurrentJson = {
-    schema_version: 3,
-    snapshot: snapKey,
-    tail_hint: rows + TAIL_ENTRIES,
-    log_seq_start: rows,
-    writer_fence: { epoch: 1, owner: "fold-cost-bench", claimed_at: "" },
-    snapshot_bytes: snapBytes.byteLength,
-    snapshot_rows: rows,
-  };
-  await storage.put(CURRENT_JSON_KEY, encodeJsonBytes(current), {
-    ifNoneMatch: "*",
-    contentType: "application/json",
-  });
-
-  return { storage, snapshotBytes: snapBytes.byteLength, rows };
-};
-
-/** A single measured fold over an already-built fixture. */
-const measureOneFold = async (
-  storage: MemoryStorage,
-): Promise<{ cpuMs: number; peakBytes: number }> => {
-  const heapStart = process.memoryUsage().heapUsed;
-  let peak = heapStart;
-  const sampler = setInterval(() => {
-    const h = process.memoryUsage().heapUsed;
-    if (h > peak) {
-      peak = h;
-    }
-  }, HEAP_SAMPLE_INTERVAL_MS);
-  // `unref` so a stray timer can never keep the process alive.
-  sampler.unref();
-
-  const cpu0 = process.cpuUsage();
-  // Whole tail in one pass (the unsliceable rebuild); no ceiling (we are
-  // measuring the fold, not the defer path). `maxEntriesPerRun` rides on
-  // the internal options object.
-  const opts: InternalCompactOptions = {
-    minEntriesToCompact: 1,
-    maxEntriesPerRun: Number.MAX_SAFE_INTEGER,
-  };
-  const res = await compact({ storage, currentJsonKey: CURRENT_JSON_KEY }, opts);
-  const cpu1 = process.cpuUsage(cpu0);
-  clearInterval(sampler);
-
-  if (!res.written) {
-    throw new Error(`fold-cost: expected a written fold, got skippedReason=${res.skippedReason}`);
-  }
-  // One last sample in case the fold finished between ticks.
-  const heapEnd = process.memoryUsage().heapUsed;
-  if (heapEnd > peak) {
-    peak = heapEnd;
-  }
-  const cpuMs = (cpu1.user + cpu1.system) / 1000; // µs → ms
-  const peakBytes = Math.max(0, peak - heapStart);
-  return { cpuMs, peakBytes };
-};
-
-const median = (xs: readonly number[]): number => {
-  const s = [...xs].toSorted((a, b) => a - b);
-  const mid = Math.floor(s.length / 2);
-  return s.length % 2 === 0 ? (s[mid - 1]! + s[mid]!) / 2 : s[mid]!;
-};
-
-/** Lexicographic `_id` comparator — same ordering the compactor uses. */
-const byIdAsc = (a: string, b: string): number => {
-  if (a < b) {
-    return -1;
-  }
-  if (a > b) {
-    return 1;
-  }
-  return 0;
-};
 
 /** Bytes → KB / MB for the summary table. */
 const kb = (b: number): string => (b / 1024).toFixed(0);

--- a/bench/lib/fold-fixture.ts
+++ b/bench/lib/fold-fixture.ts
@@ -1,0 +1,249 @@
+/**
+ * Shared fold fixture + measurement primitives for the fold benches
+ * (bench/fold-cost.ts, bench/measurement/fold-ceiling-probe.ts).
+ *
+ * A "fold" here is ONE real `compact()` — the UNSLICEABLE snapshot
+ * rebuild — run against a fresh `MemoryStorage` seeded with a
+ * `current.json` + a prior snapshot of an exact (rows, bytesPerDoc)
+ * shape + a representative log tail. The whole tail folds in a SINGLE
+ * pass (`maxEntriesPerRun` large, `minEntriesToCompact = 1`) so what is
+ * measured is the unsliceable rebuild, not a sliced drain. The fold does
+ * the production work end to end: load + hash-verify the old snapshot,
+ * apply the tail merge, re-serialize the new snapshot body, SHA-256 it,
+ * PUT it, CAS-advance `current.json`. Storage is in-memory so I/O is
+ * ~free and the measured cost is the CPU/allocation of the rebuild
+ * itself.
+ *
+ * MEASUREMENT METHOD
+ *   - **CPU**: `process.cpuUsage()` deltas (user + system µs) bracketing
+ *     the fold, reported in ms. NOT wall-clock — folds are CPU-bound on
+ *     Workers and wall would include I/O (which MemoryStorage makes ~free
+ *     anyway).
+ *   - **Peak memory**: a tight sampler on
+ *     `process.memoryUsage().heapUsed` ({@link HEAP_SAMPLE_INTERVAL_MS}
+ *     via a `setInterval`) running for the duration of the fold; the
+ *     per-fold peak is `max(sample) - heapUsedAtStart`. The fold holds
+ *     old snapshot + new snapshot + tail resident (~2–3× snapshot).
+ *     Sampling (not `--expose-gc` deltas) so the benches run with a bare
+ *     `node` like the other no-infra benches.
+ *   - **Fixture realism** — the pad is a single repeated-char string
+ *     (`"x".repeat(n)`), so absolute byte-axis numbers are a mild lower
+ *     bound vs. heterogeneous real documents; the linear *shape* (linear
+ *     in bytes, the per-row slope) is the portable signal.
+ *
+ * This module has NO module-scope side effects, so it is safe to import
+ * from a test or from another bench. Its callers own the grid, the
+ * iteration counts, and the output format. MEASURES ONLY — it changes no
+ * production behaviour and no constant.
+ */
+
+/* eslint-disable no-underscore-dangle -- `_id` is the locked primary-key
+   field on document + snapshot shapes (see `@baerly/protocol`'s
+   `Collection<T>` / the snapshot body). */
+
+import {
+  type CurrentJson,
+  type DocumentData,
+  type LogEntry,
+  MemoryStorage,
+  countKey,
+  encodeJsonBytes,
+  snapshotHash,
+  timestamp,
+} from "@baerly/protocol";
+import { type SnapshotBody, encodeSnapshotBody, snapshotKey } from "@baerly/server";
+import { compact } from "@baerly/server/maintenance";
+import type { InternalCompactOptions } from "@baerly/server/_internal/testing";
+
+// ── Fixture config. Pinned constants — tweak in the source if needed. ──
+
+/** "fold cost"; reproduction handle. Captured in every result JSON. */
+export const SEED = 0xf01d_c057;
+const SESSION = "fold000"; // 7 chars; the bench doesn't validate sessions.
+const COLLECTION = "notes";
+const CURRENT_JSON_KEY = `app/x/tenant/t/manifests/${COLLECTION}/current.json`;
+const COLLECTION_PREFIX = `app/x/tenant/t/manifests/${COLLECTION}`;
+
+/** Heap-sampling interval during a fold (ms). */
+export const HEAP_SAMPLE_INTERVAL_MS = 1;
+
+/**
+ * Tail length folded per measured rebuild. Small + fixed so the fold's
+ * cost is dominated by the snapshot rebuild (load old + serialize new +
+ * hash), not by the tail walk — which mirrors the production shape (the
+ * tail is SLICED, the snapshot rebuild is the unsliceable cost). The
+ * tail updates existing docs so the new snapshot stays the same size /
+ * row count as the old (a steady-state fold).
+ */
+export const TAIL_ENTRIES = 100;
+
+/**
+ * Mulberry32 PRNG — small, seedable, no deps. Deterministic input so
+ * two runs on the same machine produce comparable snapshot shapes.
+ */
+const mulberry32 = (seed: number): (() => number) => {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+/**
+ * Build a document whose canonical JSON byteLength is close to
+ * `targetBytes`. The doc carries a few typed fields plus a `pad` string
+ * sized to hit the target; representative of a real notes-shaped record
+ * (string body + scalars) rather than one giant blob.
+ */
+const makeDoc = (id: string, targetBytes: number, rng: () => number): DocumentData => {
+  // Fixed scaffold the encoder always emits; the pad absorbs the rest.
+  const scaffold: DocumentData = {
+    _id: id,
+    title: `note ${id}`,
+    n: Math.floor(rng() * 1_000_000),
+    done: rng() < 0.5,
+    pad: "",
+  };
+  const scaffoldBytes = encodeJsonBytes(scaffold).byteLength;
+  const padLen = Math.max(0, targetBytes - scaffoldBytes);
+  // Printable ASCII so each char is one JSON byte (no escaping / multi-
+  // byte surprises that would throw off the target).
+  return { ...scaffold, pad: "x".repeat(padLen) };
+};
+
+/** Lexicographic `_id` comparator — same ordering the compactor uses. */
+const byIdAsc = (a: string, b: string): number => {
+  if (a < b) {
+    return -1;
+  }
+  if (a > b) {
+    return 1;
+  }
+  return 0;
+};
+
+export interface FoldFixture {
+  readonly storage: MemoryStorage;
+  /** Actual canonical snapshot-body byteLength (measured, not target). */
+  readonly snapshotBytes: number;
+  readonly rows: number;
+}
+
+/**
+ * Seed a fresh `MemoryStorage` with a `current.json` + a prior snapshot
+ * of (rows × bytesPerDoc) + a `TAIL_ENTRIES`-long log tail that updates
+ * existing docs. After this returns, a single `compact()` call folds the
+ * whole tail into a rebuilt snapshot of the same shape.
+ */
+export const buildFixture = async (rows: number, bytesPerDoc: number): Promise<FoldFixture> => {
+  const storage = new MemoryStorage();
+  const rng = mulberry32(SEED ^ (rows * 0x9e37_79b1) ^ bytesPerDoc);
+
+  // 1. Prior snapshot: `rows` docs, sorted by _id (compactor invariant).
+  const docs: Array<{ _id: string; body: DocumentData }> = [];
+  for (let i = 0; i < rows; i++) {
+    const id = `doc-${i.toString().padStart(8, "0")}`;
+    docs.push({ _id: id, body: makeDoc(id, bytesPerDoc, rng) });
+  }
+  docs.sort((a, b) => byIdAsc(a._id, b._id));
+  const snapBody: SnapshotBody = {
+    schema_version: 1,
+    min_seq: 0,
+    max_seq: rows, // prior snapshot covered [0, rows)
+    collection: COLLECTION,
+    docs,
+  };
+  const snapBytes = encodeSnapshotBody(snapBody);
+  const sha = await snapshotHash(snapBytes);
+  const snapKey = snapshotKey(COLLECTION_PREFIX, 0, rows, sha);
+  await storage.put(snapKey, snapBytes, { contentType: "application/json" });
+
+  // 2. Log tail: TAIL_ENTRIES updates to existing docs at seqs
+  //    [rows, rows + TAIL_ENTRIES). U with a full post-image keeps the
+  //    rebuilt snapshot the same row count (steady-state fold).
+  for (let t = 0; t < TAIL_ENTRIES; t++) {
+    const seq = rows + t;
+    const targetIdx = Math.floor(rng() * rows);
+    const id = `doc-${targetIdx.toString().padStart(8, "0")}`;
+    const entry: LogEntry = {
+      lsn: `${timestamp(1_700_000_000_000 + seq)}_${SESSION}_${countKey(seq)}`,
+      commit_ts: new Date(1_700_000_000_000 + seq).toISOString(),
+      op: "U",
+      collection: COLLECTION,
+      doc_id: id,
+      after: makeDoc(id, bytesPerDoc, rng),
+      session: SESSION,
+      seq,
+    };
+    const entryBytes = encodeJsonBytes(entry);
+    await storage.put(`${COLLECTION_PREFIX}/log/${seq}.json`, entryBytes, {
+      contentType: "application/json",
+    });
+  }
+
+  // 3. current.json pointing at the prior snapshot with the tail live.
+  const current: CurrentJson = {
+    schema_version: 3,
+    snapshot: snapKey,
+    tail_hint: rows + TAIL_ENTRIES,
+    log_seq_start: rows,
+    writer_fence: { epoch: 1, owner: "fold-cost-bench", claimed_at: "" },
+    snapshot_bytes: snapBytes.byteLength,
+    snapshot_rows: rows,
+  };
+  await storage.put(CURRENT_JSON_KEY, encodeJsonBytes(current), {
+    ifNoneMatch: "*",
+    contentType: "application/json",
+  });
+
+  return { storage, snapshotBytes: snapBytes.byteLength, rows };
+};
+
+/** A single measured fold over an already-built fixture. */
+export const measureOneFold = async (
+  storage: MemoryStorage,
+): Promise<{ cpuMs: number; peakBytes: number }> => {
+  const heapStart = process.memoryUsage().heapUsed;
+  let peak = heapStart;
+  const sampler = setInterval(() => {
+    const h = process.memoryUsage().heapUsed;
+    if (h > peak) {
+      peak = h;
+    }
+  }, HEAP_SAMPLE_INTERVAL_MS);
+  // `unref` so a stray timer can never keep the process alive.
+  sampler.unref();
+
+  const cpu0 = process.cpuUsage();
+  // Whole tail in one pass (the unsliceable rebuild); no ceiling (we are
+  // measuring the fold, not the defer path). `maxEntriesPerRun` rides on
+  // the internal options object.
+  const opts: InternalCompactOptions = {
+    minEntriesToCompact: 1,
+    maxEntriesPerRun: Number.MAX_SAFE_INTEGER,
+  };
+  const res = await compact({ storage, currentJsonKey: CURRENT_JSON_KEY }, opts);
+  const cpu1 = process.cpuUsage(cpu0);
+  clearInterval(sampler);
+
+  if (!res.written) {
+    throw new Error(`fold-cost: expected a written fold, got skippedReason=${res.skippedReason}`);
+  }
+  // One last sample in case the fold finished between ticks.
+  const heapEnd = process.memoryUsage().heapUsed;
+  if (heapEnd > peak) {
+    peak = heapEnd;
+  }
+  const cpuMs = (cpu1.user + cpu1.system) / 1000; // µs → ms
+  const peakBytes = Math.max(0, peak - heapStart);
+  return { cpuMs, peakBytes };
+};
+
+export const median = (xs: readonly number[]): number => {
+  const s = [...xs].toSorted((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 === 0 ? (s[mid - 1]! + s[mid]!) / 2 : s[mid]!;
+};

--- a/bench/measurement/fold-ceiling-probe-run.ts
+++ b/bench/measurement/fold-ceiling-probe-run.ts
@@ -1,0 +1,212 @@
+/**
+ * Runnable entrypoint for the fold-ceiling headroom probe.
+ *
+ * Thin by design: the grid, the verdict functions, and the record shape all
+ * live in `./fold-ceiling-probe.ts`, which the test imports and which has no
+ * module-scope side effects. This file is the only place that executes the
+ * sweep, prints, and writes to disk — the same runner/library split
+ * `bench/amortized-write-cost.ts` uses over `bench/lib/write-cost-measure.ts`.
+ *
+ *   BAERLY_SUBJECT_COMMIT=$(git rev-parse HEAD) \
+ *     node --import ./bench/register-hooks.mjs \
+ *       bench/measurement/fold-ceiling-probe-run.ts
+ *
+ * Takes minutes. Run it with nothing else competing for CPU; a parallel
+ * `pnpm test` will corrupt the medians. (Observed: a run made while the
+ * agent was writing files produced a non-monotonic CPU column — 3 MB and
+ * 5 MB equal, 4 MB above both.)
+ *
+ * Set `BAERLY_FOLD_CEILING_CELLS=<record.json>` to re-derive the record from
+ * an existing run's cells instead of re-measuring.
+ *
+ * MEASURES ONLY. Changes no constant, no profile, no production behaviour.
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import {
+  type ProbeCell,
+  buildRecommendation,
+  referenceLine,
+  renderTable,
+  runProbeGrid,
+} from "./fold-ceiling-probe.ts";
+
+/**
+ * The frozen `fold-cost` baseline. Read-only, never rewritten — manifest §7
+ * makes it byte-for-byte immutable. SIX of this grid's cells also exist there
+ * (bytes 256 / 512 / 2560 rows at 2048 B/doc, rows 2048 / 8192 / 16384 at
+ * 64 B/doc), and comparing them is the only check that the fixture builder, the
+ * seed, and the measurement definitions still mean what they meant in June
+ * 2026. Don't hand-maintain this count against the grid: `overlapFindings`
+ * matches on axis + rows + bytes_per_doc and prints the number it actually
+ * compared.
+ */
+const FROZEN_BASELINE = "docs/spec/attachments/fold-cost-baseline.json";
+
+interface FrozenCell {
+  readonly axis: string;
+  readonly rows: number;
+  readonly bytes_per_doc: number;
+  readonly snapshot_bytes: number;
+  readonly cpu_ms_median: number;
+  readonly peak_bytes_median: number;
+}
+
+/** Range of a ratio series, e.g. `1.42x-2.49x`. */
+const span = (xs: readonly number[]): string =>
+  `${Math.min(...xs).toFixed(2)}x-${Math.max(...xs).toFixed(2)}x`;
+
+/**
+ * Narrow a parsed JSON document to its `cells` array, THROWING when it is
+ * absent rather than asserting the shape and letting `undefined` through.
+ *
+ * A bare `parsed as { cells: T[] }` succeeds on any valid JSON, so a file
+ * without `cells` yields `undefined` typed as an array and defers the failure
+ * to the first `.find` / `.length` — as an uncaught `TypeError`, at a call site
+ * chosen by luck rather than by the caller. Both readers below want a decision
+ * at the read, and they want DIFFERENT decisions: see each call site.
+ */
+const cellsOf = <T>(parsed: unknown, source: string): readonly T[] => {
+  const cells = (parsed as { cells?: unknown } | null)?.cells;
+  if (!Array.isArray(cells)) {
+    throw new TypeError(`${source}: expected a "cells" array, got ${typeof cells}`);
+  }
+  return cells as readonly T[];
+};
+
+/**
+ * Overlap-cell divergence against the frozen baseline. Computed here rather
+ * than in the pure module because it reads a file the pure module must not.
+ *
+ * `snapshot_bytes` is seeded and MUST match exactly. `peak_bytes_median` is an
+ * allocation measurement and should track closely. `cpu_ms_median` is
+ * host-specific and is expected to differ — how much it differs is precisely
+ * what tells a reader how far to trust this run's CPU-bound verdicts.
+ */
+const overlapFindings = async (cells: readonly ProbeCell[]): Promise<readonly string[]> => {
+  // Degrade to a SKIP finding, never throw: this runs AFTER the multi-minute
+  // sweep and BEFORE the result file is written, so anything that escapes here
+  // discards every measured cell. The shape check belongs inside the try for
+  // exactly that reason — a baseline that parses but carries no `cells` is a
+  // skippable overlap check, not a lost run.
+  let frozen: readonly FrozenCell[];
+  try {
+    const parsed: unknown = JSON.parse(await readFile(FROZEN_BASELINE, "utf8"));
+    frozen = cellsOf<FrozenCell>(parsed, FROZEN_BASELINE);
+  } catch (error: unknown) {
+    return [`overlap check SKIPPED: could not read ${FROZEN_BASELINE} (${String(error)}).`];
+  }
+
+  const mismatched: string[] = [];
+  const cpuRatios: number[] = [];
+  const peakRatios: number[] = [];
+  let compared = 0;
+  for (const cell of cells) {
+    const peer = frozen.find(
+      (f) => f.axis === cell.axis && f.rows === cell.rows && f.bytes_per_doc === cell.bytes_per_doc,
+    );
+    if (peer === undefined) {
+      continue;
+    }
+    compared += 1;
+    if (peer.snapshot_bytes !== cell.snapshot_bytes) {
+      mismatched.push(
+        `${cell.axis}/${cell.label} ${cell.snapshot_bytes} != ${peer.snapshot_bytes}`,
+      );
+    }
+    cpuRatios.push(cell.cpu_ms_median / peer.cpu_ms_median);
+    peakRatios.push(cell.peak_bytes_median / peer.peak_bytes_median);
+  }
+
+  if (compared === 0) {
+    return ["overlap check SKIPPED: no cell in this grid also exists in the frozen baseline."];
+  }
+  const bytesVerdict =
+    mismatched.length === 0
+      ? "snapshot_bytes matches the frozen baseline EXACTLY on all of them (same seed, same builder)"
+      : `snapshot_bytes DIVERGES on ${mismatched.length} cell(s): ${mismatched.join("; ")} — treat this whole run as suspect`;
+  // DERIVED, never transcribed — same rule the probe module states for its own
+  // findings. A literal "THIS HOST IS SLOWER" here would invert the portability
+  // caveat the moment the probe is re-run on faster hardware, in the one string
+  // that tells a reader how far to trust the CPU rows.
+  const slowest = Math.max(...cpuRatios);
+  const fastest = Math.min(...cpuRatios);
+  let direction: string;
+  if (fastest > 1) {
+    direction =
+      "THIS HOST IS SLOWER than the host that produced the baseline, so CPU-bound verdicts " +
+      "(the cf-free rows) are conservative on this hardware";
+  } else if (slowest < 1) {
+    direction =
+      "THIS HOST IS FASTER than the host that produced the baseline, so CPU-bound verdicts " +
+      "(the cf-free rows) are OPTIMISTIC on this hardware and must not be published as-is";
+  } else {
+    direction =
+      "this host straddles the baseline (some cells faster, some slower), so the CPU-bound " +
+      "verdicts (the cf-free rows) are not comparable cell-for-cell";
+  }
+  return [
+    `overlap vs the frozen fold-cost baseline (${compared} shared cells): ${bytesVerdict}. ` +
+      `peak_bytes_median ${span(peakRatios)} of frozen — allocation behaviour is unchanged. ` +
+      `cpu_ms_median ${span(cpuRatios)} of frozen, so ${direction}. CPU-bound verdicts are NOT ` +
+      `portable; the memory-bound verdicts (cf-paid) are.`,
+  ];
+};
+
+const main = async (): Promise<number> => {
+  // Re-derive the record from an existing run's cells instead of re-measuring.
+  // The cells ARE the measurement; everything else in the record is a pure
+  // function of them, so this reproduces a record exactly without spending
+  // another multi-minute sweep on a possibly-contended machine.
+  const reuse = process.env["BAERLY_FOLD_CEILING_CELLS"];
+  let cells: readonly ProbeCell[];
+  if (reuse === undefined || reuse === "") {
+    // Progress as each cell lands, so a multi-minute run is not a blank screen.
+    cells = await runProbeGrid((cell) => {
+      console.error(
+        `  ${cell.axis}/${cell.label}: ${cell.cpu_ms_median.toFixed(3)} ms, ` +
+          `${(cell.peak_bytes_median / (1024 * 1024)).toFixed(2)} MB peak ` +
+          `(${cell.iterations} iters)`,
+      );
+    });
+  } else {
+    // Fail FAST here, the opposite of the frozen-baseline read above: this is
+    // an operator-supplied path, it is read before any measurement runs, and a
+    // malformed file has nothing to lose by throwing. Feeding an unvalidated
+    // shape into buildRecommendation would instead produce a plausible-looking
+    // record derived from garbage.
+    const parsed: unknown = JSON.parse(await readFile(reuse, "utf8"));
+    cells = cellsOf<ProbeCell>(parsed, reuse);
+    console.error(`  re-deriving from ${cells.length} recorded cells in ${reuse} (no measurement)`);
+  }
+
+  // snake_case on purpose — it matches the serialized record shape.
+  const subject_commit = process.env["BAERLY_SUBJECT_COMMIT"] ?? "unknown";
+  const rec = buildRecommendation({
+    cells,
+    subject_commit,
+    extraFindings: await overlapFindings(cells),
+  });
+  console.log(renderTable(rec));
+  console.log("");
+  console.log(referenceLine());
+  console.log("");
+  console.log("findings");
+  for (const finding of rec.findings) {
+    console.log(`  - ${finding}`);
+  }
+
+  // One timestamped file per run, matching `bench/fold-cost.ts` and
+  // `bench/lsn-reverse-walk.ts`. A fixed `latest.json` would clobber the
+  // previous sweep — and comparing consecutive runs is how you tell a clean
+  // measurement from one taken on a contended machine, which is the failure
+  // mode this probe is most exposed to.
+  const outDir = "bench/results/fold-ceiling";
+  await mkdir(outDir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const out = `${outDir}/fold-ceiling-${stamp}.json`;
+  await writeFile(out, JSON.stringify(rec, null, 2));
+  console.log(`\nwrote ${out}`);
+  return 0;
+};
+
+process.exitCode = await main();

--- a/bench/measurement/fold-ceiling-probe-run.ts
+++ b/bench/measurement/fold-ceiling-probe-run.ts
@@ -23,8 +23,11 @@
  */
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import {
+  type FrozenBaselineCell,
   type ProbeCell,
   buildRecommendation,
+  cellsOf,
+  compareToFrozen,
   referenceLine,
   renderTable,
   runProbeGrid,
@@ -36,120 +39,32 @@ import {
  * (bytes 256 / 512 / 2560 rows at 2048 B/doc, rows 2048 / 8192 / 16384 at
  * 64 B/doc), and comparing them is the only check that the fixture builder, the
  * seed, and the measurement definitions still mean what they meant in June
- * 2026. Don't hand-maintain this count against the grid: `overlapFindings`
+ * 2026. Don't hand-maintain this count against the grid: {@link compareToFrozen}
  * matches on axis + rows + bytes_per_doc and prints the number it actually
  * compared.
  */
 const FROZEN_BASELINE = "docs/spec/attachments/fold-cost-baseline.json";
 
-interface FrozenCell {
-  readonly axis: string;
-  readonly rows: number;
-  readonly bytes_per_doc: number;
-  readonly snapshot_bytes: number;
-  readonly cpu_ms_median: number;
-  readonly peak_bytes_median: number;
-}
-
-/** Range of a ratio series, e.g. `1.42x-2.49x`. */
-const span = (xs: readonly number[]): string =>
-  `${Math.min(...xs).toFixed(2)}x-${Math.max(...xs).toFixed(2)}x`;
-
 /**
- * Narrow a parsed JSON document to its `cells` array, THROWING when it is
- * absent rather than asserting the shape and letting `undefined` through.
+ * Read the frozen baseline and hand it to {@link compareToFrozen}. The read is
+ * all that lives here; the derivation is pure and unit-tested next door.
  *
- * A bare `parsed as { cells: T[] }` succeeds on any valid JSON, so a file
- * without `cells` yields `undefined` typed as an array and defers the failure
- * to the first `.find` / `.length` — as an uncaught `TypeError`, at a call site
- * chosen by luck rather than by the caller. Both readers below want a decision
- * at the read, and they want DIFFERENT decisions: see each call site.
- */
-const cellsOf = <T>(parsed: unknown, source: string): readonly T[] => {
-  const cells = (parsed as { cells?: unknown } | null)?.cells;
-  if (!Array.isArray(cells)) {
-    throw new TypeError(`${source}: expected a "cells" array, got ${typeof cells}`);
-  }
-  return cells as readonly T[];
-};
-
-/**
- * Overlap-cell divergence against the frozen baseline. Computed here rather
- * than in the pure module because it reads a file the pure module must not.
- *
- * `snapshot_bytes` is seeded and MUST match exactly. `peak_bytes_median` is an
- * allocation measurement and should track closely. `cpu_ms_median` is
- * host-specific and is expected to differ — how much it differs is precisely
- * what tells a reader how far to trust this run's CPU-bound verdicts.
+ * Degrades to a SKIP finding, never throws: this runs AFTER the multi-minute
+ * sweep and BEFORE the result file is written, so anything that escapes here
+ * discards every measured cell. The shape check belongs inside the try for
+ * exactly that reason — a baseline that parses but carries no `cells` is a
+ * skippable overlap check, not a lost run. The reuse path in `main` wants the
+ * opposite decision from the same helper; see there.
  */
 const overlapFindings = async (cells: readonly ProbeCell[]): Promise<readonly string[]> => {
-  // Degrade to a SKIP finding, never throw: this runs AFTER the multi-minute
-  // sweep and BEFORE the result file is written, so anything that escapes here
-  // discards every measured cell. The shape check belongs inside the try for
-  // exactly that reason — a baseline that parses but carries no `cells` is a
-  // skippable overlap check, not a lost run.
-  let frozen: readonly FrozenCell[];
+  let frozen: readonly FrozenBaselineCell[];
   try {
     const parsed: unknown = JSON.parse(await readFile(FROZEN_BASELINE, "utf8"));
-    frozen = cellsOf<FrozenCell>(parsed, FROZEN_BASELINE);
+    frozen = cellsOf<FrozenBaselineCell>(parsed, FROZEN_BASELINE);
   } catch (error: unknown) {
     return [`overlap check SKIPPED: could not read ${FROZEN_BASELINE} (${String(error)}).`];
   }
-
-  const mismatched: string[] = [];
-  const cpuRatios: number[] = [];
-  const peakRatios: number[] = [];
-  let compared = 0;
-  for (const cell of cells) {
-    const peer = frozen.find(
-      (f) => f.axis === cell.axis && f.rows === cell.rows && f.bytes_per_doc === cell.bytes_per_doc,
-    );
-    if (peer === undefined) {
-      continue;
-    }
-    compared += 1;
-    if (peer.snapshot_bytes !== cell.snapshot_bytes) {
-      mismatched.push(
-        `${cell.axis}/${cell.label} ${cell.snapshot_bytes} != ${peer.snapshot_bytes}`,
-      );
-    }
-    cpuRatios.push(cell.cpu_ms_median / peer.cpu_ms_median);
-    peakRatios.push(cell.peak_bytes_median / peer.peak_bytes_median);
-  }
-
-  if (compared === 0) {
-    return ["overlap check SKIPPED: no cell in this grid also exists in the frozen baseline."];
-  }
-  const bytesVerdict =
-    mismatched.length === 0
-      ? "snapshot_bytes matches the frozen baseline EXACTLY on all of them (same seed, same builder)"
-      : `snapshot_bytes DIVERGES on ${mismatched.length} cell(s): ${mismatched.join("; ")} — treat this whole run as suspect`;
-  // DERIVED, never transcribed — same rule the probe module states for its own
-  // findings. A literal "THIS HOST IS SLOWER" here would invert the portability
-  // caveat the moment the probe is re-run on faster hardware, in the one string
-  // that tells a reader how far to trust the CPU rows.
-  const slowest = Math.max(...cpuRatios);
-  const fastest = Math.min(...cpuRatios);
-  let direction: string;
-  if (fastest > 1) {
-    direction =
-      "THIS HOST IS SLOWER than the host that produced the baseline, so CPU-bound verdicts " +
-      "(the cf-free rows) are conservative on this hardware";
-  } else if (slowest < 1) {
-    direction =
-      "THIS HOST IS FASTER than the host that produced the baseline, so CPU-bound verdicts " +
-      "(the cf-free rows) are OPTIMISTIC on this hardware and must not be published as-is";
-  } else {
-    direction =
-      "this host straddles the baseline (some cells faster, some slower), so the CPU-bound " +
-      "verdicts (the cf-free rows) are not comparable cell-for-cell";
-  }
-  return [
-    `overlap vs the frozen fold-cost baseline (${compared} shared cells): ${bytesVerdict}. ` +
-      `peak_bytes_median ${span(peakRatios)} of frozen — allocation behaviour is unchanged. ` +
-      `cpu_ms_median ${span(cpuRatios)} of frozen, so ${direction}. CPU-bound verdicts are NOT ` +
-      `portable; the memory-bound verdicts (cf-paid) are.`,
-  ];
+  return compareToFrozen(cells, frozen);
 };
 
 const main = async (): Promise<number> => {
@@ -171,9 +86,14 @@ const main = async (): Promise<number> => {
   } else {
     // Fail FAST here, the opposite of the frozen-baseline read above: this is
     // an operator-supplied path, it is read before any measurement runs, and a
-    // malformed file has nothing to lose by throwing. Feeding an unvalidated
-    // shape into buildRecommendation would instead produce a plausible-looking
-    // record derived from garbage.
+    // malformed file has nothing to lose by throwing.
+    //
+    // The check is array-shaped only. It separates "wrong file" from "our
+    // file"; it does NOT catch a bad cell inside our file — an element missing
+    // `cpu_ms_median` still propagates NaN through the margin math into the
+    // record. That is deliberate: a per-field schema here would be validating
+    // this probe's own serializer against itself, and the operator staring at
+    // the NaN is the one who produced the file a minute earlier.
     const parsed: unknown = JSON.parse(await readFile(reuse, "utf8"));
     cells = cellsOf<ProbeCell>(parsed, reuse);
     console.error(`  re-deriving from ${cells.length} recorded cells in ${reuse} (no measurement)`);

--- a/bench/measurement/fold-ceiling-probe.test.ts
+++ b/bench/measurement/fold-ceiling-probe.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, test } from "vitest";
+import {
+  HOST_BUDGETS,
+  type HostBudget,
+  type ProbeCell,
+  REPORTED_MARGINS,
+  buildRecommendation,
+  deriveFindings,
+  isPeakSampleUsable,
+  largestSustainable,
+  renderTable,
+  todayHeadroom,
+} from "./fold-ceiling-probe.ts";
+
+const cell = (over: Partial<ProbeCell> & Pick<ProbeCell, "axis" | "rows">): ProbeCell => ({
+  label: `${over.rows}`,
+  bytes_per_doc: 2048,
+  snapshot_bytes: over.rows * 2048,
+  tail_entries: 100,
+  iterations: 11,
+  cpu_ms_median: 1,
+  peak_bytes_median: 1_000_000,
+  peak_over_snapshot: 1,
+  peak_samples_discarded: 0,
+  ...over,
+});
+
+const budget = (over: Partial<HostBudget> = {}): HostBudget => ({
+  profile: "cf-free",
+  cpu_ms: 10,
+  memory_bytes: 128 * 1024 * 1024,
+  source: "test",
+  ...over,
+});
+
+/**
+ * `todayHeadroom` requires BOTH axes, so any fixture that reaches
+ * `buildRecommendation` must carry a rows cell as well as a bytes cell.
+ */
+const bothAxes: readonly ProbeCell[] = [
+  cell({ axis: "bytes", rows: 256, snapshot_bytes: 532_300 }),
+  cell({ axis: "rows", rows: 2048, bytes_per_doc: 64, snapshot_bytes: 232_287 }),
+];
+
+describe("largestSustainable", () => {
+  test("picks the largest cell that fits CPU at the given margin", () => {
+    const cells = [
+      cell({ axis: "bytes", rows: 256, cpu_ms_median: 1 }),
+      cell({ axis: "bytes", rows: 512, cpu_ms_median: 2 }),
+      cell({ axis: "bytes", rows: 1024, cpu_ms_median: 6 }),
+    ];
+    // margin 2 → need cpu*2 <= 10 → 1,2 fit (2,4); 6 does not (12).
+    const verdict = largestSustainable({ cells, budget: budget(), margin: 2 });
+    expect(verdict.max_c_bytes).toBe(512 * 2048);
+    expect(verdict.binding_axis).toBe("cpu");
+  });
+
+  test("memory can bind before CPU", () => {
+    const cells = [
+      cell({ axis: "bytes", rows: 256, cpu_ms_median: 0.1, peak_bytes_median: 10_000_000 }),
+      cell({ axis: "bytes", rows: 512, cpu_ms_median: 0.2, peak_bytes_median: 90_000_000 }),
+    ];
+    const verdict = largestSustainable({
+      cells,
+      budget: budget({ profile: "cf-paid", cpu_ms: 30_000 }),
+      margin: 2,
+    });
+    expect(verdict.max_c_bytes).toBe(256 * 2048);
+    expect(verdict.binding_axis).toBe("memory");
+  });
+
+  test("reports grid-exhausted when even the largest measured cell fits", () => {
+    const cells = [cell({ axis: "bytes", rows: 256, cpu_ms_median: 0.1 })];
+    const verdict = largestSustainable({
+      cells,
+      budget: budget({ profile: "cf-paid", cpu_ms: 30_000 }),
+      margin: 2,
+    });
+    expect(verdict.binding_axis).toBe("grid-exhausted");
+  });
+
+  test("reports none when not even the smallest cell fits", () => {
+    const cells = [cell({ axis: "bytes", rows: 256, cpu_ms_median: 100 })];
+    const verdict = largestSustainable({ cells, budget: budget(), margin: 2 });
+    expect(verdict.max_c_bytes).toBeNull();
+    expect(verdict.binding_axis).toBe("none");
+  });
+
+  test("the rows axis is read from rows-axis and cross cells, never bytes-axis", () => {
+    const cells = [
+      cell({ axis: "bytes", rows: 100_000, cpu_ms_median: 0.1 }),
+      cell({ axis: "rows", rows: 4096, bytes_per_doc: 64, cpu_ms_median: 0.1 }),
+      cell({ axis: "cross", rows: 8192, bytes_per_doc: 512, cpu_ms_median: 0.1 }),
+    ];
+    const verdict = largestSustainable({
+      cells,
+      budget: budget({ profile: "cf-paid", cpu_ms: 30_000 }),
+      margin: 2,
+    });
+    expect(verdict.max_e_rows).toBe(8192);
+    expect(verdict.max_c_bytes).toBe(100_000 * 2048);
+  });
+
+  test("expresses the verdict as a multiple of today's shipped ceilings", () => {
+    const cells = [cell({ axis: "rows", rows: 8192, bytes_per_doc: 64, cpu_ms_median: 0.1 })];
+    const verdict = largestSustainable({
+      cells,
+      budget: budget({ profile: "cf-paid", cpu_ms: 30_000 }),
+      margin: 2,
+    });
+    expect(verdict.e_multiple_of_today).toBe(4); // 8192 / 2048
+  });
+});
+
+describe("todayHeadroom", () => {
+  test("reports the measured margin at today's C and E", () => {
+    const cells = [
+      // C today = 512 KiB. Nearest bytes-axis cell at or below it.
+      cell({ axis: "bytes", rows: 256, snapshot_bytes: 532_300, cpu_ms_median: 1.43 }),
+      // E today = 2048 rows.
+      cell({
+        axis: "rows",
+        rows: 2048,
+        bytes_per_doc: 64,
+        snapshot_bytes: 232_287,
+        cpu_ms_median: 1.38,
+      }),
+    ];
+    const head = todayHeadroom({ cells, budget: budget() });
+    expect(head.at_c_cpu_ms).toBe(1.43);
+    expect(head.at_e_cpu_ms).toBe(1.38);
+    expect(head.cpu_margin_at_c).toBeCloseTo(10 / 1.43, 5);
+  });
+
+  test("throws rather than guessing when an axis is missing entirely", () => {
+    expect(() =>
+      todayHeadroom({ cells: [cell({ axis: "bytes", rows: 256 })], budget: budget() }),
+    ).toThrow(/both the bytes and rows axes/);
+  });
+});
+
+describe("isPeakSampleUsable", () => {
+  /**
+   * The first run of this grid reported a 0.03 MB peak for a 16.24 MB fold —
+   * `peakBytes` is `max(sample) - heapUsedAtStart`, so a `heapStart` captured at
+   * a pre-GC high-water mark floors the whole fold. That cell then passed the
+   * memory test and set `cf-paid maxC` outright. A peak below the snapshot size
+   * is physically impossible for a rebuild that must hold the snapshot resident.
+   */
+  test("rejects a peak below the snapshot size as GC-floored", () => {
+    expect(isPeakSampleUsable(30_000, 16_240_000)).toBe(false);
+  });
+
+  test("accepts a peak at or above the snapshot size", () => {
+    expect(isPeakSampleUsable(16_240_000, 16_240_000)).toBe(true);
+    expect(isPeakSampleUsable(35_000_000, 16_240_000)).toBe(true);
+  });
+});
+
+describe("deriveFindings", () => {
+  test("names a knee when cost per MB climbs, and quotes the bracketing cells", () => {
+    const cells = [
+      ...bothAxes,
+      cell({ axis: "bytes", rows: 1024, snapshot_bytes: 2 * 1024 * 1024, cpu_ms_median: 4 }),
+      cell({ axis: "bytes", rows: 2048, snapshot_bytes: 4 * 1024 * 1024, cpu_ms_median: 40 }),
+    ];
+    const knee = deriveFindings(cells).find((f) => f.startsWith("bytes axis:"));
+    expect(knee).toContain("knee is REAL");
+    expect(knee).toContain("4.00 MB");
+  });
+
+  test("says so plainly when there is no knee", () => {
+    const cells = [
+      ...bothAxes,
+      cell({ axis: "bytes", rows: 1024, snapshot_bytes: 2 * 1024 * 1024, cpu_ms_median: 2 }),
+      cell({ axis: "bytes", rows: 2048, snapshot_bytes: 4 * 1024 * 1024, cpu_ms_median: 4 }),
+    ];
+    expect(deriveFindings(cells).find((f) => f.startsWith("bytes axis:"))).toContain(
+      "no cost-per-MB knee",
+    );
+  });
+
+  test("marks a paid ceiling as a LOWER BOUND when the grid ran out first", () => {
+    const cheap = [
+      cell({ axis: "bytes", rows: 256, snapshot_bytes: 532_300, cpu_ms_median: 0.1 }),
+      cell({
+        axis: "rows",
+        rows: 2048,
+        bytes_per_doc: 64,
+        snapshot_bytes: 232_287,
+        cpu_ms_median: 0.1,
+      }),
+    ];
+    expect(
+      deriveFindings(cheap)
+        .filter((f) => f.includes("cf-paid @"))
+        .join("\n"),
+    ).toContain("LOWER BOUND (grid exhausted)");
+  });
+
+  test("compares every cross cell against its nearest bytes-axis peer", () => {
+    const cells = [
+      ...bothAxes,
+      cell({ axis: "bytes", rows: 2048, snapshot_bytes: 4 * 1024 * 1024, cpu_ms_median: 30 }),
+      cell({
+        axis: "cross",
+        label: "4k x 1KB",
+        rows: 4096,
+        bytes_per_doc: 1024,
+        snapshot_bytes: 4 * 1024 * 1024,
+        cpu_ms_median: 15,
+      }),
+    ];
+    const crossFinding = deriveFindings(cells).find((f) => f.startsWith("cross 4k x 1KB"));
+    expect(crossFinding).toContain("0.50x"); // 15 / 30
+  });
+
+  test("reports how many cells lost GC-floored peak samples", () => {
+    const cells = [...bothAxes, cell({ axis: "bytes", rows: 999, peak_samples_discarded: 4 })];
+    expect(deriveFindings(cells).find((f) => f.startsWith("peak-sample hygiene"))).toContain(
+      "worst cell dropped 4",
+    );
+  });
+
+  test("every finding lands in the record it describes", () => {
+    const rec = buildRecommendation({ cells: bothAxes, subject_commit: "deadbeef" });
+    expect(rec.findings).toEqual(deriveFindings(bothAxes));
+    expect(rec.findings.length).toBeGreaterThan(0);
+  });
+
+  test("runner-supplied findings are appended, not substituted", () => {
+    const rec = buildRecommendation({
+      cells: bothAxes,
+      subject_commit: "deadbeef",
+      extraFindings: ["overlap check: ok"],
+    });
+    expect(rec.findings.at(-1)).toBe("overlap check: ok");
+    expect(rec.findings.length).toBe(deriveFindings(bothAxes).length + 1);
+  });
+});
+
+describe("contract shape", () => {
+  test("budgets cover all three profiles and cite a source", () => {
+    expect(HOST_BUDGETS.map((b) => b.profile)).toEqual(["cf-free", "cf-paid", "node"]);
+    for (const b of HOST_BUDGETS) {
+      expect(b.source.length).toBeGreaterThan(0);
+      expect(b.cpu_ms).toBeGreaterThan(0);
+      expect(b.memory_bytes).toBeGreaterThan(0);
+    }
+  });
+
+  test("more than one margin is reported, so no single choice is baked in", () => {
+    expect(REPORTED_MARGINS.length).toBeGreaterThan(1);
+  });
+
+  test("the recommendation names an owner and a blocker for every change", () => {
+    const rec = buildRecommendation({ cells: bothAxes, subject_commit: "deadbeef" });
+    expect(rec.recommended_changes.length).toBeGreaterThan(0);
+    for (const change of rec.recommended_changes) {
+      expect(change.file.length).toBeGreaterThan(0);
+      expect(change.owner.length).toBeGreaterThan(0);
+      expect(change).toHaveProperty("blocked_by");
+    }
+    expect(rec.sustainable.length).toBe(HOST_BUDGETS.length * REPORTED_MARGINS.length);
+  });
+
+  test("renderTable emits something for every profile", () => {
+    const rec = buildRecommendation({ cells: bothAxes, subject_commit: "deadbeef" });
+    const table = renderTable(rec);
+    for (const b of HOST_BUDGETS) {
+      expect(table).toContain(b.profile);
+    }
+  });
+});

--- a/bench/measurement/fold-ceiling-probe.test.ts
+++ b/bench/measurement/fold-ceiling-probe.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "vitest";
 import {
+  type FrozenBaselineCell,
   HOST_BUDGETS,
   type HostBudget,
   type ProbeCell,
   REPORTED_MARGINS,
   buildRecommendation,
+  cellsOf,
+  compareToFrozen,
   deriveFindings,
   isPeakSampleUsable,
   largestSustainable,
@@ -236,6 +239,110 @@ describe("deriveFindings", () => {
     });
     expect(rec.findings.at(-1)).toBe("overlap check: ok");
     expect(rec.findings.length).toBe(deriveFindings(bothAxes).length + 1);
+  });
+});
+
+describe("cellsOf", () => {
+  test("returns the cells array when the document carries one", () => {
+    expect(cellsOf<number>({ cells: [1, 2] }, "f.json")).toEqual([1, 2]);
+    expect(cellsOf<number>({ cells: [] }, "f.json")).toEqual([]);
+  });
+
+  test("throws rather than yielding undefined typed as an array", () => {
+    // The failure this exists to prevent: `parsed as { cells: T[] }` on each of
+    // these hands back `undefined` and defers the crash to the first `.find`.
+    for (const bad of [{}, { cells: "nope" }, { cells: { 0: 1 } }, null, 7]) {
+      expect(() => cellsOf(bad, "f.json")).toThrow(TypeError);
+    }
+  });
+
+  test("names the source file so the operator knows which read failed", () => {
+    expect(() => cellsOf({}, "docs/spec/attachments/fold-cost-baseline.json")).toThrow(
+      /fold-cost-baseline\.json/,
+    );
+  });
+});
+
+describe("compareToFrozen", () => {
+  const frozen = (over: Partial<FrozenBaselineCell> = {}): FrozenBaselineCell => ({
+    axis: "bytes",
+    rows: 256,
+    bytes_per_doc: 2048,
+    snapshot_bytes: 532_300,
+    cpu_ms_median: 10,
+    peak_bytes_median: 1_000_000,
+    ...over,
+  });
+  const overlapping = (over: Partial<ProbeCell> = {}): ProbeCell =>
+    cell({ axis: "bytes", rows: 256, snapshot_bytes: 532_300, ...over });
+
+  test("skips when no cell in the grid also exists in the baseline", () => {
+    const [only] = compareToFrozen([overlapping({ rows: 999 })], [frozen()]);
+    expect(only).toMatch(/SKIPPED/);
+  });
+
+  test("matches on axis + rows + bytes_per_doc, and reports the count compared", () => {
+    const findings = compareToFrozen(
+      [overlapping(), overlapping({ rows: 512, snapshot_bytes: 1_048_576 })],
+      [frozen(), frozen({ rows: 512, snapshot_bytes: 1_048_576 })],
+    );
+    expect(findings[0]).toContain("(2 shared cells)");
+  });
+
+  test("a same-axis cell with a different bytes_per_doc is NOT a peer", () => {
+    const findings = compareToFrozen([overlapping({ bytes_per_doc: 64 })], [frozen()]);
+    expect(findings[0]).toMatch(/SKIPPED/);
+  });
+
+  test("calls the run suspect when a seeded snapshot_bytes diverges", () => {
+    const findings = compareToFrozen([overlapping({ snapshot_bytes: 999 })], [frozen()]);
+    expect(findings[0]).toContain("DIVERGES");
+    expect(findings[0]).toContain("suspect");
+  });
+
+  test("says SLOWER only when every overlap cell is slower than the baseline", () => {
+    // cpu ratios 1.5 and 2.0 — fastest > 1.
+    const findings = compareToFrozen(
+      [
+        overlapping({ cpu_ms_median: 15 }),
+        overlapping({ rows: 512, snapshot_bytes: 1_048_576, cpu_ms_median: 20 }),
+      ],
+      [frozen(), frozen({ rows: 512, snapshot_bytes: 1_048_576 })],
+    );
+    expect(findings[0]).toContain("THIS HOST IS SLOWER");
+    expect(findings[0]).toContain("conservative");
+  });
+
+  test("says FASTER — and refuses publication — only when every cell is faster", () => {
+    // cpu ratios 0.5 and 0.8 — slowest < 1.
+    const findings = compareToFrozen(
+      [
+        overlapping({ cpu_ms_median: 5 }),
+        overlapping({ rows: 512, snapshot_bytes: 1_048_576, cpu_ms_median: 8 }),
+      ],
+      [frozen(), frozen({ rows: 512, snapshot_bytes: 1_048_576 })],
+    );
+    expect(findings[0]).toContain("THIS HOST IS FASTER");
+    expect(findings[0]).toContain("must not be published as-is");
+  });
+
+  test("straddles when the cells disagree on direction", () => {
+    // cpu ratios 0.5 and 2.0 — neither bound holds.
+    const findings = compareToFrozen(
+      [
+        overlapping({ cpu_ms_median: 5 }),
+        overlapping({ rows: 512, snapshot_bytes: 1_048_576, cpu_ms_median: 20 }),
+      ],
+      [frozen(), frozen({ rows: 512, snapshot_bytes: 1_048_576 })],
+    );
+    expect(findings[0]).toContain("straddles");
+    expect(findings[0]).not.toContain("THIS HOST IS");
+  });
+
+  test("a cell exactly on the baseline straddles rather than claiming a direction", () => {
+    // The boundary the verdict turns on: ratio 1.0 is neither >1 nor <1.
+    const findings = compareToFrozen([overlapping({ cpu_ms_median: 10 })], [frozen()]);
+    expect(findings[0]).toContain("straddles");
   });
 });
 

--- a/bench/measurement/fold-ceiling-probe.ts
+++ b/bench/measurement/fold-ceiling-probe.ts
@@ -1,0 +1,644 @@
+/**
+ * Fold-ceiling headroom probe.
+ *
+ * ONE QUESTION: how much larger can `C` (snapshot bytes) and `E` (snapshot rows)
+ * be, per host profile, before one unsliceable fold stops fitting inside that
+ * host's CPU and memory budget?
+ *
+ * WHY IT EXISTS. `packages/server/src/maintenance.ts` gates a fold on
+ * `snapshotBytes <= C && snapshotRows + maxFoldEntriesPerPass <= E`. Crossing it
+ * defers compaction permanently: the tail grows without bound and the collection
+ * must graduate. All three shipped profiles use identical ceilings
+ * (`C = 512 KiB`, `E = 2048`), even though `docs/about/graduation.md` gives
+ * Cloudflare paid a 30 s CPU budget against Cloudflare free's ~10 ms.
+ * `MAINTENANCE_MAX_FOLD_ROWS`'s own JSDoc says `PROVISIONAL — bench landed; paid
+ * recalibration deferred`.
+ *
+ * RELATIONSHIP TO `bench/fold-cost.ts`. That bench established the METHOD (CPU
+ * via `process.cpuUsage()` deltas, peak heap via a 1 ms `heapUsed` sampler,
+ * median over N iterations after warmup) and a 12-cell grid tied to the
+ * `graduation.md` table. This probe REUSES its fixture builder and sampler
+ * verbatim — literally the same `bench/lib/fold-fixture.ts` module, so same seed,
+ * same tail length, same measurement definitions, and the two are directly
+ * comparable — and extends the grid where the decision needs resolution. That
+ * bench's checked-in baseline is FROZEN and is never rewritten; this probe writes
+ * a separate attachment.
+ *
+ * WHAT IS NEW IN THE GRID, and why:
+ *   - **bytes axis, 2/3/4 MB** — the frozen baseline jumps 1 MB (2.59 ms) to
+ *     5 MB (45.0 ms). That is superlinear with nothing in between, and the shape
+ *     of that knee decides how far `C` can move.
+ *   - **bytes axis, 8/16/32 MB** — Cloudflare paid's wall is ~128 MB of Worker
+ *     memory, not CPU. At the frozen baseline's ~2.4x peak-over-snapshot ratio a
+ *     32 MB snapshot lands near 77 MB peak, which is where the paid answer
+ *     actually is. Nothing above 5 MB has ever been measured.
+ *   - **rows axis, 32k/64k/128k** — the frozen baseline stops at 16384 rows
+ *     (10.28 ms), just past the CF-free line. Where per-entry cost walls on PAID
+ *     is unmeasured. NOTE: at 64 B/doc, 128k rows is an ~8 MB snapshot, so byte
+ *     cost contaminates the top of this axis; the cross axis is what
+ *     disambiguates.
+ *   - **cross axis (NEW)** — the real predicate is a CONJUNCTION over both axes,
+ *     but the frozen baseline measures each axis with the other held
+ *     deliberately unloaded (2048 B/doc on bytes, 64 B/doc on rows). A workload
+ *     with many medium documents loads both. These cells are the only ones that
+ *     resemble the predicate the runtime actually evaluates.
+ *
+ * ITERATION SCALING. Big cells are slow (a 32 MB fold, warmed and measured 16
+ * times, is minutes). Cells at or above `LARGE_CELL_BYTES` drop to
+ * `LARGE_WARMUP_ITERS` / `LARGE_MEASURE_ITERS`. Per-cell `iterations` is recorded
+ * so a reader can see which cells are noisier.
+ *
+ * MARGINS, NOT A VERDICT. Today's `C` sits at a wide margin under the CF-free CPU
+ * line. Picking a new margin is a human risk decision, not a measurement, so the
+ * table is reported at 2x, 4x, and 7x and the recommendation record names an
+ * owner rather than choosing.
+ *
+ * MEASURES ONLY. Changes no constant, no profile, no production behaviour.
+ *
+ * This module has NO module-scope side effects — the test imports it. The
+ * runnable entrypoint is `bench/measurement/fold-ceiling-probe-run.ts`.
+ */
+import {
+  CF_FREE_MAX_SAFE_FOLD_BYTES,
+  MAINTENANCE_MAX_FOLD_BYTES_DEFAULT,
+  MAINTENANCE_MAX_FOLD_ROWS,
+  NODE_MAINTENANCE_FOLD_ENTRIES_PER_PASS,
+  WRITE_TICK_FOLD_ENTRIES_PER_PASS,
+} from "@baerly/protocol";
+import { TAIL_ENTRIES, buildFixture, measureOneFold, median } from "../lib/fold-fixture.ts";
+
+export const FOLD_CEILING_PROBE_VERSION = "baerly.fold-ceiling-probe/v1" as const;
+
+export interface HostBudget {
+  readonly profile: "cf-free" | "cf-paid" | "node";
+  /** Per-invocation CPU budget in ms. */
+  readonly cpu_ms: number;
+  /** Per-isolate memory budget in bytes. */
+  readonly memory_bytes: number;
+  /** Where the number comes from, so a reader can re-derive it. */
+  readonly source: string;
+}
+
+/**
+ * From `docs/about/graduation.md`. Node has no platform-imposed CPU or memory
+ * limit, so its row is a STATED ASSUMPTION about a modest container, not a
+ * platform fact — flagged as such in `source` so nobody quotes it as one.
+ */
+export const HOST_BUDGETS: readonly HostBudget[] = [
+  {
+    profile: "cf-free",
+    cpu_ms: 10,
+    memory_bytes: 128 * 1024 * 1024,
+    source: "graduation.md — ~10 ms CPU/request, 128 MB isolate",
+  },
+  {
+    profile: "cf-paid",
+    cpu_ms: 30_000,
+    memory_bytes: 128 * 1024 * 1024,
+    source: "graduation.md — 30 s CPU default, ~128 MB Worker memory (memory is the wall)",
+  },
+  {
+    profile: "node",
+    cpu_ms: 30_000,
+    memory_bytes: 512 * 1024 * 1024,
+    source: "ASSUMPTION, not a platform limit: a modest 512 MB container, 30 s request budget",
+  },
+];
+
+/** 7x is today's de facto margin at `C`; 2x and 4x bracket a loosening. */
+export const REPORTED_MARGINS: readonly number[] = [2, 4, 7];
+
+const BYTES_PER_DOC = 2048;
+const ROWS_AXIS_BYTES_PER_DOC = 64;
+
+const WARMUP_ITERS = 5;
+const MEASURE_ITERS = 11;
+const LARGE_CELL_BYTES = 8 * 1024 * 1024;
+const LARGE_WARMUP_ITERS = 2;
+/**
+ * 9, not 5. Large cells are the ones that lose peak samples to the GC floor
+ * (see {@link isPeakSampleUsable}), and a 5-sample median can be carried by
+ * floored samples outright — which is how the first run of this grid reported a
+ * 0.03 MB peak for a 16 MB fold. 9 leaves a usable median after several discards.
+ */
+const LARGE_MEASURE_ITERS = 9;
+
+/** Byte axis: extends the frozen grid through the 1-5 MB knee and up to the paid memory wall. */
+const BYTES_AXIS_TARGETS: ReadonlyArray<{ label: string; bytes: number }> = [
+  { label: "512KB", bytes: 512 * 1024 }, // = C today; overlap cell, cross-checks the frozen baseline
+  { label: "1MB", bytes: 1024 * 1024 }, // = CF_FREE_MAX_SAFE_FOLD_BYTES warn threshold; also an overlap cell
+  { label: "2MB", bytes: 2 * 1024 * 1024 }, // NEW — knee
+  { label: "3MB", bytes: 3 * 1024 * 1024 }, // NEW — knee
+  { label: "4MB", bytes: 4 * 1024 * 1024 }, // NEW — knee
+  { label: "5MB", bytes: 5 * 1024 * 1024 }, // overlap cell with the frozen baseline
+  { label: "8MB", bytes: 8 * 1024 * 1024 }, // NEW
+  { label: "16MB", bytes: 16 * 1024 * 1024 }, // NEW
+  { label: "32MB", bytes: 32 * 1024 * 1024 }, // NEW — near the ~128 MB paid memory wall
+];
+
+/** Rows axis: extends past the frozen grid's 16384 to find the paid per-entry wall. */
+const ROWS_AXIS_ROW_COUNTS: readonly number[] = [
+  MAINTENANCE_MAX_FOLD_ROWS, // 2048 — overlap cell
+  8192, // overlap cell
+  16_384, // overlap cell — the frozen grid's top
+  32_768, // NEW
+  65_536, // NEW
+  131_072, // NEW — ~8 MB at 64 B/doc; byte cost starts to contaminate
+];
+
+/**
+ * Cross axis: both axes loaded at once, which is what `foldViable` actually
+ * gates on. No cell here exists in the frozen baseline.
+ */
+const CROSS_AXIS_CELLS: ReadonlyArray<{ label: string; rows: number; bytesPerDoc: number }> = [
+  { label: "4k x 1KB", rows: 4096, bytesPerDoc: 1024 },
+  { label: "16k x 512B", rows: 16_384, bytesPerDoc: 512 },
+  { label: "65k x 256B", rows: 65_536, bytesPerDoc: 256 },
+];
+
+export interface ProbeCell {
+  readonly axis: "bytes" | "rows" | "cross";
+  readonly label: string;
+  readonly rows: number;
+  readonly bytes_per_doc: number;
+  readonly snapshot_bytes: number;
+  readonly tail_entries: number;
+  readonly iterations: number;
+  readonly cpu_ms_median: number;
+  readonly peak_bytes_median: number;
+  readonly peak_over_snapshot: number;
+  /**
+   * Peak samples discarded as GC-floored (see {@link isPeakSampleUsable}). A
+   * non-zero value means this cell's `peak_bytes_median` is a median over fewer
+   * than `iterations` samples and is correspondingly noisier.
+   */
+  readonly peak_samples_discarded: number;
+}
+
+/**
+ * A fold must hold at least one copy of the snapshot resident, so a sampled
+ * peak-heap delta BELOW the snapshot size is not a measurement — it is the
+ * GC artifact `bench/fold-cost.ts` documents: `peakBytes` is
+ * `max(sample) - heapUsedAtStart`, so a `heapStart` captured at a pre-GC
+ * high-water mark floors the whole fold to ~0.
+ *
+ * Observed on this grid: bytes/16MB reported a 0.03 MB peak against a 16.24 MB
+ * snapshot while its 8 MB and 32 MB neighbours both sat at ~2.1-2.4x. At 11
+ * iterations the median absorbs an occasional floored sample; at the large
+ * cells' lower iteration count it does not, and a floored median silently
+ * passes the memory test and inflates the reported ceiling.
+ *
+ * Discarding is deliberately conservative — only physically impossible samples
+ * go — and the count is recorded per cell rather than hidden. The measurement
+ * definition in `bench/lib/fold-fixture.ts` is untouched, so cells remain
+ * directly comparable to the frozen `fold-cost-baseline.json`.
+ */
+export const isPeakSampleUsable = (peakBytes: number, snapshotBytes: number): boolean =>
+  peakBytes >= snapshotBytes;
+
+export interface SustainableCeiling {
+  readonly profile: HostBudget["profile"];
+  readonly margin: number;
+  /** Largest measured snapshot_bytes whose cell fits cpu AND memory at margin. */
+  readonly max_c_bytes: number | null;
+  /** Largest measured row count whose cell fits cpu AND memory at margin. */
+  readonly max_e_rows: number | null;
+  readonly binding_axis: "cpu" | "memory" | "grid-exhausted" | "none";
+  /** max_c_bytes / MAINTENANCE_MAX_FOLD_BYTES_DEFAULT, or null. */
+  readonly c_multiple_of_today: number | null;
+  /** max_e_rows / MAINTENANCE_MAX_FOLD_ROWS, or null. */
+  readonly e_multiple_of_today: number | null;
+}
+
+const fits = (cell: ProbeCell, budget: HostBudget, margin: number): boolean =>
+  cell.cpu_ms_median * margin <= budget.cpu_ms &&
+  cell.peak_bytes_median * margin <= budget.memory_bytes;
+
+/**
+ * Which resource stopped us. Evaluated on the SMALLEST cell that did not fit —
+ * the first wall encountered walking up the grid, not the worst violation
+ * anywhere in it.
+ */
+const bindingFor = (cell: ProbeCell, budget: HostBudget, margin: number): "cpu" | "memory" =>
+  cell.cpu_ms_median * margin > budget.cpu_ms ? "cpu" : "memory";
+
+/**
+ * Pure. Given measured cells and one budget, the largest cell on each axis whose
+ * `cpu_ms_median * margin <= budget.cpu_ms` AND
+ * `peak_bytes_median * margin <= budget.memory_bytes`.
+ *
+ * `binding_axis` is `"grid-exhausted"` when the LARGEST measured cell still fits
+ * — the true ceiling is above the grid and the answer is a lower bound.
+ */
+export const largestSustainable = (input: {
+  readonly cells: readonly ProbeCell[];
+  readonly budget: HostBudget;
+  readonly margin: number;
+}): SustainableCeiling => {
+  const { budget, margin } = input;
+
+  // `C` is read from the bytes axis (rows deliberately unloaded); `E` from the
+  // rows and cross axes (bytes deliberately small, or both loaded). Reading `E`
+  // off a bytes-axis cell would credit a huge row count that was never
+  // per-entry-stressed.
+  const byBytes = input.cells.filter((c) => c.axis === "bytes");
+  const byRows = input.cells.filter((c) => c.axis === "rows" || c.axis === "cross");
+
+  const fittingBytes = byBytes.filter((c) => fits(c, budget, margin));
+  const fittingRows = byRows.filter((c) => fits(c, budget, margin));
+
+  const maxC =
+    fittingBytes.length === 0 ? null : Math.max(...fittingBytes.map((c) => c.snapshot_bytes));
+  const maxE = fittingRows.length === 0 ? null : Math.max(...fittingRows.map((c) => c.rows));
+
+  const all = [...input.cells].toSorted((a, b) => a.snapshot_bytes - b.snapshot_bytes);
+  const firstMiss = all.find((c) => !fits(c, budget, margin));
+
+  let binding: SustainableCeiling["binding_axis"];
+  if (firstMiss === undefined) {
+    binding = "grid-exhausted";
+  } else if (maxC === null && maxE === null) {
+    binding = "none";
+  } else {
+    binding = bindingFor(firstMiss, budget, margin);
+  }
+
+  return {
+    profile: budget.profile,
+    margin,
+    max_c_bytes: maxC,
+    max_e_rows: maxE,
+    binding_axis: binding,
+    c_multiple_of_today: maxC === null ? null : maxC / MAINTENANCE_MAX_FOLD_BYTES_DEFAULT,
+    e_multiple_of_today: maxE === null ? null : maxE / MAINTENANCE_MAX_FOLD_ROWS,
+  };
+};
+
+/** Measured cost at today's shipped ceilings, per budget. */
+export interface TodayHeadroom {
+  readonly profile: HostBudget["profile"];
+  readonly at_c_cpu_ms: number;
+  readonly at_c_peak_bytes: number;
+  readonly at_e_cpu_ms: number;
+  readonly at_e_peak_bytes: number;
+  readonly cpu_margin_at_c: number;
+  readonly cpu_margin_at_e: number;
+  readonly memory_margin_at_c: number;
+  readonly memory_margin_at_e: number;
+}
+
+/** The largest cell on `axis` at or below `limit`, or the smallest if none is. */
+const nearestAtOrBelow = (
+  cells: readonly ProbeCell[],
+  axis: ProbeCell["axis"],
+  key: (c: ProbeCell) => number,
+  limit: number,
+): ProbeCell | undefined => {
+  const on = cells.filter((c) => c.axis === axis).toSorted((a, b) => key(a) - key(b));
+  const under = on.filter((c) => key(c) <= limit);
+  return under.length > 0 ? under[under.length - 1] : on[0];
+};
+
+export const todayHeadroom = (input: {
+  readonly cells: readonly ProbeCell[];
+  readonly budget: HostBudget;
+}): TodayHeadroom => {
+  const atC = nearestAtOrBelow(
+    input.cells,
+    "bytes",
+    (c) => c.snapshot_bytes,
+    MAINTENANCE_MAX_FOLD_BYTES_DEFAULT,
+  );
+  const atE = nearestAtOrBelow(input.cells, "rows", (c) => c.rows, MAINTENANCE_MAX_FOLD_ROWS);
+  if (atC === undefined || atE === undefined) {
+    throw new Error("fold-ceiling-probe: cells must cover both the bytes and rows axes");
+  }
+  return {
+    profile: input.budget.profile,
+    at_c_cpu_ms: atC.cpu_ms_median,
+    at_c_peak_bytes: atC.peak_bytes_median,
+    at_e_cpu_ms: atE.cpu_ms_median,
+    at_e_peak_bytes: atE.peak_bytes_median,
+    cpu_margin_at_c: input.budget.cpu_ms / atC.cpu_ms_median,
+    cpu_margin_at_e: input.budget.cpu_ms / atE.cpu_ms_median,
+    memory_margin_at_c: input.budget.memory_bytes / atC.peak_bytes_median,
+    memory_margin_at_e: input.budget.memory_bytes / atE.peak_bytes_median,
+  };
+};
+
+export interface ProbeRecommendation {
+  readonly schema: typeof FOLD_CEILING_PROBE_VERSION;
+  readonly subject_commit: string;
+  readonly node_version: string;
+  readonly platform: string;
+  readonly arch: string;
+  readonly todays_ceilings: { readonly c_bytes: number; readonly e_rows: number };
+  readonly budgets: readonly HostBudget[];
+  readonly margins: readonly number[];
+  readonly cells: readonly ProbeCell[];
+  readonly today_headroom: readonly TodayHeadroom[];
+  readonly sustainable: readonly SustainableCeiling[];
+  /** Free-text findings the probe is confident enough to assert. */
+  readonly findings: readonly string[];
+  /** Changes this probe RECOMMENDS but does not make. Owner named per entry. */
+  readonly recommended_changes: readonly {
+    readonly file: string;
+    readonly change: string;
+    readonly owner: string;
+    readonly blocked_by: string | null;
+  }[];
+}
+
+const mb = (b: number): string => (b / (1024 * 1024)).toFixed(2);
+
+const msPerMb = (c: ProbeCell): number => c.cpu_ms_median / (c.snapshot_bytes / (1024 * 1024));
+
+/** Nearest cell on `axis` to `bytes`, by absolute snapshot-size distance. */
+const nearestBySize = (
+  cells: readonly ProbeCell[],
+  axis: ProbeCell["axis"],
+  bytes: number,
+): ProbeCell | undefined =>
+  cells
+    .filter((c) => c.axis === axis)
+    .toSorted((a, b) => Math.abs(a.snapshot_bytes - bytes) - Math.abs(b.snapshot_bytes - bytes))[0];
+
+/**
+ * Findings DERIVED from the cells in the same record, never hand-transcribed.
+ *
+ * The plan asks for findings that are "independently checkable against the
+ * `cells` array in the same record". Hard-coding numbers read off one run makes
+ * that false the moment the probe is re-run — the record would carry prose from
+ * one measurement and cells from another. Deriving them makes the two
+ * inseparable by construction.
+ */
+export const deriveFindings = (cells: readonly ProbeCell[]): readonly string[] => {
+  const findings: string[] = [];
+
+  // 1. Measured margin at today's shipped ceilings, per profile.
+  for (const budget of HOST_BUDGETS) {
+    const head = todayHeadroom({ cells, budget });
+    findings.push(
+      `${budget.profile}: at today's C the fold costs ${head.at_c_cpu_ms.toFixed(2)} ms and ` +
+        `${(head.at_c_peak_bytes / (1024 * 1024)).toFixed(2)} MB peak — ` +
+        `${head.cpu_margin_at_c.toFixed(1)}x CPU margin, ${head.memory_margin_at_c.toFixed(1)}x memory margin. ` +
+        `At today's E it costs ${head.at_e_cpu_ms.toFixed(2)} ms and ` +
+        `${(head.at_e_peak_bytes / (1024 * 1024)).toFixed(2)} MB peak — ` +
+        `${head.cpu_margin_at_e.toFixed(1)}x CPU, ${head.memory_margin_at_e.toFixed(1)}x memory.`,
+    );
+  }
+
+  // 2. Where the bytes-axis cost-per-MB knee starts.
+  const byBytes = cells
+    .filter((c) => c.axis === "bytes")
+    .toSorted((a, b) => a.snapshot_bytes - b.snapshot_bytes);
+  const knee = byBytes.find(
+    (c, i) => i > 0 && msPerMb(c) > 1.25 * Math.min(...byBytes.slice(0, i).map(msPerMb)),
+  );
+  if (knee === undefined) {
+    findings.push(
+      "bytes axis: no cost-per-MB knee in the measured range — CPU stays within 1.25x of its " +
+        "cheapest per-MB rate across the whole grid.",
+    );
+  } else {
+    const before = byBytes[byBytes.indexOf(knee) - 1];
+    findings.push(
+      `bytes axis: the cost-per-MB knee is REAL and starts between ` +
+        `${mb(before?.snapshot_bytes ?? 0)} MB (${msPerMb(before ?? knee).toFixed(2)} ms/MB) and ` +
+        `${mb(knee.snapshot_bytes)} MB (${msPerMb(knee).toFixed(2)} ms/MB). ` +
+        `Series, ms/MB: ${byBytes.map((c) => `${c.label}=${msPerMb(c).toFixed(1)}`).join(", ")}.`,
+    );
+  }
+
+  // 3. The paid ceiling, marked as a lower bound when the grid ran out first.
+  for (const margin of REPORTED_MARGINS) {
+    const paid = largestSustainable({
+      cells,
+      budget: HOST_BUDGETS.find((b) => b.profile === "cf-paid") ?? HOST_BUDGETS[0]!,
+      margin,
+    });
+    const bound = paid.binding_axis === "grid-exhausted" ? "LOWER BOUND (grid exhausted)" : "wall";
+    findings.push(
+      `cf-paid @${margin}x margin: C ${paid.max_c_bytes === null ? "-" : `${mb(paid.max_c_bytes)} MB`} ` +
+        `(${paid.c_multiple_of_today === null ? "-" : `${paid.c_multiple_of_today.toFixed(1)}x`} today), ` +
+        `E ${paid.max_e_rows ?? "-"} rows ` +
+        `(${paid.e_multiple_of_today === null ? "-" : `${paid.e_multiple_of_today.toFixed(1)}x`} today), ` +
+        `bound by ${paid.binding_axis} — ${bound}.`,
+    );
+  }
+
+  // 4. THE decisive one: does a two-way (C, E) ceiling describe the cost surface?
+  for (const cross of cells.filter((c) => c.axis === "cross")) {
+    const peer = nearestBySize(cells, "bytes", cross.snapshot_bytes);
+    if (peer === undefined) {
+      continue;
+    }
+    findings.push(
+      `cross ${cross.label} (${cross.rows} rows x ${cross.bytes_per_doc} B, ${mb(cross.snapshot_bytes)} MB) ` +
+        `vs the nearest bytes-axis cell ${peer.label} (${peer.rows} rows x ${peer.bytes_per_doc} B, ` +
+        `${mb(peer.snapshot_bytes)} MB): CPU ${cross.cpu_ms_median.toFixed(1)} ms vs ` +
+        `${peer.cpu_ms_median.toFixed(1)} ms (${(cross.cpu_ms_median / peer.cpu_ms_median).toFixed(2)}x), ` +
+        `peak ${mb(cross.peak_bytes_median)} MB vs ${mb(peer.peak_bytes_median)} MB ` +
+        `(${(cross.peak_bytes_median / peer.peak_bytes_median).toFixed(2)}x). ` +
+        `peak/snapshot ${cross.peak_over_snapshot.toFixed(2)} vs ${peer.peak_over_snapshot.toFixed(2)}.`,
+    );
+  }
+
+  // 5. Sample hygiene — how much of the grid needed GC-floored samples dropped.
+  const dropped = cells.filter((c) => c.peak_samples_discarded > 0);
+  findings.push(
+    `peak-sample hygiene: ${dropped.length} of ${cells.length} cells lost at least one ` +
+      `GC-floored peak sample (see isPeakSampleUsable); worst cell dropped ` +
+      `${Math.max(0, ...cells.map((c) => c.peak_samples_discarded))} of its samples. ` +
+      `CPU is unaffected — cpuUsage() deltas have no baseline to float.`,
+  );
+
+  return findings;
+};
+
+export const buildRecommendation = (input: {
+  readonly cells: readonly ProbeCell[];
+  readonly subject_commit: string;
+  /** Findings the RUNNER derives from inputs this pure module cannot read. */
+  readonly extraFindings?: readonly string[];
+}): ProbeRecommendation => {
+  const sustainable: SustainableCeiling[] = [];
+  for (const budget of HOST_BUDGETS) {
+    for (const margin of REPORTED_MARGINS) {
+      sustainable.push(largestSustainable({ cells: input.cells, budget, margin }));
+    }
+  }
+  return {
+    schema: FOLD_CEILING_PROBE_VERSION,
+    subject_commit: input.subject_commit,
+    node_version: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    todays_ceilings: {
+      c_bytes: MAINTENANCE_MAX_FOLD_BYTES_DEFAULT,
+      e_rows: MAINTENANCE_MAX_FOLD_ROWS,
+    },
+    budgets: HOST_BUDGETS,
+    margins: REPORTED_MARGINS,
+    cells: input.cells,
+    today_headroom: HOST_BUDGETS.map((budget) => todayHeadroom({ cells: input.cells, budget })),
+    sustainable,
+    findings: [...deriveFindings(input.cells), ...(input.extraFindings ?? [])],
+    // Every actionable output is a REQUEST with a named owner. This probe
+    // changes nothing; `constants.ts` is held by a locked live session and
+    // `maintenance.ts` belongs to the Protocol owner.
+    recommended_changes: [
+      {
+        file: "packages/protocol/src/constants.ts",
+        change:
+          "Give MAINTENANCE_PROFILE_CF_PAID and MAINTENANCE_PROFILE_NODE their own " +
+          "maxFoldBytes/maxFoldRows instead of sharing the CF-free values. See the " +
+          "`sustainable` table for the measured room at each margin.",
+        owner: "Protocol owner",
+        blocked_by:
+          "worktree-fix-issue-74-readpreimage-floor holds packages/protocol/src/constants.ts (locked live session)",
+      },
+      {
+        file: "packages/server/src/maintenance.ts",
+        change:
+          "`E` has no operator override: the profile read takes `args.maxFoldBytes ?? " +
+          "profile.maxFoldBytes` for C but plain `profile.maxFoldRows` for E. Add " +
+          "BAERLY_MAINTENANCE_MAX_FOLD_ROWS to mirror the C override. " +
+          "(Manifest §11 item 6.)",
+        owner: "Protocol owner",
+        blocked_by: null,
+      },
+      {
+        file: "docs/about/graduation.md",
+        change:
+          "The `≈ 11 ms CPU per MB` model and the `1 MB | ~11 ms` table row overstate " +
+          "measured cost. Restate against measurement, or mark the model as a " +
+          "deliberate upper bound and say so.",
+        owner: "Performance owner (graduation.md is a §6.2-owned product doc)",
+        blocked_by: null,
+      },
+    ],
+  };
+};
+
+export const renderTable = (rec: ProbeRecommendation): string => {
+  const lines: string[] = [];
+  lines.push("cells");
+  lines.push(
+    "axis   label        rows     snapMB   cpuMs(med)  peakMB(med)  peak/snap  iters  gcDrop",
+  );
+  for (const c of rec.cells) {
+    lines.push(
+      `${c.axis.padEnd(6)} ${c.label.padEnd(12)} ${String(c.rows).padStart(7)}  ` +
+        `${mb(c.snapshot_bytes).padStart(7)}  ${c.cpu_ms_median.toFixed(3).padStart(10)}  ` +
+        `${mb(c.peak_bytes_median).padStart(11)}  ${c.peak_over_snapshot.toFixed(2).padStart(9)}  ` +
+        `${String(c.iterations).padStart(5)}  ${String(c.peak_samples_discarded).padStart(6)}`,
+    );
+  }
+  lines.push("");
+  lines.push(
+    `today: C = ${mb(rec.todays_ceilings.c_bytes)} MB, E = ${rec.todays_ceilings.e_rows} rows`,
+  );
+  lines.push("profile   cpuMargin@C  cpuMargin@E  memMargin@C  memMargin@E");
+  for (const h of rec.today_headroom) {
+    lines.push(
+      `${h.profile.padEnd(9)} ${h.cpu_margin_at_c.toFixed(1).padStart(11)}  ` +
+        `${h.cpu_margin_at_e.toFixed(1).padStart(11)}  ` +
+        `${h.memory_margin_at_c.toFixed(1).padStart(11)}  ` +
+        `${h.memory_margin_at_e.toFixed(1).padStart(11)}`,
+    );
+  }
+  lines.push("");
+  lines.push("sustainable ceilings");
+  lines.push("profile   margin  maxC(MB)  xToday  maxE(rows)  xToday  binding");
+  for (const s of rec.sustainable) {
+    const maxC = s.max_c_bytes === null ? "-" : mb(s.max_c_bytes);
+    const xC = s.c_multiple_of_today === null ? "-" : `${s.c_multiple_of_today.toFixed(1)}x`;
+    const maxE = s.max_e_rows === null ? "-" : String(s.max_e_rows);
+    const xE = s.e_multiple_of_today === null ? "-" : `${s.e_multiple_of_today.toFixed(1)}x`;
+    lines.push(
+      `${s.profile.padEnd(9)} ${String(s.margin).padStart(6)}  ` +
+        `${maxC.padStart(8)}  ${xC.padStart(6)}  ` +
+        `${maxE.padStart(10)}  ${xE.padStart(6)}  ` +
+        s.binding_axis,
+    );
+  }
+  return lines.join("\n");
+};
+
+const runCell = async (
+  axis: ProbeCell["axis"],
+  label: string,
+  rows: number,
+  bytesPerDoc: number,
+): Promise<ProbeCell> => {
+  const probeBytes = rows * bytesPerDoc;
+  const warmup = probeBytes >= LARGE_CELL_BYTES ? LARGE_WARMUP_ITERS : WARMUP_ITERS;
+  const measure = probeBytes >= LARGE_CELL_BYTES ? LARGE_MEASURE_ITERS : MEASURE_ITERS;
+
+  for (let i = 0; i < warmup; i++) {
+    const fixture = await buildFixture(rows, bytesPerDoc);
+    await measureOneFold(fixture.storage);
+  }
+
+  const cpu: number[] = [];
+  const peak: number[] = [];
+  let snapshotBytes = 0;
+  for (let i = 0; i < measure; i++) {
+    const fixture = await buildFixture(rows, bytesPerDoc);
+    snapshotBytes = fixture.snapshotBytes;
+    const one = await measureOneFold(fixture.storage);
+    cpu.push(one.cpuMs);
+    peak.push(one.peakBytes);
+  }
+
+  // Drop GC-floored peaks before taking the median; a floored sample is not a
+  // small measurement, it is an absent one. CPU is unaffected — `cpuUsage()`
+  // deltas have no baseline to float.
+  const usablePeak = peak.filter((p) => isPeakSampleUsable(p, snapshotBytes));
+  const peakMedian = usablePeak.length > 0 ? median(usablePeak) : median(peak);
+  return {
+    axis,
+    label,
+    rows,
+    bytes_per_doc: bytesPerDoc,
+    snapshot_bytes: snapshotBytes,
+    tail_entries: TAIL_ENTRIES,
+    iterations: measure,
+    cpu_ms_median: median(cpu),
+    peak_bytes_median: peakMedian,
+    peak_over_snapshot: peakMedian / snapshotBytes,
+    peak_samples_discarded: peak.length - usablePeak.length,
+  };
+};
+
+/** Sweep the whole grid. Minutes — the 32 MB cell alone is 7 folds of 32 MB. */
+export const runProbeGrid = async (
+  onCell?: (cell: ProbeCell) => void,
+): Promise<readonly ProbeCell[]> => {
+  const cells: ProbeCell[] = [];
+  const push = (cell: ProbeCell): void => {
+    cells.push(cell);
+    onCell?.(cell);
+  };
+
+  for (const target of BYTES_AXIS_TARGETS) {
+    const rows = Math.max(1, Math.round(target.bytes / BYTES_PER_DOC));
+    push(await runCell("bytes", target.label, rows, BYTES_PER_DOC));
+  }
+  for (const rows of ROWS_AXIS_ROW_COUNTS) {
+    push(await runCell("rows", `${rows} rows`, rows, ROWS_AXIS_BYTES_PER_DOC));
+  }
+  for (const cross of CROSS_AXIS_CELLS) {
+    push(await runCell("cross", cross.label, cross.rows, cross.bytesPerDoc));
+  }
+  return cells;
+};
+
+/** One line of shipped-constant context, printed under the table by the runner. */
+export const referenceLine = (): string =>
+  `reference: C default ${mb(MAINTENANCE_MAX_FOLD_BYTES_DEFAULT)} MB, ` +
+  `CF-free warn threshold ${mb(CF_FREE_MAX_SAFE_FOLD_BYTES)} MB, ` +
+  `E ${MAINTENANCE_MAX_FOLD_ROWS} rows, fold slice ` +
+  `${WRITE_TICK_FOLD_ENTRIES_PER_PASS} (cf-free) / ` +
+  `${NODE_MAINTENANCE_FOLD_ENTRIES_PER_PASS} (node)`;

--- a/bench/measurement/fold-ceiling-probe.ts
+++ b/bench/measurement/fold-ceiling-probe.ts
@@ -456,6 +456,121 @@ export const deriveFindings = (cells: readonly ProbeCell[]): readonly string[] =
   return findings;
 };
 
+/**
+ * One cell of the frozen `fold-cost` baseline
+ * (`docs/spec/attachments/fold-cost-baseline.json`). Only the fields the
+ * overlap comparison reads are declared; the file carries more.
+ */
+export interface FrozenBaselineCell {
+  readonly axis: string;
+  readonly rows: number;
+  readonly bytes_per_doc: number;
+  readonly snapshot_bytes: number;
+  readonly cpu_ms_median: number;
+  readonly peak_bytes_median: number;
+}
+
+/**
+ * Narrow a parsed JSON document to its `cells` array, THROWING when it is
+ * absent rather than asserting the shape and letting `undefined` through.
+ *
+ * A bare `parsed as { cells: T[] }` succeeds on any valid JSON, so a file
+ * without `cells` yields `undefined` typed as an array and defers the failure
+ * to the first `.find` / `.length` — as an uncaught `TypeError`, at a call site
+ * chosen by luck rather than by the caller. Lives here rather than in the
+ * runner because the runner ends in a module-scope `await main()`: nothing can
+ * import it, so nothing there can be tested.
+ *
+ * Checks that `cells` is an array and NOT the shape of each element. Both
+ * callers read a file this probe itself wrote, so the array check is what
+ * separates "wrong file" from "our file"; a per-field schema would be
+ * validating our own serializer.
+ */
+export const cellsOf = <T>(parsed: unknown, source: string): readonly T[] => {
+  const cells = (parsed as { cells?: unknown } | null)?.cells;
+  if (!Array.isArray(cells)) {
+    throw new TypeError(`${source}: expected a "cells" array, got ${typeof cells}`);
+  }
+  return cells as readonly T[];
+};
+
+/** Range of a ratio series, e.g. `1.42x-2.49x`. */
+const span = (xs: readonly number[]): string =>
+  `${Math.min(...xs).toFixed(2)}x-${Math.max(...xs).toFixed(2)}x`;
+
+/**
+ * Overlap-cell divergence against the frozen `fold-cost` baseline. Comparing
+ * the shared cells is the only check that the fixture builder, the seed, and
+ * the measurement definitions still mean what they meant in June 2026.
+ *
+ * Pure, and here rather than in the runner, so it can be tested: the runner
+ * owns the file read and passes the parsed cells in.
+ *
+ * `snapshot_bytes` is seeded and MUST match exactly. `peak_bytes_median` is an
+ * allocation measurement and should track closely. `cpu_ms_median` is
+ * host-specific and is expected to differ — how much it differs is precisely
+ * what tells a reader how far to trust this run's CPU-bound verdicts.
+ */
+export const compareToFrozen = (
+  cells: readonly ProbeCell[],
+  frozen: readonly FrozenBaselineCell[],
+): readonly string[] => {
+  const mismatched: string[] = [];
+  const cpuRatios: number[] = [];
+  const peakRatios: number[] = [];
+  let compared = 0;
+  for (const cell of cells) {
+    const peer = frozen.find(
+      (f) => f.axis === cell.axis && f.rows === cell.rows && f.bytes_per_doc === cell.bytes_per_doc,
+    );
+    if (peer === undefined) {
+      continue;
+    }
+    compared += 1;
+    if (peer.snapshot_bytes !== cell.snapshot_bytes) {
+      mismatched.push(
+        `${cell.axis}/${cell.label} ${cell.snapshot_bytes} != ${peer.snapshot_bytes}`,
+      );
+    }
+    cpuRatios.push(cell.cpu_ms_median / peer.cpu_ms_median);
+    peakRatios.push(cell.peak_bytes_median / peer.peak_bytes_median);
+  }
+
+  if (compared === 0) {
+    return ["overlap check SKIPPED: no cell in this grid also exists in the frozen baseline."];
+  }
+  const bytesVerdict =
+    mismatched.length === 0
+      ? "snapshot_bytes matches the frozen baseline EXACTLY on all of them (same seed, same builder)"
+      : `snapshot_bytes DIVERGES on ${mismatched.length} cell(s): ${mismatched.join("; ")} — treat this whole run as suspect`;
+  // DERIVED, never transcribed — same rule this module states for its own
+  // findings. A literal "THIS HOST IS SLOWER" here would invert the portability
+  // caveat the moment the probe is re-run on faster hardware, in the one string
+  // that tells a reader how far to trust the CPU rows.
+  const slowest = Math.max(...cpuRatios);
+  const fastest = Math.min(...cpuRatios);
+  let direction: string;
+  if (fastest > 1) {
+    direction =
+      "THIS HOST IS SLOWER than the host that produced the baseline, so CPU-bound verdicts " +
+      "(the cf-free rows) are conservative on this hardware";
+  } else if (slowest < 1) {
+    direction =
+      "THIS HOST IS FASTER than the host that produced the baseline, so CPU-bound verdicts " +
+      "(the cf-free rows) are OPTIMISTIC on this hardware and must not be published as-is";
+  } else {
+    direction =
+      "this host straddles the baseline (some cells faster, some slower), so the CPU-bound " +
+      "verdicts (the cf-free rows) are not comparable cell-for-cell";
+  }
+  return [
+    `overlap vs the frozen fold-cost baseline (${compared} shared cells): ${bytesVerdict}. ` +
+      `peak_bytes_median ${span(peakRatios)} of frozen — allocation behaviour is unchanged. ` +
+      `cpu_ms_median ${span(cpuRatios)} of frozen, so ${direction}. CPU-bound verdicts are NOT ` +
+      `portable; the memory-bound verdicts (cf-paid) are.`,
+  ];
+};
+
 export const buildRecommendation = (input: {
   readonly cells: readonly ProbeCell[];
   readonly subject_commit: string;

--- a/package.json
+++ b/package.json
@@ -220,6 +220,7 @@
     "bench:load:matrix": "node --import ./bench/register-hooks.mjs bench/load-harness/matrix.ts",
     "bench:lsn-reverse-walk": "node --import ./bench/register-hooks.mjs bench/lsn-reverse-walk.ts",
     "bench:fold-cost": "node --import ./bench/register-hooks.mjs bench/fold-cost.ts",
+    "bench:fold-ceiling": "node --import ./bench/register-hooks.mjs bench/measurement/fold-ceiling-probe-run.ts",
     "bench:maintenance-backlog": "node --import ./bench/register-hooks.mjs bench/maintenance-backlog.ts",
     "bench:amortized-write-cost": "node --import ./bench/register-hooks.mjs bench/amortized-write-cost.ts",
     "bench:write-amp-stress": "node --import ./bench/register-hooks.mjs bench/write-amp-stress.ts",


### PR DESCRIPTION
## What & why

All three maintenance profiles ship the same fold ceilings (`C = 512 KiB`, `E = 2048`) even though Cloudflare paid gets a 30 s CPU budget against free's ~10 ms, and `MAINTENANCE_MAX_FOLD_ROWS`'s JSDoc still reads `PROVISIONAL — bench landed; paid recalibration deferred`. This adds an 18-cell probe that measures how much room actually exists above those ceilings, per profile, at 2x / 4x / 7x safety margins.

**It lands the probe, not a measurement.** No baseline is checked in and none should be until three methodology blockers are resolved and the grid is re-run on a quiesced machine — `bench/README.md` states them. Measures only: no constant, profile, or production behaviour changes.

## Key points

- Adds a **cross axis** loading rows and bytes at once. Those are the only cells resembling the conjunction `maintenance.ts` actually evaluates, and they are what showed a two-way `(C, E)` ceiling doesn't describe the cost surface: against the nearest bytes-axis cell at equal snapshot size, cross cells ran CPU at 0.40x, 0.66x, and 1.46x — both directions.
- Extracts the fold fixture and CPU/heap sampler into `bench/lib/fold-fixture.ts` rather than exporting them in place: `bench/fold-cost.ts` ends in an unguarded `main().then(process.exit)`, so importing any symbol ran the whole 12-cell bench and killed the host process. Behaviour-free — all 12 deterministic columns still match the frozen `fold-cost-baseline.json` cell for cell.
- Discards peak samples below the snapshot size as GC-floored. `peakBytes` is `max(sample) - heapUsedAtStart`, so a `heapStart` caught at a pre-GC high-water mark floors a fold to ~0; the first run reported a 0.03 MB peak for a 16 MB fold and that cell then set the cf-paid ceiling outright. Discards are counted per cell, and `LARGE_MEASURE_ITERS` went 5 → 9.
- Derives `findings` from the cells in the same record instead of transcribing them, so prose and measurement cannot drift across re-runs. That includes the host-overlap direction, which is computed from the ratios rather than asserted.
- The frozen-baseline comparison (`compareToFrozen`) and the `cellsOf` narrowing live in the pure module, not the runner, so both are unit-tested. The runner keeps only the file read and its degrade-to-SKIP catch.
- One timestamped file per run under `bench/results/fold-ceiling/`, matching `fold-cost.ts` and `lsn-reverse-walk.ts`. A fixed `latest.json` clobbers the previous sweep, and comparing consecutive runs is how you tell a clean measurement from a contended one — the failure mode this probe is most exposed to.
- The sweep is a runner script rather than a test because `pnpm test:agent` hard-codes `--silent=passed-only` and the deliverable is printed output. The pure verdict half is unit-tested.

## Verification

| Check | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `oxlint bench/` | 1 problem, pre-existing (`load-harness/runner/replay.ts:10`) |
| `vitest run bench` | 173 passed (32 in `fold-ceiling-probe.test.ts`) |
| runner end-to-end | exercised via `BAERLY_FOLD_CEILING_CELLS` replaying the frozen baseline's own cells; overlap reports 12 shared cells at 1.00x and correctly straddles |
| mutation check on the new tests | relaxing `fastest > 1` to `>= 1`, and altering each direction string, each fail exactly one test |
| `pnpm test:agent` (full suite) | **not run** — `main` has a known bundle-budget failure and several flakes being fixed separately |

Bundle budgets are unaffected structurally rather than by assertion: this branch modifies nothing under `packages/`, `tests/`, or the lockfile, and `bench/` is neither an entry in `rolldown.config.ts` nor imported by any package.

Rebased onto `main` after #98 merged; the two conflicted on the `bench/measurement/` README row, resolved to describe the journal/lease seam and the probe together.

## Notes for reviewers

Start at `bench/measurement/fold-ceiling-probe.ts` — the module docstring explains the grid and why each new cell exists. `isPeakSampleUsable`, `deriveFindings`, and `compareToFrozen` are where this deviates from a naive port, and all three have tests.

The removed-baseline decision is the thing to push back on if you disagree. The first sweep published `e_multiple_of_today: 32`, which `Math.max` over the fitting set credited from a cross-axis cell surviving on 2 usable samples of 9 — while the grid's own 65536-row cell needs 157 MiB against a 128 MiB budget and fails. The probe code is sound; that run isn't citable, and an uncited artifact under `docs/spec/attachments/` is load-bearing for nothing.

## Automated review triage

Fresh Eyes ran three rounds (7 / 4 / 4 findings, all Minor or Info). Dispositions are recorded here rather than in reply threads.

**Fixed:**

- Frozen-baseline overlap comment said "Five of this grid's cells"; it is **six**. The comment now defers to the count `compareToFrozen` actually prints.
- `JSON.parse` results are narrowed by `cellsOf`, which **throws** instead of asserting a shape. The old `parsed as { cells: T[] }` let a file without `cells` through as `undefined`-typed-as-array, and the subsequent `.find` / `.length` threw an uncaught `TypeError` — which mattered because the overlap check is awaited before `writeFile`, so the crash discarded the whole multi-minute sweep. The two readers deliberately want opposite failure modes and now get them: the frozen baseline degrades to a `SKIP` finding, while `BAERLY_FOLD_CEILING_CELLS` fails fast.
- `compareToFrozen` and `cellsOf` had no test coverage because they lived in a runner that ends in a module-scope `await main()` — nothing could import them. Moved to the pure module and covered, including the ratio-exactly-1.0 boundary.
- The reuse-path comment claimed the fail-fast stopped "a plausible-looking record derived from garbage". It doesn't: `cellsOf` checks that `cells` is an array, not the shape of its elements, so `[{}]` still propagates NaN. The limit is deliberate — a per-field schema would validate this probe's own serializer against itself — but the comment now says what the code does.
- The `bench/measurement/` README row named `fold-ceiling-probe.ts`, which is the non-runnable library half. It now names `fold-ceiling-probe-run.ts`, the file `pnpm bench:fold-ceiling` runs.

**Deferred, recorded:** the all-samples-GC-floored fallback is blocker #1 in `fold-program-backlog.md`. It is not separably fixable: `largestSustainable` takes `Math.max` over the fitting *set*, not the largest fitting *prefix*, so removing floored cells narrows the ceiling-inflation hole without closing it — a merely lucky-fast cell inflates it the same way. Hardening one half here would imply a trustworthiness the aggregation doesn't have, in a PR whose whole thesis is that this is an instrument and not a measurement. Set-max versus prefix-max is a design call and belongs with the baseline work.

**Premise corrected:** the Mulberry32 finding says this PR "re-inlines a third copy" and that the docstring claims it uses "the repository's canonical Mulberry32 PRNG". Neither holds. `mulberry32` was already inlined at `bench/fold-cost.ts:162` on `main` and is gone from that file after the extraction — the copy moved, the tree's count is unchanged. The "canonical PRNG" sentence is in the README about `statistics.ts`, which does import `rng.ts`; `fold-fixture.ts` makes no such claim. The consolidation is still worth doing and is `deferred-defects.md` entry 11, whose blocker cleared when #91 merged — but it touches two benches with frozen baselines and needs its own byte-unchanged verification, so it is not smuggled in here.

**Rejected:** splitting `deriveFindings` into five helpers. The stated benefit is testability, and `deriveFindings` is already exported with six tests covering each of its five blocks.
