### PR TITLE
Gate the read-path Class A cost claim; close read-triggered banking in ADR-002

### DIFF
--- a/docs/adr/002-ephemeral-coordination.md
+++ b/docs/adr/002-ephemeral-coordination.md
@@ -2,8 +2,8 @@
 title: Ephemeral coordination
 audience: adr
 doc_type: adr
-summary: ADR 002 — coordination runs in request-bounded compute, never a resident process; maintenance is in-band on the write path and reads are pure. The runtime model lives in sync-protocol.md + the operator-burden test; this record keeps the no-daemon doctrine and the rejected coordinator/cron/lease paths.
-last-reviewed: 2026-06-28
+summary: ADR 002 — coordination runs in request-bounded compute, never a resident process; maintenance is in-band on the write path and reads are pure. The runtime model lives in sync-protocol.md + the operator-burden test; this record keeps the no-daemon doctrine and the rejected coordinator/cron/lease/read-triggered-maintenance paths.
+last-reviewed: 2026-08-04
 tags: [decision, adr, runtime-model]
 related:
   [
@@ -88,6 +88,25 @@ is a **graduation signal, not silent breakage**.
   release the next CAS. Shipped a static ceiling instead.
 - **A compaction lease.** Considered and deferred; duplicate-fold compute
   under contention is accepted and measured, not coordinated away.
+- **Read-triggered snapshot publication ("banking").** A full-scan read
+  already holds a complete materialized fold at a known `current.json`
+  ETag, so reusing it to publish a snapshot and CAS the pointer looks
+  nearly free. It is not. Pure reads are a ratified invariant
+  ([sync-protocol.md §Protocol invariants](../spec/sync-protocol.md#protocol-invariants),
+  #8), so this path must supersede that contract rather than build
+  against it — and the invariant above is what makes it structurally
+  wrong rather than merely unproved: orphan production would track
+  **read** rate while reclamation stays write-ticked, so a read-heavy
+  write-idle bucket pins sweep throughput at 0 while `p > 0`. That is
+  the seed-then-idle orphan residual
+  ([cost-model.md](../about/cost-model.md#maintenance-is-write-driven-reads-are-pure))
+  without its bound, because reads recur and an import does not.
+  Cleanup would also depend on a later write, so it is not resumable
+  from bucket state; and the payoff inverts against the Cloudflare
+  envelope, since banking is worth most exactly when the live tail is
+  long — which is when the read alone sits closest to the 50-subrequest
+  ceiling. Anti-precedent: Cassandra's `read_repair_chance`, removed in
+  4.0 ([CASSANDRA-13910](https://issues.apache.org/jira/browse/CASSANDRA-13910)).
 
 ## What would break the property
 

--- a/packages/server/src/reads-pure.test.ts
+++ b/packages/server/src/reads-pure.test.ts
@@ -100,11 +100,17 @@ const seedOverRatio = async (n: number): Promise<MemoryStorage> => {
   return storage;
 };
 
-// ── Counting proxy (Class A = PUT + DELETE; Class B = GET + LIST) ──────
+// ── Counting proxy (mutation guard: PUT + DELETE) ──────────────────────
 //
 // Reuses the same shape as the `countingStorage` helper in
-// `maintenance.test.ts`. "Class A" follows the S3 pricing vocabulary:
-// PUT / COPY / POST / DELETE = mutating ops that cost more.
+// `maintenance.test.ts`. `classA()` sums PUT + DELETE because this file
+// is a MUTATION guard: its job is proving a read leaves the bucket
+// byte-identical, and PUT + DELETE is exactly the set that could change
+// it. That predicate is deliberately NOT the billing meter — on both R2
+// and S3, LIST is Class A and DELETE is free. For cost measurement use
+// `billableClassAOps` (PUT + LIST) from `tests/fixtures/counting-storage.ts`;
+// `tests/unit/read-class-a-cost.test.ts` gates the read-path cost claim
+// in `docs/about/cost-model.md` on that meter.
 
 interface CountingProxy {
   readonly storage: Storage;

--- a/tests/unit/read-class-a-cost.test.ts
+++ b/tests/unit/read-class-a-cost.test.ts
@@ -1,0 +1,126 @@
+// Gates the read-path Class A cost claim in
+// `docs/about/cost-model.md` §"Maintenance is write-driven; reads are pure":
+//
+//   - For unindexed idle reads the expected Class A count is exactly zero.
+//   - The read-path exception is an indexed `.where()`: one `ListObjects`
+//     per equality value, so `$in` over N values costs N calls.
+//
+// `packages/server/src/reads-pure.test.ts` guards the neighbouring but
+// distinct property — that a read mutates nothing — on a PUT + DELETE
+// predicate. That predicate cannot see a LIST, and LIST is Class A on both
+// R2 and S3, so it cannot gate the cost claim. This file uses
+// `billableClassAOps` (PUT + LIST) for that.
+//
+// Assertions here pin each counter individually rather than a sum. A sum of
+// non-negative counters at zero is also satisfied by a read that did no work
+// at all, so every case additionally asserts its terminal resolved the right
+// answer, and the unindexed cases assert a GET floor.
+
+import { MemoryStorage, type Storage } from "@baerly/protocol";
+import { Db } from "@baerly/server";
+import { describe, expect, test } from "vitest";
+import { wrapCountingStorage } from "../fixtures/counting-storage.ts";
+
+const APP = "read-class-a-cost";
+const TENANT = "cost";
+const COLL = "notes";
+const INDEXES = [{ name: "by_tag", on: "tag" }] as const;
+
+const TAGS = ["x", "y", "z"] as const;
+/** 12 docs, 4 per tag value — well under the 50-entry write-tick fold floor. */
+const SEEDED = 12;
+const PER_TAG = SEEDED / TAGS.length;
+
+const dbFor = (storage: Storage, indexed: boolean): Db =>
+  Db.create({
+    storage,
+    app: APP,
+    tenant: TENANT,
+    ...(indexed ? { config: { collections: { [COLL]: { indexes: [...INDEXES] } } } } : {}),
+  });
+
+const seed = async (indexed: boolean): Promise<MemoryStorage> => {
+  const storage = new MemoryStorage();
+  const db = dbFor(storage, indexed);
+  let ordinal = 0;
+  for (let round = 0; round < PER_TAG; round++) {
+    for (const tag of TAGS) {
+      await db.collection(COLL).insert({ _id: `note-${tag}-${round}`, tag, ordinal });
+      ordinal += 1;
+    }
+  }
+  return storage;
+};
+
+// Each terminal verifies its own result, so a vacuous read cannot pass.
+const TERMINALS = [
+  {
+    name: "all",
+    read: async (db: Db): Promise<void> => {
+      const rows = await db.collection(COLL).where({ tag: "x" }).all();
+      expect(rows, "all() must resolve every matching doc").toHaveLength(PER_TAG);
+    },
+  },
+  {
+    name: "first",
+    read: async (db: Db): Promise<void> => {
+      const row = await db.collection(COLL).where({ tag: "x" }).first();
+      expect(row?.["tag"], "first() must resolve a matching doc").toBe("x");
+    },
+  },
+  {
+    name: "count",
+    read: async (db: Db): Promise<void> => {
+      const total = await db.collection(COLL).where({ tag: "x" }).count();
+      expect(total, "count() must resolve every matching doc").toBe(PER_TAG);
+    },
+  },
+] as const;
+
+describe("read-path Class A cost", () => {
+  for (const terminal of TERMINALS) {
+    test(`unindexed ${terminal.name} costs zero Class A ops`, async () => {
+      const counting = wrapCountingStorage(await seed(false));
+
+      await terminal.read(dbFor(counting.storage, false));
+
+      expect({
+        puts: counting.puts,
+        deletes: counting.deletes,
+        lists: counting.lists,
+      }).toEqual({ puts: 0, deletes: 0, lists: 0 });
+      expect(counting.billableClassAOps).toBe(0);
+      expect(counting.gets, "the read must have walked storage to be meaningful").toBeGreaterThan(
+        0,
+      );
+    });
+
+    test(`indexed ${terminal.name} costs exactly one LIST`, async () => {
+      const counting = wrapCountingStorage(await seed(true));
+
+      await terminal.read(dbFor(counting.storage, true));
+
+      expect({
+        puts: counting.puts,
+        deletes: counting.deletes,
+        lists: counting.lists,
+      }).toEqual({ puts: 0, deletes: 0, lists: 1 });
+      expect(counting.billableClassAOps).toBe(1);
+    });
+  }
+
+  test("an indexed $in walk costs exactly one LIST per equality value", async () => {
+    const counting = wrapCountingStorage(await seed(true));
+
+    const rows = await dbFor(counting.storage, true)
+      .collection(COLL)
+      .where((q) => q.in("tag", [...TAGS]))
+      .all();
+
+    expect(rows, "the $in union must resolve every seeded doc").toHaveLength(SEEDED);
+    expect(counting.lists, "cost-model.md: $in over N values costs N Class A calls").toBe(
+      TAGS.length,
+    );
+    expect({ puts: counting.puts, deletes: counting.deletes }).toEqual({ puts: 0, deletes: 0 });
+  });
+});


### PR DESCRIPTION
## What & why

`docs/about/cost-model.md` makes two read-path cost claims: an unindexed read costs zero Class A ops, and the single exception is an indexed `.where()` at one `ListObjects` per equality value. Neither was gated, and the nearest counting test could not gate them — `reads-pure.test.ts` sums PUT + DELETE, a predicate that structurally cannot see a LIST. This adds `tests/unit/read-class-a-cost.test.ts` on the real billing meter, and records read-triggered snapshot publication ("banking") as a closed path in ADR-002.

## Key points

- `reads-pure.test.ts` keeps its predicate — only the label was wrong. PUT + DELETE is exactly right for a mutation guard, since that set is what could leave the bucket non-byte-identical, but it is not the billing meter: LIST is Class A and DELETE is free on both R2 and S3. The comment claimed the S3 pricing vocabulary outright, so the gap read as covered.
- Cost cases pin each counter individually rather than a sum, and each asserts its terminal resolved the right answer — a sum of non-negative counters at zero is also satisfied by a read that did no work at all.
- Banking is closed as structurally wrong, not merely unproved. Reads-are-pure is a ratified invariant (sync-protocol.md #8), so the path would have to supersede that contract rather than build against it, and orphan production would then track read rate while reclamation stays write-ticked — pinning sweep throughput at zero on a read-heavy, write-idle bucket.
- The investigation ran as a throwaway `tests/audit/read-banking/` harness, deliberately not included here. The ADR argues from ratified invariants and cites nothing from it.
- No changeset: no user-facing behavior change.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm build` | clean |
| `pnpm test:agent` | 3070 passed, 101 skipped |
| GitHub `ci` | pass |

One of two local full-suite runs hit a 30s per-test timeout in `tests/integration/maintenance-e2e.test.ts` (local-fs), a file this PR does not touch. It passes solo at ~39s wall and on re-run at 78.8s total — faster than the `origin/main` control, which was itself green. Pre-existing load sensitivity against an undersized ceiling, not a regression here.

## Notes for reviewers

Start at `tests/unit/read-class-a-cost.test.ts`; its header comment states why it exists separately from `reads-pure.test.ts`. Those two want to stay distinct — folding the counters back together re-creates the blind spot this closes.
