### PR TITLE
test: model deterministic fold boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Planning artifacts (untracked; not shipped, not doc-validated)
 .plans/
 
+# Local git worktrees
+.worktrees/
+
 # Dependencies
 node_modules/
 .pnpm-store/

--- a/tests/model/fold-boundary/arbitraries.ts
+++ b/tests/model/fold-boundary/arbitraries.ts
@@ -1,5 +1,8 @@
 import { fc } from "@fast-check/vitest";
 
+import type { BoundaryAlgorithm, FoldBudget } from "./boundary.ts";
+import type { CrashPoint, ObserverAction } from "./schedule.ts";
+
 import {
   applySnapshot,
   emptyState,
@@ -30,6 +33,42 @@ export const arbModelLog: fc.Arbitrary<ModelLog> = fc
   );
 
 export const arbPositiveK = fc.integer({ min: 1, max: 64 });
+
+export const arbCrashPoint: fc.Arbitrary<CrashPoint> = fc.constantFrom(
+  "none",
+  "after_manifest_read",
+  "after_snapshot_put",
+);
+
+export const arbKChange: fc.Arbitrary<{
+  readonly fromK: number;
+  readonly toK: number;
+}> = fc
+  .tuple(arbPositiveK, arbPositiveK)
+  .filter(([fromK, toK]) => fromK !== toK)
+  .map(([fromK, toK]) => ({ fromK, toK }));
+
+export const arbObserverAction = (opts: {
+  readonly maxObservedTail: number;
+  readonly maxGeneration: number;
+  readonly budget: FoldBudget;
+  readonly algorithm?: BoundaryAlgorithm;
+}): fc.Arbitrary<ObserverAction> =>
+  fc.record({
+    observerId: fc.nat({ max: 7 }),
+    readsAtGeneration: fc.oneof(
+      fc.integer({ min: 0, max: opts.maxGeneration }),
+      fc.constant(Number.MAX_SAFE_INTEGER),
+    ),
+    observedTail: fc.integer({ min: 0, max: opts.maxObservedTail }),
+    k: arbPositiveK,
+    budget: fc.constant(opts.budget),
+    algorithm:
+      opts.algorithm === undefined
+        ? fc.constantFrom<BoundaryAlgorithm>("live-greedy", "aligned-observed", "aligned-manifest")
+        : fc.constant(opts.algorithm),
+    crashAt: arbCrashPoint,
+  });
 
 export const arbReachableState: fc.Arbitrary<ModelState> = arbModelLog.chain((log) =>
   fc

--- a/tests/model/fold-boundary/arbitraries.ts
+++ b/tests/model/fold-boundary/arbitraries.ts
@@ -1,0 +1,40 @@
+import { fc } from "@fast-check/vitest";
+
+import {
+  applySnapshot,
+  emptyState,
+  makeSnapshot,
+  replayAcknowledged,
+  type ModelLog,
+  type ModelOp,
+  type ModelState,
+} from "./model.ts";
+
+const arbDocId = fc.constantFrom("alpha", "bravo", "charlie", "delta");
+const arbValue = fc.integer({ min: -100, max: 100 });
+
+export const arbModelOp: fc.Arbitrary<ModelOp> = fc.oneof(
+  fc
+    .tuple(fc.constantFrom<"I" | "U">("I", "U"), arbDocId, arbValue)
+    .map(([kind, docId, value]) => ({ kind, docId, value })),
+  arbDocId.map((docId) => ({ kind: "D" as const, docId })),
+);
+
+export const arbModelLog: fc.Arbitrary<ModelLog> = fc
+  .array(arbModelOp, { maxLength: 32 })
+  .chain((ops) =>
+    fc.integer({ min: 0, max: ops.length }).map((acknowledgedTail) => ({
+      ops,
+      acknowledgedTail,
+    })),
+  );
+
+export const arbPositiveK = fc.integer({ min: 1, max: 64 });
+
+export const arbReachableState: fc.Arbitrary<ModelState> = arbModelLog.chain((log) =>
+  fc
+    .integer({ min: 0, max: log.acknowledgedTail })
+    .map((boundary) =>
+      applySnapshot(emptyState(log), makeSnapshot(replayAcknowledged(log, boundary), boundary)),
+    ),
+);

--- a/tests/model/fold-boundary/arbitraries.ts
+++ b/tests/model/fold-boundary/arbitraries.ts
@@ -74,6 +74,8 @@ export const arbReachableState: fc.Arbitrary<ModelState> = arbModelLog.chain((lo
   fc
     .integer({ min: 0, max: log.acknowledgedTail })
     .map((boundary) =>
-      applySnapshot(emptyState(log), makeSnapshot(replayAcknowledged(log, boundary), boundary)),
+      boundary === 0
+        ? emptyState(log)
+        : applySnapshot(emptyState(log), makeSnapshot(replayAcknowledged(log, boundary), boundary)),
     ),
 );

--- a/tests/model/fold-boundary/boundary.test.ts
+++ b/tests/model/fold-boundary/boundary.test.ts
@@ -277,6 +277,29 @@ describe("exact compact cost", () => {
     });
   });
 
+  test("probe cost uses supplied observation past acknowledged tail", () => {
+    const result = prepareFold({
+      state: stateAt(1, 1, 3),
+      observedTail: 3,
+      probeFloor: 1,
+      budget: roomyBudget(),
+      k: 1,
+      algorithm: "aligned-manifest",
+    });
+
+    expect(result.outcome).toBe("below_min_threshold");
+    expect(result.readSet).toEqual([]);
+    expect(result.cost).toEqual({
+      currentGets: 1,
+      probeGets: 3,
+      snapshotGets: 0,
+      logGets: 0,
+      snapshotPuts: 0,
+      currentPuts: 0,
+      total: 4,
+    });
+  });
+
   test("byte ceiling defers after replay without charging writes", () => {
     const result = prepareFold({
       state: stateAt(0, 1),

--- a/tests/model/fold-boundary/boundary.test.ts
+++ b/tests/model/fold-boundary/boundary.test.ts
@@ -11,6 +11,7 @@ import {
   type FoldBudget,
 } from "./boundary.ts";
 import { billableClassA, foldCost } from "./cost.ts";
+import { operations, roomyBudget } from "./fixtures.ts";
 import {
   applySnapshot,
   emptyState,
@@ -18,25 +19,8 @@ import {
   replayAcknowledged,
   type ModelLog,
   type ModelManifest,
-  type ModelOp,
   type ModelState,
 } from "./model.ts";
-
-const roomyBudget = (overrides: Partial<FoldBudget> = {}): FoldBudget => ({
-  maxEntriesPerRun: 100,
-  minEntriesToCompact: 1,
-  ceilingBytes: 1_000_000,
-  ceilingEntries: 1_000,
-  subrequestLimit: 10_000,
-  ...overrides,
-});
-
-const operations = (count: number): readonly ModelOp[] =>
-  Array.from({ length: count }, (_, index) => ({
-    kind: "I" as const,
-    docId: `doc-${index}`,
-    value: index,
-  }));
 
 const stateAt = (
   floor: number,

--- a/tests/model/fold-boundary/boundary.test.ts
+++ b/tests/model/fold-boundary/boundary.test.ts
@@ -1,0 +1,343 @@
+import { fc } from "@fast-check/vitest";
+import { describe, expect, test } from "vitest";
+
+import {
+  alignedManifestBoundary,
+  alignedManifestTarget,
+  alignedObservedBoundary,
+  liveGreedyBoundary,
+  prepareFold,
+  type BoundaryInput,
+  type FoldBudget,
+} from "./boundary.ts";
+import { billableClassA, foldCost } from "./cost.ts";
+import {
+  applySnapshot,
+  emptyState,
+  makeSnapshot,
+  replayAcknowledged,
+  type ModelLog,
+  type ModelManifest,
+  type ModelOp,
+  type ModelState,
+} from "./model.ts";
+
+const roomyBudget = (overrides: Partial<FoldBudget> = {}): FoldBudget => ({
+  maxEntriesPerRun: 100,
+  minEntriesToCompact: 1,
+  ceilingBytes: 1_000_000,
+  ceilingEntries: 1_000,
+  subrequestLimit: 10_000,
+  ...overrides,
+});
+
+const operations = (count: number): readonly ModelOp[] =>
+  Array.from({ length: count }, (_, index) => ({
+    kind: "I" as const,
+    docId: `doc-${index}`,
+    value: index,
+  }));
+
+const stateAt = (
+  floor: number,
+  acknowledgedTail: number,
+  physicalTail = acknowledgedTail,
+): ModelState => {
+  const log: ModelLog = {
+    ops: operations(physicalTail),
+    acknowledgedTail,
+  };
+  if (floor === 0) {
+    return emptyState(log);
+  }
+
+  return applySnapshot(emptyState(log), makeSnapshot(replayAcknowledged(log, floor), floor));
+};
+
+const inputAt = (
+  floor: number,
+  observedTail: number,
+  budget: FoldBudget,
+  k: number,
+): BoundaryInput => ({
+  manifest: stateAt(floor, Math.max(floor, observedTail)).manifest,
+  observedTail,
+  budget,
+  k,
+});
+
+describe("fold boundary hypotheses", () => {
+  test("P1a_manifestTargetIsIndependentOfObservationAndBudget", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 1_000 }),
+        fc.integer({ min: 1, max: 64 }),
+        fc.integer({ min: 0, max: 2_000 }),
+        fc.integer({ min: 0, max: 500 }),
+        (floor, k, observedTail, maxEntriesPerRun) => {
+          const want = (Math.floor(floor / k) + 1) * k;
+
+          expect(alignedManifestTarget(floor, k)).toBe(want);
+          expect(
+            alignedManifestTarget(
+              inputAt(floor, observedTail, roomyBudget({ maxEntriesPerRun }), k).manifest
+                .logSeqStart,
+              k,
+            ),
+          ).toBe(want);
+        },
+      ),
+    );
+  });
+
+  test("P1b_liveAndObservedAlignedTargetsDependOnObservedAvailability", () => {
+    const budget = roomyBudget({ maxEntriesPerRun: 20 });
+
+    expect(liveGreedyBoundary(inputAt(0, 13, budget, 5))).toBe(13);
+    expect(liveGreedyBoundary(inputAt(0, 18, budget, 5))).toBe(18);
+    expect(alignedObservedBoundary(inputAt(0, 13, budget, 5))).toBe(10);
+    expect(alignedObservedBoundary(inputAt(0, 18, budget, 5))).toBe(15);
+  });
+
+  test("P2a_fewerThanNextKEntriesProducesNoObjectOrProgress", () => {
+    const state = stateAt(1, 4);
+    const result = prepareFold({
+      state,
+      observedTail: 4,
+      probeFloor: 4,
+      budget: roomyBudget(),
+      k: 5,
+      algorithm: "aligned-manifest",
+    });
+
+    expect(result).toEqual({
+      outcome: "below_min_threshold",
+      baseGeneration: 1,
+      foldEnd: null,
+      readSet: [],
+      snapshot: null,
+      cost: {
+        currentGets: 1,
+        probeGets: 1,
+        snapshotGets: 0,
+        logGets: 0,
+        snapshotPuts: 0,
+        currentPuts: 0,
+        total: 2,
+      },
+    });
+  });
+
+  test("P2b_retryAfterAvailabilityUsesTheSameManifestTarget", () => {
+    const state = stateAt(1, 5);
+    const before = alignedManifestTarget(state.manifest.logSeqStart, 5);
+    const unavailable = alignedManifestBoundary({
+      manifest: state.manifest,
+      observedTail: 4,
+      budget: roomyBudget(),
+      k: 5,
+    });
+    const retry = prepareFold({
+      state,
+      observedTail: 5,
+      probeFloor: 5,
+      budget: roomyBudget(),
+      k: 5,
+      algorithm: "aligned-manifest",
+    });
+
+    expect(unavailable).toBeNull();
+    expect(before).toBe(5);
+    expect(retry.foldEnd).toBe(before);
+    expect(retry.outcome).toBe("prepared");
+  });
+
+  test("P4a_firstTargetAfterKChangeIsStrictlyMonotoneAndNewKAligned", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 10_000 }),
+        fc.integer({ min: 1, max: 128 }),
+        (floor, newK) => {
+          const target = alignedManifestTarget(floor, newK);
+
+          expect(target).toBeGreaterThan(floor);
+          expect(target % newK).toBe(0);
+        },
+      ),
+    );
+  });
+
+  test("P7a_everyPreparedManifestBoundaryStrictlyAdvancesAndIsAligned", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: 20 }), fc.integer({ min: 1, max: 12 }), (floor, k) => {
+        const target = (Math.floor(floor / k) + 1) * k;
+        const result = prepareFold({
+          state: stateAt(floor, target),
+          observedTail: target,
+          probeFloor: target,
+          budget: roomyBudget(),
+          k,
+          algorithm: "aligned-manifest",
+        });
+
+        expect(result.outcome).toBe("prepared");
+        expect(result.foldEnd).toBeGreaterThan(floor);
+        expect(result.foldEnd! % k).toBe(0);
+      }),
+    );
+  });
+
+  test("P7b_everyPreparedReadSetIsTheExactContiguousInterval", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 20 }),
+        fc.integer({ min: 1, max: 12 }),
+        fc.integer({ min: 0, max: 20 }),
+        (floor, k, unacknowledged) => {
+          const target = (Math.floor(floor / k) + 1) * k;
+          const result = prepareFold({
+            state: stateAt(floor, target, target + unacknowledged),
+            observedTail: target + unacknowledged,
+            probeFloor: target,
+            budget: roomyBudget(),
+            k,
+            algorithm: "aligned-manifest",
+          });
+
+          expect(result.outcome).toBe("prepared");
+          expect(result.readSet).toEqual(
+            Array.from({ length: target - floor }, (_, index) => floor + index),
+          );
+          expect(result.foldEnd).toBeLessThanOrEqual(target);
+        },
+      ),
+    );
+  });
+
+  test.each([0, -1, 1.5])("pure boundary APIs reject invalid K=%s", (k) => {
+    const input = inputAt(0, 10, roomyBudget(), k);
+
+    expect(() => liveGreedyBoundary(input)).toThrow(RangeError);
+    expect(() => alignedObservedBoundary(input)).toThrow(RangeError);
+    expect(() => alignedManifestBoundary(input)).toThrow(RangeError);
+    expect(() => alignedManifestTarget(0, k)).toThrow(RangeError);
+  });
+});
+
+describe("exact compact cost", () => {
+  test("P8a_tightKnownTailCostIsNPlusFiveWithSnapshotAndNPlusFourWithout", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: 1_000 }), (logEntriesRead) => {
+        const withSnapshot: ModelManifest = {
+          generation: 2,
+          logSeqStart: 10,
+          snapshotKey: "prior",
+          tailHint: 10 + logEntriesRead,
+        };
+        const withoutSnapshot: ModelManifest = {
+          ...withSnapshot,
+          generation: 0,
+          logSeqStart: 0,
+          snapshotKey: null,
+        };
+        const common = {
+          probeFloor: 10 + logEntriesRead,
+          observedTail: 10 + logEntriesRead,
+          logEntriesRead,
+          reachedSnapshotPut: true,
+          reachedCurrentCas: true,
+        };
+
+        expect(foldCost({ ...common, manifest: withSnapshot }).total).toBe(logEntriesRead + 5);
+        expect(foldCost({ ...common, manifest: withoutSnapshot }).total).toBe(logEntriesRead + 4);
+      }),
+    );
+  });
+
+  test("P8b_deferredAttemptStillPaysSnapshotAndLogReadsButNoPuts", () => {
+    const result = prepareFold({
+      state: stateAt(1, 3),
+      observedTail: 3,
+      probeFloor: 3,
+      budget: roomyBudget({ ceilingEntries: 1 }),
+      k: 3,
+      algorithm: "aligned-manifest",
+    });
+
+    expect(result.outcome).toBe("deferred");
+    expect(result.readSet).toEqual([1, 2]);
+    expect(result.cost).toEqual({
+      currentGets: 1,
+      probeGets: 1,
+      snapshotGets: 1,
+      logGets: 2,
+      snapshotPuts: 0,
+      currentPuts: 0,
+      total: 5,
+    });
+  });
+
+  test("byte ceiling defers after replay without charging writes", () => {
+    const result = prepareFold({
+      state: stateAt(0, 1),
+      observedTail: 1,
+      probeFloor: 1,
+      budget: roomyBudget({ ceilingBytes: 1 }),
+      k: 1,
+      algorithm: "aligned-manifest",
+    });
+
+    expect(result.outcome).toBe("deferred");
+    expect(result.readSet).toEqual([0]);
+    expect(result.cost.snapshotPuts).toBe(0);
+    expect(result.cost.currentPuts).toBe(0);
+  });
+
+  test("P8c_kAboveMaxEntriesCannotPrepare", () => {
+    const result = prepareFold({
+      state: stateAt(0, 10),
+      observedTail: 10,
+      probeFloor: 10,
+      budget: roomyBudget({ maxEntriesPerRun: 4 }),
+      k: 5,
+      algorithm: "aligned-manifest",
+    });
+
+    expect(result.outcome).toBe("below_min_threshold");
+    expect(result.foldEnd).toBeNull();
+    expect(result.readSet).toEqual([]);
+    expect(result.snapshot).toBeNull();
+  });
+
+  test("P8d_zeroMaxEntriesIsAnExplicitZeroProgressCounterexample", () => {
+    const input = inputAt(7, 20, roomyBudget({ maxEntriesPerRun: 0 }), 5);
+
+    expect(liveGreedyBoundary(input)).toBeNull();
+    expect(alignedObservedBoundary(input)).toBeNull();
+    expect(alignedManifestBoundary(input)).toBeNull();
+
+    const result = prepareFold({
+      state: stateAt(7, 20),
+      observedTail: 20,
+      probeFloor: 20,
+      budget: input.budget,
+      k: 5,
+      algorithm: "live-greedy",
+    });
+    expect(result.outcome).not.toBe("prepared");
+    expect(result.foldEnd).toBeNull();
+  });
+
+  test("billableClassA counts only snapshot and current writes", () => {
+    const cost = foldCost({
+      manifest: stateAt(0, 2).manifest,
+      probeFloor: 2,
+      observedTail: 2,
+      logEntriesRead: 2,
+      reachedSnapshotPut: true,
+      reachedCurrentCas: true,
+    });
+
+    expect(billableClassA(cost)).toBe(2);
+  });
+});

--- a/tests/model/fold-boundary/boundary.ts
+++ b/tests/model/fold-boundary/boundary.ts
@@ -90,6 +90,12 @@ export const CF_FREE_BUDGET: FoldBudget = {
   minEntriesToCompact: WRITE_TICK_MIN_ENTRIES_TO_COMPACT,
   ceilingBytes: MAINTENANCE_PROFILE_CF_FREE.maxFoldBytes,
   ceilingEntries: MAINTENANCE_PROFILE_CF_FREE.maxFoldRows,
+  // MODEL ASSUMPTION, not a kernel constant. Every other field above is
+  // imported from `@baerly/protocol`; this one is the Cloudflare Workers Free
+  // plan per-request subrequest cap, a platform limit the kernel does not
+  // model or export. It is what P8f measures the probe cost against, so it is
+  // reported under `modelAssumptions` — never `liveConstants` — in the
+  // evidence payload.
   subrequestLimit: 50,
 };
 
@@ -98,6 +104,9 @@ export const NODE_BUDGET: FoldBudget = {
   minEntriesToCompact: WRITE_TICK_MIN_ENTRIES_TO_COMPACT,
   ceilingBytes: MAINTENANCE_PROFILE_NODE.maxFoldBytes,
   ceilingEntries: MAINTENANCE_PROFILE_NODE.maxFoldRows,
+  // MODEL ASSUMPTION (see CF_FREE_BUDGET above). Self-hosted Node has no
+  // platform subrequest cap; this stands in for "effectively unbounded" so the
+  // Node arm can share one `FoldBudget` shape with the Cloudflare arm.
   subrequestLimit: 10_000,
 };
 

--- a/tests/model/fold-boundary/boundary.ts
+++ b/tests/model/fold-boundary/boundary.ts
@@ -141,11 +141,11 @@ export const prepareFold = (args: {
   readonly k: number;
   readonly algorithm: BoundaryAlgorithm;
 }): PreparedFold => {
-  const observedTail = Math.max(0, Math.min(args.observedTail, args.state.log.acknowledgedTail));
+  const availableTail = Math.max(0, Math.min(args.observedTail, args.state.log.acknowledgedTail));
   const baseGeneration = args.state.manifest.generation;
   const foldEnd = algorithms[args.algorithm]({
     manifest: args.state.manifest,
-    observedTail,
+    observedTail: availableTail,
     budget: args.budget,
     k: args.k,
   });
@@ -157,7 +157,7 @@ export const prepareFold = (args: {
       foldEnd: null,
       readSet: [],
       snapshot: null,
-      cost: noWorkCost(args.probeFloor, observedTail),
+      cost: noWorkCost(args.probeFloor, args.observedTail),
     };
   }
 
@@ -189,7 +189,7 @@ export const prepareFold = (args: {
       cost: foldCost({
         manifest: args.state.manifest,
         probeFloor: args.probeFloor,
-        observedTail,
+        observedTail: args.observedTail,
         logEntriesRead: readSet.length,
         reachedSnapshotPut: false,
         reachedCurrentCas: false,
@@ -206,7 +206,7 @@ export const prepareFold = (args: {
     cost: foldCost({
       manifest: args.state.manifest,
       probeFloor: args.probeFloor,
-      observedTail,
+      observedTail: args.observedTail,
       logEntriesRead: readSet.length,
       reachedSnapshotPut: true,
       reachedCurrentCas: true,

--- a/tests/model/fold-boundary/boundary.ts
+++ b/tests/model/fold-boundary/boundary.ts
@@ -110,14 +110,41 @@ export const NODE_BUDGET: FoldBudget = {
   subrequestLimit: 10_000,
 };
 
-export interface PreparedFold {
-  readonly outcome: "below_min_threshold" | "deferred" | "prepared";
+interface PreparedFoldBase {
   readonly baseGeneration: number;
-  readonly foldEnd: number | null;
   readonly readSet: readonly number[];
-  readonly snapshot: SnapshotObject | null;
   readonly cost: FoldCost;
 }
+
+/**
+ * The result of one fold preparation, discriminated on `outcome`.
+ *
+ * `foldEnd` and `snapshot` are state-dependent: no boundary was chosen below the
+ * minimum threshold, and a deferred fold chose a boundary but published no
+ * object. Modelling that as a union rather than a flat record with two nullable
+ * fields is what lets `schedule.ts` reach `snapshot` after an
+ * `outcome !== "prepared"` early return without a non-null assertion.
+ *
+ * Every variant still declares both fields — `null`-typed where absent — so
+ * call sites that only want to report or compare them (the evidence tables, for
+ * instance) can read `foldEnd` / `snapshot` off an un-narrowed value.
+ */
+export type PreparedFold =
+  | (PreparedFoldBase & {
+      readonly outcome: "below_min_threshold";
+      readonly foldEnd: null;
+      readonly snapshot: null;
+    })
+  | (PreparedFoldBase & {
+      readonly outcome: "deferred";
+      readonly foldEnd: number;
+      readonly snapshot: null;
+    })
+  | (PreparedFoldBase & {
+      readonly outcome: "prepared";
+      readonly foldEnd: number;
+      readonly snapshot: SnapshotObject;
+    });
 
 const algorithms: Readonly<Record<BoundaryAlgorithm, BoundaryFn>> = {
   "live-greedy": liveGreedyBoundary,

--- a/tests/model/fold-boundary/boundary.ts
+++ b/tests/model/fold-boundary/boundary.ts
@@ -1,0 +1,215 @@
+import {
+  MAINTENANCE_PROFILE_CF_FREE,
+  MAINTENANCE_PROFILE_NODE,
+  WRITE_TICK_MIN_ENTRIES_TO_COMPACT,
+} from "@baerly/protocol";
+
+import { foldCost, type FoldCost } from "./cost.ts";
+import {
+  foldRange,
+  makeSnapshot,
+  type ModelManifest,
+  type ModelState,
+  type SnapshotObject,
+} from "./model.ts";
+
+export interface FoldBudget {
+  readonly maxEntriesPerRun: number;
+  readonly minEntriesToCompact: number;
+  readonly ceilingBytes: number;
+  readonly ceilingEntries: number;
+  readonly subrequestLimit: number;
+}
+
+export type BoundaryAlgorithm = "live-greedy" | "aligned-observed" | "aligned-manifest";
+
+export interface BoundaryInput {
+  readonly manifest: ModelManifest;
+  readonly observedTail: number;
+  readonly budget: FoldBudget;
+  readonly k: number;
+}
+
+export type BoundaryFn = (input: BoundaryInput) => number | null;
+
+const validateK = (k: number): void => {
+  if (!Number.isInteger(k) || k <= 0) {
+    throw new RangeError("k must be a positive integer");
+  }
+};
+
+const hasMinimumAvailability = (input: BoundaryInput): boolean =>
+  input.observedTail - input.manifest.logSeqStart >= input.budget.minEntriesToCompact;
+
+export const liveGreedyBoundary: BoundaryFn = (input) => {
+  validateK(input.k);
+  if (!hasMinimumAvailability(input)) {
+    return null;
+  }
+
+  const boundary = Math.min(
+    input.observedTail,
+    input.manifest.logSeqStart + input.budget.maxEntriesPerRun,
+  );
+  return boundary > input.manifest.logSeqStart ? boundary : null;
+};
+
+export const alignedObservedBoundary: BoundaryFn = (input) => {
+  validateK(input.k);
+  const liveBoundary = liveGreedyBoundary(input);
+  if (liveBoundary === null) {
+    return null;
+  }
+
+  const boundary = Math.floor(liveBoundary / input.k) * input.k;
+  return boundary > input.manifest.logSeqStart ? boundary : null;
+};
+
+export const alignedManifestTarget = (floor: number, k: number): number => {
+  validateK(k);
+  return (Math.floor(floor / k) + 1) * k;
+};
+
+export const alignedManifestBoundary: BoundaryFn = (input) => {
+  validateK(input.k);
+  if (!hasMinimumAvailability(input)) {
+    return null;
+  }
+
+  const floor = input.manifest.logSeqStart;
+  const target = alignedManifestTarget(floor, input.k);
+  if (target > input.observedTail || target - floor > input.budget.maxEntriesPerRun) {
+    return null;
+  }
+
+  return target;
+};
+
+export const CF_FREE_BUDGET: FoldBudget = {
+  maxEntriesPerRun: MAINTENANCE_PROFILE_CF_FREE.maxFoldEntriesPerPass,
+  minEntriesToCompact: WRITE_TICK_MIN_ENTRIES_TO_COMPACT,
+  ceilingBytes: MAINTENANCE_PROFILE_CF_FREE.maxFoldBytes,
+  ceilingEntries: MAINTENANCE_PROFILE_CF_FREE.maxFoldRows,
+  subrequestLimit: 50,
+};
+
+export const NODE_BUDGET: FoldBudget = {
+  maxEntriesPerRun: MAINTENANCE_PROFILE_NODE.maxFoldEntriesPerPass,
+  minEntriesToCompact: WRITE_TICK_MIN_ENTRIES_TO_COMPACT,
+  ceilingBytes: MAINTENANCE_PROFILE_NODE.maxFoldBytes,
+  ceilingEntries: MAINTENANCE_PROFILE_NODE.maxFoldRows,
+  subrequestLimit: 10_000,
+};
+
+export interface PreparedFold {
+  readonly outcome: "below_min_threshold" | "deferred" | "prepared";
+  readonly baseGeneration: number;
+  readonly foldEnd: number | null;
+  readonly readSet: readonly number[];
+  readonly snapshot: SnapshotObject | null;
+  readonly cost: FoldCost;
+}
+
+const algorithms: Readonly<Record<BoundaryAlgorithm, BoundaryFn>> = {
+  "live-greedy": liveGreedyBoundary,
+  "aligned-observed": alignedObservedBoundary,
+  "aligned-manifest": alignedManifestBoundary,
+};
+
+const noWorkCost = (probeFloor: number, observedTail: number): FoldCost => {
+  const currentGets = 1;
+  const probeGets = Math.max(0, observedTail - probeFloor) + 1;
+  return {
+    currentGets,
+    probeGets,
+    snapshotGets: 0,
+    logGets: 0,
+    snapshotPuts: 0,
+    currentPuts: 0,
+    total: currentGets + probeGets,
+  };
+};
+
+const encodedSnapshotBytes = (snapshot: SnapshotObject): number =>
+  new TextEncoder().encode(JSON.stringify({ maxSeq: snapshot.maxSeq, rows: snapshot.rows })).length;
+
+export const prepareFold = (args: {
+  readonly state: ModelState;
+  readonly observedTail: number;
+  readonly probeFloor: number;
+  readonly budget: FoldBudget;
+  readonly k: number;
+  readonly algorithm: BoundaryAlgorithm;
+}): PreparedFold => {
+  const observedTail = Math.max(0, Math.min(args.observedTail, args.state.log.acknowledgedTail));
+  const baseGeneration = args.state.manifest.generation;
+  const foldEnd = algorithms[args.algorithm]({
+    manifest: args.state.manifest,
+    observedTail,
+    budget: args.budget,
+    k: args.k,
+  });
+
+  if (foldEnd === null) {
+    return {
+      outcome: "below_min_threshold",
+      baseGeneration,
+      foldEnd: null,
+      readSet: [],
+      snapshot: null,
+      cost: noWorkCost(args.probeFloor, observedTail),
+    };
+  }
+
+  const floor = args.state.manifest.logSeqStart;
+  const priorRows = (() => {
+    if (args.state.manifest.snapshotKey === null) {
+      return new Map<string, number>();
+    }
+    const prior = args.state.snapshots.get(args.state.manifest.snapshotKey);
+    if (prior === undefined) {
+      throw new Error(`missing snapshot object: ${args.state.manifest.snapshotKey}`);
+    }
+    return new Map(prior.rows);
+  })();
+  const readSet = Array.from({ length: foldEnd - floor }, (_, index) => floor + index);
+  const rows = foldRange(priorRows, args.state.log, floor, foldEnd);
+  const snapshot = makeSnapshot(rows, foldEnd);
+  const deferred =
+    snapshot.rows.length > args.budget.ceilingEntries ||
+    encodedSnapshotBytes(snapshot) > args.budget.ceilingBytes;
+
+  if (deferred) {
+    return {
+      outcome: "deferred",
+      baseGeneration,
+      foldEnd,
+      readSet,
+      snapshot: null,
+      cost: foldCost({
+        manifest: args.state.manifest,
+        probeFloor: args.probeFloor,
+        observedTail,
+        logEntriesRead: readSet.length,
+        reachedSnapshotPut: false,
+        reachedCurrentCas: false,
+      }),
+    };
+  }
+
+  return {
+    outcome: "prepared",
+    baseGeneration,
+    foldEnd,
+    readSet,
+    snapshot,
+    cost: foldCost({
+      manifest: args.state.manifest,
+      probeFloor: args.probeFloor,
+      observedTail,
+      logEntriesRead: readSet.length,
+      reachedSnapshotPut: true,
+      reachedCurrentCas: true,
+    }),
+  };
+};

--- a/tests/model/fold-boundary/cost.ts
+++ b/tests/model/fold-boundary/cost.ts
@@ -1,0 +1,39 @@
+import type { ModelManifest } from "./model.ts";
+
+export interface FoldCost {
+  readonly currentGets: number;
+  readonly probeGets: number;
+  readonly snapshotGets: number;
+  readonly logGets: number;
+  readonly snapshotPuts: number;
+  readonly currentPuts: number;
+  readonly total: number;
+}
+
+export const foldCost = (args: {
+  readonly manifest: ModelManifest;
+  readonly probeFloor: number;
+  readonly observedTail: number;
+  readonly logEntriesRead: number;
+  readonly reachedSnapshotPut: boolean;
+  readonly reachedCurrentCas: boolean;
+}): FoldCost => {
+  const currentGets = 1;
+  const probeGets = Math.max(0, args.observedTail - args.probeFloor) + 1;
+  const snapshotGets = args.manifest.snapshotKey === null ? 0 : 1;
+  const logGets = args.logEntriesRead;
+  const snapshotPuts = args.reachedSnapshotPut ? 1 : 0;
+  const currentPuts = args.reachedCurrentCas ? 1 : 0;
+
+  return {
+    currentGets,
+    probeGets,
+    snapshotGets,
+    logGets,
+    snapshotPuts,
+    currentPuts,
+    total: currentGets + probeGets + snapshotGets + logGets + snapshotPuts + currentPuts,
+  };
+};
+
+export const billableClassA = (cost: FoldCost): number => cost.snapshotPuts + cost.currentPuts;

--- a/tests/model/fold-boundary/evidence-report.test.ts
+++ b/tests/model/fold-boundary/evidence-report.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
@@ -40,7 +41,31 @@ import {
   type ObserverAction,
 } from "./schedule.ts";
 
-const BASE_SHA = "ac3ed48e5bd39aa4a758d05d40a5195e0d84eccc" as const;
+/**
+ * The commit this report was generated from, resolved at run time.
+ *
+ * Deliberately NOT a hardcoded literal. A literal is correct only until the
+ * branch is rebased, and the round-trip assertion at the bottom of this file
+ * compares the emitted value against the same constant — so a stale SHA would
+ * still pass and ship a report attributing results to the wrong commit.
+ * `sourceSha256` pins the bytes that produced the numbers; this pins the
+ * commit those bytes came from.
+ *
+ * Falls back to `"unknown"` rather than throwing: the report's own integrity
+ * does not depend on git being reachable, and a missing SHA is honest whereas
+ * a wrong one is not.
+ */
+const resolveCommitSha = (): string => {
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "unknown";
+  }
+};
+
 const DETERMINISTIC_SEED = 20260803 as const;
 const K_SWEEP = [8, 16, 20, 32, 64, 200] as const;
 const SYNTHETIC_LOG_LENGTH = 640;
@@ -159,12 +184,21 @@ interface EvidenceCounterexample {
 
 interface EvidencePayload {
   readonly status: "research-only / non-authorizing";
-  readonly baseSha: typeof BASE_SHA;
+  readonly commitSha: string;
   readonly generatedAtUtc: string;
   readonly deterministicSeed: typeof DETERMINISTIC_SEED;
   readonly effectiveFcNumRuns: number;
   readonly nodeVersion: string;
+  /** Values imported from `@baerly/protocol`. Every entry is real kernel state. */
   readonly liveConstants: Readonly<Record<string, number>>;
+  /**
+   * Values the MODEL assumes but the kernel does not export. Kept separate
+   * from `liveConstants` so a reader can tell at a glance which numbers are
+   * sourced from the implementation and which are the model's own premises.
+   */
+  readonly modelAssumptions: Readonly<
+    Record<string, { readonly value: number; readonly source: string }>
+  >;
   readonly modelParameters: {
     readonly kSweep: typeof K_SWEEP;
     readonly syntheticLogLength: number;
@@ -338,6 +372,23 @@ const declaredPropertyIdsInSource = (source: string): readonly string[] => {
   });
 };
 
+/**
+ * Scrape the real `test("P…")` declarations out of the sibling property files.
+ *
+ * This file excludes ITSELF, and that exclusion is load-bearing rather than
+ * merely tidy. `sourceTokens` treats a backtick as opening a span that runs to
+ * the next unescaped backtick; it does not track `${…}` interpolation, so a
+ * NESTED template flips backtick parity for everything after it. This file has
+ * one — the `` `\`${id}\`` `` in `renderMarkdown` — so the tokenizer misreads a
+ * large span of its own body as a single string literal. The sibling property
+ * files contain no nested templates, so they tokenize correctly.
+ *
+ * Keep it that way: if a property file ever grows a nested template, this
+ * scraper will silently stop seeing declarations after it. The failure is loud
+ * (a missing ID fails the two-way set equality against `PROPERTY_CATALOG`
+ * below) but the cause is not obvious, hence this note. The durable fix is a
+ * mode/depth stack in `sourceTokens`.
+ */
 const declaredPropertyIds = async (repoRoot: string): Promise<ReadonlySet<string>> => {
   const propertyTestFiles = SOURCE_FILES.filter(
     (path) => path.endsWith(".test.ts") && !path.endsWith("evidence-report.test.ts"),
@@ -384,7 +435,7 @@ No implementation mechanism is authorized by this report.
 
 ## Provenance
 
-- Base SHA: \`${payload.baseSha}\`
+- Commit SHA: \`${payload.commitSha}\`
 - Generated UTC: \`${payload.generatedAtUtc}\`
 - Deterministic scenario seed: \`${payload.deterministicSeed}\`
 - Effective FC_NUM_RUNS: \`${payload.effectiveFcNumRuns}\`
@@ -909,11 +960,12 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
     reclamation,
   };
   const generatedAtUtc = new Date().toISOString();
+  const generatedFromSha = resolveCommitSha();
   const effectiveFcNumRuns = Number(process.env["FC_NUM_RUNS"] ?? 100);
   expect(Number.isFinite(effectiveFcNumRuns)).toBe(true);
   const payload: EvidencePayload = {
     status: "research-only / non-authorizing",
-    baseSha: BASE_SHA,
+    commitSha: generatedFromSha,
     generatedAtUtc,
     deterministicSeed: DETERMINISTIC_SEED,
     effectiveFcNumRuns,
@@ -927,7 +979,13 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
         MAINTENANCE_PROFILE_CF_FREE.maxFoldEntriesPerPass,
       MAINTENANCE_PROFILE_NODE_MAX_FOLD_ENTRIES_PER_PASS:
         MAINTENANCE_PROFILE_NODE.maxFoldEntriesPerPass,
-      CF_FREE_SUBREQUEST_LIMIT: CF_FREE_BUDGET.subrequestLimit,
+    },
+    modelAssumptions: {
+      cfFreeSubrequestLimit: {
+        value: CF_FREE_BUDGET.subrequestLimit,
+        source:
+          "Cloudflare Workers Free plan per-request subrequest cap. Platform limit, not a kernel constant — @baerly/protocol does not export it.",
+      },
     },
     modelParameters: {
       kSweep: K_SWEEP,
@@ -940,6 +998,7 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
     unresolvedQuestions: [
       "Which K and maintenance-profile policy should be selected for each deployment class?",
       "What K compatibility rule should rolling deployments enforce while old and new observers overlap?",
+      "Does the scheduled fold path need a bounded tail probe, and what should a pass do when the bound is hit — defer the fold, or refresh the tail hint and make partial progress? See the stale-probe-budget-overflow counterexample: the O(gap) probe is hole-tolerant by design, so the writer's O(log gap) galloping tail-find is not a drop-in substitute.",
     ],
     implementationAuthorization:
       "No implementation mechanism is authorized by this research evidence.",
@@ -1010,7 +1069,10 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
   expect(parsed).toEqual(payload);
   expect(readBackMarkdown).toBe(markdown);
   expect(parsed.status).toBe("research-only / non-authorizing");
-  expect(parsed.baseSha).toBe(BASE_SHA);
+  // Shape check, not a round-trip tautology: assert the resolver produced a
+  // real object name (or the honest fallback) before trusting it as provenance.
+  expect(generatedFromSha).toMatch(/^([a-f0-9]{40}|unknown)$/);
+  expect(parsed.commitSha).toBe(generatedFromSha);
   expect(parsed.deterministicSeed).toBe(DETERMINISTIC_SEED);
   expect(parsed.modelParameters.kSweep).toEqual(K_SWEEP);
   expect(parsed.modelParameters.alignmentOrigin).toBe("absolute-sequence-zero");
@@ -1019,7 +1081,7 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
     "No implementation mechanism is authorized by this research evidence.",
   );
   expect(readBackMarkdown).toContain("No implementation mechanism is authorized by this report.");
-  expect(readBackMarkdown).toContain(`Base SHA: \`${BASE_SHA}\``);
+  expect(readBackMarkdown).toContain(`Commit SHA: \`${generatedFromSha}\``);
   expect(readBackMarkdown).toContain("## Deterministic tables");
   expect(readBackMarkdown).toContain("## Counterexamples");
   expect(readBackMarkdown).toContain("## Source SHA-256");

--- a/tests/model/fold-boundary/evidence-report.test.ts
+++ b/tests/model/fold-boundary/evidence-report.test.ts
@@ -208,7 +208,11 @@ const stateWithTail = (tail: number, tailHint = tail): ModelState => {
     ops: syntheticOperations(tail, DETERMINISTIC_SEED),
     acknowledgedTail: tail,
   });
-  return tailHint === tail ? state : { ...state, manifest: { ...state.manifest, tailHint } };
+  if (tailHint === tail) {
+    return state;
+  }
+  const manifest = { ...state.manifest, tailHint };
+  return { ...state, manifest, manifestHistory: [{ ...manifest }] };
 };
 
 const action = (overrides: Partial<ObserverAction> = {}): ObserverAction => ({

--- a/tests/model/fold-boundary/evidence-report.test.ts
+++ b/tests/model/fold-boundary/evidence-report.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
 import {
@@ -22,8 +22,10 @@ import {
   prepareFold,
   type BoundaryInput,
   type FoldBudget,
+  type PreparedFold,
 } from "./boundary.ts";
 import { foldCost } from "./cost.ts";
+import { action, roomyBudget } from "./fixtures.ts";
 import {
   applySnapshot,
   emptyState,
@@ -39,6 +41,7 @@ import {
   reclaimUnreferenced,
   runSchedule,
   type ObserverAction,
+  type ScheduleResult,
 } from "./schedule.ts";
 
 /**
@@ -70,17 +73,28 @@ const DETERMINISTIC_SEED = 20260803 as const;
 const K_SWEEP = [8, 16, 20, 32, 64, 200] as const;
 const SYNTHETIC_LOG_LENGTH = 640;
 const REPORT_ROOT = "bench/results/fold-boundary-model";
+const MODEL_DIRECTORY = "tests/model/fold-boundary";
+/**
+ * Every file whose bytes contributed to the numbers in the emitted report.
+ *
+ * The report's `sourceSha256` map is built from this list, so an omission here
+ * silently narrows provenance rather than failing — a report would then claim to
+ * pin the bytes that produced it while excluding some of them. `R6` enforces
+ * that this list equals the actual directory contents so adding a model file
+ * cannot quietly fall out of provenance coverage.
+ */
 const SOURCE_FILES = [
-  "tests/model/fold-boundary/arbitraries.ts",
-  "tests/model/fold-boundary/boundary.test.ts",
-  "tests/model/fold-boundary/boundary.ts",
-  "tests/model/fold-boundary/cost.ts",
-  "tests/model/fold-boundary/evidence-report.test.ts",
-  "tests/model/fold-boundary/model.test.ts",
-  "tests/model/fold-boundary/model.ts",
-  "tests/model/fold-boundary/orphan-bound.test.ts",
-  "tests/model/fold-boundary/progress-bound.test.ts",
-  "tests/model/fold-boundary/schedule.ts",
+  `${MODEL_DIRECTORY}/arbitraries.ts`,
+  `${MODEL_DIRECTORY}/boundary.test.ts`,
+  `${MODEL_DIRECTORY}/boundary.ts`,
+  `${MODEL_DIRECTORY}/cost.ts`,
+  `${MODEL_DIRECTORY}/evidence-report.test.ts`,
+  `${MODEL_DIRECTORY}/fixtures.ts`,
+  `${MODEL_DIRECTORY}/model.test.ts`,
+  `${MODEL_DIRECTORY}/model.ts`,
+  `${MODEL_DIRECTORY}/orphan-bound.test.ts`,
+  `${MODEL_DIRECTORY}/progress-bound.test.ts`,
+  `${MODEL_DIRECTORY}/schedule.ts`,
 ] as const;
 const PROPERTY_CATALOG = [
   {
@@ -203,6 +217,13 @@ interface EvidencePayload {
     readonly kSweep: typeof K_SWEEP;
     readonly syntheticLogLength: number;
     readonly alignmentOrigin: "absolute-sequence-zero";
+    /**
+     * The budget the deterministic tables were produced under. Published because
+     * `foldAndObjectProduction` is only interpretable against it: a
+     * `maxEntriesPerRun` below the largest `kSweep` entry would make that arm
+     * measure the per-pass cap instead of the boundary rule. See `reportBudget`.
+     */
+    readonly budget: FoldBudget;
   };
   readonly sourceSha256: Readonly<Record<string, string>>;
   readonly claims: readonly EvidenceClaim[];
@@ -212,14 +233,32 @@ interface EvidencePayload {
   readonly tables: object;
 }
 
-const roomyBudget = (overrides: Partial<FoldBudget> = {}): FoldBudget => ({
-  maxEntriesPerRun: 200,
-  minEntriesToCompact: 1,
-  ceilingBytes: 10_000_000,
-  ceilingEntries: 10_000,
-  subrequestLimit: 10_000,
-  ...overrides,
-});
+/**
+ * The report arm's budget: the shared `roomyBudget()` with every ceiling raised.
+ *
+ * The divergence is load-bearing, not incidental. `K_SWEEP` reaches 200, and
+ * `alignedManifestBoundary` refuses a target further than `maxEntriesPerRun` past
+ * the floor — so under the shared 100-entry default the K=200 arm of
+ * `foldAndObjectProduction` could never prepare, and the published table would be
+ * measuring the per-pass cap rather than the boundary rule it claims to compare.
+ * The byte and row ceilings are raised for the same reason: this arm folds a
+ * {@link SYNTHETIC_LOG_LENGTH}-entry log, not the handful of entries the property
+ * scenarios use.
+ *
+ * Published under `modelParameters.budget` so a reader of the report can see the
+ * premise the tables were produced under.
+ */
+const reportBudget = (overrides: Partial<FoldBudget> = {}): FoldBudget =>
+  roomyBudget({
+    maxEntriesPerRun: 200,
+    ceilingBytes: 10_000_000,
+    ceilingEntries: 10_000,
+    ...overrides,
+  });
+
+/** {@link action}, bound to {@link reportBudget} so every report arm shares one premise. */
+const reportAction = (overrides: Partial<ObserverAction> = {}): ObserverAction =>
+  action({ budget: reportBudget(), ...overrides });
 
 const syntheticOperations = (length: number, seed: number): readonly ModelOp[] => {
   let state = seed >>> 0;
@@ -249,22 +288,11 @@ const stateWithTail = (tail: number, tailHint = tail): ModelState => {
   return { ...state, manifest, manifestHistory: [{ ...manifest }] };
 };
 
-const action = (overrides: Partial<ObserverAction> = {}): ObserverAction => ({
-  observerId: 0,
-  readsAtGeneration: Number.MAX_SAFE_INTEGER,
-  observedTail: 20,
-  k: 5,
-  budget: roomyBudget(),
-  algorithm: "aligned-manifest",
-  crashAt: "none",
-  ...overrides,
-});
-
 const inputAt = (
   floor: number,
   observedTail: number,
   k: number,
-  budget = roomyBudget(),
+  budget = reportBudget(),
 ): BoundaryInput => {
   const log: ModelLog = {
     ops: syntheticOperations(Math.max(floor, observedTail), DETERMINISTIC_SEED),
@@ -293,9 +321,70 @@ interface SourceToken {
   readonly value: string;
 }
 
+/**
+ * Tokenize enough JavaScript to tell a real `test("P…")` declaration from a
+ * mention of one inside a comment or a string.
+ *
+ * That discrimination is the whole reason this is a scanner and not a regex: the
+ * model files discuss property IDs in prose, and `R2` pins the behavior on a
+ * fixture containing exactly those decoys.
+ *
+ * Template literals carry a `${…}` depth stack, so a template nested inside an
+ * interpolation — `` `\`${id}\`` `` in `renderMarkdown` below — no longer flips
+ * backtick parity for the rest of the file. Without it this file could not
+ * tokenize itself, and `declaredPropertyIds` had to exclude it.
+ *
+ * Regex literals are not lexed, so a `/…/` containing an unbalanced brace or an
+ * unpaired quote would desync the scanner. Unlike the template-parity bug this
+ * replaces, nothing in the model does that today, and `R3`'s two-way set equality
+ * against `PROPERTY_CATALOG` fails loudly if it ever happens.
+ */
 const sourceTokens = (source: string): readonly SourceToken[] => {
   const tokens: SourceToken[] = [];
+  // One entry per template literal currently open, innermost last. A template is
+  // "open" while the scanner is inside one of its `${…}` interpolations.
+  const templateDepth: number[] = [];
+  let braceDepth = 0;
   let index = 0;
+
+  const scanQuoted = (quote: '"' | "'"): void => {
+    const start = index + 1;
+    index = start;
+    while (index < source.length) {
+      if (source[index] === "\\") {
+        index += 2;
+        continue;
+      }
+      if (source[index] === quote) {
+        break;
+      }
+      index += 1;
+    }
+    tokens.push({ kind: "string", value: source.slice(start, index) });
+    index += 1;
+  };
+
+  // Consumes the literal span of a template up to either its closing backtick or
+  // the `${` that opens an interpolation, leaving `index` past whichever it hit.
+  const scanTemplateSpan = (): void => {
+    while (index < source.length) {
+      if (source[index] === "\\") {
+        index += 2;
+        continue;
+      }
+      if (source[index] === "`") {
+        index += 1;
+        templateDepth.pop();
+        return;
+      }
+      if (source[index] === "$" && source[index + 1] === "{") {
+        index += 2;
+        braceDepth += 1;
+        return;
+      }
+      index += 1;
+    }
+  };
 
   while (index < source.length) {
     const current = source[index]!;
@@ -305,10 +394,11 @@ const sourceTokens = (source: string): readonly SourceToken[] => {
       continue;
     }
     if (current === "/" && next === "/") {
-      index = source.indexOf("\n", index + 2);
-      if (index === -1) {
+      const lineEnd = source.indexOf("\n", index + 2);
+      if (lineEnd === -1) {
         break;
       }
+      index = lineEnd;
       continue;
     }
     if (current === "/" && next === "*") {
@@ -316,23 +406,32 @@ const sourceTokens = (source: string): readonly SourceToken[] => {
       index = end === -1 ? source.length : end + 2;
       continue;
     }
-    if (current === "`" || current === "'" || current === '"') {
-      const quote = current;
-      const start = index + 1;
-      index = start;
-      while (index < source.length) {
-        if (source[index] === "\\") {
-          index += 2;
-          continue;
-        }
-        if (source[index] === quote) {
-          break;
-        }
+    if (current === "`") {
+      index += 1;
+      templateDepth.push(braceDepth);
+      scanTemplateSpan();
+      continue;
+    }
+    if (current === '"' || current === "'") {
+      scanQuoted(current);
+      continue;
+    }
+    if (current === "{") {
+      braceDepth += 1;
+      tokens.push({ kind: "punctuation", value: current });
+      index += 1;
+      continue;
+    }
+    if (current === "}") {
+      braceDepth -= 1;
+      // Closing the brace that opened the innermost template's interpolation
+      // returns the scanner to that template's literal text.
+      if (templateDepth.at(-1) === braceDepth) {
         index += 1;
+        scanTemplateSpan();
+        continue;
       }
-      if (quote !== "`") {
-        tokens.push({ kind: "string", value: source.slice(start, index) });
-      }
+      tokens.push({ kind: "punctuation", value: current });
       index += 1;
       continue;
     }
@@ -373,26 +472,15 @@ const declaredPropertyIdsInSource = (source: string): readonly string[] => {
 };
 
 /**
- * Scrape the real `test("P…")` declarations out of the sibling property files.
+ * Scrape the real `test("P…")` declarations out of every model test file.
  *
- * This file excludes ITSELF, and that exclusion is load-bearing rather than
- * merely tidy. `sourceTokens` treats a backtick as opening a span that runs to
- * the next unescaped backtick; it does not track `${…}` interpolation, so a
- * NESTED template flips backtick parity for everything after it. This file has
- * one — the `` `\`${id}\`` `` in `renderMarkdown` — so the tokenizer misreads a
- * large span of its own body as a single string literal. The sibling property
- * files contain no nested templates, so they tokenize correctly.
- *
- * Keep it that way: if a property file ever grows a nested template, this
- * scraper will silently stop seeing declarations after it. The failure is loud
- * (a missing ID fails the two-way set equality against `PROPERTY_CATALOG`
- * below) but the cause is not obvious, hence this note. The durable fix is a
- * mode/depth stack in `sourceTokens`.
+ * Includes this file. It has to: the catalog claims to enumerate every property
+ * in the model, so a scrape that skipped a file could not detect a property
+ * declared there. `sourceTokens` handles this file's nested templates, which is
+ * what makes the self-inclusion possible.
  */
 const declaredPropertyIds = async (repoRoot: string): Promise<ReadonlySet<string>> => {
-  const propertyTestFiles = SOURCE_FILES.filter(
-    (path) => path.endsWith(".test.ts") && !path.endsWith("evidence-report.test.ts"),
-  );
+  const propertyTestFiles = SOURCE_FILES.filter((path) => path.endsWith(".test.ts"));
   const sources = await Promise.all(
     propertyTestFiles.map((path) => readFile(join(repoRoot, path), "utf8")),
   );
@@ -443,6 +531,7 @@ No implementation mechanism is authorized by this report.
 - Alignment origin: \`${payload.modelParameters.alignmentOrigin}\`
 - Synthetic log length: \`${payload.modelParameters.syntheticLogLength}\`
 - K sweep: \`${payload.modelParameters.kSweep.join(", ")}\`
+- Table budget: \`${JSON.stringify(payload.modelParameters.budget)}\`
 
 ## Claims
 
@@ -476,15 +565,98 @@ ${Object.entries(payload.sourceSha256)
   .join("\n")}
 `;
 
-test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () => {
-  const repoRoot = process.cwd();
-  const log: ModelLog = {
-    ops: syntheticOperations(SYNTHETIC_LOG_LENGTH, DETERMINISTIC_SEED),
-    acknowledgedTail: SYNTHETIC_LOG_LENGTH,
+/**
+ * The deterministic scenarios behind every published table.
+ *
+ * Split out of the report test so each table can be recomputed and asserted on
+ * its own, and so a failure names the table that moved instead of pointing at one
+ * long body.
+ *
+ * On why `R1a`–`R1f` assert exact values that the `P`-series also covers: they
+ * are not duplicate behavior verification. The `P` properties are universally
+ * quantified — `P8a` asserts `total === N + 5` for every `N`, `P1b` asserts that
+ * live boundaries track observation. Neither pins the numbers this report
+ * *publishes*. Those numbers are interpolated verbatim into the claim prose (Q1
+ * cites the floor-7 targets, Q8 cites the tight-tail totals), so if `K_SWEEP` or
+ * `SYNTHETIC_LOG_LENGTH` changed, every `P` property would still pass while the
+ * emitted evidence silently said something different. `R1a`–`R1f` are golden-value
+ * pins on the artifact; the `P` series is the behavior gate.
+ */
+interface Scenarios {
+  readonly boundaryTargetDependence: readonly {
+    readonly floor: number;
+    readonly observedTail: number;
+    readonly k: number;
+    readonly liveGreedy: number | null;
+    readonly alignedObserved: number | null;
+    readonly alignedManifest: number | null;
+    readonly manifestTarget: number;
+  }[];
+  readonly tightTailCost: readonly {
+    readonly k: number;
+    readonly withSnapshotTotal: number;
+    readonly withoutSnapshotTotal: number;
+    readonly snapshotDelta: number;
+    readonly cfFreeSubrequestLimit: number;
+  }[];
+  readonly foldAndObjectProduction: readonly {
+    readonly k: number;
+    readonly alignedWrittenFolds: number;
+    readonly alignedObjects: number;
+    readonly alignedFinalFloor: number;
+    readonly liveWrittenFolds: number;
+    readonly liveObjects: number;
+    readonly liveFinalFloor: number;
+    readonly materializedRowsEqual: boolean;
+  }[];
+  readonly sameKRacers: ContentionSummary;
+  readonly mixedKRacers: ContentionSummary;
+  readonly mixedKRacersResult: ScheduleResult;
+  readonly crashRetry: {
+    readonly outcomes: readonly string[];
+    readonly foldEnds: readonly (number | null)[];
+    readonly emittedKeys: readonly (string | null)[];
+    readonly finalGeneration: number;
   };
-  const initial = emptyState(log);
+  readonly availabilityRetry: {
+    readonly target: number;
+    readonly before: PreparedFold;
+    readonly after: PreparedFold;
+  };
+  readonly reclamation: {
+    readonly beforeFirstFold: number;
+    readonly afterSecondSuccessfulFold: number;
+    readonly storedBeforeReclamation: number;
+    readonly storedAfterReclamation: number;
+    readonly currentObjectPreserved: boolean;
+    readonly materializedRowsPreserved: boolean;
+  };
+  readonly zeroMaxEntries: PreparedFold;
+  readonly staleProbe: ScheduleResult;
+  readonly crashAfterPut: ScheduleResult;
+}
 
-  const boundaryTargetDependence = [12, 18].map((observedTail) => {
+interface ContentionSummary {
+  readonly outcomes: readonly string[];
+  readonly foldEnds: readonly (number | null)[];
+  readonly emittedKeys: readonly (string | null)[];
+  readonly storedObjects: number;
+  readonly neverReferencedObjects: number;
+}
+
+const contentionSummary = (result: ScheduleResult): ContentionSummary => ({
+  outcomes: result.attempts.map(({ outcome }) => outcome),
+  foldEnds: result.attempts.map(({ foldEnd }) => foldEnd),
+  emittedKeys: result.attempts.map(({ emittedKey }) => emittedKey),
+  storedObjects: result.finalState.snapshots.size,
+  neverReferencedObjects: result.neverReferencedSnapshots.length,
+});
+
+const sortedRows = (state: ModelState): string =>
+  JSON.stringify([...rowsAtManifest(state).entries()].toSorted());
+
+const buildBoundaryTargetDependence = (): Scenarios["boundaryTargetDependence"] =>
+  [12, 18].map((observedTail) => {
     const input = inputAt(7, observedTail, 5);
     return {
       floor: 7,
@@ -496,7 +668,375 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
       manifestTarget: alignedManifestTarget(input.manifest.logSeqStart, input.k),
     };
   });
-  expect(boundaryTargetDependence).toEqual([
+
+const buildTightTailCost = (): Scenarios["tightTailCost"] =>
+  K_SWEEP.map((k) => {
+    const withSnapshot = foldCost({
+      manifest: { generation: 1, logSeqStart: 8, snapshotKey: "prior", tailHint: 8 + k },
+      probeFloor: 8 + k,
+      observedTail: 8 + k,
+      logEntriesRead: k,
+      reachedSnapshotPut: true,
+      reachedCurrentCas: true,
+    });
+    const withoutSnapshot = foldCost({
+      manifest: { generation: 0, logSeqStart: 0, snapshotKey: null, tailHint: k },
+      probeFloor: k,
+      observedTail: k,
+      logEntriesRead: k,
+      reachedSnapshotPut: true,
+      reachedCurrentCas: true,
+    });
+    return {
+      k,
+      withSnapshotTotal: withSnapshot.total,
+      withoutSnapshotTotal: withoutSnapshot.total,
+      snapshotDelta: withSnapshot.total - withoutSnapshot.total,
+      cfFreeSubrequestLimit: CF_FREE_BUDGET.subrequestLimit,
+    };
+  });
+
+const buildFoldAndObjectProduction = (): Scenarios["foldAndObjectProduction"] => {
+  const initial = emptyState({
+    ops: syntheticOperations(SYNTHETIC_LOG_LENGTH, DETERMINISTIC_SEED),
+    acknowledgedTail: SYNTHETIC_LOG_LENGTH,
+  });
+  const budget = reportBudget();
+
+  return K_SWEEP.map((k) => {
+    const drain = (algorithm: "aligned-manifest" | "live-greedy"): ScheduleResult =>
+      drainToQuiescence({
+        initial,
+        budget,
+        k,
+        algorithm,
+        maxPasses: SYNTHETIC_LOG_LENGTH + 2,
+      });
+    const aligned = drain("aligned-manifest");
+    const live = drain("live-greedy");
+    const written = (result: ScheduleResult): number =>
+      result.attempts.filter(({ outcome }) => outcome === "written").length;
+
+    return {
+      k,
+      alignedWrittenFolds: written(aligned),
+      alignedObjects: aligned.finalState.snapshots.size,
+      alignedFinalFloor: aligned.finalState.manifest.logSeqStart,
+      liveWrittenFolds: written(live),
+      liveObjects: live.finalState.snapshots.size,
+      liveFinalFloor: live.finalState.manifest.logSeqStart,
+      materializedRowsEqual: sortedRows(aligned.finalState) === sortedRows(live.finalState),
+    };
+  });
+};
+
+const buildAvailabilityRetry = (): Scenarios["availabilityRetry"] => {
+  const unavailable = stateWithTail(4);
+  const prepareAt = (state: ModelState, tail: number): PreparedFold =>
+    prepareFold({
+      state,
+      observedTail: tail,
+      probeFloor: tail,
+      budget: reportBudget(),
+      k: 5,
+      algorithm: "aligned-manifest",
+    });
+
+  return {
+    target: alignedManifestTarget(unavailable.manifest.logSeqStart, 5),
+    before: prepareAt(unavailable, 4),
+    after: prepareAt(stateWithTail(5), 5),
+  };
+};
+
+const buildReclamation = (): Scenarios["reclamation"] => {
+  const firstFold = runSchedule({
+    initial: stateWithTail(10),
+    observers: [reportAction({ observerId: 1, observedTail: 10, k: 5 })],
+  });
+  const secondFold = runSchedule({
+    initial: firstFold.finalState,
+    observers: [reportAction({ observerId: 2, observedTail: 10, k: 5 })],
+  });
+  const reclaimed = reclaimUnreferenced(secondFold.finalState);
+
+  return {
+    beforeFirstFold: firstFold.reclaimableSnapshots.length,
+    afterSecondSuccessfulFold: secondFold.reclaimableSnapshots.length,
+    storedBeforeReclamation: secondFold.finalState.snapshots.size,
+    storedAfterReclamation: reclaimed.snapshots.size,
+    currentObjectPreserved:
+      reclaimed.manifest.snapshotKey !== null &&
+      reclaimed.snapshots.has(reclaimed.manifest.snapshotKey),
+    materializedRowsPreserved: sortedRows(secondFold.finalState) === sortedRows(reclaimed),
+  };
+};
+
+const buildScenarios = (): Scenarios => {
+  const mixedKRacersResult = runSchedule({
+    initial: stateWithTail(20),
+    observers: [
+      reportAction({ observerId: 1, readsAtGeneration: 0, observedTail: 20, k: 4 }),
+      reportAction({ observerId: 2, readsAtGeneration: 0, observedTail: 20, k: 6 }),
+    ],
+  });
+  const crashRetryResult = runSchedule({
+    initial: stateWithTail(20),
+    observers: [
+      reportAction({ observerId: 1, observedTail: 20, k: 5, crashAt: "after_snapshot_put" }),
+      reportAction({ observerId: 2, observedTail: 20, k: 5 }),
+    ],
+  });
+
+  return {
+    boundaryTargetDependence: buildBoundaryTargetDependence(),
+    tightTailCost: buildTightTailCost(),
+    foldAndObjectProduction: buildFoldAndObjectProduction(),
+    sameKRacers: contentionSummary(
+      runSchedule({
+        initial: stateWithTail(20),
+        observers: [
+          reportAction({ observerId: 1, readsAtGeneration: 0, observedTail: 5, k: 5 }),
+          reportAction({ observerId: 2, readsAtGeneration: 0, observedTail: 9, k: 5 }),
+        ],
+      }),
+    ),
+    mixedKRacers: contentionSummary(mixedKRacersResult),
+    mixedKRacersResult,
+    crashRetry: {
+      outcomes: crashRetryResult.attempts.map(({ outcome }) => outcome),
+      foldEnds: crashRetryResult.attempts.map(({ foldEnd }) => foldEnd),
+      emittedKeys: crashRetryResult.attempts.map(({ emittedKey }) => emittedKey),
+      finalGeneration: crashRetryResult.finalState.manifest.generation,
+    },
+    availabilityRetry: buildAvailabilityRetry(),
+    reclamation: buildReclamation(),
+    zeroMaxEntries: prepareFold({
+      state: stateWithTail(20),
+      observedTail: 20,
+      probeFloor: 20,
+      budget: reportBudget({ maxEntriesPerRun: 0 }),
+      k: 5,
+      algorithm: "live-greedy",
+    }),
+    staleProbe: runSchedule({
+      initial: stateWithTail(100, 0),
+      observers: [reportAction({ observedTail: 100, k: 20, budget: CF_FREE_BUDGET })],
+    }),
+    crashAfterPut: runSchedule({
+      initial: stateWithTail(20),
+      observers: [reportAction({ observedTail: 20, k: 5, crashAt: "after_snapshot_put" })],
+    }),
+  };
+};
+
+/**
+ * Memoized because `foldAndObjectProduction` drains a
+ * {@link SYNTHETIC_LOG_LENGTH}-entry log twice for each of the six `K_SWEEP`
+ * values, and several tests below need the same table.
+ *
+ * Safe to share: `buildScenarios` is a pure function of the module constants and
+ * the returned value is deeply readonly, so no test can observe another's
+ * ordering through it.
+ */
+let cachedScenarios: Scenarios | undefined;
+const scenarios = (): Scenarios => (cachedScenarios ??= buildScenarios());
+
+const buildTables = (model: Scenarios): object => ({
+  boundaryTargetDependence: model.boundaryTargetDependence,
+  tightTailCost: model.tightTailCost,
+  foldAndObjectProduction: model.foldAndObjectProduction,
+  sameGenerationSameKRacers: model.sameKRacers,
+  mixedKRacers: model.mixedKRacers,
+  crashRetry: model.crashRetry,
+  availabilityRetry: {
+    target: model.availabilityRetry.target,
+    beforeOutcome: model.availabilityRetry.before.outcome,
+    beforeFoldEnd: model.availabilityRetry.before.foldEnd,
+    afterOutcome: model.availabilityRetry.after.outcome,
+    afterFoldEnd: model.availabilityRetry.after.foldEnd,
+  },
+  reclamation: model.reclamation,
+});
+
+const buildCounterexamples = (model: Scenarios): readonly EvidenceCounterexample[] => [
+  {
+    id: "zero-max-entries-progress",
+    observed: true,
+    outcome: model.zeroMaxEntries.outcome,
+    foldEnd: model.zeroMaxEntries.foldEnd,
+  },
+  {
+    id: "stale-probe-budget-overflow",
+    observed: true,
+    totalCost: model.staleProbe.attempts[0]!.cost.total,
+    subrequestLimit: CF_FREE_BUDGET.subrequestLimit,
+  },
+  {
+    id: "mixed-k-cas-orphan",
+    observed: true,
+    loserOutcome: model.mixedKRacersResult.attempts[1]!.outcome,
+    neverReferencedObjects: model.mixedKRacers.neverReferencedObjects,
+  },
+  {
+    id: "crash-after-put-orphan",
+    observed: true,
+    outcome: model.crashAfterPut.attempts[0]!.outcome,
+    neverReferencedObjects: model.crashAfterPut.neverReferencedSnapshots.length,
+  },
+  {
+    id: "successful-fold-increases-reclaimable-objects",
+    observed: true,
+    before: model.reclamation.beforeFirstFold,
+    after: model.reclamation.afterSecondSuccessfulFold,
+  },
+];
+
+const command = (propertyPattern: string): string =>
+  `FC_NUM_RUNS=10000 pnpm test:agent tests/model/fold-boundary -t '${propertyPattern}'`;
+
+const buildClaims = (model: Scenarios): readonly EvidenceClaim[] => [
+  {
+    question: 1,
+    classification: "universally-quantified-property",
+    conclusion: `At floor 7 and K=5, the manifest target remained ${model.boundaryTargetDependence[0]!.manifestTarget} while live boundaries changed from ${model.boundaryTargetDependence[0]!.liveGreedy} to ${model.boundaryTargetDependence[1]!.liveGreedy} with observation.`,
+    propertyIds: [
+      "P1a_manifestTargetIsIndependentOfObservationAndBudget",
+      "P1b_liveAndObservedAlignedTargetsDependOnObservedAvailability",
+    ],
+    command: command("P1a_|P1b_"),
+  },
+  {
+    question: 2,
+    classification: "bounded-deterministic-observation",
+    conclusion: `With only 4 entries, target ${model.availabilityRetry.target} produced ${model.availabilityRetry.before.outcome} and no object; at 5 entries the retry prepared the same target.`,
+    propertyIds: [
+      "P2a_fewerThanNextKEntriesProducesNoObjectOrProgress",
+      "P2b_retryAfterAvailabilityUsesTheSameManifestTarget",
+    ],
+    command: command("P2a_|P2b_"),
+  },
+  {
+    question: 3,
+    classification: "bounded-deterministic-observation",
+    conclusion: `A crash after snapshot PUT left generation 0 unchanged, and retry published the same floor ${model.crashRetry.foldEnds[1]} and content-addressed key at generation ${model.crashRetry.finalGeneration}.`,
+    propertyIds: [
+      "P3a_crashBeforeCasLeavesManifestUnchangedAndRetryUsesSameTarget",
+      "P3b_laggingObserverBoundarySequenceIsAPrefixOfFullyInformedSequence",
+    ],
+    command: command("P3a_|P3b_"),
+  },
+  {
+    question: 4,
+    classification: "unresolved",
+    conclusion: `K=4 and K=6 observers from generation 0 prepared floors ${model.mixedKRacers.foldEnds.join(" and ")}; rolling-deploy K compatibility therefore remains a policy question.`,
+    propertyIds: [
+      "P4a_firstTargetAfterKChangeIsStrictlyMonotoneAndNewKAligned",
+      "P4b_mixedKObserversCanPrepareDifferentObjectsFromOneGeneration",
+    ],
+    command: command("P4a_|P4b_"),
+  },
+  {
+    question: 5,
+    classification: "universally-quantified-property",
+    conclusion: `Two generation-0, K=5 racers emitted one key, stored ${model.sameKRacers.storedObjects} object, and added ${model.sameKRacers.neverReferencedObjects} distinct CAS orphan.`,
+    propertyIds: [
+      "P5a_observersOnOppositeSidesOfOneBoundaryEmitAtMostOneObjectForOneK",
+      "P5b_sameManifestSameKAlwaysProducesTheSameObjectKey",
+    ],
+    command: command("P5a_|P5b_"),
+  },
+  {
+    question: 6,
+    classification: "explicit-counterexample",
+    conclusion: `Mixed-K CAS loss and crash-after-PUT each produced one never-referenced object, while a second successful fold increased reclaimable objects from ${model.reclamation.beforeFirstFold} to ${model.reclamation.afterSecondSuccessfulFold}.`,
+    propertyIds: [
+      "P6a_sameGenerationSameKContentionAddsNoDistinctCasOrphan",
+      "P6b_successfulFoldCanIncreaseRatherThanReduceReclaimableObjects",
+      "P6c_mixedKContentionHasAReachableDistinctCasOrphan",
+      "P6d_crashAfterPutHasAReachableNeverReferencedSnapshot",
+      "P6e_reclamationRemovesAllAndOnlyNonCurrentSnapshots",
+    ],
+    command: command("P6a_|P6b_|P6c_|P6d_|P6e_"),
+  },
+  {
+    question: 7,
+    classification: "universally-quantified-property",
+    conclusion: `Every deterministic aligned/live row compared equal after the ${SYNTHETIC_LOG_LENGTH}-entry log, including the K=200 aligned remainder at floor 600.`,
+    propertyIds: [
+      "P7a_everyPreparedManifestBoundaryStrictlyAdvancesAndIsAligned",
+      "P7b_everyPreparedReadSetIsTheExactContiguousInterval",
+      "P7c_contiguousIncrementalFoldEqualsReferenceReplay",
+      "P7d_publishedSnapshotCanPreserveEveryAcknowledgedPrefix",
+      "P7e_everyPublishedSnapshotMatchesReferenceReplayThroughItsFloor",
+    ],
+    command: command("P7a_|P7b_|P7c_|P7d_|P7e_"),
+  },
+  {
+    question: 8,
+    classification: "explicit-counterexample",
+    conclusion: `Tight-tail prior-snapshot totals ranged from ${model.tightTailCost[0]!.withSnapshotTotal} to ${model.tightTailCost.at(-1)!.withSnapshotTotal}; zero max entries made no progress, while stale probing cost ${model.staleProbe.attempts[0]!.cost.total} against the live limit ${CF_FREE_BUDGET.subrequestLimit}.`,
+    propertyIds: [
+      "P8a_tightKnownTailCostIsNPlusFiveWithSnapshotAndNPlusFourWithout",
+      "P8b_deferredAttemptStillPaysSnapshotAndLogReadsButNoPuts",
+      "P8c_kAboveMaxEntriesCannotPrepare",
+      "P8d_zeroMaxEntriesIsAnExplicitZeroProgressCounterexample",
+      "P8e_manifestAlignedProgressFitsCfFreeWithTightKnownTailForKAtMostTwenty",
+      "P8f_scheduledStaleProbeCanExceedThePerPassSubrequestLimit",
+    ],
+    command: command("P8a_|P8b_|P8c_|P8d_|P8e_|P8f_"),
+  },
+];
+
+const buildPayload = async (args: {
+  readonly repoRoot: string;
+  readonly model: Scenarios;
+  readonly generatedAtUtc: string;
+}): Promise<EvidencePayload> => ({
+  status: "research-only / non-authorizing",
+  commitSha: resolveCommitSha(),
+  generatedAtUtc: args.generatedAtUtc,
+  deterministicSeed: DETERMINISTIC_SEED,
+  effectiveFcNumRuns: Number(process.env["FC_NUM_RUNS"] ?? 100),
+  nodeVersion: process.version,
+  liveConstants: {
+    WRITE_TICK_FOLD_ENTRIES_PER_PASS,
+    WRITE_TICK_MIN_ENTRIES_TO_COMPACT,
+    MAINTENANCE_MAX_FOLD_BYTES_DEFAULT,
+    MAINTENANCE_MAX_FOLD_ROWS,
+    MAINTENANCE_PROFILE_CF_FREE_MAX_FOLD_ENTRIES_PER_PASS:
+      MAINTENANCE_PROFILE_CF_FREE.maxFoldEntriesPerPass,
+    MAINTENANCE_PROFILE_NODE_MAX_FOLD_ENTRIES_PER_PASS:
+      MAINTENANCE_PROFILE_NODE.maxFoldEntriesPerPass,
+  },
+  modelAssumptions: {
+    cfFreeSubrequestLimit: {
+      value: CF_FREE_BUDGET.subrequestLimit,
+      source:
+        "Cloudflare Workers Free plan per-request subrequest cap. Platform limit, not a kernel constant — @baerly/protocol does not export it.",
+    },
+  },
+  modelParameters: {
+    kSweep: K_SWEEP,
+    syntheticLogLength: SYNTHETIC_LOG_LENGTH,
+    alignmentOrigin: "absolute-sequence-zero",
+    budget: reportBudget(),
+  },
+  sourceSha256: await sourceHashes(args.repoRoot),
+  claims: buildClaims(args.model),
+  counterexamples: buildCounterexamples(args.model),
+  unresolvedQuestions: [
+    "Which K and maintenance-profile policy should be selected for each deployment class?",
+    "What K compatibility rule should rolling deployments enforce while old and new observers overlap?",
+    "Does the scheduled fold path need a bounded tail probe, and what should a pass do when the bound is hit — defer the fold, or refresh the tail hint and make partial progress? See the stale-probe-budget-overflow counterexample: the O(gap) probe is hole-tolerant by design, so the writer's O(log gap) galloping tail-find is not a drop-in substitute.",
+  ],
+  implementationAuthorization:
+    "No implementation mechanism is authorized by this research evidence.",
+  tables: buildTables(args.model),
+});
+
+test("R1a_publishedBoundaryTargetDependenceTableIsUnchanged", () => {
+  expect(scenarios().boundaryTargetDependence).toEqual([
     {
       floor: 7,
       observedTail: 12,
@@ -516,42 +1056,12 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
       manifestTarget: 10,
     },
   ]);
+});
 
-  const tightTailCost = K_SWEEP.map((k) => {
-    const withSnapshot = foldCost({
-      manifest: {
-        generation: 1,
-        logSeqStart: 8,
-        snapshotKey: "prior",
-        tailHint: 8 + k,
-      },
-      probeFloor: 8 + k,
-      observedTail: 8 + k,
-      logEntriesRead: k,
-      reachedSnapshotPut: true,
-      reachedCurrentCas: true,
-    });
-    const withoutSnapshot = foldCost({
-      manifest: {
-        generation: 0,
-        logSeqStart: 0,
-        snapshotKey: null,
-        tailHint: k,
-      },
-      probeFloor: k,
-      observedTail: k,
-      logEntriesRead: k,
-      reachedSnapshotPut: true,
-      reachedCurrentCas: true,
-    });
-    return {
-      k,
-      withSnapshotTotal: withSnapshot.total,
-      withoutSnapshotTotal: withoutSnapshot.total,
-      snapshotDelta: withSnapshot.total - withoutSnapshot.total,
-      cfFreeSubrequestLimit: CF_FREE_BUDGET.subrequestLimit,
-    };
-  });
+test("R1b_publishedTightTailCostTableIsUnchanged", () => {
+  const { tightTailCost } = scenarios();
+
+  expect(tightTailCost.map(({ k }) => k)).toEqual([...K_SWEEP]);
   expect(tightTailCost.map(({ withSnapshotTotal }) => withSnapshotTotal)).toEqual([
     13, 21, 25, 37, 69, 205,
   ]);
@@ -559,58 +1069,12 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
     12, 20, 24, 36, 68, 204,
   ]);
   expect(tightTailCost.map(({ snapshotDelta }) => snapshotDelta)).toEqual([1, 1, 1, 1, 1, 1]);
+});
 
-  const productionBudget = roomyBudget();
-  const foldAndObjectProduction = K_SWEEP.map((k) => {
-    const aligned = drainToQuiescence({
-      initial,
-      budget: productionBudget,
-      k,
-      algorithm: "aligned-manifest",
-      maxPasses: SYNTHETIC_LOG_LENGTH + 2,
-    });
-    const live = drainToQuiescence({
-      initial,
-      budget: productionBudget,
-      k,
-      algorithm: "live-greedy",
-      maxPasses: SYNTHETIC_LOG_LENGTH + 2,
-    });
-    return {
-      k,
-      alignedWrittenFolds: aligned.attempts.filter(({ outcome }) => outcome === "written").length,
-      alignedObjects: aligned.finalState.snapshots.size,
-      alignedFinalFloor: aligned.finalState.manifest.logSeqStart,
-      liveWrittenFolds: live.attempts.filter(({ outcome }) => outcome === "written").length,
-      liveObjects: live.finalState.snapshots.size,
-      liveFinalFloor: live.finalState.manifest.logSeqStart,
-      materializedRowsEqual:
-        JSON.stringify([...rowsAtManifest(aligned.finalState).entries()].toSorted()) ===
-        JSON.stringify([...rowsAtManifest(live.finalState).entries()].toSorted()),
-    };
-  });
-  expect(
-    foldAndObjectProduction.map(
-      ({
-        alignedWrittenFolds,
-        alignedObjects,
-        alignedFinalFloor,
-        liveWrittenFolds,
-        liveObjects,
-        liveFinalFloor,
-        materializedRowsEqual,
-      }) => ({
-        alignedWrittenFolds,
-        alignedObjects,
-        alignedFinalFloor,
-        liveWrittenFolds,
-        liveObjects,
-        liveFinalFloor,
-        materializedRowsEqual,
-      }),
-    ),
-  ).toEqual([
+test("R1c_publishedFoldAndObjectProductionTableIsUnchanged", () => {
+  expect(scenarios().foldAndObjectProduction).toEqual([
     {
+      k: 8,
       alignedWrittenFolds: 80,
       alignedObjects: 80,
       alignedFinalFloor: 640,
@@ -620,6 +1084,7 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
       materializedRowsEqual: true,
     },
     {
+      k: 16,
       alignedWrittenFolds: 40,
       alignedObjects: 40,
       alignedFinalFloor: 640,
@@ -629,6 +1094,7 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
       materializedRowsEqual: true,
     },
     {
+      k: 20,
       alignedWrittenFolds: 32,
       alignedObjects: 32,
       alignedFinalFloor: 640,
@@ -638,6 +1104,7 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
       materializedRowsEqual: true,
     },
     {
+      k: 32,
       alignedWrittenFolds: 20,
       alignedObjects: 20,
       alignedFinalFloor: 640,
@@ -647,6 +1114,7 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
       materializedRowsEqual: true,
     },
     {
+      k: 64,
       alignedWrittenFolds: 10,
       alignedObjects: 10,
       alignedFinalFloor: 640,
@@ -656,6 +1124,7 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
       materializedRowsEqual: true,
     },
     {
+      k: 200,
       alignedWrittenFolds: 3,
       alignedObjects: 3,
       alignedFinalFloor: 600,
@@ -665,85 +1134,41 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
       materializedRowsEqual: true,
     },
   ]);
+});
 
-  const sameKRacersResult = runSchedule({
-    initial: stateWithTail(20),
-    observers: [
-      action({ observerId: 1, readsAtGeneration: 0, observedTail: 5, k: 5 }),
-      action({ observerId: 2, readsAtGeneration: 0, observedTail: 9, k: 5 }),
-    ],
+test("R1d_publishedContentionAndCrashTablesAreUnchanged", () => {
+  const { sameKRacers, mixedKRacers, crashRetry } = scenarios();
+
+  expect(sameKRacers).toEqual({
+    outcomes: ["written", "cas_lost"],
+    foldEnds: [5, 5],
+    emittedKeys: sameKRacers.emittedKeys,
+    storedObjects: 1,
+    neverReferencedObjects: 0,
   });
-  const sameKRacers = {
-    outcomes: sameKRacersResult.attempts.map(({ outcome }) => outcome),
-    foldEnds: sameKRacersResult.attempts.map(({ foldEnd }) => foldEnd),
-    emittedKeys: sameKRacersResult.attempts.map(({ emittedKey }) => emittedKey),
-    storedObjects: sameKRacersResult.finalState.snapshots.size,
-    neverReferencedObjects: sameKRacersResult.neverReferencedSnapshots.length,
-  };
-  expect(sameKRacers.outcomes).toEqual(["written", "cas_lost"]);
-  expect(sameKRacers.foldEnds).toEqual([5, 5]);
   expect(new Set(sameKRacers.emittedKeys).size).toBe(1);
-  expect(sameKRacers.storedObjects).toBe(1);
-  expect(sameKRacers.neverReferencedObjects).toBe(0);
 
-  const mixedKRacersResult = runSchedule({
-    initial: stateWithTail(20),
-    observers: [
-      action({ observerId: 1, readsAtGeneration: 0, observedTail: 20, k: 4 }),
-      action({ observerId: 2, readsAtGeneration: 0, observedTail: 20, k: 6 }),
-    ],
+  expect(mixedKRacers).toEqual({
+    outcomes: ["written", "cas_lost"],
+    foldEnds: [4, 6],
+    emittedKeys: mixedKRacers.emittedKeys,
+    storedObjects: 2,
+    neverReferencedObjects: 1,
   });
-  const mixedKRacers = {
-    outcomes: mixedKRacersResult.attempts.map(({ outcome }) => outcome),
-    foldEnds: mixedKRacersResult.attempts.map(({ foldEnd }) => foldEnd),
-    emittedKeys: mixedKRacersResult.attempts.map(({ emittedKey }) => emittedKey),
-    storedObjects: mixedKRacersResult.finalState.snapshots.size,
-    neverReferencedObjects: mixedKRacersResult.neverReferencedSnapshots.length,
-  };
-  expect(mixedKRacers.outcomes).toEqual(["written", "cas_lost"]);
-  expect(mixedKRacers.foldEnds).toEqual([4, 6]);
   expect(new Set(mixedKRacers.emittedKeys).size).toBe(2);
-  expect(mixedKRacers.storedObjects).toBe(2);
-  expect(mixedKRacers.neverReferencedObjects).toBe(1);
 
-  const crashRetryResult = runSchedule({
-    initial: stateWithTail(20),
-    observers: [
-      action({ observerId: 1, observedTail: 20, k: 5, crashAt: "after_snapshot_put" }),
-      action({ observerId: 2, observedTail: 20, k: 5 }),
-    ],
+  expect(crashRetry).toEqual({
+    outcomes: ["crashed", "written"],
+    foldEnds: [5, 5],
+    emittedKeys: crashRetry.emittedKeys,
+    finalGeneration: 1,
   });
-  const crashRetry = {
-    outcomes: crashRetryResult.attempts.map(({ outcome }) => outcome),
-    foldEnds: crashRetryResult.attempts.map(({ foldEnd }) => foldEnd),
-    emittedKeys: crashRetryResult.attempts.map(({ emittedKey }) => emittedKey),
-    finalGeneration: crashRetryResult.finalState.manifest.generation,
-  };
-  expect(crashRetry.outcomes).toEqual(["crashed", "written"]);
-  expect(crashRetry.foldEnds).toEqual([5, 5]);
   expect(new Set(crashRetry.emittedKeys).size).toBe(1);
-  expect(crashRetry.finalGeneration).toBe(1);
+});
 
-  const unavailableState = stateWithTail(4);
-  const availabilityRetry = {
-    target: alignedManifestTarget(unavailableState.manifest.logSeqStart, 5),
-    before: prepareFold({
-      state: unavailableState,
-      observedTail: 4,
-      probeFloor: 4,
-      budget: roomyBudget(),
-      k: 5,
-      algorithm: "aligned-manifest",
-    }),
-    after: prepareFold({
-      state: stateWithTail(5),
-      observedTail: 5,
-      probeFloor: 5,
-      budget: roomyBudget(),
-      k: 5,
-      algorithm: "aligned-manifest",
-    }),
-  };
+test("R1e_publishedAvailabilityAndReclamationTablesAreUnchanged", () => {
+  const { availabilityRetry, reclamation } = scenarios();
+
   expect({
     target: availabilityRetry.target,
     beforeOutcome: availabilityRetry.before.outcome,
@@ -760,27 +1185,6 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
     afterFoldEnd: 5,
   });
 
-  const firstFold = runSchedule({
-    initial: stateWithTail(10),
-    observers: [action({ observerId: 1, observedTail: 10, k: 5 })],
-  });
-  const secondFold = runSchedule({
-    initial: firstFold.finalState,
-    observers: [action({ observerId: 2, observedTail: 10, k: 5 })],
-  });
-  const reclaimed = reclaimUnreferenced(secondFold.finalState);
-  const reclamation = {
-    beforeFirstFold: firstFold.reclaimableSnapshots.length,
-    afterSecondSuccessfulFold: secondFold.reclaimableSnapshots.length,
-    storedBeforeReclamation: secondFold.finalState.snapshots.size,
-    storedAfterReclamation: reclaimed.snapshots.size,
-    currentObjectPreserved:
-      reclaimed.manifest.snapshotKey !== null &&
-      reclaimed.snapshots.has(reclaimed.manifest.snapshotKey),
-    materializedRowsPreserved:
-      JSON.stringify([...rowsAtManifest(secondFold.finalState).entries()].toSorted()) ===
-      JSON.stringify([...rowsAtManifest(reclaimed).entries()].toSorted()),
-  };
   expect(reclamation).toEqual({
     beforeFirstFold: 0,
     afterSecondSuccessfulFold: 1,
@@ -789,244 +1193,76 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
     currentObjectPreserved: true,
     materializedRowsPreserved: true,
   });
+});
 
-  const zeroMaxEntriesResult = prepareFold({
-    state: stateWithTail(20),
-    observedTail: 20,
-    probeFloor: 20,
-    budget: roomyBudget({ maxEntriesPerRun: 0 }),
-    k: 5,
-    algorithm: "live-greedy",
+test("R1f_everyPublishedCounterexampleIsReproducedByItsScenario", () => {
+  const model = scenarios();
+
+  expect(model.zeroMaxEntries.outcome).toBe("below_min_threshold");
+  expect(model.zeroMaxEntries.foldEnd).toBeNull();
+  expect(model.staleProbe.attempts[0]!.cost.total).toBeGreaterThan(CF_FREE_BUDGET.subrequestLimit);
+  expect(model.crashAfterPut.attempts[0]!.outcome).toBe("crashed");
+  expect(model.crashAfterPut.neverReferencedSnapshots).toHaveLength(1);
+
+  expect(buildCounterexamples(model).map(({ id }) => id)).toEqual([
+    "zero-max-entries-progress",
+    "stale-probe-budget-overflow",
+    "mixed-k-cas-orphan",
+    "crash-after-put-orphan",
+    "successful-fold-increases-reclaimable-objects",
+  ]);
+  expect(buildCounterexamples(model).every(({ observed }) => observed)).toBe(true);
+});
+
+/**
+ * Assembled line-by-line from quoted strings rather than written as one template
+ * literal, because the fixture must contain genuinely UNESCAPED nested backticks
+ * — an escaped `` \` `` does not reproduce the failure this pins.
+ *
+ * The nested-template line is the discriminating case. A parity-based scanner (no
+ * `${…}` depth stack) misreads the span as ending at the inner opening backtick,
+ * resumes in code mode mid-literal, and there meets the apostrophe in `don't` —
+ * which it takes as opening a single-quoted string that never closes. Every
+ * declaration after that point is then invisible: the scanner returns `[]` for
+ * this fixture instead of the one real declaration.
+ */
+const SCRAPER_FIXTURE = [
+  '// test("P1z_lineCommentOnly", () => {});',
+  "/*",
+  'test("P1z_blockCommentOnly", () => {});',
+  "*/",
+  "const text = 'test(\"P1z_stringLiteralOnly\", () => {})';",
+  'const nested = `a ${xs.map((x) => `don\'t ${x}`).join("")} b`;',
+  'test("P1a_realDeclaration", () => {});',
+  'describe.skip("P1z_notATestCall", () => {});',
+].join("\n");
+
+test("R2_propertyIdScraperSeesOnlyRealDeclarations", () => {
+  expect(declaredPropertyIdsInSource(SCRAPER_FIXTURE)).toEqual(["P1a_realDeclaration"]);
+});
+
+test("R3_everyDeclaredPropertyIdIsCatalogued", async () => {
+  const declared = await declaredPropertyIds(process.cwd());
+  const catalogued = PROPERTY_CATALOG.flatMap(({ propertyIds }) => propertyIds);
+
+  expect(catalogued).toHaveLength(new Set(catalogued).size);
+  expect([...declared].toSorted()).toEqual([...catalogued].toSorted());
+});
+
+test("R4_payloadIsSelfConsistentAndFullyProvenanced", async () => {
+  const repoRoot = process.cwd();
+  const payload = await buildPayload({
+    repoRoot,
+    model: scenarios(),
+    generatedAtUtc: new Date().toISOString(),
   });
-  expect(zeroMaxEntriesResult.outcome).toBe("below_min_threshold");
-  expect(zeroMaxEntriesResult.foldEnd).toBeNull();
 
-  const staleProbeResult = runSchedule({
-    initial: stateWithTail(100, 0),
-    observers: [action({ observedTail: 100, k: 20, budget: CF_FREE_BUDGET })],
-  });
-  expect(staleProbeResult.attempts[0]!.cost.probeGets).toBe(101);
-  expect(staleProbeResult.attempts[0]!.cost.total).toBeGreaterThan(CF_FREE_BUDGET.subrequestLimit);
-
-  const crashAfterPutResult = runSchedule({
-    initial: stateWithTail(20),
-    observers: [action({ observedTail: 20, k: 5, crashAt: "after_snapshot_put" })],
-  });
-  expect(crashAfterPutResult.attempts[0]!.outcome).toBe("crashed");
-  expect(crashAfterPutResult.neverReferencedSnapshots).toHaveLength(1);
-
-  const counterexamples = [
-    {
-      id: "zero-max-entries-progress",
-      observed: true,
-      outcome: zeroMaxEntriesResult.outcome,
-      foldEnd: zeroMaxEntriesResult.foldEnd,
-    },
-    {
-      id: "stale-probe-budget-overflow",
-      observed: true,
-      totalCost: staleProbeResult.attempts[0]!.cost.total,
-      subrequestLimit: CF_FREE_BUDGET.subrequestLimit,
-    },
-    {
-      id: "mixed-k-cas-orphan",
-      observed: true,
-      loserOutcome: mixedKRacersResult.attempts[1]!.outcome,
-      neverReferencedObjects: mixedKRacersResult.neverReferencedSnapshots.length,
-    },
-    {
-      id: "crash-after-put-orphan",
-      observed: true,
-      outcome: crashAfterPutResult.attempts[0]!.outcome,
-      neverReferencedObjects: crashAfterPutResult.neverReferencedSnapshots.length,
-    },
-    {
-      id: "successful-fold-increases-reclaimable-objects",
-      observed: true,
-      before: firstFold.reclaimableSnapshots.length,
-      after: secondFold.reclaimableSnapshots.length,
-    },
-  ] as const;
-
-  const command = (propertyPattern: string): string =>
-    `FC_NUM_RUNS=10000 pnpm test:agent tests/model/fold-boundary -t '${propertyPattern}'`;
-  const claims: readonly EvidenceClaim[] = [
-    {
-      question: 1,
-      classification: "universally-quantified-property",
-      conclusion: `At floor 7 and K=5, the manifest target remained ${boundaryTargetDependence[0]!.manifestTarget} while live boundaries changed from ${boundaryTargetDependence[0]!.liveGreedy} to ${boundaryTargetDependence[1]!.liveGreedy} with observation.`,
-      propertyIds: [
-        "P1a_manifestTargetIsIndependentOfObservationAndBudget",
-        "P1b_liveAndObservedAlignedTargetsDependOnObservedAvailability",
-      ],
-      command: command("P1a_|P1b_"),
-    },
-    {
-      question: 2,
-      classification: "bounded-deterministic-observation",
-      conclusion: `With only 4 entries, target ${availabilityRetry.target} produced ${availabilityRetry.before.outcome} and no object; at 5 entries the retry prepared the same target.`,
-      propertyIds: [
-        "P2a_fewerThanNextKEntriesProducesNoObjectOrProgress",
-        "P2b_retryAfterAvailabilityUsesTheSameManifestTarget",
-      ],
-      command: command("P2a_|P2b_"),
-    },
-    {
-      question: 3,
-      classification: "bounded-deterministic-observation",
-      conclusion: `A crash after snapshot PUT left generation 0 unchanged, and retry published the same floor ${crashRetry.foldEnds[1]} and content-addressed key at generation ${crashRetry.finalGeneration}.`,
-      propertyIds: [
-        "P3a_crashBeforeCasLeavesManifestUnchangedAndRetryUsesSameTarget",
-        "P3b_laggingObserverBoundarySequenceIsAPrefixOfFullyInformedSequence",
-      ],
-      command: command("P3a_|P3b_"),
-    },
-    {
-      question: 4,
-      classification: "unresolved",
-      conclusion: `K=4 and K=6 observers from generation 0 prepared floors ${mixedKRacers.foldEnds.join(" and ")}; rolling-deploy K compatibility therefore remains a policy question.`,
-      propertyIds: [
-        "P4a_firstTargetAfterKChangeIsStrictlyMonotoneAndNewKAligned",
-        "P4b_mixedKObserversCanPrepareDifferentObjectsFromOneGeneration",
-      ],
-      command: command("P4a_|P4b_"),
-    },
-    {
-      question: 5,
-      classification: "universally-quantified-property",
-      conclusion: `Two generation-0, K=5 racers emitted one key, stored ${sameKRacers.storedObjects} object, and added ${sameKRacers.neverReferencedObjects} distinct CAS orphan.`,
-      propertyIds: [
-        "P5a_observersOnOppositeSidesOfOneBoundaryEmitAtMostOneObjectForOneK",
-        "P5b_sameManifestSameKAlwaysProducesTheSameObjectKey",
-      ],
-      command: command("P5a_|P5b_"),
-    },
-    {
-      question: 6,
-      classification: "explicit-counterexample",
-      conclusion: `Mixed-K CAS loss and crash-after-PUT each produced one never-referenced object, while a second successful fold increased reclaimable objects from ${reclamation.beforeFirstFold} to ${reclamation.afterSecondSuccessfulFold}.`,
-      propertyIds: [
-        "P6a_sameGenerationSameKContentionAddsNoDistinctCasOrphan",
-        "P6b_successfulFoldCanIncreaseRatherThanReduceReclaimableObjects",
-        "P6c_mixedKContentionHasAReachableDistinctCasOrphan",
-        "P6d_crashAfterPutHasAReachableNeverReferencedSnapshot",
-        "P6e_reclamationRemovesAllAndOnlyNonCurrentSnapshots",
-      ],
-      command: command("P6a_|P6b_|P6c_|P6d_|P6e_"),
-    },
-    {
-      question: 7,
-      classification: "universally-quantified-property",
-      conclusion: `Every deterministic aligned/live row compared equal after the ${SYNTHETIC_LOG_LENGTH}-entry log, including the K=200 aligned remainder at floor 600.`,
-      propertyIds: [
-        "P7a_everyPreparedManifestBoundaryStrictlyAdvancesAndIsAligned",
-        "P7b_everyPreparedReadSetIsTheExactContiguousInterval",
-        "P7c_contiguousIncrementalFoldEqualsReferenceReplay",
-        "P7d_publishedSnapshotCanPreserveEveryAcknowledgedPrefix",
-        "P7e_everyPublishedSnapshotMatchesReferenceReplayThroughItsFloor",
-      ],
-      command: command("P7a_|P7b_|P7c_|P7d_|P7e_"),
-    },
-    {
-      question: 8,
-      classification: "explicit-counterexample",
-      conclusion: `Tight-tail prior-snapshot totals ranged from ${tightTailCost[0]!.withSnapshotTotal} to ${tightTailCost.at(-1)!.withSnapshotTotal}; zero max entries made no progress, while stale probing cost ${staleProbeResult.attempts[0]!.cost.total} against the live limit ${CF_FREE_BUDGET.subrequestLimit}.`,
-      propertyIds: [
-        "P8a_tightKnownTailCostIsNPlusFiveWithSnapshotAndNPlusFourWithout",
-        "P8b_deferredAttemptStillPaysSnapshotAndLogReadsButNoPuts",
-        "P8c_kAboveMaxEntriesCannotPrepare",
-        "P8d_zeroMaxEntriesIsAnExplicitZeroProgressCounterexample",
-        "P8e_manifestAlignedProgressFitsCfFreeWithTightKnownTailForKAtMostTwenty",
-        "P8f_scheduledStaleProbeCanExceedThePerPassSubrequestLimit",
-      ],
-      command: command("P8a_|P8b_|P8c_|P8d_|P8e_|P8f_"),
-    },
-  ];
-
-  const tables = {
-    boundaryTargetDependence,
-    tightTailCost,
-    foldAndObjectProduction,
-    sameGenerationSameKRacers: sameKRacers,
-    mixedKRacers,
-    crashRetry,
-    availabilityRetry: {
-      target: availabilityRetry.target,
-      beforeOutcome: availabilityRetry.before.outcome,
-      beforeFoldEnd: availabilityRetry.before.foldEnd,
-      afterOutcome: availabilityRetry.after.outcome,
-      afterFoldEnd: availabilityRetry.after.foldEnd,
-    },
-    reclamation,
-  };
-  const generatedAtUtc = new Date().toISOString();
-  const generatedFromSha = resolveCommitSha();
-  const effectiveFcNumRuns = Number(process.env["FC_NUM_RUNS"] ?? 100);
-  expect(Number.isFinite(effectiveFcNumRuns)).toBe(true);
-  const payload: EvidencePayload = {
-    status: "research-only / non-authorizing",
-    commitSha: generatedFromSha,
-    generatedAtUtc,
-    deterministicSeed: DETERMINISTIC_SEED,
-    effectiveFcNumRuns,
-    nodeVersion: process.version,
-    liveConstants: {
-      WRITE_TICK_FOLD_ENTRIES_PER_PASS,
-      WRITE_TICK_MIN_ENTRIES_TO_COMPACT,
-      MAINTENANCE_MAX_FOLD_BYTES_DEFAULT,
-      MAINTENANCE_MAX_FOLD_ROWS,
-      MAINTENANCE_PROFILE_CF_FREE_MAX_FOLD_ENTRIES_PER_PASS:
-        MAINTENANCE_PROFILE_CF_FREE.maxFoldEntriesPerPass,
-      MAINTENANCE_PROFILE_NODE_MAX_FOLD_ENTRIES_PER_PASS:
-        MAINTENANCE_PROFILE_NODE.maxFoldEntriesPerPass,
-    },
-    modelAssumptions: {
-      cfFreeSubrequestLimit: {
-        value: CF_FREE_BUDGET.subrequestLimit,
-        source:
-          "Cloudflare Workers Free plan per-request subrequest cap. Platform limit, not a kernel constant — @baerly/protocol does not export it.",
-      },
-    },
-    modelParameters: {
-      kSweep: K_SWEEP,
-      syntheticLogLength: SYNTHETIC_LOG_LENGTH,
-      alignmentOrigin: "absolute-sequence-zero",
-    },
-    sourceSha256: await sourceHashes(repoRoot),
-    claims,
-    counterexamples,
-    unresolvedQuestions: [
-      "Which K and maintenance-profile policy should be selected for each deployment class?",
-      "What K compatibility rule should rolling deployments enforce while old and new observers overlap?",
-      "Does the scheduled fold path need a bounded tail probe, and what should a pass do when the bound is hit — defer the fold, or refresh the tail hint and make partial progress? See the stale-probe-budget-overflow counterexample: the O(gap) probe is hole-tolerant by design, so the writer's O(log gap) galloping tail-find is not a drop-in substitute.",
-    ],
-    implementationAuthorization:
-      "No implementation mechanism is authorized by this research evidence.",
-    tables,
-  };
-  const markdown = renderMarkdown(payload);
-
-  expect(
-    declaredPropertyIdsInSource(`
-      // test("P1z_lineCommentOnly", () => {});
-      /*
-      test("P1z_blockCommentOnly", () => {});
-      */
-      const text = 'test("P1z_stringLiteralOnly", () => {})';
-      test("P1a_realDeclaration", () => {});
-    `),
-  ).toEqual(["P1a_realDeclaration"]);
-  const actualPropertyIds = await declaredPropertyIds(repoRoot);
-  const canonicalPropertyIds = PROPERTY_CATALOG.flatMap(
-    ({ propertyIds: catalogPropertyIds }) => catalogPropertyIds,
-  );
-  expect(canonicalPropertyIds).toHaveLength(new Set(canonicalPropertyIds).size);
-  expect([...actualPropertyIds].toSorted()).toEqual([...canonicalPropertyIds].toSorted());
+  expect(Number.isFinite(payload.effectiveFcNumRuns)).toBe(true);
   expect(payload.claims.map(({ question }) => question)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
   expect(
-    payload.claims.map(({ question, propertyIds: claimPropertyIds, command: claimCommand }) => ({
+    payload.claims.map(({ question, propertyIds, command: claimCommand }) => ({
       question,
-      propertyIds: claimPropertyIds,
+      propertyIds,
       command: claimCommand,
     })),
   ).toEqual(PROPERTY_CATALOG);
@@ -1034,14 +1270,20 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
   expect(Object.values(payload.sourceSha256).every((digest) => /^[a-f0-9]{64}$/.test(digest))).toBe(
     true,
   );
-  expect(payload.counterexamples.map(({ id }) => id)).toEqual([
-    "zero-max-entries-progress",
-    "stale-probe-budget-overflow",
-    "mixed-k-cas-orphan",
-    "crash-after-put-orphan",
-    "successful-fold-increases-reclaimable-objects",
-  ]);
-  expect(payload.counterexamples.every(({ observed }) => observed)).toBe(true);
+  // Shape check, not a round-trip tautology: assert the resolver produced a real
+  // object name (or the honest fallback) before trusting it as provenance.
+  expect(payload.commitSha).toMatch(/^([a-f0-9]{40}|unknown)$/);
+  expect(payload.modelParameters.budget).toEqual(reportBudget());
+});
+
+test("R5_reportWriteIsCollisionSafeAndRoundTrips", async () => {
+  const repoRoot = process.cwd();
+  const payload = await buildPayload({
+    repoRoot,
+    model: scenarios(),
+    generatedAtUtc: new Date().toISOString(),
+  });
+  const markdown = renderMarkdown(payload);
 
   const firstDirectory = await writeReport(repoRoot, payload, markdown);
   const firstJsonBeforeCollision = await readFile(join(firstDirectory, "report.json"), "utf8");
@@ -1053,6 +1295,7 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
   );
   const directorySuffix = (directory: string): number =>
     directory === reportBaseDirectory ? 0 : Number(directory.slice(reportBaseDirectory.length + 1));
+
   expect(secondDirectory).not.toBe(firstDirectory);
   expect(directorySuffix(secondDirectory)).toBeGreaterThan(directorySuffix(firstDirectory));
   await expect(readFile(join(firstDirectory, "report.json"), "utf8")).resolves.toBe(
@@ -1064,25 +1307,29 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
 
   const parsed = JSON.parse(
     await readFile(join(secondDirectory, "report.json"), "utf8"),
-  ) as typeof payload;
+  ) as EvidencePayload;
   const readBackMarkdown = await readFile(join(secondDirectory, "report.md"), "utf8");
+
   expect(parsed).toEqual(payload);
   expect(readBackMarkdown).toBe(markdown);
   expect(parsed.status).toBe("research-only / non-authorizing");
-  // Shape check, not a round-trip tautology: assert the resolver produced a
-  // real object name (or the honest fallback) before trusting it as provenance.
-  expect(generatedFromSha).toMatch(/^([a-f0-9]{40}|unknown)$/);
-  expect(parsed.commitSha).toBe(generatedFromSha);
-  expect(parsed.deterministicSeed).toBe(DETERMINISTIC_SEED);
-  expect(parsed.modelParameters.kSweep).toEqual(K_SWEEP);
-  expect(parsed.modelParameters.alignmentOrigin).toBe("absolute-sequence-zero");
-  expect(parsed.sourceSha256).toEqual(await sourceHashes(repoRoot));
   expect(parsed.implementationAuthorization).toBe(
     "No implementation mechanism is authorized by this research evidence.",
   );
   expect(readBackMarkdown).toContain("No implementation mechanism is authorized by this report.");
-  expect(readBackMarkdown).toContain(`Commit SHA: \`${generatedFromSha}\``);
+  expect(readBackMarkdown).toContain(`Commit SHA: \`${payload.commitSha}\``);
   expect(readBackMarkdown).toContain("## Deterministic tables");
   expect(readBackMarkdown).toContain("## Counterexamples");
   expect(readBackMarkdown).toContain("## Source SHA-256");
+});
+
+test("R6_sourceHashesCoverEveryModelFile", async () => {
+  const entries = await readdir(join(process.cwd(), MODEL_DIRECTORY));
+  const onDisk = entries
+    .filter((entry) => entry.endsWith(".ts"))
+    .map((entry) => `${MODEL_DIRECTORY}/${entry}`)
+    .toSorted();
+
+  expect(onDisk.length).toBeGreaterThan(0);
+  expect([...SOURCE_FILES].toSorted()).toEqual(onDisk);
 });

--- a/tests/model/fold-boundary/evidence-report.test.ts
+++ b/tests/model/fold-boundary/evidence-report.test.ts
@@ -57,6 +57,85 @@ const SOURCE_FILES = [
   "tests/model/fold-boundary/progress-bound.test.ts",
   "tests/model/fold-boundary/schedule.ts",
 ] as const;
+const PROPERTY_CATALOG = [
+  {
+    question: 1,
+    propertyIds: [
+      "P1a_manifestTargetIsIndependentOfObservationAndBudget",
+      "P1b_liveAndObservedAlignedTargetsDependOnObservedAvailability",
+    ],
+    command: "FC_NUM_RUNS=10000 pnpm test:agent tests/model/fold-boundary -t 'P1a_|P1b_'",
+  },
+  {
+    question: 2,
+    propertyIds: [
+      "P2a_fewerThanNextKEntriesProducesNoObjectOrProgress",
+      "P2b_retryAfterAvailabilityUsesTheSameManifestTarget",
+    ],
+    command: "FC_NUM_RUNS=10000 pnpm test:agent tests/model/fold-boundary -t 'P2a_|P2b_'",
+  },
+  {
+    question: 3,
+    propertyIds: [
+      "P3a_crashBeforeCasLeavesManifestUnchangedAndRetryUsesSameTarget",
+      "P3b_laggingObserverBoundarySequenceIsAPrefixOfFullyInformedSequence",
+    ],
+    command: "FC_NUM_RUNS=10000 pnpm test:agent tests/model/fold-boundary -t 'P3a_|P3b_'",
+  },
+  {
+    question: 4,
+    propertyIds: [
+      "P4a_firstTargetAfterKChangeIsStrictlyMonotoneAndNewKAligned",
+      "P4b_mixedKObserversCanPrepareDifferentObjectsFromOneGeneration",
+    ],
+    command: "FC_NUM_RUNS=10000 pnpm test:agent tests/model/fold-boundary -t 'P4a_|P4b_'",
+  },
+  {
+    question: 5,
+    propertyIds: [
+      "P5a_observersOnOppositeSidesOfOneBoundaryEmitAtMostOneObjectForOneK",
+      "P5b_sameManifestSameKAlwaysProducesTheSameObjectKey",
+    ],
+    command: "FC_NUM_RUNS=10000 pnpm test:agent tests/model/fold-boundary -t 'P5a_|P5b_'",
+  },
+  {
+    question: 6,
+    propertyIds: [
+      "P6a_sameGenerationSameKContentionAddsNoDistinctCasOrphan",
+      "P6b_successfulFoldCanIncreaseRatherThanReduceReclaimableObjects",
+      "P6c_mixedKContentionHasAReachableDistinctCasOrphan",
+      "P6d_crashAfterPutHasAReachableNeverReferencedSnapshot",
+      "P6e_reclamationRemovesAllAndOnlyNonCurrentSnapshots",
+    ],
+    command:
+      "FC_NUM_RUNS=10000 pnpm test:agent tests/model/fold-boundary -t 'P6a_|P6b_|P6c_|P6d_|P6e_'",
+  },
+  {
+    question: 7,
+    propertyIds: [
+      "P7a_everyPreparedManifestBoundaryStrictlyAdvancesAndIsAligned",
+      "P7b_everyPreparedReadSetIsTheExactContiguousInterval",
+      "P7c_contiguousIncrementalFoldEqualsReferenceReplay",
+      "P7d_publishedSnapshotCanPreserveEveryAcknowledgedPrefix",
+      "P7e_everyPublishedSnapshotMatchesReferenceReplayThroughItsFloor",
+    ],
+    command:
+      "FC_NUM_RUNS=10000 pnpm test:agent tests/model/fold-boundary -t 'P7a_|P7b_|P7c_|P7d_|P7e_'",
+  },
+  {
+    question: 8,
+    propertyIds: [
+      "P8a_tightKnownTailCostIsNPlusFiveWithSnapshotAndNPlusFourWithout",
+      "P8b_deferredAttemptStillPaysSnapshotAndLogReadsButNoPuts",
+      "P8c_kAboveMaxEntriesCannotPrepare",
+      "P8d_zeroMaxEntriesIsAnExplicitZeroProgressCounterexample",
+      "P8e_manifestAlignedProgressFitsCfFreeWithTightKnownTailForKAtMostTwenty",
+      "P8f_scheduledStaleProbeCanExceedThePerPassSubrequestLimit",
+    ],
+    command:
+      "FC_NUM_RUNS=10000 pnpm test:agent tests/model/fold-boundary -t 'P8a_|P8b_|P8c_|P8d_|P8e_|P8f_'",
+  },
+] as const;
 
 type ClaimClassification =
   | "universally-quantified-property"
@@ -171,20 +250,98 @@ const sourceHashes = async (repoRoot: string): Promise<Readonly<Record<string, s
     ),
   );
 
-const namedPropertyIds = async (repoRoot: string): Promise<ReadonlySet<string>> => {
+interface SourceToken {
+  readonly kind: "identifier" | "punctuation" | "string";
+  readonly value: string;
+}
+
+const sourceTokens = (source: string): readonly SourceToken[] => {
+  const tokens: SourceToken[] = [];
+  let index = 0;
+
+  while (index < source.length) {
+    const current = source[index]!;
+    const next = source[index + 1];
+    if (/\s/.test(current)) {
+      index += 1;
+      continue;
+    }
+    if (current === "/" && next === "/") {
+      index = source.indexOf("\n", index + 2);
+      if (index === -1) {
+        break;
+      }
+      continue;
+    }
+    if (current === "/" && next === "*") {
+      const end = source.indexOf("*/", index + 2);
+      index = end === -1 ? source.length : end + 2;
+      continue;
+    }
+    if (current === "`" || current === "'" || current === '"') {
+      const quote = current;
+      const start = index + 1;
+      index = start;
+      while (index < source.length) {
+        if (source[index] === "\\") {
+          index += 2;
+          continue;
+        }
+        if (source[index] === quote) {
+          break;
+        }
+        index += 1;
+      }
+      if (quote !== "`") {
+        tokens.push({ kind: "string", value: source.slice(start, index) });
+      }
+      index += 1;
+      continue;
+    }
+    if (/[A-Za-z_$]/.test(current)) {
+      const start = index;
+      index += 1;
+      while (index < source.length && /[A-Za-z0-9_$]/.test(source[index]!)) {
+        index += 1;
+      }
+      tokens.push({ kind: "identifier", value: source.slice(start, index) });
+      continue;
+    }
+
+    tokens.push({ kind: "punctuation", value: current });
+    index += 1;
+  }
+
+  return tokens;
+};
+
+const declaredPropertyIdsInSource = (source: string): readonly string[] => {
+  const tokens = sourceTokens(source);
+  return tokens.flatMap((token, index) => {
+    const previous = tokens[index - 1];
+    const openParen = tokens[index + 1];
+    const propertyId = tokens[index + 2];
+    const comma = tokens[index + 3];
+    return token.kind === "identifier" &&
+      token.value === "test" &&
+      previous?.value !== "." &&
+      openParen?.value === "(" &&
+      propertyId?.kind === "string" &&
+      /^P[1-8][a-z]_[A-Za-z0-9]+$/.test(propertyId.value) &&
+      comma?.value === ","
+      ? [propertyId.value]
+      : [];
+  });
+};
+
+const declaredPropertyIds = async (repoRoot: string): Promise<ReadonlySet<string>> => {
   const propertyTestFiles = SOURCE_FILES.filter(
     (path) => path.endsWith(".test.ts") && !path.endsWith("evidence-report.test.ts"),
   );
   const sources = await Promise.all(
     propertyTestFiles.map((path) => readFile(join(repoRoot, path), "utf8")),
   );
-  return new Set(
-    sources.flatMap((source) =>
-      [...source.matchAll(/test\("(?<id>P[1-8][a-z]_[^"]+)"/g)].map(
-        (match) => match.groups!["id"]!,
-      ),
-    ),
-  );
+  return new Set(sources.flatMap(declaredPropertyIdsInSource));
 };
 
 const writeReport = async (
@@ -786,14 +943,30 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
   };
   const markdown = renderMarkdown(payload);
 
-  const propertyIds = await namedPropertyIds(repoRoot);
-  expect(propertyIds.size).toBeGreaterThan(0);
+  expect(
+    declaredPropertyIdsInSource(`
+      // test("P1z_lineCommentOnly", () => {});
+      /*
+      test("P1z_blockCommentOnly", () => {});
+      */
+      const text = 'test("P1z_stringLiteralOnly", () => {})';
+      test("P1a_realDeclaration", () => {});
+    `),
+  ).toEqual(["P1a_realDeclaration"]);
+  const actualPropertyIds = await declaredPropertyIds(repoRoot);
+  const canonicalPropertyIds = PROPERTY_CATALOG.flatMap(
+    ({ propertyIds: catalogPropertyIds }) => catalogPropertyIds,
+  );
+  expect(canonicalPropertyIds).toHaveLength(new Set(canonicalPropertyIds).size);
+  expect([...actualPropertyIds].toSorted()).toEqual([...canonicalPropertyIds].toSorted());
   expect(payload.claims.map(({ question }) => question)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
-  for (const claim of payload.claims) {
-    expect(claim.propertyIds.length).toBeGreaterThan(0);
-    expect(claim.propertyIds.every((propertyId) => propertyIds.has(propertyId))).toBe(true);
-    expect(claim.command).toContain("FC_NUM_RUNS=10000");
-  }
+  expect(
+    payload.claims.map(({ question, propertyIds: claimPropertyIds, command: claimCommand }) => ({
+      question,
+      propertyIds: claimPropertyIds,
+      command: claimCommand,
+    })),
+  ).toEqual(PROPERTY_CATALOG);
   expect(Object.keys(payload.sourceSha256).toSorted()).toEqual([...SOURCE_FILES].toSorted());
   expect(Object.values(payload.sourceSha256).every((digest) => /^[a-f0-9]{64}$/.test(digest))).toBe(
     true,
@@ -831,6 +1004,7 @@ test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () 
   ) as typeof payload;
   const readBackMarkdown = await readFile(join(secondDirectory, "report.md"), "utf8");
   expect(parsed).toEqual(payload);
+  expect(readBackMarkdown).toBe(markdown);
   expect(parsed.status).toBe("research-only / non-authorizing");
   expect(parsed.baseSha).toBe(BASE_SHA);
   expect(parsed.deterministicSeed).toBe(DETERMINISTIC_SEED);

--- a/tests/model/fold-boundary/evidence-report.test.ts
+++ b/tests/model/fold-boundary/evidence-report.test.ts
@@ -1,0 +1,848 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+import {
+  MAINTENANCE_MAX_FOLD_BYTES_DEFAULT,
+  MAINTENANCE_MAX_FOLD_ROWS,
+  MAINTENANCE_PROFILE_CF_FREE,
+  MAINTENANCE_PROFILE_NODE,
+  WRITE_TICK_FOLD_ENTRIES_PER_PASS,
+  WRITE_TICK_MIN_ENTRIES_TO_COMPACT,
+} from "@baerly/protocol";
+import { expect, test } from "vitest";
+
+import {
+  alignedManifestBoundary,
+  alignedManifestTarget,
+  alignedObservedBoundary,
+  CF_FREE_BUDGET,
+  liveGreedyBoundary,
+  prepareFold,
+  type BoundaryInput,
+  type FoldBudget,
+} from "./boundary.ts";
+import { foldCost } from "./cost.ts";
+import {
+  applySnapshot,
+  emptyState,
+  makeSnapshot,
+  replayAcknowledged,
+  rowsAtManifest,
+  type ModelLog,
+  type ModelOp,
+  type ModelState,
+} from "./model.ts";
+import {
+  drainToQuiescence,
+  reclaimUnreferenced,
+  runSchedule,
+  type ObserverAction,
+} from "./schedule.ts";
+
+const BASE_SHA = "ac3ed48e5bd39aa4a758d05d40a5195e0d84eccc" as const;
+const DETERMINISTIC_SEED = 20260803 as const;
+const K_SWEEP = [8, 16, 20, 32, 64, 200] as const;
+const SYNTHETIC_LOG_LENGTH = 640;
+const REPORT_ROOT = "bench/results/fold-boundary-model";
+const SOURCE_FILES = [
+  "tests/model/fold-boundary/arbitraries.ts",
+  "tests/model/fold-boundary/boundary.test.ts",
+  "tests/model/fold-boundary/boundary.ts",
+  "tests/model/fold-boundary/cost.ts",
+  "tests/model/fold-boundary/evidence-report.test.ts",
+  "tests/model/fold-boundary/model.test.ts",
+  "tests/model/fold-boundary/model.ts",
+  "tests/model/fold-boundary/orphan-bound.test.ts",
+  "tests/model/fold-boundary/progress-bound.test.ts",
+  "tests/model/fold-boundary/schedule.ts",
+] as const;
+
+type ClaimClassification =
+  | "universally-quantified-property"
+  | "bounded-deterministic-observation"
+  | "explicit-counterexample"
+  | "unresolved";
+
+interface EvidenceClaim {
+  readonly question: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+  readonly classification: ClaimClassification;
+  readonly conclusion: string;
+  readonly propertyIds: readonly string[];
+  readonly command: string;
+}
+
+interface EvidenceCounterexample {
+  readonly id: string;
+  readonly observed: boolean;
+  readonly [key: string]: unknown;
+}
+
+interface EvidencePayload {
+  readonly status: "research-only / non-authorizing";
+  readonly baseSha: typeof BASE_SHA;
+  readonly generatedAtUtc: string;
+  readonly deterministicSeed: typeof DETERMINISTIC_SEED;
+  readonly effectiveFcNumRuns: number;
+  readonly nodeVersion: string;
+  readonly liveConstants: Readonly<Record<string, number>>;
+  readonly modelParameters: {
+    readonly kSweep: typeof K_SWEEP;
+    readonly syntheticLogLength: number;
+    readonly alignmentOrigin: "absolute-sequence-zero";
+  };
+  readonly sourceSha256: Readonly<Record<string, string>>;
+  readonly claims: readonly EvidenceClaim[];
+  readonly counterexamples: readonly EvidenceCounterexample[];
+  readonly unresolvedQuestions: readonly string[];
+  readonly implementationAuthorization: "No implementation mechanism is authorized by this research evidence.";
+  readonly tables: object;
+}
+
+const roomyBudget = (overrides: Partial<FoldBudget> = {}): FoldBudget => ({
+  maxEntriesPerRun: 200,
+  minEntriesToCompact: 1,
+  ceilingBytes: 10_000_000,
+  ceilingEntries: 10_000,
+  subrequestLimit: 10_000,
+  ...overrides,
+});
+
+const syntheticOperations = (length: number, seed: number): readonly ModelOp[] => {
+  let state = seed >>> 0;
+  return Array.from({ length }, (_, sequence) => {
+    state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+    const docId = `doc-${state % 97}`;
+    if (sequence % 11 === 10) {
+      return { kind: "D" as const, docId };
+    }
+    return {
+      kind: sequence < 97 ? ("I" as const) : ("U" as const),
+      docId,
+      value: state,
+    };
+  });
+};
+
+const stateWithTail = (tail: number, tailHint = tail): ModelState => {
+  const state = emptyState({
+    ops: syntheticOperations(tail, DETERMINISTIC_SEED),
+    acknowledgedTail: tail,
+  });
+  return tailHint === tail ? state : { ...state, manifest: { ...state.manifest, tailHint } };
+};
+
+const action = (overrides: Partial<ObserverAction> = {}): ObserverAction => ({
+  observerId: 0,
+  readsAtGeneration: Number.MAX_SAFE_INTEGER,
+  observedTail: 20,
+  k: 5,
+  budget: roomyBudget(),
+  algorithm: "aligned-manifest",
+  crashAt: "none",
+  ...overrides,
+});
+
+const inputAt = (
+  floor: number,
+  observedTail: number,
+  k: number,
+  budget = roomyBudget(),
+): BoundaryInput => {
+  const log: ModelLog = {
+    ops: syntheticOperations(Math.max(floor, observedTail), DETERMINISTIC_SEED),
+    acknowledgedTail: Math.max(floor, observedTail),
+  };
+  const base = emptyState(log);
+  const state =
+    floor === 0 ? base : applySnapshot(base, makeSnapshot(replayAcknowledged(log, floor), floor));
+  return { manifest: state.manifest, observedTail, budget, k };
+};
+
+const sha256 = (contents: Buffer | string): string =>
+  createHash("sha256").update(contents).digest("hex");
+
+const sourceHashes = async (repoRoot: string): Promise<Readonly<Record<string, string>>> =>
+  Object.fromEntries(
+    await Promise.all(
+      SOURCE_FILES.map(
+        async (path) => [path, sha256(await readFile(join(repoRoot, path)))] as const,
+      ),
+    ),
+  );
+
+const namedPropertyIds = async (repoRoot: string): Promise<ReadonlySet<string>> => {
+  const propertyTestFiles = SOURCE_FILES.filter(
+    (path) => path.endsWith(".test.ts") && !path.endsWith("evidence-report.test.ts"),
+  );
+  const sources = await Promise.all(
+    propertyTestFiles.map((path) => readFile(join(repoRoot, path), "utf8")),
+  );
+  return new Set(
+    sources.flatMap((source) =>
+      [...source.matchAll(/test\("(?<id>P[1-8][a-z]_[^"]+)"/g)].map(
+        (match) => match.groups!["id"]!,
+      ),
+    ),
+  );
+};
+
+const writeReport = async (
+  repoRoot: string,
+  payload: EvidencePayload,
+  markdown: string,
+): Promise<string> => {
+  const root = resolve(repoRoot, REPORT_ROOT);
+  await mkdir(root, { recursive: true });
+  const timestamp = payload.generatedAtUtc.replaceAll(":", "-");
+  let suffix = 0;
+
+  for (;;) {
+    const candidate = join(root, `${timestamp}${suffix === 0 ? "" : `-${suffix}`}`);
+    try {
+      await mkdir(candidate);
+      await writeFile(join(candidate, "report.json"), `${JSON.stringify(payload, null, 2)}\n`, {
+        flag: "wx",
+      });
+      await writeFile(join(candidate, "report.md"), markdown, { flag: "wx" });
+      return candidate;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error;
+      }
+      suffix += 1;
+    }
+  }
+};
+
+const renderMarkdown = (payload: EvidencePayload): string => `# Fold-boundary research evidence
+
+Status: **${payload.status}**
+
+No implementation mechanism is authorized by this report.
+
+## Provenance
+
+- Base SHA: \`${payload.baseSha}\`
+- Generated UTC: \`${payload.generatedAtUtc}\`
+- Deterministic scenario seed: \`${payload.deterministicSeed}\`
+- Effective FC_NUM_RUNS: \`${payload.effectiveFcNumRuns}\`
+- Node: \`${payload.nodeVersion}\`
+- Alignment origin: \`${payload.modelParameters.alignmentOrigin}\`
+- Synthetic log length: \`${payload.modelParameters.syntheticLogLength}\`
+- K sweep: \`${payload.modelParameters.kSweep.join(", ")}\`
+
+## Claims
+
+${payload.claims
+  .map(
+    (claim) =>
+      `### Q${claim.question} — ${claim.classification}\n\n${claim.conclusion}\n\nProperties: ${claim.propertyIds.map((id) => `\`${id}\``).join(", ")}\n\nCommand: \`${claim.command}\``,
+  )
+  .join("\n\n")}
+
+## Deterministic tables
+
+\`\`\`json
+${JSON.stringify(payload.tables, null, 2)}
+\`\`\`
+
+## Counterexamples
+
+\`\`\`json
+${JSON.stringify(payload.counterexamples, null, 2)}
+\`\`\`
+
+## Unresolved questions
+
+${payload.unresolvedQuestions.map((question) => `- ${question}`).join("\n")}
+
+## Source SHA-256
+
+${Object.entries(payload.sourceSha256)
+  .map(([path, digest]) => `- \`${digest}\`  \`${path}\``)
+  .join("\n")}
+`;
+
+test("R1_reportIsCollisionSafeSelfConsistentAndTraceableToProperties", async () => {
+  const repoRoot = process.cwd();
+  const log: ModelLog = {
+    ops: syntheticOperations(SYNTHETIC_LOG_LENGTH, DETERMINISTIC_SEED),
+    acknowledgedTail: SYNTHETIC_LOG_LENGTH,
+  };
+  const initial = emptyState(log);
+
+  const boundaryTargetDependence = [12, 18].map((observedTail) => {
+    const input = inputAt(7, observedTail, 5);
+    return {
+      floor: 7,
+      observedTail,
+      k: 5,
+      liveGreedy: liveGreedyBoundary(input),
+      alignedObserved: alignedObservedBoundary(input),
+      alignedManifest: alignedManifestBoundary(input),
+      manifestTarget: alignedManifestTarget(input.manifest.logSeqStart, input.k),
+    };
+  });
+  expect(boundaryTargetDependence).toEqual([
+    {
+      floor: 7,
+      observedTail: 12,
+      k: 5,
+      liveGreedy: 12,
+      alignedObserved: 10,
+      alignedManifest: 10,
+      manifestTarget: 10,
+    },
+    {
+      floor: 7,
+      observedTail: 18,
+      k: 5,
+      liveGreedy: 18,
+      alignedObserved: 15,
+      alignedManifest: 10,
+      manifestTarget: 10,
+    },
+  ]);
+
+  const tightTailCost = K_SWEEP.map((k) => {
+    const withSnapshot = foldCost({
+      manifest: {
+        generation: 1,
+        logSeqStart: 8,
+        snapshotKey: "prior",
+        tailHint: 8 + k,
+      },
+      probeFloor: 8 + k,
+      observedTail: 8 + k,
+      logEntriesRead: k,
+      reachedSnapshotPut: true,
+      reachedCurrentCas: true,
+    });
+    const withoutSnapshot = foldCost({
+      manifest: {
+        generation: 0,
+        logSeqStart: 0,
+        snapshotKey: null,
+        tailHint: k,
+      },
+      probeFloor: k,
+      observedTail: k,
+      logEntriesRead: k,
+      reachedSnapshotPut: true,
+      reachedCurrentCas: true,
+    });
+    return {
+      k,
+      withSnapshotTotal: withSnapshot.total,
+      withoutSnapshotTotal: withoutSnapshot.total,
+      snapshotDelta: withSnapshot.total - withoutSnapshot.total,
+      cfFreeSubrequestLimit: CF_FREE_BUDGET.subrequestLimit,
+    };
+  });
+  expect(tightTailCost.map(({ withSnapshotTotal }) => withSnapshotTotal)).toEqual([
+    13, 21, 25, 37, 69, 205,
+  ]);
+  expect(tightTailCost.map(({ withoutSnapshotTotal }) => withoutSnapshotTotal)).toEqual([
+    12, 20, 24, 36, 68, 204,
+  ]);
+  expect(tightTailCost.map(({ snapshotDelta }) => snapshotDelta)).toEqual([1, 1, 1, 1, 1, 1]);
+
+  const productionBudget = roomyBudget();
+  const foldAndObjectProduction = K_SWEEP.map((k) => {
+    const aligned = drainToQuiescence({
+      initial,
+      budget: productionBudget,
+      k,
+      algorithm: "aligned-manifest",
+      maxPasses: SYNTHETIC_LOG_LENGTH + 2,
+    });
+    const live = drainToQuiescence({
+      initial,
+      budget: productionBudget,
+      k,
+      algorithm: "live-greedy",
+      maxPasses: SYNTHETIC_LOG_LENGTH + 2,
+    });
+    return {
+      k,
+      alignedWrittenFolds: aligned.attempts.filter(({ outcome }) => outcome === "written").length,
+      alignedObjects: aligned.finalState.snapshots.size,
+      alignedFinalFloor: aligned.finalState.manifest.logSeqStart,
+      liveWrittenFolds: live.attempts.filter(({ outcome }) => outcome === "written").length,
+      liveObjects: live.finalState.snapshots.size,
+      liveFinalFloor: live.finalState.manifest.logSeqStart,
+      materializedRowsEqual:
+        JSON.stringify([...rowsAtManifest(aligned.finalState).entries()].toSorted()) ===
+        JSON.stringify([...rowsAtManifest(live.finalState).entries()].toSorted()),
+    };
+  });
+  expect(
+    foldAndObjectProduction.map(
+      ({
+        alignedWrittenFolds,
+        alignedObjects,
+        alignedFinalFloor,
+        liveWrittenFolds,
+        liveObjects,
+        liveFinalFloor,
+        materializedRowsEqual,
+      }) => ({
+        alignedWrittenFolds,
+        alignedObjects,
+        alignedFinalFloor,
+        liveWrittenFolds,
+        liveObjects,
+        liveFinalFloor,
+        materializedRowsEqual,
+      }),
+    ),
+  ).toEqual([
+    {
+      alignedWrittenFolds: 80,
+      alignedObjects: 80,
+      alignedFinalFloor: 640,
+      liveWrittenFolds: 4,
+      liveObjects: 4,
+      liveFinalFloor: 640,
+      materializedRowsEqual: true,
+    },
+    {
+      alignedWrittenFolds: 40,
+      alignedObjects: 40,
+      alignedFinalFloor: 640,
+      liveWrittenFolds: 4,
+      liveObjects: 4,
+      liveFinalFloor: 640,
+      materializedRowsEqual: true,
+    },
+    {
+      alignedWrittenFolds: 32,
+      alignedObjects: 32,
+      alignedFinalFloor: 640,
+      liveWrittenFolds: 4,
+      liveObjects: 4,
+      liveFinalFloor: 640,
+      materializedRowsEqual: true,
+    },
+    {
+      alignedWrittenFolds: 20,
+      alignedObjects: 20,
+      alignedFinalFloor: 640,
+      liveWrittenFolds: 4,
+      liveObjects: 4,
+      liveFinalFloor: 640,
+      materializedRowsEqual: true,
+    },
+    {
+      alignedWrittenFolds: 10,
+      alignedObjects: 10,
+      alignedFinalFloor: 640,
+      liveWrittenFolds: 4,
+      liveObjects: 4,
+      liveFinalFloor: 640,
+      materializedRowsEqual: true,
+    },
+    {
+      alignedWrittenFolds: 3,
+      alignedObjects: 3,
+      alignedFinalFloor: 600,
+      liveWrittenFolds: 4,
+      liveObjects: 4,
+      liveFinalFloor: 640,
+      materializedRowsEqual: true,
+    },
+  ]);
+
+  const sameKRacersResult = runSchedule({
+    initial: stateWithTail(20),
+    observers: [
+      action({ observerId: 1, readsAtGeneration: 0, observedTail: 5, k: 5 }),
+      action({ observerId: 2, readsAtGeneration: 0, observedTail: 9, k: 5 }),
+    ],
+  });
+  const sameKRacers = {
+    outcomes: sameKRacersResult.attempts.map(({ outcome }) => outcome),
+    foldEnds: sameKRacersResult.attempts.map(({ foldEnd }) => foldEnd),
+    emittedKeys: sameKRacersResult.attempts.map(({ emittedKey }) => emittedKey),
+    storedObjects: sameKRacersResult.finalState.snapshots.size,
+    neverReferencedObjects: sameKRacersResult.neverReferencedSnapshots.length,
+  };
+  expect(sameKRacers.outcomes).toEqual(["written", "cas_lost"]);
+  expect(sameKRacers.foldEnds).toEqual([5, 5]);
+  expect(new Set(sameKRacers.emittedKeys).size).toBe(1);
+  expect(sameKRacers.storedObjects).toBe(1);
+  expect(sameKRacers.neverReferencedObjects).toBe(0);
+
+  const mixedKRacersResult = runSchedule({
+    initial: stateWithTail(20),
+    observers: [
+      action({ observerId: 1, readsAtGeneration: 0, observedTail: 20, k: 4 }),
+      action({ observerId: 2, readsAtGeneration: 0, observedTail: 20, k: 6 }),
+    ],
+  });
+  const mixedKRacers = {
+    outcomes: mixedKRacersResult.attempts.map(({ outcome }) => outcome),
+    foldEnds: mixedKRacersResult.attempts.map(({ foldEnd }) => foldEnd),
+    emittedKeys: mixedKRacersResult.attempts.map(({ emittedKey }) => emittedKey),
+    storedObjects: mixedKRacersResult.finalState.snapshots.size,
+    neverReferencedObjects: mixedKRacersResult.neverReferencedSnapshots.length,
+  };
+  expect(mixedKRacers.outcomes).toEqual(["written", "cas_lost"]);
+  expect(mixedKRacers.foldEnds).toEqual([4, 6]);
+  expect(new Set(mixedKRacers.emittedKeys).size).toBe(2);
+  expect(mixedKRacers.storedObjects).toBe(2);
+  expect(mixedKRacers.neverReferencedObjects).toBe(1);
+
+  const crashRetryResult = runSchedule({
+    initial: stateWithTail(20),
+    observers: [
+      action({ observerId: 1, observedTail: 20, k: 5, crashAt: "after_snapshot_put" }),
+      action({ observerId: 2, observedTail: 20, k: 5 }),
+    ],
+  });
+  const crashRetry = {
+    outcomes: crashRetryResult.attempts.map(({ outcome }) => outcome),
+    foldEnds: crashRetryResult.attempts.map(({ foldEnd }) => foldEnd),
+    emittedKeys: crashRetryResult.attempts.map(({ emittedKey }) => emittedKey),
+    finalGeneration: crashRetryResult.finalState.manifest.generation,
+  };
+  expect(crashRetry.outcomes).toEqual(["crashed", "written"]);
+  expect(crashRetry.foldEnds).toEqual([5, 5]);
+  expect(new Set(crashRetry.emittedKeys).size).toBe(1);
+  expect(crashRetry.finalGeneration).toBe(1);
+
+  const unavailableState = stateWithTail(4);
+  const availabilityRetry = {
+    target: alignedManifestTarget(unavailableState.manifest.logSeqStart, 5),
+    before: prepareFold({
+      state: unavailableState,
+      observedTail: 4,
+      probeFloor: 4,
+      budget: roomyBudget(),
+      k: 5,
+      algorithm: "aligned-manifest",
+    }),
+    after: prepareFold({
+      state: stateWithTail(5),
+      observedTail: 5,
+      probeFloor: 5,
+      budget: roomyBudget(),
+      k: 5,
+      algorithm: "aligned-manifest",
+    }),
+  };
+  expect({
+    target: availabilityRetry.target,
+    beforeOutcome: availabilityRetry.before.outcome,
+    beforeFoldEnd: availabilityRetry.before.foldEnd,
+    beforeSnapshot: availabilityRetry.before.snapshot,
+    afterOutcome: availabilityRetry.after.outcome,
+    afterFoldEnd: availabilityRetry.after.foldEnd,
+  }).toEqual({
+    target: 5,
+    beforeOutcome: "below_min_threshold",
+    beforeFoldEnd: null,
+    beforeSnapshot: null,
+    afterOutcome: "prepared",
+    afterFoldEnd: 5,
+  });
+
+  const firstFold = runSchedule({
+    initial: stateWithTail(10),
+    observers: [action({ observerId: 1, observedTail: 10, k: 5 })],
+  });
+  const secondFold = runSchedule({
+    initial: firstFold.finalState,
+    observers: [action({ observerId: 2, observedTail: 10, k: 5 })],
+  });
+  const reclaimed = reclaimUnreferenced(secondFold.finalState);
+  const reclamation = {
+    beforeFirstFold: firstFold.reclaimableSnapshots.length,
+    afterSecondSuccessfulFold: secondFold.reclaimableSnapshots.length,
+    storedBeforeReclamation: secondFold.finalState.snapshots.size,
+    storedAfterReclamation: reclaimed.snapshots.size,
+    currentObjectPreserved:
+      reclaimed.manifest.snapshotKey !== null &&
+      reclaimed.snapshots.has(reclaimed.manifest.snapshotKey),
+    materializedRowsPreserved:
+      JSON.stringify([...rowsAtManifest(secondFold.finalState).entries()].toSorted()) ===
+      JSON.stringify([...rowsAtManifest(reclaimed).entries()].toSorted()),
+  };
+  expect(reclamation).toEqual({
+    beforeFirstFold: 0,
+    afterSecondSuccessfulFold: 1,
+    storedBeforeReclamation: 2,
+    storedAfterReclamation: 1,
+    currentObjectPreserved: true,
+    materializedRowsPreserved: true,
+  });
+
+  const zeroMaxEntriesResult = prepareFold({
+    state: stateWithTail(20),
+    observedTail: 20,
+    probeFloor: 20,
+    budget: roomyBudget({ maxEntriesPerRun: 0 }),
+    k: 5,
+    algorithm: "live-greedy",
+  });
+  expect(zeroMaxEntriesResult.outcome).toBe("below_min_threshold");
+  expect(zeroMaxEntriesResult.foldEnd).toBeNull();
+
+  const staleProbeResult = runSchedule({
+    initial: stateWithTail(100, 0),
+    observers: [action({ observedTail: 100, k: 20, budget: CF_FREE_BUDGET })],
+  });
+  expect(staleProbeResult.attempts[0]!.cost.probeGets).toBe(101);
+  expect(staleProbeResult.attempts[0]!.cost.total).toBeGreaterThan(CF_FREE_BUDGET.subrequestLimit);
+
+  const crashAfterPutResult = runSchedule({
+    initial: stateWithTail(20),
+    observers: [action({ observedTail: 20, k: 5, crashAt: "after_snapshot_put" })],
+  });
+  expect(crashAfterPutResult.attempts[0]!.outcome).toBe("crashed");
+  expect(crashAfterPutResult.neverReferencedSnapshots).toHaveLength(1);
+
+  const counterexamples = [
+    {
+      id: "zero-max-entries-progress",
+      observed: true,
+      outcome: zeroMaxEntriesResult.outcome,
+      foldEnd: zeroMaxEntriesResult.foldEnd,
+    },
+    {
+      id: "stale-probe-budget-overflow",
+      observed: true,
+      totalCost: staleProbeResult.attempts[0]!.cost.total,
+      subrequestLimit: CF_FREE_BUDGET.subrequestLimit,
+    },
+    {
+      id: "mixed-k-cas-orphan",
+      observed: true,
+      loserOutcome: mixedKRacersResult.attempts[1]!.outcome,
+      neverReferencedObjects: mixedKRacersResult.neverReferencedSnapshots.length,
+    },
+    {
+      id: "crash-after-put-orphan",
+      observed: true,
+      outcome: crashAfterPutResult.attempts[0]!.outcome,
+      neverReferencedObjects: crashAfterPutResult.neverReferencedSnapshots.length,
+    },
+    {
+      id: "successful-fold-increases-reclaimable-objects",
+      observed: true,
+      before: firstFold.reclaimableSnapshots.length,
+      after: secondFold.reclaimableSnapshots.length,
+    },
+  ] as const;
+
+  const command = (propertyPattern: string): string =>
+    `FC_NUM_RUNS=10000 pnpm test:agent tests/model/fold-boundary -t '${propertyPattern}'`;
+  const claims: readonly EvidenceClaim[] = [
+    {
+      question: 1,
+      classification: "universally-quantified-property",
+      conclusion: `At floor 7 and K=5, the manifest target remained ${boundaryTargetDependence[0]!.manifestTarget} while live boundaries changed from ${boundaryTargetDependence[0]!.liveGreedy} to ${boundaryTargetDependence[1]!.liveGreedy} with observation.`,
+      propertyIds: [
+        "P1a_manifestTargetIsIndependentOfObservationAndBudget",
+        "P1b_liveAndObservedAlignedTargetsDependOnObservedAvailability",
+      ],
+      command: command("P1a_|P1b_"),
+    },
+    {
+      question: 2,
+      classification: "bounded-deterministic-observation",
+      conclusion: `With only 4 entries, target ${availabilityRetry.target} produced ${availabilityRetry.before.outcome} and no object; at 5 entries the retry prepared the same target.`,
+      propertyIds: [
+        "P2a_fewerThanNextKEntriesProducesNoObjectOrProgress",
+        "P2b_retryAfterAvailabilityUsesTheSameManifestTarget",
+      ],
+      command: command("P2a_|P2b_"),
+    },
+    {
+      question: 3,
+      classification: "bounded-deterministic-observation",
+      conclusion: `A crash after snapshot PUT left generation 0 unchanged, and retry published the same floor ${crashRetry.foldEnds[1]} and content-addressed key at generation ${crashRetry.finalGeneration}.`,
+      propertyIds: [
+        "P3a_crashBeforeCasLeavesManifestUnchangedAndRetryUsesSameTarget",
+        "P3b_laggingObserverBoundarySequenceIsAPrefixOfFullyInformedSequence",
+      ],
+      command: command("P3a_|P3b_"),
+    },
+    {
+      question: 4,
+      classification: "unresolved",
+      conclusion: `K=4 and K=6 observers from generation 0 prepared floors ${mixedKRacers.foldEnds.join(" and ")}; rolling-deploy K compatibility therefore remains a policy question.`,
+      propertyIds: [
+        "P4a_firstTargetAfterKChangeIsStrictlyMonotoneAndNewKAligned",
+        "P4b_mixedKObserversCanPrepareDifferentObjectsFromOneGeneration",
+      ],
+      command: command("P4a_|P4b_"),
+    },
+    {
+      question: 5,
+      classification: "universally-quantified-property",
+      conclusion: `Two generation-0, K=5 racers emitted one key, stored ${sameKRacers.storedObjects} object, and added ${sameKRacers.neverReferencedObjects} distinct CAS orphan.`,
+      propertyIds: [
+        "P5a_observersOnOppositeSidesOfOneBoundaryEmitAtMostOneObjectForOneK",
+        "P5b_sameManifestSameKAlwaysProducesTheSameObjectKey",
+      ],
+      command: command("P5a_|P5b_"),
+    },
+    {
+      question: 6,
+      classification: "explicit-counterexample",
+      conclusion: `Mixed-K CAS loss and crash-after-PUT each produced one never-referenced object, while a second successful fold increased reclaimable objects from ${reclamation.beforeFirstFold} to ${reclamation.afterSecondSuccessfulFold}.`,
+      propertyIds: [
+        "P6a_sameGenerationSameKContentionAddsNoDistinctCasOrphan",
+        "P6b_successfulFoldCanIncreaseRatherThanReduceReclaimableObjects",
+        "P6c_mixedKContentionHasAReachableDistinctCasOrphan",
+        "P6d_crashAfterPutHasAReachableNeverReferencedSnapshot",
+        "P6e_reclamationRemovesAllAndOnlyNonCurrentSnapshots",
+      ],
+      command: command("P6a_|P6b_|P6c_|P6d_|P6e_"),
+    },
+    {
+      question: 7,
+      classification: "universally-quantified-property",
+      conclusion: `Every deterministic aligned/live row compared equal after the ${SYNTHETIC_LOG_LENGTH}-entry log, including the K=200 aligned remainder at floor 600.`,
+      propertyIds: [
+        "P7a_everyPreparedManifestBoundaryStrictlyAdvancesAndIsAligned",
+        "P7b_everyPreparedReadSetIsTheExactContiguousInterval",
+        "P7c_contiguousIncrementalFoldEqualsReferenceReplay",
+        "P7d_publishedSnapshotCanPreserveEveryAcknowledgedPrefix",
+        "P7e_everyPublishedSnapshotMatchesReferenceReplayThroughItsFloor",
+      ],
+      command: command("P7a_|P7b_|P7c_|P7d_|P7e_"),
+    },
+    {
+      question: 8,
+      classification: "explicit-counterexample",
+      conclusion: `Tight-tail prior-snapshot totals ranged from ${tightTailCost[0]!.withSnapshotTotal} to ${tightTailCost.at(-1)!.withSnapshotTotal}; zero max entries made no progress, while stale probing cost ${staleProbeResult.attempts[0]!.cost.total} against the live limit ${CF_FREE_BUDGET.subrequestLimit}.`,
+      propertyIds: [
+        "P8a_tightKnownTailCostIsNPlusFiveWithSnapshotAndNPlusFourWithout",
+        "P8b_deferredAttemptStillPaysSnapshotAndLogReadsButNoPuts",
+        "P8c_kAboveMaxEntriesCannotPrepare",
+        "P8d_zeroMaxEntriesIsAnExplicitZeroProgressCounterexample",
+        "P8e_manifestAlignedProgressFitsCfFreeWithTightKnownTailForKAtMostTwenty",
+        "P8f_scheduledStaleProbeCanExceedThePerPassSubrequestLimit",
+      ],
+      command: command("P8a_|P8b_|P8c_|P8d_|P8e_|P8f_"),
+    },
+  ];
+
+  const tables = {
+    boundaryTargetDependence,
+    tightTailCost,
+    foldAndObjectProduction,
+    sameGenerationSameKRacers: sameKRacers,
+    mixedKRacers,
+    crashRetry,
+    availabilityRetry: {
+      target: availabilityRetry.target,
+      beforeOutcome: availabilityRetry.before.outcome,
+      beforeFoldEnd: availabilityRetry.before.foldEnd,
+      afterOutcome: availabilityRetry.after.outcome,
+      afterFoldEnd: availabilityRetry.after.foldEnd,
+    },
+    reclamation,
+  };
+  const generatedAtUtc = new Date().toISOString();
+  const effectiveFcNumRuns = Number(process.env["FC_NUM_RUNS"] ?? 100);
+  expect(Number.isFinite(effectiveFcNumRuns)).toBe(true);
+  const payload: EvidencePayload = {
+    status: "research-only / non-authorizing",
+    baseSha: BASE_SHA,
+    generatedAtUtc,
+    deterministicSeed: DETERMINISTIC_SEED,
+    effectiveFcNumRuns,
+    nodeVersion: process.version,
+    liveConstants: {
+      WRITE_TICK_FOLD_ENTRIES_PER_PASS,
+      WRITE_TICK_MIN_ENTRIES_TO_COMPACT,
+      MAINTENANCE_MAX_FOLD_BYTES_DEFAULT,
+      MAINTENANCE_MAX_FOLD_ROWS,
+      MAINTENANCE_PROFILE_CF_FREE_MAX_FOLD_ENTRIES_PER_PASS:
+        MAINTENANCE_PROFILE_CF_FREE.maxFoldEntriesPerPass,
+      MAINTENANCE_PROFILE_NODE_MAX_FOLD_ENTRIES_PER_PASS:
+        MAINTENANCE_PROFILE_NODE.maxFoldEntriesPerPass,
+      CF_FREE_SUBREQUEST_LIMIT: CF_FREE_BUDGET.subrequestLimit,
+    },
+    modelParameters: {
+      kSweep: K_SWEEP,
+      syntheticLogLength: SYNTHETIC_LOG_LENGTH,
+      alignmentOrigin: "absolute-sequence-zero",
+    },
+    sourceSha256: await sourceHashes(repoRoot),
+    claims,
+    counterexamples,
+    unresolvedQuestions: [
+      "Which K and maintenance-profile policy should be selected for each deployment class?",
+      "What K compatibility rule should rolling deployments enforce while old and new observers overlap?",
+    ],
+    implementationAuthorization:
+      "No implementation mechanism is authorized by this research evidence.",
+    tables,
+  };
+  const markdown = renderMarkdown(payload);
+
+  const propertyIds = await namedPropertyIds(repoRoot);
+  expect(propertyIds.size).toBeGreaterThan(0);
+  expect(payload.claims.map(({ question }) => question)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  for (const claim of payload.claims) {
+    expect(claim.propertyIds.length).toBeGreaterThan(0);
+    expect(claim.propertyIds.every((propertyId) => propertyIds.has(propertyId))).toBe(true);
+    expect(claim.command).toContain("FC_NUM_RUNS=10000");
+  }
+  expect(Object.keys(payload.sourceSha256).toSorted()).toEqual([...SOURCE_FILES].toSorted());
+  expect(Object.values(payload.sourceSha256).every((digest) => /^[a-f0-9]{64}$/.test(digest))).toBe(
+    true,
+  );
+  expect(payload.counterexamples.map(({ id }) => id)).toEqual([
+    "zero-max-entries-progress",
+    "stale-probe-budget-overflow",
+    "mixed-k-cas-orphan",
+    "crash-after-put-orphan",
+    "successful-fold-increases-reclaimable-objects",
+  ]);
+  expect(payload.counterexamples.every(({ observed }) => observed)).toBe(true);
+
+  const firstDirectory = await writeReport(repoRoot, payload, markdown);
+  const firstJsonBeforeCollision = await readFile(join(firstDirectory, "report.json"), "utf8");
+  const firstMarkdownBeforeCollision = await readFile(join(firstDirectory, "report.md"), "utf8");
+  const secondDirectory = await writeReport(repoRoot, payload, markdown);
+  const reportBaseDirectory = join(
+    resolve(repoRoot, REPORT_ROOT),
+    payload.generatedAtUtc.replaceAll(":", "-"),
+  );
+  const directorySuffix = (directory: string): number =>
+    directory === reportBaseDirectory ? 0 : Number(directory.slice(reportBaseDirectory.length + 1));
+  expect(secondDirectory).not.toBe(firstDirectory);
+  expect(directorySuffix(secondDirectory)).toBeGreaterThan(directorySuffix(firstDirectory));
+  await expect(readFile(join(firstDirectory, "report.json"), "utf8")).resolves.toBe(
+    firstJsonBeforeCollision,
+  );
+  await expect(readFile(join(firstDirectory, "report.md"), "utf8")).resolves.toBe(
+    firstMarkdownBeforeCollision,
+  );
+
+  const parsed = JSON.parse(
+    await readFile(join(secondDirectory, "report.json"), "utf8"),
+  ) as typeof payload;
+  const readBackMarkdown = await readFile(join(secondDirectory, "report.md"), "utf8");
+  expect(parsed).toEqual(payload);
+  expect(parsed.status).toBe("research-only / non-authorizing");
+  expect(parsed.baseSha).toBe(BASE_SHA);
+  expect(parsed.deterministicSeed).toBe(DETERMINISTIC_SEED);
+  expect(parsed.modelParameters.kSweep).toEqual(K_SWEEP);
+  expect(parsed.modelParameters.alignmentOrigin).toBe("absolute-sequence-zero");
+  expect(parsed.sourceSha256).toEqual(await sourceHashes(repoRoot));
+  expect(parsed.implementationAuthorization).toBe(
+    "No implementation mechanism is authorized by this research evidence.",
+  );
+  expect(readBackMarkdown).toContain("No implementation mechanism is authorized by this report.");
+  expect(readBackMarkdown).toContain(`Base SHA: \`${BASE_SHA}\``);
+  expect(readBackMarkdown).toContain("## Deterministic tables");
+  expect(readBackMarkdown).toContain("## Counterexamples");
+  expect(readBackMarkdown).toContain("## Source SHA-256");
+});

--- a/tests/model/fold-boundary/fixtures.ts
+++ b/tests/model/fold-boundary/fixtures.ts
@@ -1,0 +1,59 @@
+import type { FoldBudget } from "./boundary.ts";
+import type { ModelOp } from "./model.ts";
+import type { ObserverAction } from "./schedule.ts";
+
+/**
+ * The default budget for scenarios that are not studying a ceiling.
+ *
+ * Every field is deliberately far above what the scenarios reach, so a property
+ * that fails does so because of the boundary rule under test and not because a
+ * ceiling clipped it. Override the one field a scenario is actually probing —
+ * `roomyBudget({ maxEntriesPerRun: 0 })`, `roomyBudget({ ceilingEntries: 1 })` —
+ * rather than defining a second budget, so the deviation is visible at the call
+ * site.
+ *
+ * `subrequestLimit` is a model assumption, not a kernel constant; see
+ * `CF_FREE_BUDGET` in `boundary.ts`.
+ */
+export const roomyBudget = (overrides: Partial<FoldBudget> = {}): FoldBudget => ({
+  maxEntriesPerRun: 100,
+  minEntriesToCompact: 1,
+  ceilingBytes: 1_000_000,
+  ceilingEntries: 1_000,
+  subrequestLimit: 10_000,
+  ...overrides,
+});
+
+/**
+ * A log of `count` distinct inserts, one document each.
+ *
+ * Deliberately the simplest possible log: no updates, no deletes, no key
+ * collisions, so row count equals sequence number and a boundary assertion reads
+ * directly off the fold end. Scenarios that need overwrite and delete traffic
+ * build their own log (see `syntheticOperations` in `evidence-report.test.ts`).
+ */
+export const operations = (count: number): readonly ModelOp[] =>
+  Array.from({ length: count }, (_, index) => ({
+    kind: "I" as const,
+    docId: `doc-${index}`,
+    value: index,
+  }));
+
+/**
+ * One observer's fold attempt, defaulting to a fully-informed, non-crashing,
+ * manifest-aligned pass.
+ *
+ * `readsAtGeneration: Number.MAX_SAFE_INTEGER` is the sentinel `schedule.ts`
+ * reads as "latest generation"; override it with a concrete generation to model
+ * a lagging observer.
+ */
+export const action = (overrides: Partial<ObserverAction> = {}): ObserverAction => ({
+  observerId: 0,
+  readsAtGeneration: Number.MAX_SAFE_INTEGER,
+  observedTail: 20,
+  k: 5,
+  budget: roomyBudget(),
+  algorithm: "aligned-manifest",
+  crashAt: "none",
+  ...overrides,
+});

--- a/tests/model/fold-boundary/model.test.ts
+++ b/tests/model/fold-boundary/model.test.ts
@@ -1,0 +1,130 @@
+import { createHash } from "node:crypto";
+
+import { fc } from "@fast-check/vitest";
+import { describe, expect, test } from "vitest";
+
+import {
+  applySnapshot,
+  emptyState,
+  foldRange,
+  makeSnapshot,
+  replayAcknowledged,
+  rowsAtManifest,
+  type ModelLog,
+  type ModelRows,
+} from "./model.ts";
+import { arbModelLog, arbPositiveK } from "./arbitraries.ts";
+
+const sortedRows = (rows: ModelRows): readonly (readonly [string, number])[] =>
+  [...rows.entries()].toSorted(([left], [right]) => left.localeCompare(right));
+
+const rowsAt = (log: ModelLog, to: number): ModelRows => replayAcknowledged(log, to);
+
+describe("fold-boundary reference model", () => {
+  test("P7c_contiguousIncrementalFoldEqualsReferenceReplay", () => {
+    fc.assert(
+      fc.property(arbModelLog, arbPositiveK, (log, requestedBoundary) => {
+        const boundary = Math.min(requestedBoundary, log.acknowledgedTail);
+        const base = rowsAt(log, boundary);
+
+        expect(sortedRows(foldRange(base, log, boundary, log.acknowledgedTail))).toEqual(
+          sortedRows(replayAcknowledged(log)),
+        );
+      }),
+    );
+  });
+
+  test("P7d_publishedSnapshotCanPreserveEveryAcknowledgedPrefix", () => {
+    fc.assert(
+      fc.property(arbModelLog, arbPositiveK, (log, requestedBoundary) => {
+        const boundary = Math.min(requestedBoundary, log.acknowledgedTail);
+        const snapshot = makeSnapshot(rowsAt(log, boundary), boundary);
+        const published = applySnapshot(emptyState(log), snapshot);
+
+        expect(sortedRows(rowsAtManifest(published))).toEqual(sortedRows(replayAcknowledged(log)));
+      }),
+    );
+  });
+
+  test("model_neverReplaysPastAcknowledgedTail", () => {
+    const log: ModelLog = {
+      ops: [
+        { kind: "I", docId: "alpha", value: 1 },
+        { kind: "U", docId: "alpha", value: 2 },
+        { kind: "I", docId: "unacknowledged", value: 3 },
+      ],
+      acknowledgedTail: 2,
+    };
+
+    expect(sortedRows(replayAcknowledged(log))).toEqual([["alpha", 2]]);
+    expect(sortedRows(foldRange(new Map(), log, 0, log.ops.length))).toEqual([["alpha", 2]]);
+  });
+
+  test("model_snapshotIdentityIsCanonicalAndContentAddressed", () => {
+    const first = makeSnapshot(
+      new Map([
+        ["bravo", 2],
+        ["alpha", 1],
+      ]),
+      4,
+    );
+    const reordered = makeSnapshot(
+      new Map([
+        ["alpha", 1],
+        ["bravo", 2],
+      ]),
+      4,
+    );
+    const changedBoundary = makeSnapshot(new Map(first.rows), 5);
+    const canonicalBytes = JSON.stringify({
+      maxSeq: 4,
+      rows: [
+        ["alpha", 1],
+        ["bravo", 2],
+      ],
+    });
+    const expectedKey = createHash("sha256").update(canonicalBytes).digest("hex");
+
+    expect(first.rows).toEqual([
+      ["alpha", 1],
+      ["bravo", 2],
+    ]);
+    expect(first.key).toBe(expectedKey);
+    expect(reordered.key).toBe(first.key);
+    expect(changedBoundary.key).not.toBe(first.key);
+  });
+
+  test("model_logAndStateTransitionsDoNotMutateInputs", () => {
+    const log: ModelLog = {
+      ops: [
+        { kind: "I", docId: "alpha", value: 1 },
+        { kind: "D", docId: "alpha" },
+      ],
+      acknowledgedTail: 2,
+    };
+    const base = new Map<string, number>([["before", 0]]);
+    const state = emptyState(log);
+    const snapshotRows = new Map<string, number>([["bravo", 2]]);
+    const snapshot = makeSnapshot(snapshotRows, 1);
+    const originalState = {
+      manifest: state.manifest,
+      snapshots: [...state.snapshots.entries()],
+    };
+
+    foldRange(base, log, 0, 1);
+    replayAcknowledged(log);
+    applySnapshot(state, snapshot);
+
+    expect(sortedRows(base)).toEqual([["before", 0]]);
+    expect(log).toEqual({
+      ops: [
+        { kind: "I", docId: "alpha", value: 1 },
+        { kind: "D", docId: "alpha" },
+      ],
+      acknowledgedTail: 2,
+    });
+    expect(sortedRows(snapshotRows)).toEqual([["bravo", 2]]);
+    expect(state.manifest).toBe(originalState.manifest);
+    expect([...state.snapshots.entries()]).toEqual(originalState.snapshots);
+  });
+});

--- a/tests/model/fold-boundary/model.test.ts
+++ b/tests/model/fold-boundary/model.test.ts
@@ -123,6 +123,7 @@ describe("fold-boundary reference model", () => {
     const snapshot = makeSnapshot(snapshotRows, 1);
     const originalState = {
       manifest: state.manifest,
+      manifestHistory: state.manifestHistory,
       snapshots: [...state.snapshots.entries()],
     };
 
@@ -140,7 +141,25 @@ describe("fold-boundary reference model", () => {
     });
     expect(sortedRows(snapshotRows)).toEqual([["bravo", 2]]);
     expect(state.manifest).toBe(originalState.manifest);
+    expect(state.manifestHistory).toBe(originalState.manifestHistory);
     expect([...state.snapshots.entries()]).toEqual(originalState.snapshots);
+  });
+
+  test("model_manifestHistoryUsesClonedRecordsAndAppendsImmutably", () => {
+    const log: ModelLog = {
+      ops: [{ kind: "I", docId: "alpha", value: 1 }],
+      acknowledgedTail: 1,
+    };
+    const state = emptyState(log);
+    const published = applySnapshot(state, makeSnapshot(replayAcknowledged(log), 1));
+
+    expect(state.manifestHistory).toEqual([state.manifest]);
+    expect(state.manifestHistory[0]).not.toBe(state.manifest);
+    expect(published.manifestHistory.map(({ generation }) => generation)).toEqual([0, 1]);
+    expect(published.manifestHistory.at(-1)).toEqual(published.manifest);
+    expect(published.manifestHistory.at(-1)).not.toBe(published.manifest);
+    expect(published.manifestHistory).not.toBe(state.manifestHistory);
+    expect(state.manifestHistory).toHaveLength(1);
   });
 
   test("reachableStateArbitraryNeverPublishesANonAdvancingSnapshot", () => {

--- a/tests/model/fold-boundary/model.test.ts
+++ b/tests/model/fold-boundary/model.test.ts
@@ -13,7 +13,7 @@ import {
   type ModelLog,
   type ModelRows,
 } from "./model.ts";
-import { arbModelLog, arbPositiveK } from "./arbitraries.ts";
+import { arbModelLog, arbPositiveK, arbReachableState } from "./arbitraries.ts";
 
 const sortedRows = (rows: ModelRows): readonly (readonly [string, number])[] =>
   [...rows.entries()].toSorted(([left], [right]) => left.localeCompare(right));
@@ -141,5 +141,21 @@ describe("fold-boundary reference model", () => {
     expect(sortedRows(snapshotRows)).toEqual([["bravo", 2]]);
     expect(state.manifest).toBe(originalState.manifest);
     expect([...state.snapshots.entries()]).toEqual(originalState.snapshots);
+  });
+
+  test("reachableStateArbitraryNeverPublishesANonAdvancingSnapshot", () => {
+    fc.assert(
+      fc.property(arbReachableState, (state) => {
+        if (state.manifest.logSeqStart === 0) {
+          expect(state.manifest.generation).toBe(0);
+          expect(state.manifest.snapshotKey).toBeNull();
+          expect(state.snapshots.size).toBe(0);
+        } else {
+          expect(state.manifest.generation).toBe(1);
+          expect(state.manifest.snapshotKey).not.toBeNull();
+        }
+      }),
+      { numRuns: 1_000, seed: 20_260_803 },
+    );
   });
 });

--- a/tests/model/fold-boundary/model.test.ts
+++ b/tests/model/fold-boundary/model.test.ts
@@ -18,17 +18,30 @@ import { arbModelLog, arbPositiveK } from "./arbitraries.ts";
 const sortedRows = (rows: ModelRows): readonly (readonly [string, number])[] =>
   [...rows.entries()].toSorted(([left], [right]) => left.localeCompare(right));
 
-const rowsAt = (log: ModelLog, to: number): ModelRows => replayAcknowledged(log, to);
+const oracleRowsAt = (log: ModelLog, to: number): ModelRows => {
+  const rows = new Map<string, number>();
+  const acknowledgedEnd = Math.max(0, Math.min(to, log.acknowledgedTail));
+
+  for (const operation of log.ops.slice(0, acknowledgedEnd)) {
+    if (operation.kind === "D") {
+      rows.delete(operation.docId);
+    } else {
+      rows.set(operation.docId, operation.value);
+    }
+  }
+
+  return rows;
+};
 
 describe("fold-boundary reference model", () => {
   test("P7c_contiguousIncrementalFoldEqualsReferenceReplay", () => {
     fc.assert(
       fc.property(arbModelLog, arbPositiveK, (log, requestedBoundary) => {
         const boundary = Math.min(requestedBoundary, log.acknowledgedTail);
-        const base = rowsAt(log, boundary);
+        const base = oracleRowsAt(log, boundary);
 
         expect(sortedRows(foldRange(base, log, boundary, log.acknowledgedTail))).toEqual(
-          sortedRows(replayAcknowledged(log)),
+          sortedRows(oracleRowsAt(log, log.acknowledgedTail)),
         );
       }),
     );
@@ -38,10 +51,12 @@ describe("fold-boundary reference model", () => {
     fc.assert(
       fc.property(arbModelLog, arbPositiveK, (log, requestedBoundary) => {
         const boundary = Math.min(requestedBoundary, log.acknowledgedTail);
-        const snapshot = makeSnapshot(rowsAt(log, boundary), boundary);
+        const snapshot = makeSnapshot(oracleRowsAt(log, boundary), boundary);
         const published = applySnapshot(emptyState(log), snapshot);
 
-        expect(sortedRows(rowsAtManifest(published))).toEqual(sortedRows(replayAcknowledged(log)));
+        expect(sortedRows(rowsAtManifest(published))).toEqual(
+          sortedRows(oracleRowsAt(log, log.acknowledgedTail)),
+        );
       }),
     );
   });

--- a/tests/model/fold-boundary/model.ts
+++ b/tests/model/fold-boundary/model.ts
@@ -1,0 +1,128 @@
+import { createHash } from "node:crypto";
+
+export type DocId = string;
+export type ModelOp =
+  | { readonly kind: "I" | "U"; readonly docId: DocId; readonly value: number }
+  | { readonly kind: "D"; readonly docId: DocId };
+export interface ModelLog {
+  readonly ops: readonly ModelOp[];
+  readonly acknowledgedTail: number;
+}
+export type ModelRows = ReadonlyMap<DocId, number>;
+export interface SnapshotObject {
+  readonly key: string;
+  readonly maxSeq: number;
+  readonly rows: readonly (readonly [DocId, number])[];
+}
+export interface ModelManifest {
+  readonly generation: number;
+  readonly logSeqStart: number;
+  readonly snapshotKey: string | null;
+  readonly tailHint: number;
+}
+export interface ModelState {
+  readonly log: ModelLog;
+  readonly manifest: ModelManifest;
+  readonly snapshots: ReadonlyMap<string, SnapshotObject>;
+}
+
+const compareDocIds = (left: DocId, right: DocId): number => {
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
+};
+
+const copySnapshot = (snapshot: SnapshotObject): SnapshotObject => ({
+  key: snapshot.key,
+  maxSeq: snapshot.maxSeq,
+  rows: snapshot.rows.map(([docId, value]) => [docId, value] as const),
+});
+
+const boundedSequence = (log: ModelLog, sequence: number): number =>
+  Math.max(0, Math.min(sequence, log.acknowledgedTail));
+
+export const modelTail = (log: ModelLog): number => log.ops.length;
+
+export const emptyState = (log: ModelLog): ModelState => ({
+  log,
+  manifest: {
+    generation: 0,
+    logSeqStart: 0,
+    snapshotKey: null,
+    tailHint: modelTail(log),
+  },
+  snapshots: new Map(),
+});
+
+export const foldRange = (base: ModelRows, log: ModelLog, from: number, to: number): ModelRows => {
+  const rows = new Map(base);
+  const start = boundedSequence(log, from);
+  const end = boundedSequence(log, to);
+
+  for (const operation of log.ops.slice(start, end)) {
+    if (operation.kind === "D") {
+      rows.delete(operation.docId);
+    } else {
+      rows.set(operation.docId, operation.value);
+    }
+  }
+
+  return rows;
+};
+
+export const replayAcknowledged = (log: ModelLog, to = log.acknowledgedTail): ModelRows =>
+  foldRange(new Map(), log, 0, to);
+
+export const makeSnapshot = (rows: ModelRows, maxSeq: number): SnapshotObject => {
+  const canonicalRows = [...rows.entries()]
+    .toSorted(([left], [right]) => compareDocIds(left, right))
+    .map(([docId, value]) => [docId, value] as const);
+  const canonicalBytes = JSON.stringify({ maxSeq, rows: canonicalRows });
+
+  return {
+    key: createHash("sha256").update(canonicalBytes).digest("hex"),
+    maxSeq,
+    rows: canonicalRows,
+  };
+};
+
+export const applySnapshot = (state: ModelState, snapshot: SnapshotObject): ModelState => {
+  const snapshots = new Map(state.snapshots);
+  snapshots.set(snapshot.key, copySnapshot(snapshot));
+
+  return {
+    log: state.log,
+    manifest: {
+      ...state.manifest,
+      generation: state.manifest.generation + 1,
+      logSeqStart: snapshot.maxSeq,
+      snapshotKey: snapshot.key,
+    },
+    snapshots,
+  };
+};
+
+export const rowsAtManifest = (
+  state: ModelState,
+  manifest: ModelManifest = state.manifest,
+): ModelRows => {
+  const base =
+    manifest.snapshotKey === null
+      ? new Map<DocId, number>()
+      : snapshotRows(state, manifest.snapshotKey);
+
+  return foldRange(base, state.log, manifest.logSeqStart, state.log.acknowledgedTail);
+};
+
+const snapshotRows = (state: ModelState, snapshotKey: string): ModelRows => {
+  const snapshot = state.snapshots.get(snapshotKey);
+  if (snapshot === undefined) {
+    throw new Error(`missing snapshot object: ${snapshotKey}`);
+  }
+
+  return new Map(snapshot.rows);
+};

--- a/tests/model/fold-boundary/model.ts
+++ b/tests/model/fold-boundary/model.ts
@@ -23,6 +23,7 @@ export interface ModelManifest {
 export interface ModelState {
   readonly log: ModelLog;
   readonly manifest: ModelManifest;
+  readonly manifestHistory: readonly ModelManifest[];
   readonly snapshots: ReadonlyMap<string, SnapshotObject>;
 }
 
@@ -42,21 +43,27 @@ const copySnapshot = (snapshot: SnapshotObject): SnapshotObject => ({
   rows: snapshot.rows.map(([docId, value]) => [docId, value] as const),
 });
 
+const copyManifest = (manifest: ModelManifest): ModelManifest => ({ ...manifest });
+
 const boundedSequence = (log: ModelLog, sequence: number): number =>
   Math.max(0, Math.min(sequence, log.acknowledgedTail));
 
 export const modelTail = (log: ModelLog): number => log.ops.length;
 
-export const emptyState = (log: ModelLog): ModelState => ({
-  log,
-  manifest: {
+export const emptyState = (log: ModelLog): ModelState => {
+  const manifest: ModelManifest = {
     generation: 0,
     logSeqStart: 0,
     snapshotKey: null,
     tailHint: modelTail(log),
-  },
-  snapshots: new Map(),
-});
+  };
+  return {
+    log,
+    manifest,
+    manifestHistory: [copyManifest(manifest)],
+    snapshots: new Map(),
+  };
+};
 
 export const foldRange = (base: ModelRows, log: ModelLog, from: number, to: number): ModelRows => {
   const rows = new Map(base);
@@ -93,15 +100,17 @@ export const makeSnapshot = (rows: ModelRows, maxSeq: number): SnapshotObject =>
 export const applySnapshot = (state: ModelState, snapshot: SnapshotObject): ModelState => {
   const snapshots = new Map(state.snapshots);
   snapshots.set(snapshot.key, copySnapshot(snapshot));
+  const manifest: ModelManifest = {
+    ...state.manifest,
+    generation: state.manifest.generation + 1,
+    logSeqStart: snapshot.maxSeq,
+    snapshotKey: snapshot.key,
+  };
 
   return {
     log: state.log,
-    manifest: {
-      ...state.manifest,
-      generation: state.manifest.generation + 1,
-      logSeqStart: snapshot.maxSeq,
-      snapshotKey: snapshot.key,
-    },
+    manifest,
+    manifestHistory: [...state.manifestHistory, copyManifest(manifest)],
     snapshots,
   };
 };

--- a/tests/model/fold-boundary/orphan-bound.test.ts
+++ b/tests/model/fold-boundary/orphan-bound.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "vitest";
 import { type FoldBudget } from "./boundary.ts";
 import { emptyState, rowsAtManifest, type ModelOp, type ModelState } from "./model.ts";
 import {
+  drainToQuiescence,
   reclaimUnreferenced,
   runSchedule,
   type ObserverAction,
@@ -104,6 +105,7 @@ const stateProjection = (state: ModelState) => ({
     ops: state.log.ops.map((operation) => ({ ...operation })),
   },
   manifest: { ...state.manifest },
+  manifestHistory: state.manifestHistory.map((manifest) => ({ ...manifest })),
   snapshots: [...state.snapshots.entries()].map(([key, snapshot]) => [
     key,
     {
@@ -189,14 +191,16 @@ describe("orphan and reclamation bounds", () => {
   });
 
   test("P6d_crashAfterPutHasAReachableNeverReferencedSnapshot", () => {
+    const initial = stateWithTail(20);
     const result = runSchedule({
-      initial: stateWithTail(20),
+      initial,
       observers: [action({ observerId: 1, observedTail: 20, k: 5, crashAt: "after_snapshot_put" })],
     });
     const [crashedKey] = result.attempts.map(({ emittedKey }) => emittedKey);
     const expected = expectedClassification(result);
 
     expect(result.attempts.map(({ outcome }) => outcome)).toEqual(["crashed"]);
+    expect(result.finalState.manifestHistory).toBe(initial.manifestHistory);
     expect(crashedKey).not.toBeNull();
     expect(sortedKeys(result.finalState)).toEqual([crashedKey]);
     expect(expected.neverReferenced).toEqual([crashedKey]);
@@ -222,6 +226,7 @@ describe("orphan and reclamation bounds", () => {
           expect([...rowsAtManifest(reclaimed).entries()].toSorted()).toEqual(beforeRows);
           expect(reclaimed.log).toBe(state.log);
           expect(reclaimed.manifest).toBe(state.manifest);
+          expect(reclaimed.manifestHistory).toBe(state.manifestHistory);
           expect(reclaimed.snapshots).not.toBe(state.snapshots);
           expect(stateProjection(state)).toEqual(before);
           expect(freshClassification.neverReferencedSnapshots).toEqual([]);
@@ -242,7 +247,6 @@ describe("orphan and reclamation bounds", () => {
     });
     const restarted = runSchedule({
       initial: prefix.finalState,
-      priorGenerations: prefix.generations,
       observers: [],
     });
     const [olderSnapshot] = [...prefix.finalState.snapshots.keys()];
@@ -258,27 +262,55 @@ describe("orphan and reclamation bounds", () => {
     const observers = [
       action({ observerId: 1, observedTail: 15, k: 5 }),
       action({ observerId: 2, observedTail: 15, k: 5 }),
-      action({ observerId: 3, observedTail: 15, k: 5 }),
+      action({ observerId: 3, readsAtGeneration: 1, observedTail: 15, k: 5 }),
     ];
     const uninterrupted = runSchedule({ initial, observers });
     const prefix = runSchedule({ initial, observers: observers.slice(0, 2) });
     const resumed = runSchedule({
       initial: prefix.finalState,
-      priorGenerations: prefix.generations,
       observers: observers.slice(2),
     });
 
+    expect(resumed.attempts[0]).toMatchObject({ baseGeneration: 1, outcome: "cas_lost" });
     expect(resumed.generations).toEqual(uninterrupted.generations);
     expect(resumed.neverReferencedSnapshots).toEqual(uninterrupted.neverReferencedSnapshots);
     expect(resumed.supersededSnapshots).toEqual(uninterrupted.supersededSnapshots);
     expect(resumed.reclaimableSnapshots).toEqual(uninterrupted.reclaimableSnapshots);
   });
 
+  test("scheduler_resumedDrainPreservesLifetimeSnapshotProvenance", () => {
+    const prefix = runSchedule({
+      initial: stateWithTail(20),
+      observers: [
+        action({ observerId: 1, observedTail: 20, k: 5 }),
+        action({ observerId: 2, observedTail: 20, k: 5 }),
+      ],
+    });
+    const resumed = drainToQuiescence({
+      initial: prefix.finalState,
+      budget: roomyBudget(),
+      k: 5,
+      algorithm: "aligned-manifest",
+      maxPasses: 4,
+    });
+
+    expect(resumed.attempts.map(({ outcome }) => outcome)).toEqual([
+      "written",
+      "written",
+      "below_min_threshold",
+    ]);
+    expect(resumed.generations.map(({ generation }) => generation)).toEqual([0, 1, 2, 3, 4]);
+    expect(resumed.neverReferencedSnapshots).toEqual([]);
+    expect(resumed.supersededSnapshots).toHaveLength(3);
+  });
+
   test("reclamation rejects a missing current snapshot instead of fabricating it", () => {
     const state = stateWithTail(2);
+    const missingManifest = { ...state.manifest, snapshotKey: "missing-current-snapshot" };
     const missingCurrent: ModelState = {
       ...state,
-      manifest: { ...state.manifest, snapshotKey: "missing-current-snapshot" },
+      manifest: missingManifest,
+      manifestHistory: [{ ...missingManifest }],
     };
 
     expect(() => reclaimUnreferenced(missingCurrent)).toThrow(

--- a/tests/model/fold-boundary/orphan-bound.test.ts
+++ b/tests/model/fold-boundary/orphan-bound.test.ts
@@ -232,6 +232,48 @@ describe("orphan and reclamation bounds", () => {
     );
   });
 
+  test("scheduler_preservesReferencedSnapshotProvenanceAcrossAnEmptyRestart", () => {
+    const prefix = runSchedule({
+      initial: stateWithTail(15),
+      observers: [
+        action({ observerId: 1, observedTail: 15, k: 5 }),
+        action({ observerId: 2, observedTail: 15, k: 5 }),
+      ],
+    });
+    const restarted = runSchedule({
+      initial: prefix.finalState,
+      priorGenerations: prefix.generations,
+      observers: [],
+    });
+    const [olderSnapshot] = [...prefix.finalState.snapshots.keys()];
+
+    expect(prefix.attempts.map(({ outcome }) => outcome)).toEqual(["written", "written"]);
+    expect(olderSnapshot).toBeDefined();
+    expect(restarted.neverReferencedSnapshots).toEqual([]);
+    expect(restarted.supersededSnapshots).toEqual([olderSnapshot]);
+  });
+
+  test("scheduler_classificationIsInvariantWhenAScheduleIsSplitWithProvenance", () => {
+    const initial = stateWithTail(15);
+    const observers = [
+      action({ observerId: 1, observedTail: 15, k: 5 }),
+      action({ observerId: 2, observedTail: 15, k: 5 }),
+      action({ observerId: 3, observedTail: 15, k: 5 }),
+    ];
+    const uninterrupted = runSchedule({ initial, observers });
+    const prefix = runSchedule({ initial, observers: observers.slice(0, 2) });
+    const resumed = runSchedule({
+      initial: prefix.finalState,
+      priorGenerations: prefix.generations,
+      observers: observers.slice(2),
+    });
+
+    expect(resumed.generations).toEqual(uninterrupted.generations);
+    expect(resumed.neverReferencedSnapshots).toEqual(uninterrupted.neverReferencedSnapshots);
+    expect(resumed.supersededSnapshots).toEqual(uninterrupted.supersededSnapshots);
+    expect(resumed.reclaimableSnapshots).toEqual(uninterrupted.reclaimableSnapshots);
+  });
+
   test("reclamation rejects a missing current snapshot instead of fabricating it", () => {
     const state = stateWithTail(2);
     const missingCurrent: ModelState = {

--- a/tests/model/fold-boundary/orphan-bound.test.ts
+++ b/tests/model/fold-boundary/orphan-bound.test.ts
@@ -42,6 +42,15 @@ const action = (overrides: Partial<ObserverAction> = {}): ObserverAction => ({
 
 const sortedKeys = (state: ModelState): readonly string[] => [...state.snapshots.keys()].toSorted();
 
+type ReclamationScenario = "empty" | "crashed" | "mixed-k" | "successive-fold";
+
+const reclamationScenarios: readonly ReclamationScenario[] = [
+  "empty",
+  "crashed",
+  "mixed-k",
+  "successive-fold",
+];
+
 const expectedClassification = (result: ScheduleResult) => {
   const referenced = new Set(
     result.generations.flatMap(({ snapshotKey }) => (snapshotKey === null ? [] : [snapshotKey])),
@@ -57,6 +66,53 @@ const expectedClassification = (result: ScheduleResult) => {
     reclaimable: [...new Set([...neverReferenced, ...superseded])].toSorted(),
   };
 };
+
+const reclamationState = (scenario: ReclamationScenario, tail: number): ModelState => {
+  const initial = stateWithTail(tail);
+  if (scenario === "empty") {
+    return runSchedule({ initial, observers: [] }).finalState;
+  }
+  if (scenario === "crashed") {
+    return runSchedule({
+      initial,
+      observers: [action({ observedTail: tail, k: 1, crashAt: "after_snapshot_put" })],
+    }).finalState;
+  }
+  if (scenario === "mixed-k") {
+    return runSchedule({
+      initial,
+      observers: [
+        action({ observerId: 1, readsAtGeneration: 0, observedTail: tail, k: 1 }),
+        action({ observerId: 2, readsAtGeneration: 0, observedTail: tail, k: 2 }),
+      ],
+    }).finalState;
+  }
+
+  const first = runSchedule({
+    initial,
+    observers: [action({ observerId: 1, observedTail: tail, k: 1 })],
+  });
+  return runSchedule({
+    initial: first.finalState,
+    observers: [action({ observerId: 2, observedTail: tail, k: 1 })],
+  }).finalState;
+};
+
+const stateProjection = (state: ModelState) => ({
+  log: {
+    acknowledgedTail: state.log.acknowledgedTail,
+    ops: state.log.ops.map((operation) => ({ ...operation })),
+  },
+  manifest: { ...state.manifest },
+  snapshots: [...state.snapshots.entries()].map(([key, snapshot]) => [
+    key,
+    {
+      key: snapshot.key,
+      maxSeq: snapshot.maxSeq,
+      rows: snapshot.rows.map(([docId, value]) => [docId, value] as const),
+    },
+  ]),
+});
 
 describe("orphan and reclamation bounds", () => {
   test("P6a_sameGenerationSameKContentionAddsNoDistinctCasOrphan", () => {
@@ -152,64 +208,27 @@ describe("orphan and reclamation bounds", () => {
 
   test("P6e_reclamationRemovesAllAndOnlyNonCurrentSnapshots", () => {
     fc.assert(
-      fc.property(
-        fc.constantFrom("empty", "crashed", "mixed-k", "successive-fold"),
-        fc.integer({ min: 2, max: 32 }),
-        (scenario, tail) => {
-          const initial = stateWithTail(tail);
-          const state = (() => {
-            if (scenario === "empty") {
-              return runSchedule({ initial, observers: [] }).finalState;
-            }
-            if (scenario === "crashed") {
-              return runSchedule({
-                initial,
-                observers: [action({ observedTail: tail, k: 1, crashAt: "after_snapshot_put" })],
-              }).finalState;
-            }
-            if (scenario === "mixed-k") {
-              return runSchedule({
-                initial,
-                observers: [
-                  action({ observerId: 1, readsAtGeneration: 0, observedTail: tail, k: 1 }),
-                  action({ observerId: 2, readsAtGeneration: 0, observedTail: tail, k: 2 }),
-                ],
-              }).finalState;
-            }
-
-            const first = runSchedule({
-              initial,
-              observers: [action({ observerId: 1, observedTail: tail, k: 1 })],
-            });
-            return runSchedule({
-              initial: first.finalState,
-              observers: [action({ observerId: 2, observedTail: tail, k: 1 })],
-            }).finalState;
-          })();
-          const before = {
-            log: state.log,
-            manifest: state.manifest,
-            snapshots: [...state.snapshots.entries()],
-            rows: [...rowsAtManifest(state).entries()].toSorted(),
-          };
+      fc.property(fc.integer({ min: 2, max: 32 }), (tail) => {
+        for (const scenario of reclamationScenarios) {
+          const state = reclamationState(scenario, tail);
+          const before = stateProjection(state);
+          const beforeRows = [...rowsAtManifest(state).entries()].toSorted();
           const expectedKeys =
             state.manifest.snapshotKey === null ? [] : [state.manifest.snapshotKey];
           const reclaimed = reclaimUnreferenced(state);
           const freshClassification = runSchedule({ initial: reclaimed, observers: [] });
 
           expect(sortedKeys(reclaimed)).toEqual(expectedKeys);
-          expect([...rowsAtManifest(reclaimed).entries()].toSorted()).toEqual(before.rows);
-          expect(reclaimed.log).toBe(before.log);
-          expect(reclaimed.manifest).toBe(before.manifest);
+          expect([...rowsAtManifest(reclaimed).entries()].toSorted()).toEqual(beforeRows);
+          expect(reclaimed.log).toBe(state.log);
+          expect(reclaimed.manifest).toBe(state.manifest);
           expect(reclaimed.snapshots).not.toBe(state.snapshots);
-          expect(state.log).toBe(before.log);
-          expect(state.manifest).toBe(before.manifest);
-          expect([...state.snapshots.entries()]).toEqual(before.snapshots);
+          expect(stateProjection(state)).toEqual(before);
           expect(freshClassification.neverReferencedSnapshots).toEqual([]);
           expect(freshClassification.supersededSnapshots).toEqual([]);
           expect(freshClassification.reclaimableSnapshots).toEqual([]);
-        },
-      ),
+        }
+      }),
     );
   });
 

--- a/tests/model/fold-boundary/orphan-bound.test.ts
+++ b/tests/model/fold-boundary/orphan-bound.test.ts
@@ -1,0 +1,227 @@
+import { fc } from "@fast-check/vitest";
+import { describe, expect, test } from "vitest";
+
+import { type FoldBudget } from "./boundary.ts";
+import { emptyState, rowsAtManifest, type ModelOp, type ModelState } from "./model.ts";
+import {
+  reclaimUnreferenced,
+  runSchedule,
+  type ObserverAction,
+  type ScheduleResult,
+} from "./schedule.ts";
+
+const roomyBudget = (overrides: Partial<FoldBudget> = {}): FoldBudget => ({
+  maxEntriesPerRun: 100,
+  minEntriesToCompact: 1,
+  ceilingBytes: 1_000_000,
+  ceilingEntries: 1_000,
+  subrequestLimit: 10_000,
+  ...overrides,
+});
+
+const operations = (count: number): readonly ModelOp[] =>
+  Array.from({ length: count }, (_, index) => ({
+    kind: "I" as const,
+    docId: `doc-${index}`,
+    value: index,
+  }));
+
+const stateWithTail = (tail: number): ModelState =>
+  emptyState({ ops: operations(tail), acknowledgedTail: tail });
+
+const action = (overrides: Partial<ObserverAction> = {}): ObserverAction => ({
+  observerId: 0,
+  readsAtGeneration: Number.MAX_SAFE_INTEGER,
+  observedTail: 20,
+  k: 5,
+  budget: roomyBudget(),
+  algorithm: "aligned-manifest",
+  crashAt: "none",
+  ...overrides,
+});
+
+const sortedKeys = (state: ModelState): readonly string[] => [...state.snapshots.keys()].toSorted();
+
+const expectedClassification = (result: ScheduleResult) => {
+  const referenced = new Set(
+    result.generations.flatMap(({ snapshotKey }) => (snapshotKey === null ? [] : [snapshotKey])),
+  );
+  const present = sortedKeys(result.finalState);
+  const current = result.finalState.manifest.snapshotKey;
+  const neverReferenced = present.filter((key) => !referenced.has(key));
+  const superseded = present.filter((key) => referenced.has(key) && key !== current);
+
+  return {
+    neverReferenced,
+    superseded,
+    reclaimable: [...new Set([...neverReferenced, ...superseded])].toSorted(),
+  };
+};
+
+describe("orphan and reclamation bounds", () => {
+  test("P6a_sameGenerationSameKContentionAddsNoDistinctCasOrphan", () => {
+    const result = runSchedule({
+      initial: stateWithTail(20),
+      observers: [
+        action({ observerId: 1, readsAtGeneration: 0, observedTail: 20, k: 5 }),
+        action({ observerId: 2, readsAtGeneration: 0, observedTail: 20, k: 5 }),
+      ],
+    });
+    const [winner, loser] = result.attempts.map(({ emittedKey }) => emittedKey);
+    const expected = expectedClassification(result);
+
+    expect(result.attempts.map(({ outcome }) => outcome)).toEqual(["written", "cas_lost"]);
+    expect(winner).not.toBeNull();
+    expect(loser).toBe(winner);
+    expect(sortedKeys(result.finalState)).toEqual([winner]);
+    expect(result.finalState.snapshots.size).toBe(1);
+    expect(expected.neverReferenced).toEqual([]);
+    expect(result.neverReferencedSnapshots).toEqual(expected.neverReferenced);
+    expect(result.supersededSnapshots).toEqual(expected.superseded);
+    expect(result.reclaimableSnapshots).toEqual(expected.reclaimable);
+  });
+
+  test("P6b_successfulFoldCanIncreaseRatherThanReduceReclaimableObjects", () => {
+    const initial = stateWithTail(10);
+    const first = runSchedule({
+      initial,
+      observers: [action({ observerId: 1, observedTail: 10, k: 5 })],
+    });
+    const second = runSchedule({
+      initial: first.finalState,
+      observers: [action({ observerId: 2, observedTail: 10, k: 5 })],
+    });
+    const oldHead = first.finalState.manifest.snapshotKey;
+    const newHead = second.finalState.manifest.snapshotKey;
+    const expected = expectedClassification(second);
+
+    expect(first.reclaimableSnapshots).toEqual([]);
+    expect(second.attempts.map(({ outcome }) => outcome)).toEqual(["written"]);
+    expect(oldHead).not.toBeNull();
+    expect(newHead).not.toBeNull();
+    expect(newHead).not.toBe(oldHead);
+    expect(sortedKeys(second.finalState)).toEqual([oldHead!, newHead!].toSorted());
+    expect(expected.neverReferenced).toEqual([]);
+    expect(expected.superseded).toEqual([oldHead]);
+    expect(second.neverReferencedSnapshots).toEqual(expected.neverReferenced);
+    expect(second.supersededSnapshots).toEqual(expected.superseded);
+    expect(second.reclaimableSnapshots).toEqual(expected.reclaimable);
+    expect(second.reclaimableSnapshots.length).toBeGreaterThan(first.reclaimableSnapshots.length);
+  });
+
+  test("P6c_mixedKContentionHasAReachableDistinctCasOrphan", () => {
+    const result = runSchedule({
+      initial: stateWithTail(20),
+      observers: [
+        action({ observerId: 1, readsAtGeneration: 0, observedTail: 20, k: 4 }),
+        action({ observerId: 2, readsAtGeneration: 0, observedTail: 20, k: 6 }),
+      ],
+    });
+    const [winner, loser] = result.attempts.map(({ emittedKey }) => emittedKey);
+    const expected = expectedClassification(result);
+
+    expect(result.attempts.map(({ outcome }) => outcome)).toEqual(["written", "cas_lost"]);
+    expect(winner).not.toBeNull();
+    expect(loser).not.toBeNull();
+    expect(loser).not.toBe(winner);
+    expect(sortedKeys(result.finalState)).toEqual([winner!, loser!].toSorted());
+    expect(expected.neverReferenced).toEqual([loser]);
+    expect(expected.superseded).toEqual([]);
+    expect(result.neverReferencedSnapshots).toEqual(expected.neverReferenced);
+    expect(result.supersededSnapshots).toEqual(expected.superseded);
+    expect(result.reclaimableSnapshots).toEqual(expected.reclaimable);
+  });
+
+  test("P6d_crashAfterPutHasAReachableNeverReferencedSnapshot", () => {
+    const result = runSchedule({
+      initial: stateWithTail(20),
+      observers: [action({ observerId: 1, observedTail: 20, k: 5, crashAt: "after_snapshot_put" })],
+    });
+    const [crashedKey] = result.attempts.map(({ emittedKey }) => emittedKey);
+    const expected = expectedClassification(result);
+
+    expect(result.attempts.map(({ outcome }) => outcome)).toEqual(["crashed"]);
+    expect(crashedKey).not.toBeNull();
+    expect(sortedKeys(result.finalState)).toEqual([crashedKey]);
+    expect(expected.neverReferenced).toEqual([crashedKey]);
+    expect(expected.superseded).toEqual([]);
+    expect(result.neverReferencedSnapshots).toEqual(expected.neverReferenced);
+    expect(result.supersededSnapshots).toEqual(expected.superseded);
+    expect(result.reclaimableSnapshots).toEqual(expected.reclaimable);
+  });
+
+  test("P6e_reclamationRemovesAllAndOnlyNonCurrentSnapshots", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom("empty", "crashed", "mixed-k", "successive-fold"),
+        fc.integer({ min: 2, max: 32 }),
+        (scenario, tail) => {
+          const initial = stateWithTail(tail);
+          const state = (() => {
+            if (scenario === "empty") {
+              return runSchedule({ initial, observers: [] }).finalState;
+            }
+            if (scenario === "crashed") {
+              return runSchedule({
+                initial,
+                observers: [action({ observedTail: tail, k: 1, crashAt: "after_snapshot_put" })],
+              }).finalState;
+            }
+            if (scenario === "mixed-k") {
+              return runSchedule({
+                initial,
+                observers: [
+                  action({ observerId: 1, readsAtGeneration: 0, observedTail: tail, k: 1 }),
+                  action({ observerId: 2, readsAtGeneration: 0, observedTail: tail, k: 2 }),
+                ],
+              }).finalState;
+            }
+
+            const first = runSchedule({
+              initial,
+              observers: [action({ observerId: 1, observedTail: tail, k: 1 })],
+            });
+            return runSchedule({
+              initial: first.finalState,
+              observers: [action({ observerId: 2, observedTail: tail, k: 1 })],
+            }).finalState;
+          })();
+          const before = {
+            log: state.log,
+            manifest: state.manifest,
+            snapshots: [...state.snapshots.entries()],
+            rows: [...rowsAtManifest(state).entries()].toSorted(),
+          };
+          const expectedKeys =
+            state.manifest.snapshotKey === null ? [] : [state.manifest.snapshotKey];
+          const reclaimed = reclaimUnreferenced(state);
+          const freshClassification = runSchedule({ initial: reclaimed, observers: [] });
+
+          expect(sortedKeys(reclaimed)).toEqual(expectedKeys);
+          expect([...rowsAtManifest(reclaimed).entries()].toSorted()).toEqual(before.rows);
+          expect(reclaimed.log).toBe(before.log);
+          expect(reclaimed.manifest).toBe(before.manifest);
+          expect(reclaimed.snapshots).not.toBe(state.snapshots);
+          expect(state.log).toBe(before.log);
+          expect(state.manifest).toBe(before.manifest);
+          expect([...state.snapshots.entries()]).toEqual(before.snapshots);
+          expect(freshClassification.neverReferencedSnapshots).toEqual([]);
+          expect(freshClassification.supersededSnapshots).toEqual([]);
+          expect(freshClassification.reclaimableSnapshots).toEqual([]);
+        },
+      ),
+    );
+  });
+
+  test("reclamation rejects a missing current snapshot instead of fabricating it", () => {
+    const state = stateWithTail(2);
+    const missingCurrent: ModelState = {
+      ...state,
+      manifest: { ...state.manifest, snapshotKey: "missing-current-snapshot" },
+    };
+
+    expect(() => reclaimUnreferenced(missingCurrent)).toThrow(
+      "missing snapshot object: missing-current-snapshot",
+    );
+  });
+});

--- a/tests/model/fold-boundary/orphan-bound.test.ts
+++ b/tests/model/fold-boundary/orphan-bound.test.ts
@@ -1,45 +1,17 @@
 import { fc } from "@fast-check/vitest";
 import { describe, expect, test } from "vitest";
 
-import { type FoldBudget } from "./boundary.ts";
-import { emptyState, rowsAtManifest, type ModelOp, type ModelState } from "./model.ts";
+import { action, operations, roomyBudget } from "./fixtures.ts";
+import { emptyState, rowsAtManifest, type ModelState } from "./model.ts";
 import {
   drainToQuiescence,
   reclaimUnreferenced,
   runSchedule,
-  type ObserverAction,
   type ScheduleResult,
 } from "./schedule.ts";
 
-const roomyBudget = (overrides: Partial<FoldBudget> = {}): FoldBudget => ({
-  maxEntriesPerRun: 100,
-  minEntriesToCompact: 1,
-  ceilingBytes: 1_000_000,
-  ceilingEntries: 1_000,
-  subrequestLimit: 10_000,
-  ...overrides,
-});
-
-const operations = (count: number): readonly ModelOp[] =>
-  Array.from({ length: count }, (_, index) => ({
-    kind: "I" as const,
-    docId: `doc-${index}`,
-    value: index,
-  }));
-
 const stateWithTail = (tail: number): ModelState =>
   emptyState({ ops: operations(tail), acknowledgedTail: tail });
-
-const action = (overrides: Partial<ObserverAction> = {}): ObserverAction => ({
-  observerId: 0,
-  readsAtGeneration: Number.MAX_SAFE_INTEGER,
-  observedTail: 20,
-  k: 5,
-  budget: roomyBudget(),
-  algorithm: "aligned-manifest",
-  crashAt: "none",
-  ...overrides,
-});
 
 const sortedKeys = (state: ModelState): readonly string[] => [...state.snapshots.keys()].toSorted();
 

--- a/tests/model/fold-boundary/progress-bound.test.ts
+++ b/tests/model/fold-boundary/progress-bound.test.ts
@@ -82,21 +82,21 @@ describe("fold crash and observer schedules", () => {
     });
     expect(result.attempts[1]!.cost).toEqual({
       currentGets: 1,
-      probeGets: 1,
+      probeGets: 181,
       snapshotGets: 0,
       logGets: 5,
       snapshotPuts: 1,
       currentPuts: 0,
-      total: 8,
+      total: 188,
     });
     expect(result.attempts[2]!.cost).toEqual({
       currentGets: 1,
-      probeGets: 1,
+      probeGets: 181,
       snapshotGets: 0,
       logGets: 5,
       snapshotPuts: 1,
       currentPuts: 1,
-      total: 9,
+      total: 189,
     });
     expect(result.attempts[1]!.emittedKey).toBe(result.attempts[2]!.emittedKey);
     expect(

--- a/tests/model/fold-boundary/progress-bound.test.ts
+++ b/tests/model/fold-boundary/progress-bound.test.ts
@@ -24,7 +24,8 @@ const operations = (count: number): readonly ModelOp[] =>
 
 const stateWithTail = (tail: number, tailHint = tail): ModelState => {
   const state = emptyState({ ops: operations(tail), acknowledgedTail: tail });
-  return { ...state, manifest: { ...state.manifest, tailHint } };
+  const manifest = { ...state.manifest, tailHint };
+  return { ...state, manifest, manifestHistory: [{ ...manifest }] };
 };
 
 const action = (overrides: Partial<ObserverAction> = {}): ObserverAction => ({
@@ -325,9 +326,11 @@ describe("fold publication and progress bounds", () => {
       initial: stateWithTail(20, 0),
       observers: [action({ observedTail: 5, k: 5 })],
     }).finalState;
+    const staleManifest = { ...published.manifest, tailHint: 0 };
     const staleHintBelowFloor: ModelState = {
       ...published,
-      manifest: { ...published.manifest, tailHint: 0 },
+      manifest: staleManifest,
+      manifestHistory: [...published.manifestHistory.slice(0, -1), { ...staleManifest }],
     };
     const result = runSchedule({
       initial: staleHintBelowFloor,

--- a/tests/model/fold-boundary/progress-bound.test.ts
+++ b/tests/model/fold-boundary/progress-bound.test.ts
@@ -1,0 +1,304 @@
+import { WRITE_TICK_FOLD_ENTRIES_PER_PASS } from "@baerly/protocol";
+import { fc } from "@fast-check/vitest";
+import { describe, expect, test } from "vitest";
+
+import { CF_FREE_BUDGET, type FoldBudget } from "./boundary.ts";
+import { emptyState, type ModelLog, type ModelOp, type ModelState } from "./model.ts";
+import { drainToQuiescence, runSchedule, type ObserverAction } from "./schedule.ts";
+
+const roomyBudget = (overrides: Partial<FoldBudget> = {}): FoldBudget => ({
+  maxEntriesPerRun: 100,
+  minEntriesToCompact: 1,
+  ceilingBytes: 1_000_000,
+  ceilingEntries: 1_000,
+  subrequestLimit: 10_000,
+  ...overrides,
+});
+
+const operations = (count: number): readonly ModelOp[] =>
+  Array.from({ length: count }, (_, index) => ({
+    kind: "I" as const,
+    docId: `doc-${index}`,
+    value: index,
+  }));
+
+const stateWithTail = (tail: number, tailHint = tail): ModelState => {
+  const state = emptyState({ ops: operations(tail), acknowledgedTail: tail });
+  return { ...state, manifest: { ...state.manifest, tailHint } };
+};
+
+const action = (overrides: Partial<ObserverAction> = {}): ObserverAction => ({
+  observerId: 0,
+  readsAtGeneration: Number.MAX_SAFE_INTEGER,
+  observedTail: 20,
+  k: 5,
+  budget: roomyBudget(),
+  algorithm: "aligned-manifest",
+  crashAt: "none",
+  ...overrides,
+});
+
+const localReplay = (log: ModelLog, to: number): readonly (readonly [string, number])[] => {
+  const rows = new Map<string, number>();
+  const end = Math.min(to, log.acknowledgedTail);
+
+  for (let sequence = 0; sequence < end; sequence += 1) {
+    const operation = log.ops[sequence]!;
+    if (operation.kind === "D") {
+      rows.delete(operation.docId);
+    } else {
+      rows.set(operation.docId, operation.value);
+    }
+  }
+
+  return [...rows.entries()].toSorted(([left], [right]) => left.localeCompare(right));
+};
+
+describe("fold crash and observer schedules", () => {
+  test("P3a_crashBeforeCasLeavesManifestUnchangedAndRetryUsesSameTarget", () => {
+    const initial = stateWithTail(20);
+    const result = runSchedule({
+      initial,
+      observers: [
+        action({ observerId: 1, crashAt: "after_manifest_read" }),
+        action({ observerId: 2, observedTail: 200, crashAt: "after_snapshot_put" }),
+        action({ observerId: 2, observedTail: 200 }),
+      ],
+    });
+
+    expect(result.attempts.map(({ outcome, foldEnd }) => ({ outcome, foldEnd }))).toEqual([
+      { outcome: "crashed", foldEnd: null },
+      { outcome: "crashed", foldEnd: 5 },
+      { outcome: "written", foldEnd: 5 },
+    ]);
+    expect(result.attempts[0]!.cost).toEqual({
+      currentGets: 1,
+      probeGets: 0,
+      snapshotGets: 0,
+      logGets: 0,
+      snapshotPuts: 0,
+      currentPuts: 0,
+      total: 1,
+    });
+    expect(result.attempts[1]!.cost).toEqual({
+      currentGets: 1,
+      probeGets: 1,
+      snapshotGets: 0,
+      logGets: 5,
+      snapshotPuts: 1,
+      currentPuts: 0,
+      total: 8,
+    });
+    expect(result.attempts[2]!.cost).toEqual({
+      currentGets: 1,
+      probeGets: 1,
+      snapshotGets: 0,
+      logGets: 5,
+      snapshotPuts: 1,
+      currentPuts: 1,
+      total: 9,
+    });
+    expect(result.attempts[1]!.emittedKey).toBe(result.attempts[2]!.emittedKey);
+    expect(
+      result.generations.map(({ generation, logSeqStart }) => [generation, logSeqStart]),
+    ).toEqual([
+      [0, 0],
+      [1, 5],
+    ]);
+    expect(result.finalState.snapshots.size).toBe(1);
+    expect(result.neverReferencedSnapshots).toEqual([]);
+    expect(() => runSchedule({ initial, observers: [action({ readsAtGeneration: 1 })] })).toThrow(
+      RangeError,
+    );
+  });
+
+  test("P3b_laggingObserverBoundarySequenceIsAPrefixOfFullyInformedSequence", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 10 }),
+        fc.integer({ min: 1, max: 8 }),
+        (k, lagPasses) => {
+          const tail = k * 10;
+          const allPasses = 10;
+          const initial = stateWithTail(tail);
+          const fullyInformed = runSchedule({
+            initial,
+            observers: Array.from({ length: allPasses }, (_, index) =>
+              action({ observerId: index, observedTail: tail, k }),
+            ),
+          });
+          const lagging = runSchedule({
+            initial,
+            observers: Array.from({ length: lagPasses }, (_, index) =>
+              action({ observerId: index, observedTail: (index + 1) * k, k }),
+            ),
+          });
+          const fullBoundaries = fullyInformed.attempts
+            .filter(({ outcome }) => outcome === "written")
+            .map(({ foldEnd }) => foldEnd);
+          const laggingBoundaries = lagging.attempts
+            .filter(({ outcome }) => outcome === "written")
+            .map(({ foldEnd }) => foldEnd);
+
+          expect(laggingBoundaries).toEqual(fullBoundaries.slice(0, laggingBoundaries.length));
+        },
+      ),
+    );
+  });
+
+  test("P4b_mixedKObserversCanPrepareDifferentObjectsFromOneGeneration", () => {
+    const result = runSchedule({
+      initial: stateWithTail(20),
+      observers: [
+        action({ observerId: 1, k: 4, crashAt: "after_snapshot_put" }),
+        action({ observerId: 2, k: 6, crashAt: "after_snapshot_put" }),
+      ],
+    });
+
+    expect(result.attempts.map(({ baseGeneration, foldEnd }) => [baseGeneration, foldEnd])).toEqual(
+      [
+        [0, 4],
+        [0, 6],
+      ],
+    );
+    expect(new Set(result.attempts.map(({ emittedKey }) => emittedKey)).size).toBe(2);
+    expect(result.neverReferencedSnapshots).toHaveLength(2);
+  });
+
+  test("P5a_observersOnOppositeSidesOfOneBoundaryEmitAtMostOneObjectForOneK", () => {
+    const result = runSchedule({
+      initial: stateWithTail(20),
+      observers: [
+        action({ observerId: 1, readsAtGeneration: 0, observedTail: 5 }),
+        action({ observerId: 2, readsAtGeneration: 0, observedTail: 9 }),
+      ],
+    });
+
+    expect(result.attempts.map(({ foldEnd }) => foldEnd)).toEqual([5, 5]);
+    expect(result.attempts.map(({ outcome }) => outcome)).toEqual(["written", "cas_lost"]);
+    expect(result.attempts[1]!.cost).toEqual({
+      currentGets: 1,
+      probeGets: 1,
+      snapshotGets: 0,
+      logGets: 5,
+      snapshotPuts: 1,
+      currentPuts: 1,
+      total: 9,
+    });
+    expect(result.attempts[0]!.emittedKey).toBe(result.attempts[1]!.emittedKey);
+    expect(result.finalState.snapshots.size).toBe(1);
+  });
+
+  test("P5b_sameManifestSameKAlwaysProducesTheSameObjectKey", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 20 }),
+        fc.integer({ min: 0, max: 30 }),
+        fc.integer({ min: 0, max: 30 }),
+        (k, leftExtra, rightExtra) => {
+          const tail = k + Math.max(leftExtra, rightExtra);
+          const result = runSchedule({
+            initial: stateWithTail(tail),
+            observers: [
+              action({
+                observerId: 1,
+                observedTail: k + leftExtra,
+                k,
+                crashAt: "after_snapshot_put",
+              }),
+              action({
+                observerId: 2,
+                observedTail: k + rightExtra,
+                k,
+                crashAt: "after_snapshot_put",
+              }),
+            ],
+          });
+
+          expect(result.attempts[0]!.emittedKey).toBe(result.attempts[1]!.emittedKey);
+          expect(result.finalState.snapshots.size).toBe(1);
+        },
+      ),
+    );
+  });
+});
+
+describe("fold publication and progress bounds", () => {
+  test("P7e_everyPublishedSnapshotMatchesReferenceReplayThroughItsFloor", () => {
+    const log: ModelLog = {
+      ops: [
+        { kind: "I", docId: "alpha", value: 1 },
+        { kind: "I", docId: "bravo", value: 2 },
+        { kind: "U", docId: "alpha", value: 3 },
+        { kind: "D", docId: "bravo" },
+        { kind: "I", docId: "charlie", value: 5 },
+        { kind: "U", docId: "alpha", value: 6 },
+        { kind: "I", docId: "delta", value: 7 },
+        { kind: "D", docId: "alpha" },
+      ],
+      acknowledgedTail: 8,
+    };
+    const result = runSchedule({
+      initial: emptyState(log),
+      observers: [
+        action({ k: 3, observedTail: 8 }),
+        action({ k: 4, observedTail: 8 }),
+        action({ k: 3, observedTail: 8 }),
+      ],
+    });
+
+    expect(result.attempts.map(({ outcome }) => outcome)).toEqual([
+      "written",
+      "written",
+      "written",
+    ]);
+    for (const manifest of result.generations.slice(1)) {
+      const snapshot = result.finalState.snapshots.get(manifest.snapshotKey!);
+      expect(snapshot?.maxSeq).toBe(manifest.logSeqStart);
+      expect(snapshot?.rows).toEqual(localReplay(log, manifest.logSeqStart));
+    }
+    expect(result.supersededSnapshots).toHaveLength(2);
+    expect(result.reclaimableSnapshots).toEqual(result.supersededSnapshots);
+  });
+
+  test("P8e_manifestAlignedProgressFitsCfFreeWithTightKnownTailForKAtMostTwenty", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: WRITE_TICK_FOLD_ENTRIES_PER_PASS }),
+        fc.integer({ min: 3, max: 8 }),
+        (k, passes) => {
+          const tail = CF_FREE_BUDGET.minEntriesToCompact + k * passes;
+          const result = drainToQuiescence({
+            initial: stateWithTail(tail),
+            budget: CF_FREE_BUDGET,
+            k,
+            algorithm: "aligned-manifest",
+            maxPasses: passes + 2,
+          });
+          expect(result.attempts).toHaveLength(passes + 2);
+          expect(result.attempts.slice(0, -1).map(({ outcome }) => outcome)).toEqual(
+            Array.from({ length: passes + 1 }, () => "written"),
+          );
+          expect(result.attempts.at(-1)?.outcome).toBe("below_min_threshold");
+          expect(
+            result.attempts
+              .slice(0, -1)
+              .every(({ cost }) => cost.total <= CF_FREE_BUDGET.subrequestLimit),
+          ).toBe(true);
+          expect(result.finalState.manifest.logSeqStart).toBe(k * (passes + 1));
+        },
+      ),
+    );
+  });
+
+  test("P8f_scheduledStaleProbeCanExceedThePerPassSubrequestLimit", () => {
+    const result = runSchedule({
+      initial: stateWithTail(100, 0),
+      observers: [action({ observedTail: 100, k: 20, budget: CF_FREE_BUDGET })],
+    });
+
+    expect(result.attempts[0]!.outcome).toBe("written");
+    expect(result.attempts[0]!.cost.probeGets).toBe(101);
+    expect(result.attempts[0]!.cost.total).toBeGreaterThan(CF_FREE_BUDGET.subrequestLimit);
+  });
+});

--- a/tests/model/fold-boundary/progress-bound.test.ts
+++ b/tests/model/fold-boundary/progress-bound.test.ts
@@ -2,42 +2,16 @@ import { WRITE_TICK_FOLD_ENTRIES_PER_PASS } from "@baerly/protocol";
 import { fc } from "@fast-check/vitest";
 import { describe, expect, test } from "vitest";
 
-import { CF_FREE_BUDGET, type FoldBudget } from "./boundary.ts";
-import { emptyState, type ModelLog, type ModelOp, type ModelState } from "./model.ts";
-import { drainToQuiescence, runSchedule, type ObserverAction } from "./schedule.ts";
-
-const roomyBudget = (overrides: Partial<FoldBudget> = {}): FoldBudget => ({
-  maxEntriesPerRun: 100,
-  minEntriesToCompact: 1,
-  ceilingBytes: 1_000_000,
-  ceilingEntries: 1_000,
-  subrequestLimit: 10_000,
-  ...overrides,
-});
-
-const operations = (count: number): readonly ModelOp[] =>
-  Array.from({ length: count }, (_, index) => ({
-    kind: "I" as const,
-    docId: `doc-${index}`,
-    value: index,
-  }));
+import { CF_FREE_BUDGET } from "./boundary.ts";
+import { action, operations } from "./fixtures.ts";
+import { emptyState, type ModelLog, type ModelState } from "./model.ts";
+import { drainToQuiescence, runSchedule } from "./schedule.ts";
 
 const stateWithTail = (tail: number, tailHint = tail): ModelState => {
   const state = emptyState({ ops: operations(tail), acknowledgedTail: tail });
   const manifest = { ...state.manifest, tailHint };
   return { ...state, manifest, manifestHistory: [{ ...manifest }] };
 };
-
-const action = (overrides: Partial<ObserverAction> = {}): ObserverAction => ({
-  observerId: 0,
-  readsAtGeneration: Number.MAX_SAFE_INTEGER,
-  observedTail: 20,
-  k: 5,
-  budget: roomyBudget(),
-  algorithm: "aligned-manifest",
-  crashAt: "none",
-  ...overrides,
-});
 
 const localReplay = (log: ModelLog, to: number): readonly (readonly [string, number])[] => {
   const rows = new Map<string, number>();

--- a/tests/model/fold-boundary/progress-bound.test.ts
+++ b/tests/model/fold-boundary/progress-bound.test.ts
@@ -301,4 +301,41 @@ describe("fold publication and progress bounds", () => {
     expect(result.attempts[0]!.cost.probeGets).toBe(101);
     expect(result.attempts[0]!.cost.total).toBeGreaterThan(CF_FREE_BUDGET.subrequestLimit);
   });
+
+  test("scheduler_advancesTailHintAndAmortizesAStaleProbeAcrossSuccessfulPasses", () => {
+    const first = runSchedule({
+      initial: stateWithTail(100, 0),
+      observers: [action({ observedTail: 100, k: 20 })],
+    });
+    const second = runSchedule({
+      initial: first.finalState,
+      observers: [action({ observedTail: 100, k: 20 })],
+    });
+
+    expect(first.attempts[0]!.outcome).toBe("written");
+    expect(first.attempts[0]!.cost.probeGets).toBe(101);
+    expect(first.finalState.manifest.tailHint).toBe(100);
+    expect(second.attempts[0]!.outcome).toBe("written");
+    expect(second.attempts[0]!.cost.probeGets).toBe(1);
+    expect(second.finalState.manifest.tailHint).toBe(100);
+  });
+
+  test("scheduler_neverProbesBelowAPublishedLogFloor", () => {
+    const published = runSchedule({
+      initial: stateWithTail(20, 0),
+      observers: [action({ observedTail: 5, k: 5 })],
+    }).finalState;
+    const staleHintBelowFloor: ModelState = {
+      ...published,
+      manifest: { ...published.manifest, tailHint: 0 },
+    };
+    const result = runSchedule({
+      initial: staleHintBelowFloor,
+      observers: [action({ observedTail: 5, k: 5 })],
+    });
+
+    expect(staleHintBelowFloor.manifest.logSeqStart).toBe(5);
+    expect(result.attempts[0]!.outcome).toBe("below_min_threshold");
+    expect(result.attempts[0]!.cost.probeGets).toBe(1);
+  });
 });

--- a/tests/model/fold-boundary/schedule.ts
+++ b/tests/model/fold-boundary/schedule.ts
@@ -1,0 +1,233 @@
+import { prepareFold, type BoundaryAlgorithm, type FoldBudget } from "./boundary.ts";
+import type { FoldCost } from "./cost.ts";
+import type { ModelManifest, ModelState, SnapshotObject } from "./model.ts";
+
+export type CrashPoint = "none" | "after_manifest_read" | "after_snapshot_put";
+
+export interface ObserverAction {
+  readonly observerId: number;
+  readonly readsAtGeneration: number;
+  readonly observedTail: number;
+  readonly k: number;
+  readonly budget: FoldBudget;
+  readonly algorithm: BoundaryAlgorithm;
+  readonly crashAt: CrashPoint;
+}
+
+export interface FoldAttempt {
+  readonly observerId: number;
+  readonly outcome: "below_min_threshold" | "deferred" | "crashed" | "cas_lost" | "written";
+  readonly baseGeneration: number;
+  readonly foldEnd: number | null;
+  readonly emittedKey: string | null;
+  readonly readSet: readonly number[];
+  readonly cost: FoldCost;
+}
+
+export interface ScheduleResult {
+  readonly attempts: readonly FoldAttempt[];
+  readonly finalState: ModelState;
+  readonly generations: readonly ModelManifest[];
+  readonly neverReferencedSnapshots: readonly string[];
+  readonly supersededSnapshots: readonly string[];
+  readonly reclaimableSnapshots: readonly string[];
+}
+
+interface MutableSchedule {
+  state: ModelState;
+  readonly attempts: FoldAttempt[];
+  readonly generations: ModelManifest[];
+}
+
+const manifestReadCost = (): FoldCost => ({
+  currentGets: 1,
+  probeGets: 0,
+  snapshotGets: 0,
+  logGets: 0,
+  snapshotPuts: 0,
+  currentPuts: 0,
+  total: 1,
+});
+
+const withoutCurrentPut = (cost: FoldCost): FoldCost => ({
+  ...cost,
+  currentPuts: 0,
+  total: cost.total - cost.currentPuts,
+});
+
+const storeSnapshot = (state: ModelState, snapshot: SnapshotObject): ModelState => {
+  const snapshots = new Map(state.snapshots);
+  snapshots.set(snapshot.key, snapshot);
+  return { ...state, snapshots };
+};
+
+const selectedManifest = (
+  generations: readonly ModelManifest[],
+  action: ObserverAction,
+): ModelManifest => {
+  if (action.readsAtGeneration === Number.MAX_SAFE_INTEGER) {
+    return generations.at(-1)!;
+  }
+
+  const manifest = generations.find(({ generation }) => generation === action.readsAtGeneration);
+  if (manifest === undefined) {
+    throw new RangeError(`generation ${action.readsAtGeneration} has not been created`);
+  }
+  return manifest;
+};
+
+const performAttempt = (schedule: MutableSchedule, action: ObserverAction): FoldAttempt => {
+  const manifest = selectedManifest(schedule.generations, action);
+  if (action.crashAt === "after_manifest_read") {
+    return {
+      observerId: action.observerId,
+      outcome: "crashed",
+      baseGeneration: manifest.generation,
+      foldEnd: null,
+      emittedKey: null,
+      readSet: [],
+      cost: manifestReadCost(),
+    };
+  }
+
+  const observedTail = Math.max(
+    0,
+    Math.min(action.observedTail, schedule.state.log.acknowledgedTail),
+  );
+  const historicalState: ModelState = {
+    log: schedule.state.log,
+    manifest,
+    snapshots: schedule.state.snapshots,
+  };
+  const prepared = prepareFold({
+    state: historicalState,
+    observedTail,
+    probeFloor: manifest.tailHint,
+    budget: action.budget,
+    k: action.k,
+    algorithm: action.algorithm,
+  });
+
+  if (prepared.outcome !== "prepared") {
+    return {
+      observerId: action.observerId,
+      outcome: prepared.outcome,
+      baseGeneration: prepared.baseGeneration,
+      foldEnd: prepared.foldEnd,
+      emittedKey: null,
+      readSet: prepared.readSet,
+      cost: prepared.cost,
+    };
+  }
+
+  const snapshot = prepared.snapshot!;
+  schedule.state = storeSnapshot(schedule.state, snapshot);
+  if (action.crashAt === "after_snapshot_put") {
+    return {
+      observerId: action.observerId,
+      outcome: "crashed",
+      baseGeneration: prepared.baseGeneration,
+      foldEnd: prepared.foldEnd,
+      emittedKey: snapshot.key,
+      readSet: prepared.readSet,
+      cost: withoutCurrentPut(prepared.cost),
+    };
+  }
+
+  if (schedule.state.manifest.generation !== prepared.baseGeneration) {
+    return {
+      observerId: action.observerId,
+      outcome: "cas_lost",
+      baseGeneration: prepared.baseGeneration,
+      foldEnd: prepared.foldEnd,
+      emittedKey: snapshot.key,
+      readSet: prepared.readSet,
+      cost: prepared.cost,
+    };
+  }
+
+  const published: ModelManifest = {
+    ...manifest,
+    generation: manifest.generation + 1,
+    logSeqStart: snapshot.maxSeq,
+    snapshotKey: snapshot.key,
+  };
+  schedule.state = { ...schedule.state, manifest: published };
+  schedule.generations.push(published);
+  return {
+    observerId: action.observerId,
+    outcome: "written",
+    baseGeneration: prepared.baseGeneration,
+    foldEnd: prepared.foldEnd,
+    emittedKey: snapshot.key,
+    readSet: prepared.readSet,
+    cost: prepared.cost,
+  };
+};
+
+const finish = (schedule: MutableSchedule): ScheduleResult => {
+  const referenced = new Set(
+    schedule.generations.flatMap(({ snapshotKey }) => (snapshotKey === null ? [] : [snapshotKey])),
+  );
+  const currentKey = schedule.state.manifest.snapshotKey;
+  const present = [...schedule.state.snapshots.keys()];
+  const neverReferencedSnapshots = present.filter((key) => !referenced.has(key)).toSorted();
+  const supersededSnapshots = present
+    .filter((key) => referenced.has(key) && key !== currentKey)
+    .toSorted();
+  const reclaimableSnapshots = [
+    ...new Set([...neverReferencedSnapshots, ...supersededSnapshots]),
+  ].toSorted();
+
+  return {
+    attempts: schedule.attempts,
+    finalState: schedule.state,
+    generations: schedule.generations,
+    neverReferencedSnapshots,
+    supersededSnapshots,
+    reclaimableSnapshots,
+  };
+};
+
+const mutableSchedule = (initial: ModelState): MutableSchedule => ({
+  state: initial,
+  attempts: [],
+  generations: [initial.manifest],
+});
+
+export const runSchedule = (args: {
+  readonly initial: ModelState;
+  readonly observers: readonly ObserverAction[];
+}): ScheduleResult => {
+  const schedule = mutableSchedule(args.initial);
+  for (const observer of args.observers) {
+    schedule.attempts.push(performAttempt(schedule, observer));
+  }
+  return finish(schedule);
+};
+
+export const drainToQuiescence = (args: {
+  readonly initial: ModelState;
+  readonly budget: FoldBudget;
+  readonly k: number;
+  readonly algorithm: BoundaryAlgorithm;
+  readonly maxPasses: number;
+}): ScheduleResult => {
+  const schedule = mutableSchedule(args.initial);
+  for (let pass = 0; pass < args.maxPasses; pass += 1) {
+    const attempt = performAttempt(schedule, {
+      observerId: pass,
+      readsAtGeneration: Number.MAX_SAFE_INTEGER,
+      observedTail: schedule.state.log.acknowledgedTail,
+      k: args.k,
+      budget: args.budget,
+      algorithm: args.algorithm,
+      crashAt: "none",
+    });
+    schedule.attempts.push(attempt);
+    if (attempt.outcome !== "written") {
+      break;
+    }
+  }
+  return finish(schedule);
+};

--- a/tests/model/fold-boundary/schedule.ts
+++ b/tests/model/fold-boundary/schedule.ts
@@ -227,3 +227,17 @@ export const drainToQuiescence = (args: {
   }
   return finish(schedule);
 };
+
+export const reclaimUnreferenced: (state: ModelState) => ModelState = (state) => {
+  const currentKey = state.manifest.snapshotKey;
+  if (currentKey === null) {
+    return { ...state, snapshots: new Map() };
+  }
+
+  const current = state.snapshots.get(currentKey);
+  if (current === undefined) {
+    throw new Error(`missing snapshot object: ${currentKey}`);
+  }
+
+  return { ...state, snapshots: new Map([[currentKey, current]]) };
+};

--- a/tests/model/fold-boundary/schedule.ts
+++ b/tests/model/fold-boundary/schedule.ts
@@ -90,10 +90,6 @@ const performAttempt = (schedule: MutableSchedule, action: ObserverAction): Fold
     };
   }
 
-  const observedTail = Math.max(
-    0,
-    Math.min(action.observedTail, schedule.state.log.acknowledgedTail),
-  );
   const historicalState: ModelState = {
     log: schedule.state.log,
     manifest,
@@ -101,7 +97,7 @@ const performAttempt = (schedule: MutableSchedule, action: ObserverAction): Fold
   };
   const prepared = prepareFold({
     state: historicalState,
-    observedTail,
+    observedTail: action.observedTail,
     probeFloor: manifest.tailHint,
     budget: action.budget,
     k: action.k,

--- a/tests/model/fold-boundary/schedule.ts
+++ b/tests/model/fold-boundary/schedule.ts
@@ -117,7 +117,7 @@ const performAttempt = (schedule: MutableSchedule, action: ObserverAction): Fold
     };
   }
 
-  const snapshot = prepared.snapshot!;
+  const { snapshot } = prepared;
   schedule.state = storeSnapshot(schedule.state, snapshot);
   if (action.crashAt === "after_snapshot_put") {
     return {

--- a/tests/model/fold-boundary/schedule.ts
+++ b/tests/model/fold-boundary/schedule.ts
@@ -95,10 +95,11 @@ const performAttempt = (schedule: MutableSchedule, action: ObserverAction): Fold
     manifest,
     snapshots: schedule.state.snapshots,
   };
+  const probeFloor = Math.max(manifest.logSeqStart, manifest.tailHint);
   const prepared = prepareFold({
     state: historicalState,
     observedTail: action.observedTail,
-    probeFloor: manifest.tailHint,
+    probeFloor,
     budget: action.budget,
     k: action.k,
     algorithm: action.algorithm,
@@ -147,6 +148,10 @@ const performAttempt = (schedule: MutableSchedule, action: ObserverAction): Fold
     generation: manifest.generation + 1,
     logSeqStart: snapshot.maxSeq,
     snapshotKey: snapshot.key,
+    tailHint: Math.max(
+      manifest.tailHint,
+      Math.max(0, Math.min(action.observedTail, schedule.state.log.acknowledgedTail)),
+    ),
   };
   schedule.state = { ...schedule.state, manifest: published };
   schedule.generations.push(published);
@@ -185,17 +190,21 @@ const finish = (schedule: MutableSchedule): ScheduleResult => {
   };
 };
 
-const mutableSchedule = (initial: ModelState): MutableSchedule => ({
+const mutableSchedule = (
+  initial: ModelState,
+  priorGenerations: readonly ModelManifest[] = [initial.manifest],
+): MutableSchedule => ({
   state: initial,
   attempts: [],
-  generations: [initial.manifest],
+  generations: [...priorGenerations],
 });
 
 export const runSchedule = (args: {
   readonly initial: ModelState;
+  readonly priorGenerations?: readonly ModelManifest[];
   readonly observers: readonly ObserverAction[];
 }): ScheduleResult => {
-  const schedule = mutableSchedule(args.initial);
+  const schedule = mutableSchedule(args.initial, args.priorGenerations);
   for (const observer of args.observers) {
     schedule.attempts.push(performAttempt(schedule, observer));
   }

--- a/tests/model/fold-boundary/schedule.ts
+++ b/tests/model/fold-boundary/schedule.ts
@@ -36,7 +36,6 @@ export interface ScheduleResult {
 interface MutableSchedule {
   state: ModelState;
   readonly attempts: FoldAttempt[];
-  readonly generations: ModelManifest[];
 }
 
 const manifestReadCost = (): FoldCost => ({
@@ -77,7 +76,7 @@ const selectedManifest = (
 };
 
 const performAttempt = (schedule: MutableSchedule, action: ObserverAction): FoldAttempt => {
-  const manifest = selectedManifest(schedule.generations, action);
+  const manifest = selectedManifest(schedule.state.manifestHistory, action);
   if (action.crashAt === "after_manifest_read") {
     return {
       observerId: action.observerId,
@@ -93,6 +92,7 @@ const performAttempt = (schedule: MutableSchedule, action: ObserverAction): Fold
   const historicalState: ModelState = {
     log: schedule.state.log,
     manifest,
+    manifestHistory: schedule.state.manifestHistory,
     snapshots: schedule.state.snapshots,
   };
   const probeFloor = Math.max(manifest.logSeqStart, manifest.tailHint);
@@ -153,8 +153,11 @@ const performAttempt = (schedule: MutableSchedule, action: ObserverAction): Fold
       Math.max(0, Math.min(action.observedTail, schedule.state.log.acknowledgedTail)),
     ),
   };
-  schedule.state = { ...schedule.state, manifest: published };
-  schedule.generations.push(published);
+  schedule.state = {
+    ...schedule.state,
+    manifest: published,
+    manifestHistory: [...schedule.state.manifestHistory, { ...published }],
+  };
   return {
     observerId: action.observerId,
     outcome: "written",
@@ -168,7 +171,9 @@ const performAttempt = (schedule: MutableSchedule, action: ObserverAction): Fold
 
 const finish = (schedule: MutableSchedule): ScheduleResult => {
   const referenced = new Set(
-    schedule.generations.flatMap(({ snapshotKey }) => (snapshotKey === null ? [] : [snapshotKey])),
+    schedule.state.manifestHistory.flatMap(({ snapshotKey }) =>
+      snapshotKey === null ? [] : [snapshotKey],
+    ),
   );
   const currentKey = schedule.state.manifest.snapshotKey;
   const present = [...schedule.state.snapshots.keys()];
@@ -183,28 +188,23 @@ const finish = (schedule: MutableSchedule): ScheduleResult => {
   return {
     attempts: schedule.attempts,
     finalState: schedule.state,
-    generations: schedule.generations,
+    generations: schedule.state.manifestHistory,
     neverReferencedSnapshots,
     supersededSnapshots,
     reclaimableSnapshots,
   };
 };
 
-const mutableSchedule = (
-  initial: ModelState,
-  priorGenerations: readonly ModelManifest[] = [initial.manifest],
-): MutableSchedule => ({
+const mutableSchedule = (initial: ModelState): MutableSchedule => ({
   state: initial,
   attempts: [],
-  generations: [...priorGenerations],
 });
 
 export const runSchedule = (args: {
   readonly initial: ModelState;
-  readonly priorGenerations?: readonly ModelManifest[];
   readonly observers: readonly ObserverAction[];
 }): ScheduleResult => {
-  const schedule = mutableSchedule(args.initial, args.priorGenerations);
+  const schedule = mutableSchedule(args.initial);
   for (const observer of args.observers) {
     schedule.attempts.push(performAttempt(schedule, observer));
   }


### PR DESCRIPTION
## What & why

Adds an executable, property-based research model for deterministic `K`-aligned fold boundaries so the boundary, cost, crash, contention, and reclamation hypotheses can be evaluated without changing production behavior. The model compares the current greedy rule with aligned alternatives and emits collision-safe, source-hashed evidence marked research-only and non-authorizing.

## Key points

- Keeps all changes within eleven files under `tests/model/fold-boundary/`; no production, configuration, dependency, script, or tracked-document change.
- Models immutable replay, exact S3 operation costs, crash/CAS schedules, manifest history, content-addressed snapshot deduplication, and orphan reclamation.
- Records eight traceable research claims with exact property IDs and reproducible commands; rolling-deploy `K` compatibility remains explicitly unresolved.
- Two invariants the report now enforces about itself: `R6` asserts `SOURCE_FILES` equals the model directory contents, because an omission there narrowed provenance silently; and `modelParameters.budget` publishes the budget the deterministic tables were produced under, without which `foldAndObjectProduction` is not interpretable.

## Verification

| Command | Result |
| --- | --- |
| `pnpm test:agent tests/model/fold-boundary` | 54 passed |
| `FC_NUM_RUNS=10000 pnpm test:randomize tests/model/fold-boundary --reporter=dot` | 54 passed |
| `pnpm verify:agent` | clean |
| `pnpm build` | clean |
| `pnpm test:agent` | 2,905 passed; 101 skipped |

## Notes for reviewers

Start with `boundary.ts`, `schedule.ts`, and the Q1–Q8 claim catalog in `evidence-report.test.ts`. Generated reports are intentionally ignored under `bench/results/fold-boundary-model/`.

Two conventions in `evidence-report.test.ts` are load-bearing and documented in place, so they are not re-litigated: the `R1a`–`R1f` assertions are golden-value pins on the numbers the report *publishes* (the universally-quantified `P`-series does not constrain them), and `sourceTokens` is a scanner rather than a regex because the model files discuss property IDs in prose and the scraper has to tell a declaration from a mention.