### PR TITLE
build(scripts): gate the packed export map and consumer type resolution

### DIFF
--- a/scripts/check-exports.mjs
+++ b/scripts/check-exports.mjs
@@ -16,7 +16,16 @@
 // by scripts/publish.mjs. Not wired into verify. Set BAERLY_SKIP_BUILD=1
 // to reuse an existing dist/ (publish.mjs builds once, then sets it).
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readdirSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -59,3 +68,234 @@ if (!tarball) {
 // ~6-line block per entry point — ~90 lines that repeat the same ignored
 // node10/node16-CJS resolutions across all 13 subpaths.
 run("pnpm", ["exec", "attw", join(outDir, tarball), "--profile", "esm-only", "-f", "table"]);
+
+// ---------------------------------------------------------------------
+// Packed public-surface gate.
+//
+// attw proves the published entry points RESOLVE. This proves the packed
+// surface contains what it should and NOTHING it shouldn't. A grep over
+// hash-suffixed declaration chunks is not a valid gate: rolldown emits
+// shared chunks, so a private symbol can exist in a chunk without being
+// reachable from any published entry. The only sound test is to extract
+// the real tarball and compile a consumer against it.
+//
+// Two fixture classes:
+//   - POSITIVE: must compile clean. This is the non-vacuity guard — if the
+//     harness stops actually running tsgo, the positive control fails.
+//   - NEGATIVE: must fail, AND the diagnostic must be attributed to that
+//     fixture's own file with one of its declared expected codes, so an
+//     unrelated TypeScript error can never satisfy a negative test.
+// ---------------------------------------------------------------------
+
+const consumerRoot = mkdtempSync(join(tmpdir(), "baerly-consumer-"));
+const packedRoot = join(consumerRoot, "node_modules", "@gusto", "baerly-storage");
+mkdirSync(packedRoot, { recursive: true });
+
+run("tar", ["-xzf", join(outDir, tarball), "-C", packedRoot, "--strip-components", "1"]);
+
+// The packed declarations `import`/`reference` ambient type packages. `types: []`
+// below disables AUTOMATIC @types inclusion for the fixture itself; these
+// symlinks exist so resolution reached FROM the packed .d.ts still succeeds,
+// keeping a diagnostic about OUR surface rather than a missing @types/node.
+mkdirSync(join(consumerRoot, "node_modules", "@types"), { recursive: true });
+mkdirSync(join(consumerRoot, "node_modules", "@cloudflare"), { recursive: true });
+symlinkSync(
+  realpathSync("node_modules/@types/node"),
+  join(consumerRoot, "node_modules", "@types", "node"),
+  "dir",
+);
+symlinkSync(
+  realpathSync("node_modules/@cloudflare/workers-types"),
+  join(consumerRoot, "node_modules", "@cloudflare", "workers-types"),
+  "dir",
+);
+
+const packedManifest = JSON.parse(readFileSync(join(packedRoot, "package.json"), "utf8"));
+const packedExports = packedManifest.exports ?? {};
+
+// 1. No `_internal` subpath may be published.
+const internalSubpaths = Object.keys(packedExports).filter((s) => s.startsWith("./_internal"));
+if (internalSubpaths.length > 0) {
+  console.error(
+    `check-exports: packed exports must not contain an _internal subpath; found ${internalSubpaths.join(", ")}`,
+  );
+  process.exit(1);
+}
+
+// 2. Every packed export's `types` target must exist in the tarball.
+const packedEntries = Object.entries(packedExports);
+if (packedEntries.length === 0) {
+  console.error("check-exports: packed exports map is empty (vacuous gate)");
+  process.exit(1);
+}
+for (const [subpath, condition] of packedEntries) {
+  const types = typeof condition === "object" && condition !== null ? condition.types : undefined;
+  if (types === undefined) {
+    console.error(`check-exports: packed export "${subpath}" declares no types condition`);
+    process.exit(1);
+  }
+  if (!existsSync(join(packedRoot, types))) {
+    console.error(`check-exports: packed export "${subpath}" types target ${types} is missing`);
+    process.exit(1);
+  }
+}
+
+// 3. Attributed consumer fixtures.
+const CONSUMER_TSCONFIG = {
+  compilerOptions: {
+    target: "ES2025",
+    lib: ["ES2025", "DOM", "DOM.Iterable"],
+    module: "preserve",
+    moduleResolution: "bundler",
+    strict: true,
+    noEmit: true,
+    skipLibCheck: true,
+    types: [],
+  },
+  files: ["fixture.ts"],
+};
+
+/**
+ * `expect: "compiles"` — the non-vacuity positive control.
+ * `expect: "fails"` — must fail with one of `codes`, reported against
+ * `fixture.ts` itself.
+ */
+const CONSUMER_FIXTURES = [
+  {
+    name: "positive-public-maintenance-surface",
+    expect: "compiles",
+    source: `
+import type { CompactOptions, MaintenanceOptions } from "@gusto/baerly-storage/maintenance";
+import { runScheduledMaintenance } from "@gusto/baerly-storage/maintenance";
+
+const compactOptions: CompactOptions = { minEntriesToCompact: 100 };
+const options: MaintenanceOptions = { compact: compactOptions };
+void options;
+void runScheduledMaintenance;
+`,
+  },
+  {
+    name: "negative-internal-compact-options-from-root",
+    expect: "fails",
+    codes: ["TS2305", "TS2724"],
+    source: `
+import type { InternalCompactOptions } from "@gusto/baerly-storage";
+export type Leaked = InternalCompactOptions;
+`,
+  },
+  {
+    name: "negative-internal-compact-options-from-maintenance",
+    expect: "fails",
+    codes: ["TS2305", "TS2724"],
+    source: `
+import type { InternalCompactOptions } from "@gusto/baerly-storage/maintenance";
+export type Leaked = InternalCompactOptions;
+`,
+  },
+  {
+    name: "negative-internal-maintenance-options-from-maintenance",
+    expect: "fails",
+    codes: ["TS2305", "TS2724"],
+    source: `
+import type { InternalMaintenanceOptions } from "@gusto/baerly-storage/maintenance";
+export type Leaked = InternalMaintenanceOptions;
+`,
+  },
+  {
+    name: "negative-internal-run-gc-options-from-maintenance",
+    expect: "fails",
+    codes: ["TS2305", "TS2724"],
+    source: `
+import type { InternalRunGcOptions } from "@gusto/baerly-storage/maintenance";
+export type Leaked = InternalRunGcOptions;
+`,
+  },
+  {
+    // Weak by construction: the name exists nowhere in the repo, so this
+    // fails trivially today. Retained as a forward guard against a future
+    // `compactInternal()` split reaching the published surface.
+    name: "negative-compact-internal-from-maintenance",
+    expect: "fails",
+    codes: ["TS2305", "TS2724"],
+    source: `
+import { compactInternal } from "@gusto/baerly-storage/maintenance";
+export const leaked = compactInternal;
+`,
+  },
+  {
+    name: "negative-internal-testing-subpath",
+    expect: "fails",
+    codes: ["TS2307"],
+    source: `
+import type { InternalCompactOptions } from "@gusto/baerly-storage/_internal/testing";
+export type Leaked = InternalCompactOptions;
+`,
+  },
+  {
+    name: "negative-internal-excess-property-on-maintenance-options",
+    expect: "fails",
+    codes: ["TS2353", "TS2322"],
+    source: `
+import type { MaintenanceOptions } from "@gusto/baerly-storage/maintenance";
+
+const leaked: MaintenanceOptions = {
+  compact: { maxEntriesPerRun: 40 },
+};
+void leaked;
+`,
+  },
+];
+
+let failures = 0;
+for (const fixture of CONSUMER_FIXTURES) {
+  const dir = join(consumerRoot, "fixtures", fixture.name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "fixture.ts"), fixture.source);
+  writeFileSync(join(dir, "tsconfig.json"), JSON.stringify(CONSUMER_TSCONFIG, null, 2));
+
+  const result = spawnSync(
+    "pnpm",
+    ["exec", "tsgo", "--noEmit", "--pretty", "false", "-p", join(dir, "tsconfig.json")],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+
+  if (fixture.expect === "compiles") {
+    if (result.status !== 0) {
+      failures += 1;
+      console.error(
+        `check-exports: positive control "${fixture.name}" must compile against the packed tarball but did not:\n${output}`,
+      );
+    }
+    continue;
+  }
+
+  if (result.status === 0) {
+    failures += 1;
+    console.error(
+      `check-exports: negative control "${fixture.name}" compiled — that name is reachable from the packed public surface`,
+    );
+    continue;
+  }
+
+  const attributed = output
+    .split("\n")
+    .filter((line) => line.includes("fixture.ts") && line.includes(fixture.name))
+    .filter((line) => fixture.codes.some((code) => line.includes(`error ${code}:`)));
+
+  if (attributed.length === 0) {
+    failures += 1;
+    console.error(
+      `check-exports: negative control "${fixture.name}" failed, but not with ${fixture.codes.join("/")} on its own fixture.ts. An unrelated error cannot satisfy this test.\n${output}`,
+    );
+  }
+}
+
+if (failures > 0) {
+  console.error(`check-exports: ${failures} packed-surface fixture(s) failed`);
+  process.exit(1);
+}
+
+console.log(
+  `check-exports: packed-surface gate passed (${CONSUMER_FIXTURES.length} attributed fixtures, ${packedEntries.length} published subpaths)`,
+);


### PR DESCRIPTION
## What & why

`pnpm verify:package` was named as the binding public-surface gate, but it only proved the published entry points *resolve* — it packed the tarball and handed it to `attw`, and never looked at what the packed surface actually contains. Nothing stopped an `_internal` subpath or an `Internal*` type from reaching consumers.

`scripts/check-exports.mjs` now extracts the real tarball, asserts the packed export map, and type-checks consumer fixtures against it. A grep over the hash-suffixed declaration chunks would not do: rolldown emits shared chunks, so a private symbol can sit in a chunk without being reachable from any published entry. Compiling a real consumer is the only sound test.

## Key points

- Negative fixtures pass only when tsgo reports one of that fixture's declared error codes *against its own `fixture.ts` path* — a bare non-zero exit does not satisfy them, so an unrelated type error can never launder a leak into a pass.
- One fixture must *compile*, and its failure fails the gate: if the harness ever stops invoking tsgo, that positive control is what catches it rather than the whole suite silently passing.
- An empty packed exports map is an explicit failure, not a vacuous pass.
- `negative-compact-internal-from-maintenance` is weak by construction — the name exists nowhere, so it fails trivially today. Retained as a forward guard against a future `compactInternal()` split reaching the published surface.
- The two `@types` symlinks exist so resolution reached *from* the packed `.d.ts` files succeeds; `types: []` in the fixture tsconfig disables automatic `@types` inclusion for the fixture itself. Without them a diagnostic about our surface would be replaced by a missing-`@types/node` error.

## Verification

| `pnpm verify:package` | pass — `packed-surface gate passed (8 attributed fixtures, 14 published subpaths)`, attw 14/14, publint clean |
| `pnpm verify:agent`   | clean |
| `pnpm test:agent`     | 2737 passed, 1 failed |

The one failure is `maintenance-e2e.test.ts` local-fs "idle reader" — `Test timed out in 30000ms`, not an assertion. It passes 8/8 when the file is run in isolation; this diff is a build script no test imports.

Falsifiability was checked by mutating a copy of the script so one negative fixture compiles: the mutant exits 1 with `negative control "negative-internal-compact-options-from-maintenance" compiled`.

## Notes for reviewers

Start at the `CONSUMER_FIXTURES` array and the attribution filter below it — that filter is the whole point of the change, and loosening it to a bare non-zero exit would make every negative test vacuous.
