### PR TITLE
feat(bench): add the storage journal and lease seam under bench/measurement

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -20,7 +20,7 @@ Two harnesses live under `bench/`:
 | `bench/amortized-write-cost.ts` | Amortized BILLABLE Class A ops (PUT+LIST; DeleteObject is $0) per logical write, INCLUDING in-band maintenance (folds + GC), across workload shapes × profile (cf-free / node). Source of truth for the write-amp constants in the cost CLI + the effective-write-amp claim in docs/about/cost-model.md. No infra (MemoryStorage). MEASURES ONLY. | When revisiting the write-amplification claim or the cost-CLI projection |
 | `bench/write-amp-stress.ts` | STRESS variant of `amortized-write-cost.ts`: drives pathological churn workloads (100%-update tiny set, unbounded insert growth, 500-doc full rewrite) under aggressive in-band maintenance to find the PEAK billable Class A ops per logical write. Tracks `peak_billable_class_a_per_write` (single-writer; the route past ~4× is a CAS-retry storm, governed by the throughput ceiling, not measured here). Backs the "peaks ~4×, never reaches the retired >6 trigger" claim. No infra (MemoryStorage). MEASURES ONLY. Baseline at `docs/spec/attachments/amortized-write-cost-stress-baseline.json`. | When revisiting whether the retired `write-amp > 6` graduation trigger could ever fire |
 | `bench/collection-fanout.ts` | Storage op cost of `discoverCollections` (LIST count) + full `admin usage` scan (LIST + GET count) vs. N collections under one tenant prefix, measured via a counting Storage proxy on MemoryStorage. No infra. MEASURES ONLY — re-derives the collections/tenant fan-out limit. A checked-in baseline lives at `docs/spec/attachments/collection-fanout-baseline.json`. | When revisiting the collections/tenant fan-out limit in docs/about/graduation.md or docs/about/workload-fit.md |
-| `bench/measurement/` | Not a harness — the algorithm-tagged statistics **library** the harnesses above summarize their results with. Quantiles, MAD, three bootstraps, two binomial upper bounds, and OLS via Householder QR, each carrying its algorithm tag and every parameter that determined the number. Pure; no infra; no runnable entry point. | When a bench emits a `p95`, a confidence interval, or a regression coefficient — import from here rather than hand-rolling one |
+| `bench/measurement/` | Not a harness — the shared measurement **library** the harnesses above build on. `statistics.ts` holds the algorithm-tagged summaries (quantiles, MAD, three bootstraps, two binomial upper bounds, OLS via Householder QR), each carrying its algorithm tag and every parameter that determined the number. `storage-journal.ts` and `storage-factory.ts` hold the recording and isolation seam: a timer-free `Storage` decorator producing an ordered operation journal plus an exact namespace journal, and a per-attempt backend lease whose cleanup authority is one in-memory instance, one `mkdtemp` root, or an explicit key list. Pure; no infra. | When a bench emits a `p95`, a confidence interval, or a regression coefficient; or when it needs a recorded, disposable backend rather than a shared one |
 
 Both require `pnpm dev:storage` (Minio `:9102` + Toxiproxy `:9104`)
 for the Minio-backed variants. Neither is a per-PR CI gate. The
@@ -243,6 +243,84 @@ reads those coefficients as physics must preregister a bar on
 
 ```sh
 pnpm vitest run bench/measurement/statistics.test.ts
+```
+
+### storage-journal.ts — what a run did, without a clock
+
+`wrapJournaledStorage` decorates any `Storage` and records two things.
+The **operation journal** is ordered: method, key, the request options
+that change semantics, PUT byte length and SHA-256, the result or error
+class, and an attempt id. The **namespace journal** is exact — key and
+byte-length state assembled from benchmark-owned provisioning plus
+observed PUT/DELETE outcomes, with zero LIST calls spent to maintain it.
+
+Timing is deliberately absent: no wall-clock field, no clock or timer
+call, and no runtime import beyond the global Web Crypto digest. Tests
+pin all three, the last two by reading the module's own source. That
+keeps a semantics comparison free of clock noise and keeps the module
+loadable outside Node.
+
+Three behaviours to know before you consume a snapshot:
+
+- **`snapshotOperations()` throws on non-quiescence.** A dispatched but
+  unsettled row raises `JournalNotQuiescentError` rather than being
+  omitted, because journal equality is the primary consumer and two
+  silently-truncated lists compare equal to each other.
+  `snapshotSettledOperations()` is the explicit opt-out.
+- **`list` allocates its index at the first `next()`,** not at the call,
+  so it rides a different clock from get/put/delete. A test pins the
+  resulting interleaving rather than hiding it — any downstream
+  comparator has to normalize for it.
+- **An ambiguous PUT/DELETE failure marks that key uncertain,** so
+  orphan accounting fails closed after a lost acknowledgement. The
+  parallel `uncertainty` array carries the classification, the operation
+  index, and whether the signal was already aborted at dispatch.
+
+`billingClassOf` implements the [cost-model](../docs/about/cost-model.md)
+definition — puts and lists bill, DELETE is $0. That is one definition,
+not a resolution: a test records all three live and mutually
+inconsistent definitions in the tree as evidence for their owner. Note
+it counts `Storage` calls, not billable requests, so against a remote
+backend that paginates or retries inside one call it understates Class A.
+
+### storage-factory.ts — one disposable backend per attempt
+
+`StorageFactory` provisions a fresh journaled backend; `StorageLease`
+owns removing it. Cleanup authority is the point of the module, and it
+is narrow by construction: a single in-memory instance, the single
+`mkdtemp` directory the factory created, or an explicit key list.
+Nothing here can delete a bucket, a parent directory, or a prefix.
+Exact-key cleanup issues one DELETE per sorted, de-duplicated key, never
+a LIST, and does not stop at the first failure.
+
+`create()` turns a provisioning error into a structured
+`{ status: "failed", failure }` rather than rejecting. Read that as a
+statement about **provisioning** — the memory factory wraps its whole
+body, while the local-fs factory wraps only the `mkdtemp` that can
+actually fail; `new LocalFsStorage()` and `makeLease()` sit outside its
+`try` because neither has a throw path (the former is a `resolve()` on a
+string, the latter takes an already-branded `AttemptId`). Adding a
+`catch` around them would ship an arm no test can reach, which is the
+same reason `isWithinCleanupAuthority` is exported instead of inlined. If
+either ever gains a throw path, widen the `try` then — and note the
+`mkdtemp` directory is already created by that point, so the widened
+catch has to remove it.
+
+`cleanup()` is memoized, flips the lease to `cleaned` on first call
+regardless of outcome, and reports `clean` / `partial` / `failed` naming
+every failed target.
+
+`withStorageLease(factory, work)` is the runner. It samples
+`pendingOperationCount()` **before** cleanup and reports it on both
+settled arms: a non-zero value means `work` abandoned an in-flight
+operation and the backend was torn out from under it. It neither throws
+nor waits on that — throwing would mask the work's own error, and there
+is no safe general way to await an operation the caller abandoned — so
+treat a result carrying `pending_operations_at_cleanup > 0` as invalid.
+
+```sh
+pnpm vitest run bench/measurement/storage-journal.test.ts \
+  bench/measurement/storage-factory.test.ts
 ```
 
 ## bench/fold-cost.ts

--- a/bench/measurement/storage-factory.test.ts
+++ b/bench/measurement/storage-factory.test.ts
@@ -1,0 +1,472 @@
+import { mkdir, mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import {
+  BaerlyError,
+  type Storage,
+  type StorageListEntry,
+  type StoragePutResult,
+} from "@baerly/protocol";
+import { afterAll, describe, expect, test } from "vitest";
+import { asAttemptId, wrapJournaledStorage } from "./storage-journal.ts";
+import {
+  type StorageFactory,
+  type StorageLease,
+  createExactKeyCleanup,
+  createLocalFsStorageFactory,
+  createMemoryStorageFactory,
+  isWithinCleanupAuthority,
+  withStorageLease,
+} from "./storage-factory.ts";
+
+const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
+const roots: string[] = [];
+
+afterAll(async () => {
+  for (const root of roots) {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+const makeParent = async (): Promise<string> => {
+  const parent = await mkdtemp(join(tmpdir(), "baerly-lane-a-parent-"));
+  roots.push(parent);
+  return parent;
+};
+
+/** Minimal key-addressable storage whose DELETE can be scripted to fail. */
+class DeletableStorage implements Storage {
+  readonly objects = new Map<string, Uint8Array>();
+  readonly calls: string[] = [];
+  readonly failDeletes = new Set<string>();
+
+  async get(key: string): Promise<{ body: Uint8Array; etag: string } | null> {
+    this.calls.push(`get:${key}`);
+    const body = this.objects.get(key);
+    return body === undefined ? null : { body, etag: '"e"' };
+  }
+
+  async put(key: string, body: Uint8Array): Promise<StoragePutResult> {
+    this.calls.push(`put:${key}`);
+    this.objects.set(key, body);
+    return { etag: '"e"' };
+  }
+
+  async delete(key: string): Promise<void> {
+    this.calls.push(`delete:${key}`);
+    if (this.failDeletes.has(key)) {
+      throw new BaerlyError("NetworkError", `delete ${key} failed`);
+    }
+    this.objects.delete(key);
+  }
+
+  async *list(prefix: string): AsyncIterable<StorageListEntry> {
+    this.calls.push(`list:${prefix}`);
+    for (const key of [...this.objects.keys()].toSorted()) {
+      if (key.startsWith(prefix)) {
+        yield { key, etag: '"e"' };
+      }
+    }
+  }
+}
+
+// ── REVISION 2: the authority guard, tested directly ─────────────────────────
+describe("isWithinCleanupAuthority", () => {
+  test("accepts a direct child carrying the prefix", () => {
+    expect(
+      isWithinCleanupAuthority({
+        root: "/tmp/parent/baerly-measurement-abc123",
+        parent: "/tmp/parent",
+        prefix: "baerly-measurement-",
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects a grandchild, so a nested path can never be swept", () => {
+    expect(
+      isWithinCleanupAuthority({
+        root: "/tmp/parent/nested/baerly-measurement-abc",
+        parent: "/tmp/parent",
+        prefix: "baerly-measurement-",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects the parent itself", () => {
+    expect(
+      isWithinCleanupAuthority({
+        root: "/tmp/parent",
+        parent: "/tmp/parent",
+        prefix: "baerly-measurement-",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects a sibling that does not carry the prefix", () => {
+    expect(
+      isWithinCleanupAuthority({
+        root: "/tmp/parent/someone-elses-dir",
+        parent: "/tmp/parent",
+        prefix: "baerly-measurement-",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects a path outside the parent entirely", () => {
+    expect(
+      isWithinCleanupAuthority({
+        root: "/etc/baerly-measurement-abc",
+        parent: "/tmp/parent",
+        prefix: "baerly-measurement-",
+      }),
+    ).toBe(false);
+  });
+});
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("memory factory", () => {
+  test("issues a fresh instance and a unique namespace per create", async () => {
+    const factory = createMemoryStorageFactory();
+    const first = await factory.create({ attemptId: asAttemptId("a-1") });
+    const second = await factory.create({ attemptId: asAttemptId("a-2") });
+    expect(first.status).toBe("created");
+    expect(second.status).toBe("created");
+    if (first.status !== "created" || second.status !== "created") {
+      throw new Error("expected both creates to succeed");
+    }
+    expect(first.lease.namespace_id).not.toBe(second.lease.namespace_id);
+    expect(first.lease.storage).not.toBe(second.lease.storage);
+    expect(first.lease.backend).toBe("memory");
+    await first.lease.storage.put("shared", enc("one"));
+    await expect(second.lease.storage.get("shared")).resolves.toBeNull();
+  });
+
+  test("cleanup is clean, idempotent, and flips lifecycle once", async () => {
+    const factory = createMemoryStorageFactory();
+    const created = await factory.create({ attemptId: asAttemptId("a-3") });
+    if (created.status !== "created") {
+      throw new Error("expected create to succeed");
+    }
+    const lease: StorageLease = created.lease;
+    expect(lease.lifecycle()).toBe("active");
+    expect(lease.cleanup_authority.kind).toBe("memory-instance");
+    const report = await lease.cleanup();
+    expect(report.status).toBe("clean");
+    expect(report.failures).toEqual([]);
+    expect(lease.lifecycle()).toBe("cleaned");
+    await expect(lease.cleanup()).resolves.toBe(report);
+  });
+});
+
+describe("local-fs factory", () => {
+  test("issues distinct mkdtemp roots", async () => {
+    const parent = await makeParent();
+    const factory = createLocalFsStorageFactory({ temp_parent: parent });
+    const first = await factory.create({ attemptId: asAttemptId("b-1") });
+    const second = await factory.create({ attemptId: asAttemptId("b-2") });
+    if (first.status !== "created" || second.status !== "created") {
+      throw new Error("expected both creates to succeed");
+    }
+    expect(first.lease.namespace_id).not.toBe(second.lease.namespace_id);
+    expect(dirname(first.lease.namespace_id)).toBe(parent);
+    expect(basename(first.lease.namespace_id).startsWith("baerly-measurement-")).toBe(true);
+    await first.lease.cleanup();
+    await second.lease.cleanup();
+  });
+
+  test("cleanup removes its exact root and spares a sibling", async () => {
+    const parent = await makeParent();
+    const sentinel = join(parent, "sentinel");
+    await mkdir(sentinel);
+    const factory = createLocalFsStorageFactory({ temp_parent: parent });
+    const created = await factory.create({ attemptId: asAttemptId("b-3") });
+    if (created.status !== "created") {
+      throw new Error("expected create to succeed");
+    }
+    await created.lease.storage.put("nested/doc", enc("payload"));
+    const report = await created.lease.cleanup();
+    expect(report.status).toBe("clean");
+    expect(report.authority).toEqual({
+      kind: "exact-directory",
+      absolute_path: created.lease.namespace_id,
+    });
+    await expect(stat(created.lease.namespace_id)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(sentinel)).resolves.toBeDefined();
+    await expect(stat(parent)).resolves.toBeDefined();
+  });
+
+  test("a provisioning error becomes a structured failure, not a rejection", async () => {
+    const parent = await makeParent();
+    const factory = createLocalFsStorageFactory({
+      temp_parent: join(parent, "does", "not", "exist"),
+    });
+    const created = await factory.create({ attemptId: asAttemptId("b-4") });
+    expect(created.status).toBe("failed");
+    if (created.status !== "failed") {
+      throw new Error("expected create to fail");
+    }
+    expect(created.failure).toMatchObject({
+      stage: "provision",
+      factory_id: factory.id,
+      backend: "local-fs",
+      code: "ENOENT",
+    });
+    expect(typeof created.failure.message).toBe("string");
+    expect(typeof created.failure.name).toBe("string");
+  });
+
+  test("mkdtemp on macOS appends a mixed-case suffix, which the guard tolerates", async () => {
+    // `mkdtemp` appends a base-58 mixed-case suffix on macOS. The guard checks
+    // `basename().startsWith(prefix)`, never a lowercase comparison, so a
+    // mixed-case suffix must not make cleanup refuse.
+    const parent = await makeParent();
+    const factory = createLocalFsStorageFactory({ temp_parent: parent });
+    const created = await factory.create({ attemptId: asAttemptId("b-5") });
+    if (created.status !== "created") {
+      throw new Error("expected create to succeed");
+    }
+    const report = await created.lease.cleanup();
+    expect(report.status).toBe("clean");
+    expect(report.cleaned_targets).toEqual([created.lease.namespace_id]);
+  });
+});
+
+describe("exact-key cleanup", () => {
+  test("deletes only the named keys and never lists", async () => {
+    const inner = new DeletableStorage();
+    await inner.put("a/1", enc("1"));
+    await inner.put("a/2", enc("2"));
+    await inner.put("a/3", enc("3"));
+    inner.calls.length = 0;
+    const cleanup = createExactKeyCleanup({ storage: inner, keys: ["a/2", "a/1", "a/1"] });
+    expect(cleanup.authority).toEqual({ kind: "exact-keys", keys: ["a/1", "a/2"] });
+    const report = await cleanup.cleanup();
+    expect(report.status).toBe("clean");
+    expect(report.cleaned_targets).toEqual(["a/1", "a/2"]);
+    expect(inner.calls).toEqual(["delete:a/1", "delete:a/2"]);
+    expect([...inner.objects.keys()]).toEqual(["a/3"]);
+  });
+
+  test("one failing delete yields partial and still attempts later keys", async () => {
+    const inner = new DeletableStorage();
+    await inner.put("a/1", enc("1"));
+    await inner.put("a/2", enc("2"));
+    await inner.put("a/3", enc("3"));
+    inner.failDeletes.add("a/2");
+    inner.calls.length = 0;
+    const cleanup = createExactKeyCleanup({ storage: inner, keys: ["a/1", "a/2", "a/3"] });
+    const report = await cleanup.cleanup();
+    expect(report.status).toBe("partial");
+    expect(report.attempted_targets).toEqual(["a/1", "a/2", "a/3"]);
+    expect(report.cleaned_targets).toEqual(["a/1", "a/3"]);
+    expect(report.failures).toHaveLength(1);
+    expect(report.failures[0]).toMatchObject({ target: "a/2", code: "NetworkError" });
+    expect(inner.calls).toEqual(["delete:a/1", "delete:a/2", "delete:a/3"]);
+  });
+
+  test("a repeat cleanup issues zero additional storage calls", async () => {
+    const inner = new DeletableStorage();
+    await inner.put("a/1", enc("1"));
+    inner.calls.length = 0;
+    const cleanup = createExactKeyCleanup({ storage: inner, keys: ["a/1"] });
+    const first = await cleanup.cleanup();
+    const callsAfterFirst = inner.calls.length;
+    const second = await cleanup.cleanup();
+    expect(second).toBe(first);
+    expect(inner.calls).toHaveLength(callsAfterFirst);
+  });
+});
+
+describe("withStorageLease", () => {
+  /** Factory whose cleanup always fails, so cleanup outcome can be exercised. */
+  const failingCleanupFactory = (inner: DeletableStorage): StorageFactory => ({
+    id: "test.failing-cleanup/v1",
+    backend: "test-failing",
+    create: async ({ attemptId }) => {
+      const journaled = wrapJournaledStorage({ attemptId, storage: inner });
+      const cleanup = createExactKeyCleanup({ storage: inner, keys: ["boom"] });
+      let lifecycle: "active" | "cleaned" = "active";
+      let report: Awaited<ReturnType<typeof cleanup.cleanup>> | undefined;
+      return {
+        status: "created",
+        lease: {
+          attempt_id: attemptId,
+          factory_id: "test.failing-cleanup/v1",
+          backend: "test-failing",
+          namespace_id: "test-failing-0",
+          storage: journaled.storage,
+          journal: journaled.journal,
+          cleanup_authority: cleanup.authority,
+          lifecycle: () => lifecycle,
+          cleanup: async () => {
+            lifecycle = "cleaned";
+            report ??= await cleanup.cleanup();
+            return report;
+          },
+        },
+      };
+    },
+  });
+
+  test("returns the work value plus the cleanup report", async () => {
+    const factory = createMemoryStorageFactory();
+    const outcome = await withStorageLease(factory, asAttemptId("c-1"), async (lease) => {
+      await lease.storage.put("x", enc("y"));
+      return lease.journal.snapshotOperations().length;
+    });
+    expect(outcome.status).toBe("returned");
+    if (outcome.status !== "returned") {
+      throw new Error("expected returned");
+    }
+    expect(outcome.value).toBe(1);
+    expect(outcome.cleanup.status).toBe("clean");
+    expect(outcome.pending_operations_at_cleanup).toBe(0);
+  });
+
+  test("surfaces a provisioning failure without running the work", async () => {
+    const parent = await makeParent();
+    const factory = createLocalFsStorageFactory({ temp_parent: join(parent, "absent") });
+    let ran = false;
+    const outcome = await withStorageLease(factory, asAttemptId("c-2"), async () => {
+      ran = true;
+      return 1;
+    });
+    expect(ran).toBe(false);
+    expect(outcome.status).toBe("provision_failed");
+  });
+
+  test("preserves the thrown object by identity when cleanup also fails", async () => {
+    const inner = new DeletableStorage();
+    await inner.put("boom", enc("v"));
+    inner.failDeletes.add("boom");
+    const thrown = new BaerlyError("Internal", "work exploded");
+    const outcome = await withStorageLease(
+      failingCleanupFactory(inner),
+      asAttemptId("c-3"),
+      async () => {
+        throw thrown;
+      },
+    );
+    expect(outcome.status).toBe("threw");
+    if (outcome.status !== "threw") {
+      throw new Error("expected threw");
+    }
+    expect(outcome.error).toBe(thrown);
+    expect(outcome.cleanup.status).toBe("failed");
+    expect(outcome.cleanup.failures).toHaveLength(1);
+  });
+
+  test("marks the lease cleaned even when cleanup fails", async () => {
+    const inner = new DeletableStorage();
+    await inner.put("boom", enc("v"));
+    inner.failDeletes.add("boom");
+    const created = await failingCleanupFactory(inner).create({ attemptId: asAttemptId("c-4") });
+    if (created.status !== "created") {
+      throw new Error("expected create to succeed");
+    }
+    expect(created.lease.lifecycle()).toBe("active");
+    const report = await created.lease.cleanup();
+    expect(report.status).toBe("failed");
+    expect(created.lease.lifecycle()).toBe("cleaned");
+  });
+
+  // ── REVISION 2: non-quiescence is reported, not hidden and not thrown ─────
+  test("reports in-flight operations at cleanup instead of silently tearing down", async () => {
+    const factory = createMemoryStorageFactory();
+    let leaked: Promise<unknown> | undefined;
+    const outcome = await withStorageLease(factory, asAttemptId("c-5"), async (lease) => {
+      // Deliberately abandon an operation: the work function returns without
+      // awaiting it, so the lease's storage is about to be torn out from under
+      // an in-flight call. That must be VISIBLE in the result.
+      leaked = lease.storage.put("abandoned", enc("v"));
+      return "done";
+    });
+    expect(outcome.status).toBe("returned");
+    if (outcome.status !== "returned") {
+      throw new Error("expected returned");
+    }
+    expect(outcome.pending_operations_at_cleanup).toBeGreaterThan(0);
+    await leaked;
+  });
+
+  test("does not let a non-quiescent journal mask the work's own error", async () => {
+    const factory = createMemoryStorageFactory();
+    const thrown = new BaerlyError("Internal", "work exploded");
+    let leaked: Promise<unknown> | undefined;
+    const outcome = await withStorageLease(factory, asAttemptId("c-6"), async (lease) => {
+      leaked = lease.storage.put("abandoned", enc("v"));
+      throw thrown;
+    });
+    expect(outcome.status).toBe("threw");
+    if (outcome.status !== "threw") {
+      throw new Error("expected threw");
+    }
+    expect(outcome.error).toBe(thrown);
+    await leaked;
+  });
+
+  test("empties the memory backend rather than reporting a clean it did not do", async () => {
+    const factory = createMemoryStorageFactory();
+    const created = await factory.create({ attemptId: asAttemptId("c-7") });
+    if (created.status !== "created") {
+      throw new Error("expected created");
+    }
+    const { lease } = created;
+    await lease.storage.put("kept", enc("payload"));
+    await expect(lease.storage.get("kept")).resolves.not.toBeNull();
+
+    const report = await lease.cleanup();
+
+    expect(report.status).toBe("clean");
+    // The lease and the journal closure both still reference the instance, so
+    // "dropped the reference" was never available to this factory. A `clean`
+    // report has to mean the bytes are actually gone.
+    await expect(lease.storage.get("kept")).resolves.toBeNull();
+  });
+
+  test("reports a rejecting cleanup as failed instead of masking the work's error", async () => {
+    const boom = new BaerlyError("Internal", "cleanup exploded");
+    const thrown = new BaerlyError("Internal", "work exploded");
+    const rejectingCleanupFactory: StorageFactory = {
+      id: "test.rejecting-cleanup/v1",
+      backend: "test-rejecting",
+      create: async ({ attemptId }) => {
+        const journaled = wrapJournaledStorage({ attemptId, storage: new DeletableStorage() });
+        return {
+          status: "created",
+          lease: {
+            attempt_id: attemptId,
+            factory_id: "test.rejecting-cleanup/v1",
+            backend: "test-rejecting",
+            namespace_id: "test-rejecting-0",
+            storage: journaled.storage,
+            journal: journaled.journal,
+            cleanup_authority: { kind: "memory-instance", lease_id: "test-rejecting-0" },
+            lifecycle: () => "cleaned",
+            cleanup: () => Promise.reject(boom),
+          },
+        };
+      },
+    };
+
+    const outcome = await withStorageLease(
+      rejectingCleanupFactory,
+      asAttemptId("c-8"),
+      async () => {
+        throw thrown;
+      },
+    );
+
+    expect(outcome.status).toBe("threw");
+    if (outcome.status !== "threw") {
+      throw new Error("expected threw");
+    }
+    // The work's error survives by identity — a rejecting cleanup must not
+    // replace it, which is what a bare `await lease.cleanup()` would do.
+    expect(outcome.error).toBe(thrown);
+    expect(outcome.cleanup.status).toBe("failed");
+    expect(outcome.cleanup.failures).toHaveLength(1);
+    expect(outcome.cleanup.failures[0]?.message).toBe("cleanup exploded");
+  });
+  // ──────────────────────────────────────────────────────────────────────────
+});

--- a/bench/measurement/storage-factory.ts
+++ b/bench/measurement/storage-factory.ts
@@ -1,0 +1,412 @@
+/**
+ * Per-attempt storage provisioning with **exact** cleanup authority.
+ *
+ * A factory hands back one fresh backend plus the narrowest possible authority
+ * to remove it: a single in-memory instance, the single `mkdtemp` directory it
+ * created, or an explicit list of known keys. Nothing here can delete a bucket,
+ * a parent directory, or a prefix — that restriction is the point of the
+ * module, not an implementation detail.
+ *
+ * Node-only: it reads `node:fs/promises`, `node:os`, and `node:path`. The
+ * journal module it composes with stays runtime-import-free.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { MemoryStorage, type Storage } from "@baerly/protocol";
+import { LocalFsStorage } from "@baerly/dev";
+import {
+  type AttemptId,
+  type StorageJournal,
+  describeThrown,
+  wrapJournaledStorage,
+} from "./storage-journal.ts";
+
+const DEFAULT_DIRECTORY_PREFIX = "baerly-measurement-";
+
+export type CleanupAuthority =
+  | { readonly kind: "memory-instance"; readonly lease_id: string }
+  | { readonly kind: "exact-directory"; readonly absolute_path: string }
+  | { readonly kind: "exact-keys"; readonly keys: readonly string[] };
+
+export interface CleanupFailure {
+  readonly target: string;
+  readonly name: string;
+  readonly code?: string;
+  readonly message: string;
+}
+
+export interface CleanupReport {
+  readonly status: "clean" | "partial" | "failed";
+  readonly authority: CleanupAuthority;
+  readonly attempted_targets: readonly string[];
+  readonly cleaned_targets: readonly string[];
+  readonly failures: readonly CleanupFailure[];
+}
+
+export interface StorageLease {
+  readonly attempt_id: AttemptId;
+  readonly factory_id: string;
+  readonly backend: string;
+  readonly namespace_id: string;
+  readonly storage: Storage;
+  readonly journal: StorageJournal;
+  readonly cleanup_authority: CleanupAuthority;
+  lifecycle(): "active" | "cleaned";
+  cleanup(): Promise<CleanupReport>;
+}
+
+export interface ProvisioningFailure {
+  readonly stage: "provision";
+  readonly factory_id: string;
+  readonly backend: string;
+  readonly name: string;
+  readonly code?: string;
+  readonly message: string;
+}
+
+export type StorageFactoryCreateResult =
+  | { readonly status: "created"; readonly lease: StorageLease }
+  | { readonly status: "failed"; readonly failure: ProvisioningFailure };
+
+export interface StorageFactory {
+  readonly id: string;
+  readonly backend: string;
+  create(input: { readonly attemptId: AttemptId }): Promise<StorageFactoryCreateResult>;
+}
+
+export interface ExactKeyCleanup {
+  readonly authority: CleanupAuthority;
+  cleanup(): Promise<CleanupReport>;
+}
+
+export type WithStorageLeaseResult<T> =
+  | { readonly status: "provision_failed"; readonly failure: ProvisioningFailure }
+  | {
+      readonly status: "returned";
+      readonly value: T;
+      readonly cleanup: CleanupReport;
+      readonly pending_operations_at_cleanup: number;
+    }
+  | {
+      readonly status: "threw";
+      readonly error: unknown;
+      readonly cleanup: CleanupReport;
+      readonly pending_operations_at_cleanup: number;
+    };
+
+/**
+ * True iff `root` is a direct child of `parent` whose basename carries
+ * `prefix`. Exported and separately tested because inside the local-fs cleanup
+ * closure the condition is unreachable by construction — `mkdtemp(join(parent,
+ * prefix))` guarantees it — so the refusal branch would otherwise ship with no
+ * coverage at all.
+ *
+ * `parent` is expected already `resolve`d and must NOT be `realpath`ed:
+ * `os.tmpdir()` is a symlink on macOS, and resolving one side of the comparison
+ * but not the other rejects every real root. `startsWith` is a case-SENSITIVE
+ * comparison on purpose — `mkdtemp` appends a mixed-case suffix on macOS, and
+ * lowercasing either side would be the bug, not the fix.
+ */
+export const isWithinCleanupAuthority = (input: {
+  readonly root: string;
+  readonly parent: string;
+  readonly prefix: string;
+}): boolean =>
+  dirname(input.root) === input.parent && basename(input.root).startsWith(input.prefix);
+
+// Process-monotone so no two leases in one process can collide, even across
+// two factory instances of the same backend.
+let leaseCounter = 0;
+const nextLeaseId = (backend: string): string => {
+  leaseCounter += 1;
+  return `${backend}-lease-${leaseCounter}`;
+};
+
+const reportStatus = (
+  cleaned: readonly string[],
+  failures: readonly CleanupFailure[],
+): CleanupReport["status"] => {
+  if (failures.length === 0) {
+    return "clean";
+  }
+  return cleaned.length === 0 ? "failed" : "partial";
+};
+
+const buildReport = (
+  authority: CleanupAuthority,
+  attempted: readonly string[],
+  cleaned: readonly string[],
+  failures: readonly CleanupFailure[],
+): CleanupReport =>
+  Object.freeze<CleanupReport>({
+    status: reportStatus(cleaned, failures),
+    authority,
+    attempted_targets: Object.freeze([...attempted]),
+    cleaned_targets: Object.freeze([...cleaned]),
+    failures: Object.freeze([...failures]),
+  });
+
+const toCleanupFailure = (target: string, error: unknown): CleanupFailure => {
+  const described = describeThrown(error);
+  return {
+    target,
+    name: described.name,
+    ...(described.code !== undefined && { code: described.code }),
+    message: described.message,
+  };
+};
+
+const toProvisioningFailure = (
+  factoryId: string,
+  backend: string,
+  error: unknown,
+): ProvisioningFailure => {
+  const described = describeThrown(error);
+  return {
+    stage: "provision",
+    factory_id: factoryId,
+    backend,
+    name: described.name,
+    ...(described.code !== undefined && { code: described.code }),
+    message: described.message,
+  };
+};
+
+/**
+ * Delete an explicit, sorted, de-duplicated key list. Never a prefix, never a
+ * LIST, and never short-circuited: a failure on one key does not skip the rest.
+ * Pass the **inner** (unwrapped) storage so teardown deletes stay out of the
+ * attempt's operation journal.
+ */
+export const createExactKeyCleanup = (input: {
+  readonly storage: Storage;
+  readonly keys: readonly string[];
+}): ExactKeyCleanup => {
+  const keys = Object.freeze([...new Set(input.keys)].toSorted());
+  const authority: CleanupAuthority = { kind: "exact-keys", keys };
+  let memoized: CleanupReport | undefined;
+  return {
+    authority,
+    cleanup: async (): Promise<CleanupReport> => {
+      if (memoized !== undefined) {
+        return memoized;
+      }
+      const cleaned: string[] = [];
+      const failures: CleanupFailure[] = [];
+      for (const key of keys) {
+        try {
+          await input.storage.delete(key);
+          cleaned.push(key);
+        } catch (error: unknown) {
+          failures.push(toCleanupFailure(key, error));
+        }
+      }
+      memoized = buildReport(authority, keys, cleaned, failures);
+      return memoized;
+    },
+  };
+};
+
+const makeLease = (input: {
+  readonly attemptId: AttemptId;
+  readonly factoryId: string;
+  readonly backend: string;
+  readonly namespaceId: string;
+  readonly storage: Storage;
+  readonly authority: CleanupAuthority;
+  readonly runCleanup: () => Promise<{
+    readonly cleaned: readonly string[];
+    readonly failures: readonly CleanupFailure[];
+    readonly attempted: readonly string[];
+  }>;
+}): StorageLease => {
+  const journaled = wrapJournaledStorage({
+    attemptId: input.attemptId,
+    storage: input.storage,
+  });
+  let lifecycle: "active" | "cleaned" = "active";
+  let memoized: CleanupReport | undefined;
+  return {
+    attempt_id: input.attemptId,
+    factory_id: input.factoryId,
+    backend: input.backend,
+    namespace_id: input.namespaceId,
+    storage: journaled.storage,
+    journal: journaled.journal,
+    cleanup_authority: input.authority,
+    lifecycle: () => lifecycle,
+    cleanup: async (): Promise<CleanupReport> => {
+      if (memoized !== undefined) {
+        return memoized;
+      }
+      lifecycle = "cleaned";
+      const outcome = await input.runCleanup();
+      memoized = buildReport(input.authority, outcome.attempted, outcome.cleaned, outcome.failures);
+      return memoized;
+    },
+  };
+};
+
+/**
+ * One isolated {@link MemoryStorage} per attempt. Cleanup empties that
+ * instance — the lease and the journal closure both retain a reference to it,
+ * so "drop the reference" was never something this factory could do, and a
+ * report of `clean` for a backend that still holds every byte is exactly the
+ * fabricated authority this module exists to rule out.
+ */
+export const createMemoryStorageFactory = (): StorageFactory => {
+  const id = "measurement.memory/v1";
+  const backend = "memory";
+  return {
+    id,
+    backend,
+    create: async ({ attemptId }): Promise<StorageFactoryCreateResult> => {
+      try {
+        const leaseId = nextLeaseId(backend);
+        const instance = new MemoryStorage();
+        return {
+          status: "created",
+          lease: makeLease({
+            attemptId,
+            factoryId: id,
+            backend,
+            namespaceId: leaseId,
+            storage: instance,
+            authority: { kind: "memory-instance", lease_id: leaseId },
+            runCleanup: async () => {
+              instance._clear();
+              return { attempted: [leaseId], cleaned: [leaseId], failures: [] };
+            },
+          }),
+        };
+      } catch (error: unknown) {
+        return { status: "failed", failure: toProvisioningFailure(id, backend, error) };
+      }
+    },
+  };
+};
+
+/**
+ * One `mkdtemp` root per attempt under the selected temp parent. Cleanup
+ * removes **only** that root, and only after {@link isWithinCleanupAuthority}
+ * re-derives that it is a direct child of the selected parent carrying the
+ * requested prefix.
+ */
+export const createLocalFsStorageFactory = (input?: {
+  readonly temp_parent?: string;
+  readonly directory_prefix?: string;
+}): StorageFactory => {
+  const id = "measurement.local-fs/v1";
+  const backend = "local-fs";
+  const parent = resolve(input?.temp_parent ?? tmpdir());
+  const prefix = input?.directory_prefix ?? DEFAULT_DIRECTORY_PREFIX;
+  return {
+    id,
+    backend,
+    create: async ({ attemptId }): Promise<StorageFactoryCreateResult> => {
+      let root: string;
+      try {
+        root = await mkdtemp(join(parent, prefix));
+      } catch (error: unknown) {
+        return { status: "failed", failure: toProvisioningFailure(id, backend, error) };
+      }
+      return {
+        status: "created",
+        lease: makeLease({
+          attemptId,
+          factoryId: id,
+          backend,
+          namespaceId: root,
+          storage: new LocalFsStorage({ root }),
+          authority: { kind: "exact-directory", absolute_path: root },
+          runCleanup: async () => {
+            if (!isWithinCleanupAuthority({ root, parent, prefix })) {
+              return {
+                attempted: [root],
+                cleaned: [],
+                failures: [
+                  {
+                    target: root,
+                    name: "CleanupAuthorityError",
+                    code: "OutOfAuthority",
+                    message:
+                      `refusing to remove ${root}: not a direct child of ${parent} ` +
+                      `with prefix ${prefix}`,
+                  },
+                ],
+              };
+            }
+            try {
+              await rm(root, { recursive: true, force: true });
+              return { attempted: [root], cleaned: [root], failures: [] };
+            } catch (error: unknown) {
+              return {
+                attempted: [root],
+                cleaned: [],
+                failures: [toCleanupFailure(root, error)],
+              };
+            }
+          },
+        }),
+      };
+    },
+  };
+};
+
+/**
+ * Provision, run, then always clean up. Provisioning failure short-circuits
+ * before `work` runs. A throw from `work` is returned **by identity** alongside
+ * the cleanup report — cleanup never replaces or masks it.
+ *
+ * `pending_operations_at_cleanup` is sampled from the journal BEFORE cleanup
+ * runs. A non-zero value means `work` returned or threw while one of its own
+ * storage operations was still in flight, so the backend may have been torn out
+ * from under it: the local-fs factory `rm -rf`s the root, and the memory factory
+ * drops the only reference. The runner does NOT throw on this — that would mask
+ * `work`'s own error, which is the one thing the caller most needs — and it does
+ * NOT wait, because there is no safe general way to wait for an operation the
+ * caller abandoned. It reports. A caller seeing a non-zero value must treat the
+ * result as invalid.
+ */
+export const withStorageLease = async <T>(
+  factory: StorageFactory,
+  attemptId: AttemptId,
+  work: (lease: StorageLease) => Promise<T>,
+): Promise<WithStorageLeaseResult<T>> => {
+  const created = await factory.create({ attemptId });
+  if (created.status === "failed") {
+    return { status: "provision_failed", failure: created.failure };
+  }
+  const { lease } = created;
+  const settled = await work(lease).then(
+    (value: T) => ({ ok: true, value }) as const,
+    (error: unknown) => ({ ok: false, error }) as const,
+  );
+  const pendingAtCleanup = lease.journal.pendingOperationCount();
+  // Settled, not bare-awaited. `work`'s error is the one thing the caller most
+  // needs, and the doc above promises it comes back by identity — but
+  // `withStorageLease` takes an ARBITRARY factory (the test suite supplies one
+  // whose cleanup fails), so a lease whose `cleanup()` rejects rather than
+  // returning a `failed` report would reject this whole call and discard
+  // `work`'s exception. Convert the rejection into the `failed` report the
+  // contract already has a shape for.
+  const cleanup = await lease.cleanup().then(
+    (report: CleanupReport) => report,
+    (error: unknown): CleanupReport =>
+      buildReport(lease.cleanup_authority, [], [], [toCleanupFailure(lease.namespace_id, error)]),
+  );
+  return settled.ok
+    ? {
+        status: "returned",
+        value: settled.value,
+        cleanup,
+        pending_operations_at_cleanup: pendingAtCleanup,
+      }
+    : {
+        status: "threw",
+        error: settled.error,
+        cleanup,
+        pending_operations_at_cleanup: pendingAtCleanup,
+      };
+};

--- a/bench/measurement/storage-journal.test.ts
+++ b/bench/measurement/storage-journal.test.ts
@@ -1,0 +1,748 @@
+/* eslint-disable no-underscore-dangle -- `_entry` marks a deliberately unused
+   loop binding where the test only needs the iterable DRAINED (or broken out
+   of) and not the yielded value. Same convention, and same file-level opt-out,
+   as `tests/integration/maintenance-e2e.test.ts`. */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  BaerlyError,
+  type Storage,
+  type StorageGetOptions,
+  type StorageGetResult,
+  type StorageListEntry,
+  type StoragePutOptions,
+  type StoragePutResult,
+} from "@baerly/protocol";
+import { describe, expect, test, vi } from "vitest";
+import {
+  InvalidAttemptIdError,
+  JournalNotQuiescentError,
+  NAMESPACE_JOURNAL_VERSION,
+  OPERATION_JOURNAL_VERSION,
+  asAttemptId,
+  billingClassOf,
+  classifyStorageError,
+  wrapJournaledStorage,
+} from "./storage-journal.ts";
+
+const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+/**
+ * Clock-free scriptable backend. `MemoryStorage` cannot be used for the
+ * zero-clock-read assertion below because its `put` returns
+ * `serverDate: new Date()` — a real wall-clock read on every write.
+ */
+class StubStorage implements Storage {
+  readonly objects = new Map<string, { body: Uint8Array; etag: string }>();
+  readonly calls: string[] = [];
+  readonly completions: string[] = [];
+  readonly getTicks = new Map<string, number>();
+  readonly failOn = new Map<string, unknown>();
+  /** Resolve manually to hold an operation in flight. */
+  readonly gates = new Map<string, () => void>();
+  #etag = 0;
+
+  async get(key: string, _opts?: StorageGetOptions): Promise<StorageGetResult | null> {
+    this.calls.push(`get:${key}`);
+    const ticks = this.getTicks.get(key) ?? 0;
+    for (let i = 0; i < ticks; i++) {
+      await Promise.resolve();
+    }
+    if (this.gates.has(`get:${key}`)) {
+      await new Promise<void>((resolve) => this.gates.set(`get:${key}`, resolve));
+    }
+    this.completions.push(`get:${key}`);
+    const failure = this.failOn.get(`get:${key}`);
+    if (failure !== undefined) {
+      throw failure;
+    }
+    const stored = this.objects.get(key);
+    return stored === undefined ? null : { body: stored.body, etag: stored.etag };
+  }
+
+  async put(key: string, body: Uint8Array, _opts?: StoragePutOptions): Promise<StoragePutResult> {
+    this.calls.push(`put:${key}`);
+    const failure = this.failOn.get(`put:${key}`);
+    if (failure !== undefined) {
+      throw failure;
+    }
+    this.#etag += 1;
+    const etag = `"${this.#etag}"`;
+    this.objects.set(key, { body, etag });
+    return { etag };
+  }
+
+  async delete(key: string, _opts?: { signal?: AbortSignal }): Promise<void> {
+    this.calls.push(`delete:${key}`);
+    const failure = this.failOn.get(`delete:${key}`);
+    if (failure !== undefined) {
+      throw failure;
+    }
+    this.objects.delete(key);
+  }
+
+  async *list(
+    prefix: string,
+    _opts?: { startAfter?: string; maxKeys?: number; signal?: AbortSignal },
+  ): AsyncIterable<StorageListEntry> {
+    this.calls.push(`list:${prefix}`);
+    const failure = this.failOn.get(`list:${prefix}`);
+    if (failure !== undefined) {
+      throw failure;
+    }
+    for (const [key, stored] of [...this.objects].toSorted((a, b) => (a[0] < b[0] ? -1 : 1))) {
+      if (key.startsWith(prefix)) {
+        yield { key, etag: stored.etag };
+      }
+    }
+  }
+}
+
+const abortedError = (): unknown => {
+  const controller = new AbortController();
+  controller.abort();
+  try {
+    controller.signal.throwIfAborted();
+  } catch (error: unknown) {
+    return error;
+  }
+  throw new Error("unreachable: throwIfAborted did not throw");
+};
+
+describe("attempt identity", () => {
+  test("accepts a conventional id and brands it", () => {
+    expect(asAttemptId("attempt-1")).toBe("attempt-1");
+    expect(asAttemptId("study.fold:cell_07")).toBe("study.fold:cell_07");
+  });
+
+  test("rejects ids that would be unsafe as a filename or JSON key", () => {
+    for (const bad of ["", " ", "a b", "a/b", "a\\b", "a\nb", "x".repeat(129), "é"]) {
+      expect(() => asAttemptId(bad)).toThrow(InvalidAttemptIdError);
+    }
+  });
+
+  test("the thrown error carries the offending value", () => {
+    try {
+      asAttemptId("a/b");
+      throw new Error("expected a throw");
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(InvalidAttemptIdError);
+      expect((error as InvalidAttemptIdError).value).toBe("a/b");
+    }
+  });
+});
+
+describe("operation journal", () => {
+  test("records method, key, and dispatch-ordered indices", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-1"),
+      storage: stub,
+    });
+    await storage.put("a/1", enc("abc"));
+    await storage.get("a/1");
+    await storage.delete("a/1");
+    for await (const _entry of storage.list("a/")) {
+      /* drain */
+    }
+    const ops = journal.snapshotOperations();
+    expect(ops.map((o) => o.method)).toEqual(["put", "get", "delete", "list"]);
+    expect(ops.map((o) => o.operation_index)).toEqual([0, 1, 2, 3]);
+    expect(ops.every((o) => o.schema === OPERATION_JOURNAL_VERSION)).toBe(true);
+    expect(ops.every((o) => o.attempt_id === "attempt-1")).toBe(true);
+    expect(journal.pendingOperationCount()).toBe(0);
+  });
+
+  test("indices follow dispatch even when GETs settle in reverse", async () => {
+    const stub = new StubStorage();
+    stub.objects.set("k/1", { body: enc("one"), etag: '"e1"' });
+    stub.objects.set("k/2", { body: enc("two"), etag: '"e2"' });
+    stub.getTicks.set("k/1", 20);
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-2"),
+      storage: stub,
+    });
+    const first = storage.get("k/1");
+    const second = storage.get("k/2");
+    await Promise.all([first, second]);
+    expect(stub.completions).toEqual(["get:k/2", "get:k/1"]);
+    const ops = journal.snapshotOperations();
+    expect(ops.map((o) => o.key)).toEqual(["k/1", "k/2"]);
+    expect(ops.map((o) => o.operation_index)).toEqual([0, 1]);
+  });
+
+  // ── REVISION 2: quiescence is enforced, not advertised ────────────────────
+  test("snapshotOperations THROWS while an operation is in flight", async () => {
+    const stub = new StubStorage();
+    stub.gates.set("get:slow", () => {});
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-q1"),
+      storage: stub,
+    });
+    const inflight = storage.get("slow");
+    await Promise.resolve();
+    expect(journal.pendingOperationCount()).toBe(1);
+    expect(() => journal.snapshotOperations()).toThrow(JournalNotQuiescentError);
+    // The settled-only view is the explicit opt-out and never throws.
+    expect(journal.snapshotSettledOperations()).toEqual([]);
+    expect(journal.pendingOperations()).toEqual([
+      { operation_index: 0, method: "get", key: "slow" },
+    ]);
+    stub.gates.get("get:slow")?.();
+    await inflight;
+    expect(journal.snapshotOperations()).toHaveLength(1);
+  });
+
+  test("the quiescence error names every pending row", async () => {
+    const stub = new StubStorage();
+    stub.gates.set("get:a", () => {});
+    stub.gates.set("get:b", () => {});
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-q2"),
+      storage: stub,
+    });
+    const a = storage.get("a");
+    const b = storage.get("b");
+    await Promise.resolve();
+    try {
+      journal.snapshotOperations();
+      throw new Error("expected a throw");
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(JournalNotQuiescentError);
+      expect((error as JournalNotQuiescentError).pending.map((p) => p.key)).toEqual(["a", "b"]);
+    }
+    stub.gates.get("get:a")?.();
+    stub.gates.get("get:b")?.();
+    await Promise.all([a, b]);
+  });
+  // ──────────────────────────────────────────────────────────────────────────
+
+  test("records PUT byte length and the SHA-256 of the exact bytes", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-3"),
+      storage: stub,
+    });
+    await storage.put("d", enc("abc"));
+    const [op] = journal.snapshotOperations();
+    expect(op?.put).toEqual({
+      byte_length: 3,
+      sha256: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    });
+  });
+
+  test("digests the bytes as of dispatch, not as of later mutation", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-4"),
+      storage: stub,
+    });
+    const body = enc("abc");
+    const inflight = storage.put("d", body);
+    body[0] = 0x7a;
+    await inflight;
+    const [op] = journal.snapshotOperations();
+    expect(op?.put?.sha256).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+  });
+
+  test("passes the ORIGINAL array to the inner storage, not the digest copy", async () => {
+    const stub = new StubStorage();
+    const { storage } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-4b"),
+      storage: stub,
+    });
+    const body = enc("abc");
+    await storage.put("d", body);
+    // MemoryStorage-shaped backends retain the caller's array by reference;
+    // substituting the copy would change what the system under test observes.
+    expect(stub.objects.get("d")?.body).toBe(body);
+  });
+
+  test("captures only the options that were supplied", async () => {
+    const stub = new StubStorage();
+    stub.objects.set("o", { body: enc("x"), etag: '"e"' });
+    const live = new AbortController();
+    const dead = new AbortController();
+    dead.abort();
+    const signalIds = new Map<AbortSignal, string>([
+      [live.signal, "writer-signal"],
+      [dead.signal, "cancelled-signal"],
+    ]);
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-5"),
+      storage: stub,
+      signalIds,
+    });
+    await storage.get("o");
+    await storage.put("o", enc("y"), { ifMatch: '"e"', contentType: "application/json" });
+    await storage.put("o2", enc("y"), { ifNoneMatch: "*" });
+    await storage.get("o", { versionId: "v7", signal: live.signal });
+    await storage.get("o", { ifNoneMatch: '"e"', signal: dead.signal });
+    for await (const _entry of storage.list("o", { startAfter: "o", maxKeys: 5 })) {
+      /* drain */
+    }
+    const ops = journal.snapshotOperations();
+    expect(Object.keys(ops[0]?.options ?? { missing: true })).toEqual([]);
+    expect(ops[1]?.options).toEqual({ if_match: '"e"', content_type: "application/json" });
+    expect(ops[2]?.options).toEqual({ if_none_match: "*" });
+    expect(ops[3]?.options).toEqual({
+      version_id: "v7",
+      signal: { id: "writer-signal", present: true, aborted_at_dispatch: false },
+    });
+    expect(ops[4]?.options).toEqual({
+      if_none_match: '"e"',
+      signal: { id: "cancelled-signal", present: true, aborted_at_dispatch: true },
+    });
+    expect(ops[5]?.options).toEqual({ start_after: "o", max_keys: 5 });
+  });
+
+  test("names an unnamed signal deterministically and stably", async () => {
+    const stub = new StubStorage();
+    const first = new AbortController();
+    const second = new AbortController();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-5b"),
+      storage: stub,
+    });
+    await storage.get("a", { signal: first.signal });
+    await storage.get("b", { signal: second.signal });
+    await storage.get("c", { signal: first.signal });
+    const ids = journal.snapshotOperations().map((o) => o.options.signal?.id);
+    expect(ids).toEqual(["signal-1", "signal-2", "signal-1"]);
+  });
+
+  test("classifies returned results", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-6"),
+      storage: stub,
+    });
+    await storage.get("absent");
+    await storage.put("p", enc("v"));
+    await storage.get("p");
+    await storage.delete("p");
+    for await (const _entry of storage.list("")) {
+      /* drain */
+    }
+    const ops = journal.snapshotOperations();
+    expect(ops.map((o) => o.result.classification)).toEqual([
+      "not_found",
+      "put_ok",
+      "found",
+      "delete_ok",
+      "list_ok",
+    ]);
+    expect(ops[2]?.result).toMatchObject({ status: "returned", etag: '"1"' });
+    expect(ops[4]?.result).toMatchObject({ status: "returned", listed_entries: 0 });
+  });
+
+  test("classifies every error class and rethrows the same object", async () => {
+    const cases: readonly { readonly thrown: unknown; readonly expected: string }[] = [
+      { thrown: abortedError(), expected: "aborted" },
+      { thrown: new BaerlyError("Conflict", "precondition failed"), expected: "conflict" },
+      { thrown: new BaerlyError("NetworkError", "503"), expected: "network_error" },
+      { thrown: new BaerlyError("InvalidResponse", "bad xml"), expected: "invalid_response" },
+      { thrown: new BaerlyError("Internal", "bug"), expected: "internal" },
+      { thrown: new BaerlyError("InvalidConfig", "no bucket"), expected: "invalid_config" },
+      { thrown: new Error("boom"), expected: "unknown" },
+    ];
+    for (const [index, entry] of cases.entries()) {
+      const stub = new StubStorage();
+      const key = `e${index}`;
+      stub.failOn.set(`put:${key}`, entry.thrown);
+      const { storage, journal } = wrapJournaledStorage({
+        attemptId: asAttemptId(`attempt-err-${index}`),
+        storage: stub,
+      });
+      let caught: unknown;
+      try {
+        await storage.put(key, enc("v"));
+      } catch (error: unknown) {
+        caught = error;
+      }
+      expect(caught).toBe(entry.thrown);
+      const [op] = journal.snapshotOperations();
+      expect(op?.result.status).toBe("threw");
+      expect(op?.result.classification).toBe(entry.expected);
+      expect(classifyStorageError(entry.thrown)).toBe(entry.expected);
+    }
+  });
+
+  test("never writes a numeric DOMException code into the string code field", async () => {
+    const stub = new StubStorage();
+    stub.failOn.set("get:x", abortedError());
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-dom"),
+      storage: stub,
+    });
+    await expect(storage.get("x")).rejects.toThrow("aborted");
+    const result = journal.snapshotOperations()[0]?.result;
+    if (result === undefined || result.status !== "threw") {
+      throw new Error("expected a threw result");
+    }
+    expect(result.classification).toBe("aborted");
+    expect(result.name).toBe("AbortError");
+    expect(result.code).toBeUndefined();
+  });
+
+  test("allocates the LIST index at iteration start and counts yielded entries", async () => {
+    const stub = new StubStorage();
+    stub.objects.set("l/1", { body: enc("1"), etag: '"1"' });
+    stub.objects.set("l/2", { body: enc("2"), etag: '"2"' });
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-7"),
+      storage: stub,
+    });
+    const iterable = storage.list("l/");
+    expect(journal.snapshotOperations()).toEqual([]);
+    expect(stub.calls).toEqual([]);
+    let seen = 0;
+    for await (const _entry of iterable) {
+      seen += 1;
+    }
+    expect(seen).toBe(2);
+    const [op] = journal.snapshotOperations();
+    expect(op?.result).toMatchObject({ classification: "list_ok", listed_entries: 2 });
+  });
+
+  // ── REVISION 2: the list-index hazard, pinned rather than hidden ──────────
+  test("a LIST created early but iterated late sorts on the ITERATION clock", async () => {
+    const stub = new StubStorage();
+    stub.objects.set("l/1", { body: enc("1"), etag: '"1"' });
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-7b"),
+      storage: stub,
+    });
+    const deferred = storage.list("l/"); // created FIRST
+    await storage.get("later"); // dispatched second
+    for await (const _entry of deferred) {
+      /* drain */
+    }
+    const ops = journal.snapshotOperations();
+    // The GET, dispatched after `.list()` was CALLED, carries the LOWER index.
+    // This is the parent plan's "allocate when iteration begins" rule, and it
+    // means `list` is not on the same clock as the other three verbs. Any
+    // downstream journal comparator must avoid separating `.list()` from its
+    // iteration, or normalize. See Semantics §2 and Open question 6.
+    expect(ops.map((o) => `${o.method}:${o.operation_index}`)).toEqual(["get:0", "list:1"]);
+  });
+  // ──────────────────────────────────────────────────────────────────────────
+
+  test("settles a broken-out LIST with the partial count", async () => {
+    const stub = new StubStorage();
+    stub.objects.set("l/1", { body: enc("1"), etag: '"1"' });
+    stub.objects.set("l/2", { body: enc("2"), etag: '"2"' });
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-8"),
+      storage: stub,
+    });
+    for await (const _entry of storage.list("l/")) {
+      break;
+    }
+    const [op] = journal.snapshotOperations();
+    expect(op?.result).toMatchObject({ classification: "list_ok", listed_entries: 1 });
+    expect(journal.pendingOperationCount()).toBe(0);
+  });
+
+  test("a LIST that is never iterated journals nothing at all", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-8b"),
+      storage: stub,
+    });
+    void storage.list("l/");
+    await Promise.resolve();
+    expect(journal.snapshotOperations()).toEqual([]);
+    expect(journal.pendingOperationCount()).toBe(0);
+  });
+});
+
+describe("billing class", () => {
+  /**
+   * ONE definition, deliberately NOT a resolution. Manifest §11 item 1 records
+   * three live and mutually inconsistent "Class A" definitions in this repo:
+   *
+   *   D1  packages/server/src/reads-pure.test.ts   put + delete
+   *   D2  tests/integration/maintenance-e2e.test.ts put + delete + list
+   *   D3  docs/about/cost-model.md                 put + list   (DELETE is $0)
+   *       — matching bench/storage.ts's `billableClassAOps` getter and
+   *         coordination design §4.5's `billableClassAOps = puts + lists`
+   *
+   * D1 governs a CI gate; D2 backs the published "< 1 Class A op / writer /
+   * hour" claim; D3 governs the fold program's cost arguments. The journal uses
+   * D3 because that is what §4.5 binds it to. This test exists so the
+   * disagreement is discoverable evidence for the Protocol/product owner named
+   * in §11, not so this lane resolves it.
+   */
+  test("uses the cost-model definition: puts and lists bill, deletes are free", () => {
+    expect(billingClassOf("put")).toBe("A");
+    expect(billingClassOf("list")).toBe("A");
+    expect(billingClassOf("get")).toBe("B");
+    expect(billingClassOf("delete")).toBe("free");
+  });
+
+  test("billingSummary counts settled rows by class", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-bill"),
+      storage: stub,
+    });
+    await storage.put("a", enc("1"));
+    await storage.put("b", enc("2"));
+    await storage.get("a");
+    await storage.delete("b");
+    for await (const _entry of storage.list("")) {
+      /* drain */
+    }
+    expect(journal.billingSummary()).toEqual({ class_a: 3, class_b: 1, free: 1 });
+  });
+
+  test("a failed operation still counts — the request was still billed", async () => {
+    const stub = new StubStorage();
+    stub.failOn.set("put:x", new BaerlyError("Conflict", "precondition failed"));
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-bill-2"),
+      storage: stub,
+    });
+    await expect(storage.put("x", enc("v"))).rejects.toMatchObject({ code: "Conflict" });
+    expect(journal.billingSummary()).toEqual({ class_a: 1, class_b: 0, free: 0 });
+  });
+});
+
+describe("namespace journal", () => {
+  test("tracks provisioning, PUT, and DELETE without any LIST", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-ns-1"),
+      storage: stub,
+    });
+    journal.recordProvisioned([
+      { key: "seed/b", byte_length: 10 },
+      { key: "seed/a", byte_length: 4 },
+    ]);
+    await storage.put("live/1", enc("abcd"));
+    await storage.put("live/1", enc("abcdef"));
+    await storage.delete("seed/a");
+    const snapshot = journal.snapshotNamespace();
+    expect(snapshot.schema).toBe(NAMESPACE_JOURNAL_VERSION);
+    expect(snapshot.exact).toBe(true);
+    expect(snapshot.uncertain_keys).toEqual([]);
+    expect(snapshot.uncertainty).toEqual([]);
+    expect(snapshot.entries).toEqual([
+      { key: "live/1", byte_length: 6, last_operation_index: 1, source: "put" },
+      { key: "seed/b", byte_length: 10, last_operation_index: null, source: "provisioned" },
+    ]);
+    expect(stub.calls.filter((c) => c.startsWith("list:"))).toEqual([]);
+  });
+
+  test("a conflicting PUT leaves namespace truth unchanged", async () => {
+    const stub = new StubStorage();
+    stub.failOn.set("put:c", new BaerlyError("Conflict", "precondition failed"));
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-ns-2"),
+      storage: stub,
+    });
+    journal.recordProvisioned([{ key: "c", byte_length: 3 }]);
+    await expect(storage.put("c", enc("zzzz"))).rejects.toMatchObject({ code: "Conflict" });
+    const snapshot = journal.snapshotNamespace();
+    expect(snapshot.exact).toBe(true);
+    expect(snapshot.entries).toEqual([
+      { key: "c", byte_length: 3, last_operation_index: null, source: "provisioned" },
+    ]);
+  });
+
+  test("an ambiguous PUT or DELETE failure marks that exact key uncertain", async () => {
+    const stub = new StubStorage();
+    stub.failOn.set("put:u", new BaerlyError("NetworkError", "retries exhausted"));
+    stub.failOn.set("delete:d", abortedError());
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-ns-3"),
+      storage: stub,
+    });
+    journal.recordProvisioned([
+      { key: "u", byte_length: 3 },
+      { key: "d", byte_length: 5 },
+      { key: "safe", byte_length: 1 },
+    ]);
+    await expect(storage.put("u", enc("x"))).rejects.toMatchObject({ code: "NetworkError" });
+    await expect(storage.delete("d")).rejects.toThrow("aborted");
+    const snapshot = journal.snapshotNamespace();
+    expect(snapshot.exact).toBe(false);
+    expect(snapshot.uncertain_keys).toEqual(["d", "u"]);
+    expect(snapshot.entries).toEqual([
+      { key: "safe", byte_length: 1, last_operation_index: null, source: "provisioned" },
+    ]);
+  });
+
+  // ── REVISION 2: the evidence array, so a consumer can narrow ──────────────
+  test("uncertainty carries the evidence needed to narrow without guessing", async () => {
+    const stub = new StubStorage();
+    stub.failOn.set("put:net", new BaerlyError("NetworkError", "retries exhausted"));
+    stub.failOn.set("delete:pre", abortedError());
+    const dead = new AbortController();
+    dead.abort();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-ns-3b"),
+      storage: stub,
+    });
+    await expect(storage.put("net", enc("x"))).rejects.toMatchObject({ code: "NetworkError" });
+    await expect(storage.delete("pre", { signal: dead.signal })).rejects.toThrow("aborted");
+    const snapshot = journal.snapshotNamespace();
+    expect(snapshot.uncertainty).toEqual([
+      {
+        key: "net",
+        operation_index: 0,
+        method: "put",
+        classification: "network_error",
+        aborted_at_dispatch: false,
+      },
+      {
+        key: "pre",
+        operation_index: 1,
+        method: "delete",
+        classification: "aborted",
+        aborted_at_dispatch: true,
+      },
+    ]);
+    // Both are still uncertain — the journal fails CLOSED. The `pre` row simply
+    // carries enough evidence for a consumer to decide otherwise, without the
+    // journal baking in an assumption the `Storage` contract does not state.
+    expect(snapshot.uncertain_keys).toEqual(["net", "pre"]);
+    expect(snapshot.exact).toBe(false);
+  });
+
+  test("a later successful PUT clears both the key and its uncertainty row", async () => {
+    const stub = new StubStorage();
+    stub.failOn.set("put:flaky", new BaerlyError("NetworkError", "boom"));
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-ns-3c"),
+      storage: stub,
+    });
+    await expect(storage.put("flaky", enc("x"))).rejects.toMatchObject({ code: "NetworkError" });
+    expect(journal.snapshotNamespace().exact).toBe(false);
+    stub.failOn.delete("put:flaky");
+    await storage.put("flaky", enc("xy"));
+    const snapshot = journal.snapshotNamespace();
+    expect(snapshot.exact).toBe(true);
+    expect(snapshot.uncertain_keys).toEqual([]);
+    expect(snapshot.uncertainty).toEqual([]);
+    expect(snapshot.entries).toEqual([
+      { key: "flaky", byte_length: 2, last_operation_index: 1, source: "put" },
+    ]);
+  });
+  // ──────────────────────────────────────────────────────────────────────────
+
+  test("LIST is journaled but never changes namespace truth", async () => {
+    const stub = new StubStorage();
+    stub.objects.set("ghost", { body: enc("xyz"), etag: '"g"' });
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-ns-4"),
+      storage: stub,
+    });
+    for await (const _entry of storage.list("")) {
+      /* drain */
+    }
+    expect(journal.snapshotOperations()).toHaveLength(1);
+    expect(journal.snapshotNamespace().entries).toEqual([]);
+  });
+});
+
+describe("timer-free guarantee", () => {
+  const SOURCE = readFileSync(
+    fileURLToPath(new URL("./storage-journal.ts", import.meta.url)),
+    "utf8",
+  );
+
+  test("the module contains no clock or timer call site", () => {
+    expect(SOURCE).not.toMatch(/new\s+Date\b/);
+    expect(SOURCE).not.toMatch(/Date\s*\.\s*now/);
+    expect(SOURCE).not.toMatch(/performance\s*\.\s*now/);
+    expect(SOURCE).not.toMatch(/process\s*\.\s*hrtime/);
+    expect(SOURCE).not.toMatch(/set(?:Timeout|Interval|Immediate)\s*\(/);
+  });
+
+  test("the module imports nothing at runtime", () => {
+    // `import type` is erased; a bare `import ... from` is not. The probe module
+    // reads clocks by design, so importing it here would silently break the
+    // guarantee above.
+    expect(SOURCE).not.toMatch(/^import\s+(?!type\b)/m);
+  });
+
+  test("no journal operation reads a clock", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-clock"),
+      storage: stub,
+    });
+    const dateNow = vi.spyOn(Date, "now");
+    const perfNow = vi.spyOn(performance, "now");
+    try {
+      await storage.put("k", enc("abc"));
+      await storage.get("k");
+      for await (const _entry of storage.list("")) {
+        /* drain */
+      }
+      await storage.delete("k");
+      journal.recordProvisioned([{ key: "z", byte_length: 1 }]);
+      journal.snapshotOperations();
+      journal.snapshotNamespace();
+      journal.billingSummary();
+    } finally {
+      dateNow.mockRestore();
+      perfNow.mockRestore();
+    }
+    expect(dateNow).not.toHaveBeenCalled();
+    expect(perfNow).not.toHaveBeenCalled();
+  });
+
+  test("keeps byte_length when the digest fails", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-digest-fail"),
+      storage: stub,
+    });
+    const digest = vi
+      .spyOn(crypto.subtle, "digest")
+      .mockRejectedValue(new Error("no webcrypto here"));
+    try {
+      await storage.put("k", enc("abcd"));
+    } finally {
+      digest.mockRestore();
+    }
+    const [record] = journal.snapshotOperations();
+    // A crypto failure must not take the byte accounting down with it — a
+    // journal reporting zero bytes written still compares equal to another
+    // such journal, which is the silent-truncation failure this module exists
+    // to rule out.
+    expect(record?.put?.byte_length).toBe(4);
+    expect(record?.put?.sha256).toBeUndefined();
+  });
+
+  test("hands out records that cannot mutate the journal's internal rows", async () => {
+    const stub = new StubStorage();
+    const { storage, journal } = wrapJournaledStorage({
+      attemptId: asAttemptId("attempt-alias"),
+      storage: stub,
+    });
+    const controller = new AbortController();
+    await storage.put("k", enc("abcd"), { signal: controller.signal });
+
+    const [first] = journal.snapshotOperations();
+    if (first === undefined) {
+      throw new Error("expected one record");
+    }
+    // A downstream comparator normalizing before it diffs is the realistic
+    // caller; `Object.freeze` in `toRecord` is one level deep, so `options`
+    // must be frozen at capture or this mutation reaches the internal row.
+    expect(() => {
+      (first.options as { signal?: unknown }).signal = undefined;
+    }).toThrow(/Cannot assign to read only property/);
+
+    const [second] = journal.snapshotOperations();
+    expect(second?.options.signal?.present).toBe(true);
+    expect(second?.options.signal?.aborted_at_dispatch).toBe(false);
+  });
+});

--- a/bench/measurement/storage-journal.ts
+++ b/bench/measurement/storage-journal.ts
@@ -1,0 +1,641 @@
+/**
+ * Timer-free semantic journals over the `Storage` seam.
+ *
+ * Two journals are produced from one decorator: an ordered **operation
+ * journal** (method, key, semantically-relevant request options, PUT byte
+ * length and digest, result/error class, attempt id) and an exact **namespace
+ * journal** (known key/byte-length state from benchmark-owned provisioning plus
+ * observed PUT/DELETE outcomes).
+ *
+ * This module holds no wall-clock field and issues no wall-clock or timer call.
+ * Latency is a separate observation so a semantics comparison can ignore clock
+ * noise; `bench/storage.ts`'s latency wrapper and
+ * `bench/measurement/fold-ceiling-probe.ts` are deliberately outside this
+ * contract and must never be imported here.
+ *
+ * It also imports nothing at runtime — only types plus the global Web Crypto
+ * digest — so it stays loadable outside Node.
+ */
+import type {
+  Branded,
+  Storage,
+  StorageGetResult,
+  StorageListEntry,
+  StoragePutResult,
+} from "@baerly/protocol";
+
+/** Contract version of {@link StorageOperationRecord}. */
+export const OPERATION_JOURNAL_VERSION = "baerly.storage-operation-journal/v1" as const;
+/** Contract version of {@link NamespaceSnapshot}. */
+export const NAMESPACE_JOURNAL_VERSION = "baerly.namespace-journal/v1" as const;
+
+/** Identity of one measurement attempt. Every journal row carries it. */
+export type AttemptId = Branded<string, "AttemptId">;
+
+/**
+ * Attempt ids reach filenames, directory names, and JSON keys in downstream
+ * lanes, so the charset is narrow on purpose: ASCII alphanumerics plus `.`,
+ * `_`, `:`, and `-`, 1-128 characters. No slash, no whitespace, no non-ASCII.
+ */
+export const ATTEMPT_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+
+export class InvalidAttemptIdError extends Error {
+  readonly value: string;
+  constructor(value: string) {
+    super(`invalid attempt id ${JSON.stringify(value)}: expected ${String(ATTEMPT_ID_PATTERN)}`);
+    this.name = "InvalidAttemptIdError";
+    this.value = value;
+  }
+}
+
+/**
+ * Single deliberate boundary for minting an {@link AttemptId}. Validates rather
+ * than casting: an unchecked cast makes the brand decorative, and this repo's
+ * convention is that branded types are load-bearing.
+ */
+export const asAttemptId = (value: string): AttemptId => {
+  if (!ATTEMPT_ID_PATTERN.test(value)) {
+    throw new InvalidAttemptIdError(value);
+  }
+  return value as AttemptId;
+};
+
+export type StorageMethod = "get" | "put" | "delete" | "list";
+
+/**
+ * Billing class of one storage verb.
+ *
+ * `docs/about/cost-model.md` and coordination design §4.5 both define the
+ * billable set as `puts + lists`; DeleteObject is $0 on both S3 and R2, so
+ * `delete` is neither A nor B. `bench/storage.ts`'s `billableClassAOps` getter
+ * already agrees.
+ *
+ * This is ONE definition, not a resolution. Two other definitions are live in
+ * the tree (see the `billing class` describe block in the test file). Their
+ * owner is the Protocol/product owner named in the integration manifest's open
+ * contradictions table.
+ */
+export type BillingClass = "A" | "B" | "free";
+
+export const billingClassOf = (method: StorageMethod): BillingClass => {
+  if (method === "put" || method === "list") {
+    return "A";
+  }
+  return method === "get" ? "B" : "free";
+};
+
+export interface BillingSummary {
+  readonly class_a: number;
+  readonly class_b: number;
+  readonly free: number;
+}
+
+export type StorageErrorClass =
+  | "aborted"
+  | "conflict"
+  | "network_error"
+  | "invalid_response"
+  | "internal"
+  | "invalid_config"
+  | "unknown";
+
+export interface ThrownDescription {
+  readonly name: string;
+  readonly code?: string;
+  readonly message: string;
+}
+
+const stringField = (error: unknown, field: "name" | "message" | "code"): string | undefined => {
+  if (typeof error !== "object" || error === null || !(field in error)) {
+    return undefined;
+  }
+  const value = (error as Record<string, unknown>)[field];
+  return typeof value === "string" ? value : undefined;
+};
+
+const CODE_TO_CLASS: Readonly<Record<string, StorageErrorClass>> = {
+  Conflict: "conflict",
+  NetworkError: "network_error",
+  InvalidResponse: "invalid_response",
+  Internal: "internal",
+  InvalidConfig: "invalid_config",
+};
+
+/**
+ * Map a thrown value onto the journal's closed error vocabulary.
+ *
+ * Abort is detected by `name`, never by `code`: a `DOMException` exposes a
+ * legacy **numeric** `code` (`AbortError` is `20`), which is why
+ * {@link stringField} discards non-string values instead of forwarding them.
+ */
+export const classifyStorageError = (error: unknown): StorageErrorClass => {
+  const name = stringField(error, "name");
+  if (name === "AbortError" || name === "TimeoutError") {
+    return "aborted";
+  }
+  const code = stringField(error, "code");
+  if (code === undefined) {
+    return "unknown";
+  }
+  return CODE_TO_CLASS[code] ?? "unknown";
+};
+
+/** Structured, string-safe description of a thrown value. */
+export const describeThrown = (error: unknown): ThrownDescription => {
+  const code = stringField(error, "code");
+  return {
+    name: stringField(error, "name") ?? "UnknownError",
+    ...(code !== undefined && { code }),
+    message: stringField(error, "message") ?? String(error),
+  };
+};
+
+export interface JournalSignal {
+  readonly id: string;
+  readonly present: true;
+  readonly aborted_at_dispatch: boolean;
+}
+
+export interface JournalRequestOptions {
+  readonly if_match?: string;
+  readonly if_none_match?: string;
+  readonly content_type?: string;
+  readonly version_id?: string;
+  readonly start_after?: string;
+  readonly max_keys?: number;
+  readonly signal?: JournalSignal;
+}
+
+export type StorageOperationResult =
+  | {
+      readonly status: "returned";
+      readonly classification: "found" | "not_found" | "put_ok" | "delete_ok" | "list_ok";
+      readonly etag?: string;
+      readonly version_id?: string;
+      readonly listed_entries?: number;
+    }
+  | {
+      readonly status: "threw";
+      readonly classification: StorageErrorClass;
+      readonly name: string;
+      readonly code?: string;
+    };
+
+export interface StorageOperationRecord {
+  readonly schema: typeof OPERATION_JOURNAL_VERSION;
+  readonly attempt_id: AttemptId;
+  readonly operation_index: number;
+  readonly method: StorageMethod;
+  readonly key: string;
+  readonly options: JournalRequestOptions;
+  /**
+   * `byte_length` is always present for a PUT — it is read straight off the
+   * defensive copy and needs no crypto. `sha256` is absent when the digest
+   * itself failed (no WebCrypto, a rejecting `subtle`, an OOM on a large
+   * body); the byte accounting must survive that, or a journal missing its
+   * digests silently reports zero bytes written and still compares equal to
+   * another such journal.
+   */
+  readonly put?: { readonly byte_length: number; readonly sha256?: string };
+  readonly result: StorageOperationResult;
+}
+
+export interface NamespaceEntry {
+  readonly key: string;
+  readonly byte_length: number;
+  readonly last_operation_index: number | null;
+  readonly source: "provisioned" | "put";
+}
+
+/**
+ * Why one key is uncertain. `uncertain_keys` stays the fail-closed answer; this
+ * carries the evidence so a downstream consumer can narrow WITHOUT assuming
+ * anything about adapter behavior. In particular `aborted_at_dispatch === true`
+ * means the signal was already aborted when the wrapper was called.
+ */
+export interface NamespaceUncertainty {
+  readonly key: string;
+  readonly operation_index: number;
+  readonly method: "put" | "delete";
+  readonly classification: StorageErrorClass;
+  readonly aborted_at_dispatch: boolean;
+}
+
+export interface NamespaceSnapshot {
+  readonly schema: typeof NAMESPACE_JOURNAL_VERSION;
+  readonly exact: boolean;
+  readonly entries: readonly NamespaceEntry[];
+  readonly uncertain_keys: readonly string[];
+  readonly uncertainty: readonly NamespaceUncertainty[];
+}
+
+export interface PendingOperation {
+  readonly operation_index: number;
+  readonly method: StorageMethod;
+  readonly key: string;
+}
+
+export class JournalNotQuiescentError extends Error {
+  readonly pending: readonly PendingOperation[];
+  constructor(pending: readonly PendingOperation[]) {
+    const names = pending.map((p) => `${p.operation_index}:${p.method} ${p.key}`).join(", ");
+    super(
+      `journal is not quiescent: ${pending.length} operation(s) dispatched but unsettled ` +
+        `[${names}]. Await them, or call snapshotSettledOperations() if a mid-flight ` +
+        `view is what you actually want.`,
+    );
+    this.name = "JournalNotQuiescentError";
+    this.pending = pending;
+  }
+}
+
+export interface StorageJournal {
+  readonly attemptId: AttemptId;
+  /**
+   * THROWS `JournalNotQuiescentError` when any dispatched row is unsettled,
+   * instead of silently omitting it. Journal equality is this lane's primary
+   * consumer and a silently short list is the failure mode that passes green.
+   */
+  snapshotOperations(): readonly StorageOperationRecord[];
+  /** Settled rows only, never throws. For deliberate mid-flight inspection. */
+  snapshotSettledOperations(): readonly StorageOperationRecord[];
+  pendingOperations(): readonly PendingOperation[];
+  /** Count of rows dispatched but not yet settled. Zero means quiescent. */
+  pendingOperationCount(): number;
+  snapshotNamespace(): NamespaceSnapshot;
+  recordProvisioned(entries: readonly { key: string; byte_length: number }[]): void;
+  /** Derived from settled rows only. */
+  billingSummary(): BillingSummary;
+}
+
+export interface JournaledStorage {
+  readonly storage: Storage;
+  readonly journal: StorageJournal;
+}
+
+const HEX = "0123456789abcdef";
+
+// `Uint8Array.prototype.toHex` type-checks under `ESNext.TypedArrays` but
+// throws at run time on Node 24 and workerd (gated behind a V8 flag), so the
+// hex loop is hand-rolled on purpose.
+const toHex = (bytes: Uint8Array): string => {
+  let out = "";
+  for (const byte of bytes) {
+    out += HEX.charAt(byte >> 4);
+    out += HEX.charAt(byte & 15);
+  }
+  return out;
+};
+
+const sha256Hex = async (bytes: Uint8Array<ArrayBuffer>): Promise<string> => {
+  // `bytes` is already the dispatch-time copy, allocated over a fresh
+  // `ArrayBuffer` — tsgo narrows a bare `Uint8Array` to
+  // `Uint8Array<ArrayBufferLike>`, which `crypto.subtle.digest` rejects (it
+  // wants `ArrayBufferView<ArrayBuffer>`). Same constraint, and the same
+  // workaround, as `packages/protocol/src/sha256.ts`.
+  // See microsoft/TypeScript#61375.
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return toHex(new Uint8Array(digest));
+};
+
+interface MutableRow {
+  readonly index: number;
+  readonly method: StorageMethod;
+  readonly key: string;
+  readonly options: JournalRequestOptions;
+  put?: { readonly byte_length: number; readonly sha256?: string };
+  result?: StorageOperationResult;
+}
+
+interface MutableUncertainty {
+  readonly key: string;
+  readonly operation_index: number;
+  readonly method: "put" | "delete";
+  readonly classification: StorageErrorClass;
+  readonly aborted_at_dispatch: boolean;
+}
+
+/**
+ * Record ordering for `entries` / `uncertainty` — plain string comparison on
+ * the key, NOT the S3 UTF-8 list-order contract. Written as an if/return block
+ * because `.oxlintrc.json` sets `eslint/no-nested-ternary` to `error`; do not
+ * "simplify" it back to a nested ternary.
+ */
+const byKeyAsc = (a: { key: string }, b: { key: string }): number => {
+  if (a.key < b.key) {
+    return -1;
+  }
+  return a.key > b.key ? 1 : 0;
+};
+
+interface CapturableOptions {
+  ifMatch?: string;
+  ifNoneMatch?: string;
+  contentType?: string;
+  versionId?: string;
+  startAfter?: string;
+  maxKeys?: number;
+  signal?: AbortSignal;
+}
+
+export const wrapJournaledStorage = (input: {
+  readonly attemptId: AttemptId;
+  readonly storage: Storage;
+  readonly signalIds?: ReadonlyMap<AbortSignal, string>;
+}): JournaledStorage => {
+  const inner = input.storage;
+  const rows: MutableRow[] = [];
+  const entries = new Map<
+    string,
+    { byte_length: number; last_operation_index: number | null; source: "provisioned" | "put" }
+  >();
+  const uncertain = new Map<string, MutableUncertainty>();
+  const anonymousNames = new WeakMap<AbortSignal, string>();
+  let anonymousCount = 0;
+  let nextIndex = 0;
+
+  const nameSignal = (signal: AbortSignal): string => {
+    const provided = input.signalIds?.get(signal);
+    if (provided !== undefined) {
+      return provided;
+    }
+    const known = anonymousNames.get(signal);
+    if (known !== undefined) {
+      return known;
+    }
+    anonymousCount += 1;
+    const generated = `signal-${anonymousCount}`;
+    anonymousNames.set(signal, generated);
+    return generated;
+  };
+
+  /**
+   * Frozen at capture, including the nested `signal`. `toRecord`'s
+   * `Object.freeze` is one level deep, so every snapshot hands out THIS object
+   * by reference; without freezing here, a downstream consumer that normalizes
+   * a returned record (`delete r.options.signal`) would permanently mutate the
+   * journal's internal row and corrupt the `aborted_at_dispatch` provenance
+   * that `markUncertain` reads back later.
+   */
+  const capture = (opts?: CapturableOptions): JournalRequestOptions =>
+    Object.freeze({
+      ...(opts?.ifMatch !== undefined && { if_match: opts.ifMatch }),
+      ...(opts?.ifNoneMatch !== undefined && { if_none_match: opts.ifNoneMatch }),
+      ...(opts?.contentType !== undefined && { content_type: opts.contentType }),
+      ...(opts?.versionId !== undefined && { version_id: opts.versionId }),
+      ...(opts?.startAfter !== undefined && { start_after: opts.startAfter }),
+      ...(opts?.maxKeys !== undefined && { max_keys: opts.maxKeys }),
+      ...(opts?.signal !== undefined && {
+        signal: Object.freeze({
+          id: nameSignal(opts.signal),
+          present: true as const,
+          aborted_at_dispatch: opts.signal.aborted,
+        }),
+      }),
+    });
+
+  const openRow = (
+    method: StorageMethod,
+    key: string,
+    options: JournalRequestOptions,
+  ): MutableRow => {
+    const row: MutableRow = { index: nextIndex, method, key, options };
+    nextIndex += 1;
+    rows.push(row);
+    return row;
+  };
+
+  const threwResult = (error: unknown): StorageOperationResult => {
+    const described = describeThrown(error);
+    return {
+      status: "threw",
+      classification: classifyStorageError(error),
+      name: described.name,
+      ...(described.code !== undefined && { code: described.code }),
+    };
+  };
+
+  /**
+   * Conflict leaves prior state unchanged; any other failure class removes the
+   * key from the exactly-known set and records WHY. The evidence row is what
+   * lets a downstream consumer narrow (see `aborted_at_dispatch`) without this
+   * module assuming anything the `Storage` contract does not state.
+   */
+  const markUncertain = (row: MutableRow, method: "put" | "delete", error: unknown): void => {
+    const classification = classifyStorageError(error);
+    if (classification === "conflict") {
+      return;
+    }
+    entries.delete(row.key);
+    uncertain.set(row.key, {
+      key: row.key,
+      operation_index: row.index,
+      method,
+      classification,
+      aborted_at_dispatch: row.options.signal?.aborted_at_dispatch ?? false,
+    });
+  };
+
+  const storage: Storage = {
+    get: async (key, opts) => {
+      const row = openRow("get", key, capture(opts));
+      try {
+        const result: StorageGetResult | null = await inner.get(key, opts);
+        row.result =
+          result === null
+            ? { status: "returned", classification: "not_found" }
+            : {
+                status: "returned",
+                classification: "found",
+                etag: result.etag,
+                ...(result.versionId !== undefined && { version_id: result.versionId }),
+              };
+        return result;
+      } catch (error: unknown) {
+        row.result = threwResult(error);
+        throw error;
+      }
+    },
+
+    put: async (key, body, opts) => {
+      const row = openRow("put", key, capture(opts));
+      // Copy at dispatch so later caller mutation cannot alter the journal.
+      // The ORIGINAL `body` is handed to the inner storage: `MemoryStorage`
+      // stores the caller's array by reference, and substituting a copy would
+      // change what the system under test observes.
+      const copy = new Uint8Array(body.byteLength);
+      copy.set(body);
+      // Settle the digest to an option rather than awaiting it bare: a digest
+      // rejection must never replace the storage error, which is the outcome
+      // the caller actually needs.
+      const digest = sha256Hex(copy).then(
+        (sha256) => ({ ok: true, sha256 }) as const,
+        () => ({ ok: false }) as const,
+      );
+      const settled = await inner.put(key, body, opts).then(
+        (value: StoragePutResult) => ({ ok: true, value }) as const,
+        (error: unknown) => ({ ok: false, error }) as const,
+      );
+      const digested = await digest;
+      // `byte_length` is unconditional — gating it behind the digest would let
+      // a crypto failure silently zero the byte accounting.
+      row.put = Object.freeze({
+        byte_length: copy.byteLength,
+        ...(digested.ok && { sha256: digested.sha256 }),
+      });
+      if (!settled.ok) {
+        row.result = threwResult(settled.error);
+        markUncertain(row, "put", settled.error);
+        throw settled.error;
+      }
+      row.result = {
+        status: "returned",
+        classification: "put_ok",
+        etag: settled.value.etag,
+        ...(settled.value.versionId !== undefined && { version_id: settled.value.versionId }),
+      };
+      uncertain.delete(key);
+      entries.set(key, {
+        byte_length: copy.byteLength,
+        last_operation_index: row.index,
+        source: "put",
+      });
+      return settled.value;
+    },
+
+    delete: async (key, opts) => {
+      const row = openRow("delete", key, capture(opts));
+      try {
+        await inner.delete(key, opts);
+        row.result = { status: "returned", classification: "delete_ok" };
+        entries.delete(key);
+        uncertain.delete(key);
+      } catch (error: unknown) {
+        row.result = threwResult(error);
+        markUncertain(row, "delete", error);
+        throw error;
+      }
+    },
+
+    // The generator body does not run until the first `next()`, so the row is
+    // opened when ITERATION begins, per the parent plan. That is a different
+    // clock from the other three verbs — see Semantics §2 and Open question 6.
+    list: async function* (prefix, opts): AsyncIterable<StorageListEntry> {
+      const row = openRow("list", prefix, capture(opts));
+      let listed = 0;
+      try {
+        for await (const entry of inner.list(prefix, opts)) {
+          listed += 1;
+          yield entry;
+        }
+        row.result = { status: "returned", classification: "list_ok", listed_entries: listed };
+      } catch (error: unknown) {
+        row.result = threwResult(error);
+        throw error;
+      } finally {
+        // An early `break` disposes the generator without reaching either
+        // branch above; settle with the partial count so the row never leaks.
+        row.result ??= {
+          status: "returned",
+          classification: "list_ok",
+          listed_entries: listed,
+        };
+      }
+    },
+  };
+
+  const settledRows = (): (MutableRow & { result: StorageOperationResult })[] =>
+    rows
+      .filter(
+        (row): row is MutableRow & { result: StorageOperationResult } => row.result !== undefined,
+      )
+      .toSorted((a, b) => a.index - b.index);
+
+  const toRecord = (row: MutableRow & { result: StorageOperationResult }): StorageOperationRecord =>
+    Object.freeze<StorageOperationRecord>({
+      schema: OPERATION_JOURNAL_VERSION,
+      attempt_id: input.attemptId,
+      operation_index: row.index,
+      method: row.method,
+      key: row.key,
+      options: row.options,
+      ...(row.put !== undefined && { put: row.put }),
+      result: row.result,
+    });
+
+  const pending = (): PendingOperation[] =>
+    rows
+      .filter((row) => row.result === undefined)
+      .toSorted((a, b) => a.index - b.index)
+      .map((row) => ({ operation_index: row.index, method: row.method, key: row.key }));
+
+  const journal: StorageJournal = {
+    attemptId: input.attemptId,
+
+    /**
+     * Throws when the journal is not quiescent. Journal EQUALITY is this
+     * contract's primary consumer, and two silently-truncated lists compare
+     * equal to each other — the exact failure that passes green.
+     */
+    snapshotOperations: (): readonly StorageOperationRecord[] => {
+      const unsettled = pending();
+      if (unsettled.length > 0) {
+        throw new JournalNotQuiescentError(unsettled);
+      }
+      return settledRows().map(toRecord);
+    },
+
+    snapshotSettledOperations: (): readonly StorageOperationRecord[] => settledRows().map(toRecord),
+
+    pendingOperations: (): readonly PendingOperation[] => pending(),
+
+    pendingOperationCount: (): number =>
+      rows.reduce((count, row) => (row.result === undefined ? count + 1 : count), 0),
+
+    snapshotNamespace: (): NamespaceSnapshot =>
+      Object.freeze<NamespaceSnapshot>({
+        schema: NAMESPACE_JOURNAL_VERSION,
+        exact: uncertain.size === 0,
+        entries: [...entries]
+          .map(([key, value]) => ({
+            key,
+            byte_length: value.byte_length,
+            last_operation_index: value.last_operation_index,
+            source: value.source,
+          }))
+          .toSorted(byKeyAsc),
+        uncertain_keys: [...uncertain.keys()].toSorted(),
+        uncertainty: [...uncertain.values()].toSorted(byKeyAsc),
+      }),
+
+    recordProvisioned: (provisioned): void => {
+      for (const entry of provisioned) {
+        uncertain.delete(entry.key);
+        entries.set(entry.key, {
+          byte_length: entry.byte_length,
+          last_operation_index: null,
+          source: "provisioned",
+        });
+      }
+    },
+
+    billingSummary: (): BillingSummary => {
+      let classA = 0;
+      let classB = 0;
+      let free = 0;
+      for (const row of settledRows()) {
+        const cls = billingClassOf(row.method);
+        if (cls === "A") {
+          classA += 1;
+        } else if (cls === "B") {
+          classB += 1;
+        } else {
+          free += 1;
+        }
+      }
+      return { class_a: classA, class_b: classB, free };
+    },
+  };
+
+  return { storage, journal };
+};


### PR DESCRIPTION
## What & why

Two foundation modules the rest of the fold measurement program builds on: a timer-free `Storage` decorator producing an ordered operation journal plus an exact namespace journal, and a `StorageFactory` / `StorageLease` seam giving each attempt a fresh backend whose cleanup authority is narrowed to one in-memory instance, one `mkdtemp` root, or an explicit key list.

**No consumer yet** — these are a seam, landed ahead of the lanes that use them so their contracts can be reviewed on their own rather than inside a study. Nothing outside `bench/measurement/` imports them, and `bench/` is not bundled into `@gusto/baerly-storage`.

## Key points

- **Timing is deliberately absent** from the journal: no wall-clock field, no clock or timer call, no runtime import beyond the global Web Crypto digest. Tests pin all three, the last two by reading the module's own source. That keeps a semantics comparison free of clock noise and keeps the module loadable outside Node.
- `snapshotOperations()` **throws** on non-quiescence rather than returning a short list — journal equality is the primary consumer, and two silently-truncated lists compare equal. `snapshotSettledOperations()` is the opt-out.
- `byte_length` is set unconditionally off the defensive copy rather than alongside the SHA-256, so a rejecting `crypto.subtle` leaves a visible missing hash instead of silently dropping bytes out of a written-bytes total. `toRecord` freezes `options`, `put`, and the nested `signal` at capture, so a downstream comparator normalising before it diffs can't mutate the journal through a shared reference.
- `isWithinCleanupAuthority` is exported and tested in both polarities because inside the local-fs cleanup closure the `rm -rf` refusal branch is unreachable by construction and would otherwise ship uncovered. The temp parent is `resolve`d and deliberately **not** `realpath`ed — `os.tmpdir()` is a symlink on macOS, and resolving one side would reject every real root.
- The memory factory's cleanup hoists the instance and `_clear()`s it rather than claiming to drop a reference it cannot drop: the lease holds `storage` and the journal closure holds `inner` / `rows` / `entries`, so a hand-written `clean` report would have been fabricated for a bucket whose keys still read back.
- `withStorageLease` samples `pendingOperationCount()` before cleanup and reports it on both settled arms; it neither throws nor waits, because throwing would mask the work's own error and there is no safe general way to await an operation the caller abandoned. Cleanup settles through `.then(onFulfilled, onRejected)` like `work` does, so a rejecting factory cleanup becomes the `failed` report the contract already has a shape for.
- `billingClassOf` implements the `cost-model.md` definition (puts + lists bill, DELETE is $0). One definition, **not** a resolution: a test records all three live disagreeing definitions in the tree as evidence for their owner. It counts `Storage` calls rather than billable requests, which `bench/README.md` now says out loud — that gap must close before the first S3-backed factory.

## Verification

| `pnpm verify:agent` | clean |
| `oxlint bench/` | 1 problem, pre-existing (`load-harness/runner/replay.ts:10`) |
| `vitest run bench` | 141 passed |
| `pnpm test:agent` (full suite) | **not run** — `main` has a known bundle-budget failure and several flakes being fixed separately |

Bundle budgets are unaffected structurally rather than by assertion: this branch modifies nothing under `packages/`, `tests/`, or the lockfile, and `bench/` is neither an entry in `rolldown.config.ts` nor imported by any package.

## Notes for reviewers

Read `storage-journal.ts` first — `storage-factory.ts` depends on it and not the reverse. The `bench/README.md` section is the durable statement of the three journal behaviours a consumer has to know before reading a snapshot.

Both modules ship with hardening gaps that no current caller can reach, recorded rather than fixed; the `billingSummary` call-vs-request accounting is the one with a hard deadline (first S3-backed factory).

## Automated review triage

Fresh Eyes raised five Minor findings plus one Info. Resolved as follows — no reply threads, the disposition is here.

**Addressed in this PR (doc, not code):** the local-fs `create()` wraps only `mkdtemp`, while the memory factory wraps its whole body, which the README's flat "create() never rejects" overstated. The README now says what is actually true and why: `new LocalFsStorage()` is a `resolve()` on a string and `makeLease()` takes an already-branded `AttemptId`, so neither has a throw path, and wrapping them would ship a `catch` arm no test can reach — the same reason `isWithinCleanupAuthority` is exported rather than inlined. It also records the condition for revisiting (widen the `try` if either gains a throw path, and remove the already-created `mkdtemp` directory when doing so).

**Deferred, recorded in `deferred-defects.md`:**
- The Info finding is the most consequential of the set and is now entry 16 at **High — availability**. An abandoned in-flight operation rejects against the torn-down backend with no handler attached, so Node exits 1 *after* `withStorageLease` returned a success report — and `pending_operations_at_cleanup`, the field built for that case, is unreadable in that case. Deferred because the fix is not small: the journal retains **no promise handle** (`MutableRow` is `{index, method, key, options}`, pendingness inferred from `result === undefined`), so making one attachable means restructuring all four verb wrappers to construct and retain their own promise — a deliberate change to a module whose stated property is holding no live handles, and not something to fold into a history-restructure PR.
- `MemoryStorage._clear()` being `@internal`/test-only is entry 17. Real boundary smell; the fix is a public `clear()` on `MemoryStorage`, which touches `packages/protocol` and its bundle budget and is a protocol-owner call.
- `billingClassOf`'s non-exhaustive fallthrough is a bullet on entry 12, and the untested `list` throw path is already a bullet on entry 14.

**Declined, recorded so it doesn't return:** a guard against `work` throwing *synchronously* defends against a caller violating its own `Promise<T>` signature, and testing it requires an `as` cast to construct the violation. Noted on entry 13.

These, plus the unhandled-rejection fix and the two missing tests, are the contents of a planned follow-up PR — reviewable as hardening rather than smuggled into this one.
