### PR TITLE
fix(maintenance): bound Cloudflare Free scheduled tail discovery

### DIFF
--- a/.changeset/bounded-scheduled-fold-tail-probe.md
+++ b/.changeset/bounded-scheduled-fold-tail-probe.md
@@ -1,0 +1,68 @@
+---
+"@gusto/baerly-storage": minor
+---
+
+Bound Cloudflare Free scheduled maintenance tail discovery.
+
+`CLOUDFLARE_FREE_TIER` now bounds both scheduled tail probes. Alternate
+direct `compact()` and `runGc()` calls (for example, compact on even-minute
+ticks and GC on odd-minute ticks); `runScheduledMaintenance()` always runs
+both phases and is not safe under Cloudflare Free's 50-operation limit in one
+invocation. That was true before this release too — the previous guidance,
+which said one call with this profile fits the budget, was wrong.
+
+`CLOUDFLARE_FREE_TIER.compact.minEntriesToCompact` drops from 50 to 20, so
+Free-tier scheduled compaction now folds as soon as one pass's worth of log
+entries is available. A threshold above the 25-slot probe budget is not
+reachable in a single pass, so the old 50 would have made bounded passes
+checkpoint repeatedly before folding anything.
+
+Compaction walks at most 25 stale-tail log slots per pass. A pass that cannot
+yet prove the fold threshold durably advances `tail_hint` and returns
+`skippedReason: "probe-budget-checkpointed"`; later scheduled passes resume
+from that checkpoint. Bounded GC likewise checkpoints tail progress before
+deferring only orphan-content discovery. Malformed occupied probe slots retain
+safe occupancy progress but make content classification incomplete.
+
+Deferring passes report why, via the `contentDeferredReason` field and
+`db.gc.content_deferred_total` metric added alongside this release. Two of the
+reasons are budget-driven and self-clear; the others are degraded and do not.
+The new `isDegradedContentDeferral` predicate is what tells them apart — it is
+the only place that classification lives, so it stays correct as reasons are
+added. A cron handler sees no metrics outside an HTTP scope, so read the field:
+
+```ts
+import { isDegradedContentDeferral, runGc } from "@gusto/baerly-storage/maintenance";
+
+const gc = await runGc({ storage, currentJsonKey }, CLOUDFLARE_FREE_TIER.gc);
+if (isDegradedContentDeferral(gc.contentDeferredReason)) {
+  console.error("orphan-content GC is degraded:", gc.contentDeferredReason);
+}
+```
+
+A GC pass that loses its admission-checkpoint CAS now reports the deferral too,
+rather than returning a result indistinguishable from an idle no-op, and counts
+the loss as `db.gc.cas_lost_total`.
+
+The exact Free-tier per-phase maxima are now pinned: compaction 49 operations,
+admitted content-marking GC 46, and content-deferred GC 49 — so every
+alternating single-collection phase remains within the 50-operation invocation
+limit.
+
+If you exhaustively switch on `CompactResult.skippedReason`, handle the new
+case:
+
+```ts
+// before
+switch (result.skippedReason) {
+  // existing cases only
+}
+
+// after
+switch (result.skippedReason) {
+  case "probe-budget-checkpointed":
+    // No snapshot was published; allow the next scheduled tick to resume.
+    break;
+  // existing cases
+}
+```

--- a/bundle-sizes.json
+++ b/bundle-sizes.json
@@ -16,9 +16,9 @@
   "entries": {
     "index.js": {
       "tier": "shipped",
-      "raw": 257489,
-      "gz": 81197,
-      "minGz": 21716,
+      "raw": 259243,
+      "gz": 81760,
+      "minGz": 21748,
       "note": "kernel barrel; every consumer pays. Must not pull the observability subgraph — see the dedicated test."
     },
     "client.js": {
@@ -37,9 +37,9 @@
     },
     "cloudflare.js": {
       "tier": "shipped",
-      "raw": 446398,
-      "gz": 135138,
-      "minGz": 45504,
+      "raw": 448152,
+      "gz": 135686,
+      "minGz": 45545,
       "note": "Worker isolate cold start. Aggregator: closure includes the index.js and http.js subgraphs, so growth that slips past those entries still surfaces here."
     },
     "s3.js": {
@@ -58,9 +58,9 @@
     },
     "http.js": {
       "tier": "shipped",
-      "raw": 385954,
-      "gz": 115756,
-      "minGz": 38209,
+      "raw": 387708,
+      "gz": 116319,
+      "minGz": 38246,
       "note": "server-side. Also inside the cloudflare.js closure, so growth here shows up on that entry too."
     },
     "auth.js": {
@@ -72,9 +72,9 @@
     },
     "maintenance.js": {
       "tier": "shipped",
-      "raw": 148349,
-      "gz": 45871,
-      "minGz": 12822,
+      "raw": 150103,
+      "gz": 46421,
+      "minGz": 12848,
       "note": "operator-side; reached from the cloudflare.js closure."
     },
     "observability.js": {
@@ -102,12 +102,12 @@
     },
     "node.js": {
       "tier": "tooling",
-      "raw": 611224,
+      "raw": 612978,
       "note": "server-only aggregator. Raw-only dep-creep tripwire; live-external-import creep is caught separately by the bare-specifier allowlist test."
     },
     "dev-vite.js": {
       "tier": "tooling",
-      "raw": 620137,
+      "raw": 621891,
       "note": "dev-only aggregator. Raw-only dep-creep tripwire; see node.js."
     }
   }

--- a/bundle-sizes.json
+++ b/bundle-sizes.json
@@ -16,8 +16,8 @@
   "entries": {
     "index.js": {
       "tier": "shipped",
-      "raw": 259243,
-      "gz": 81760,
+      "raw": 259578,
+      "gz": 81858,
       "minGz": 21748,
       "note": "kernel barrel; every consumer pays. Must not pull the observability subgraph — see the dedicated test."
     },
@@ -37,9 +37,9 @@
     },
     "cloudflare.js": {
       "tier": "shipped",
-      "raw": 448152,
-      "gz": 135686,
-      "minGz": 45545,
+      "raw": 448487,
+      "gz": 135804,
+      "minGz": 45543,
       "note": "Worker isolate cold start. Aggregator: closure includes the index.js and http.js subgraphs, so growth that slips past those entries still surfaces here."
     },
     "s3.js": {
@@ -58,9 +58,9 @@
     },
     "http.js": {
       "tier": "shipped",
-      "raw": 387708,
-      "gz": 116319,
-      "minGz": 38246,
+      "raw": 388043,
+      "gz": 116436,
+      "minGz": 38244,
       "note": "server-side. Also inside the cloudflare.js closure, so growth here shows up on that entry too."
     },
     "auth.js": {
@@ -72,9 +72,9 @@
     },
     "maintenance.js": {
       "tier": "shipped",
-      "raw": 150103,
-      "gz": 46421,
-      "minGz": 12848,
+      "raw": 150438,
+      "gz": 46533,
+      "minGz": 12849,
       "note": "operator-side; reached from the cloudflare.js closure."
     },
     "observability.js": {
@@ -102,12 +102,12 @@
     },
     "node.js": {
       "tier": "tooling",
-      "raw": 612978,
+      "raw": 613313,
       "note": "server-only aggregator. Raw-only dep-creep tripwire; live-external-import creep is caught separately by the bare-specifier allowlist test."
     },
     "dev-vite.js": {
       "tier": "tooling",
-      "raw": 621891,
+      "raw": 622226,
       "note": "dev-only aggregator. Raw-only dep-creep tripwire; see node.js."
     }
   }

--- a/bundle-sizes.json
+++ b/bundle-sizes.json
@@ -16,9 +16,9 @@
   "entries": {
     "index.js": {
       "tier": "shipped",
-      "raw": 252694,
-      "gz": 79822,
-      "minGz": 21208,
+      "raw": 257489,
+      "gz": 81197,
+      "minGz": 21716,
       "note": "kernel barrel; every consumer pays. Must not pull the observability subgraph — see the dedicated test."
     },
     "client.js": {
@@ -37,9 +37,9 @@
     },
     "cloudflare.js": {
       "tier": "shipped",
-      "raw": 441603,
-      "gz": 133782,
-      "minGz": 44986,
+      "raw": 446398,
+      "gz": 135138,
+      "minGz": 45504,
       "note": "Worker isolate cold start. Aggregator: closure includes the index.js and http.js subgraphs, so growth that slips past those entries still surfaces here."
     },
     "s3.js": {
@@ -58,9 +58,9 @@
     },
     "http.js": {
       "tier": "shipped",
-      "raw": 381159,
-      "gz": 114358,
-      "minGz": 37731,
+      "raw": 385954,
+      "gz": 115756,
+      "minGz": 38209,
       "note": "server-side. Also inside the cloudflare.js closure, so growth here shows up on that entry too."
     },
     "auth.js": {
@@ -72,9 +72,9 @@
     },
     "maintenance.js": {
       "tier": "shipped",
-      "raw": 143495,
-      "gz": 44487,
-      "minGz": 12324,
+      "raw": 148349,
+      "gz": 45871,
+      "minGz": 12822,
       "note": "operator-side; reached from the cloudflare.js closure."
     },
     "observability.js": {
@@ -102,12 +102,12 @@
     },
     "node.js": {
       "tier": "tooling",
-      "raw": 606429,
+      "raw": 611224,
       "note": "server-only aggregator. Raw-only dep-creep tripwire; live-external-import creep is caught separately by the bare-specifier allowlist test."
     },
     "dev-vite.js": {
       "tier": "tooling",
-      "raw": 615342,
+      "raw": 620137,
       "note": "dev-only aggregator. Raw-only dep-creep tripwire; see node.js."
     }
   }

--- a/bundle-sizes.json
+++ b/bundle-sizes.json
@@ -16,9 +16,9 @@
   "entries": {
     "index.js": {
       "tier": "shipped",
-      "raw": 248865,
-      "gz": 78689,
-      "minGz": 20855,
+      "raw": 252694,
+      "gz": 79822,
+      "minGz": 21208,
       "note": "kernel barrel; every consumer pays. Must not pull the observability subgraph — see the dedicated test."
     },
     "client.js": {
@@ -37,9 +37,9 @@
     },
     "cloudflare.js": {
       "tier": "shipped",
-      "raw": 437774,
-      "gz": 132674,
-      "minGz": 44638,
+      "raw": 441603,
+      "gz": 133782,
+      "minGz": 44986,
       "note": "Worker isolate cold start. Aggregator: closure includes the index.js and http.js subgraphs, so growth that slips past those entries still surfaces here."
     },
     "s3.js": {
@@ -58,9 +58,9 @@
     },
     "http.js": {
       "tier": "shipped",
-      "raw": 377330,
-      "gz": 113265,
-      "minGz": 37380,
+      "raw": 381159,
+      "gz": 114358,
+      "minGz": 37731,
       "note": "server-side. Also inside the cloudflare.js closure, so growth here shows up on that entry too."
     },
     "auth.js": {
@@ -72,9 +72,9 @@
     },
     "maintenance.js": {
       "tier": "shipped",
-      "raw": 139666,
-      "gz": 43391,
-      "minGz": 12024,
+      "raw": 143495,
+      "gz": 44487,
+      "minGz": 12324,
       "note": "operator-side; reached from the cloudflare.js closure."
     },
     "observability.js": {
@@ -102,12 +102,12 @@
     },
     "node.js": {
       "tier": "tooling",
-      "raw": 602600,
+      "raw": 606429,
       "note": "server-only aggregator. Raw-only dep-creep tripwire; live-external-import creep is caught separately by the bare-specifier allowlist test."
     },
     "dev-vite.js": {
       "tier": "tooling",
-      "raw": 611513,
+      "raw": 615342,
       "note": "dev-only aggregator. Raw-only dep-creep tripwire; see node.js."
     }
   }

--- a/docs/contributing/conventions/observability.md
+++ b/docs/contributing/conventions/observability.md
@@ -165,14 +165,23 @@ The load-bearing kernel metrics today (canonical list in
 - `db.gc.swept_total` — GC counter, labelled by reason.
 - `db.gc.content_deferred_total` — GC counter, labelled by the
   `ContentDeferralReason` for a pass that skipped orphan-content
-  discovery. Emitted only on a deferred pass. The label names the
-  unreadable artifact, not the fault class, so a single occurrence can
-  be a transient storage error that clears on the next pass; a
-  SUSTAINED non-zero rate is the alertable signal, and means
-  orphan-content GC is parked for as long as the fault persists. Cron
-  callers see no metrics outside an HTTP scope —
-  `RunGcResult.contentDeferredReason` carries the same value for them
-  to log.
+  discovery. Emitted only on a deferred pass. Budget reasons are
+  expected under `CLOUDFLARE_FREE_TIER` and self-clear; degraded ones
+  do not, and park orphan-content GC for as long as the fault
+  persists. A degraded reason names the unreadable artifact, not the
+  fault class, so a single occurrence can be a transient storage error
+  that clears on the next pass — a SUSTAINED non-zero rate is the
+  alertable signal. `isDegradedContentDeferral` is the authority on
+  which reason is which — branch on it in code rather than on a
+  literal list, and read the union's members off it when writing a
+  label-matching alert rule, because a reason added later will be
+  classified there and nowhere else. Cron callers see no metrics
+  outside an HTTP scope — `RunGcResult.contentDeferredReason` carries
+  the same value for them to pass to that predicate.
+- `db.gc.cas_lost_total` — GC counter for a lost admission-checkpoint
+  CAS on `current.json` (per-collection label). The GC-side sibling of
+  the compactor's `db.compaction.cas_lost_total`; sustained non-zero on
+  either is write contention above the envelope.
 - `db.orphan.candidate_count` — GC gauge (`gc/pending.json` depth).
 - `db.storage.<op>.calls_total` / `db.storage.<op>.errors_total` /
   `db.storage.<op>.duration_ms` — storage decorator counters +

--- a/docs/spec/sync-protocol.md
+++ b/docs/spec/sync-protocol.md
@@ -3,7 +3,7 @@ title: Sync protocol
 audience: spec
 doc_type: current-contract
 summary: Atomic document writes over object storage via single-write commit — the numbered log append is the commit (one linearizable If-None-Match create); current.json is compactor-owned compaction state with a non-authoritative tail_hint; readers discover the tail by forward-probe.
-last-reviewed: 2026-06-28
+last-reviewed: 2026-08-03
 tags: [protocol, sync, current-json, causal-consistency]
 related:
   [
@@ -363,9 +363,12 @@ snapshot:
    `log_seq_start` advances to the folded end, and
    `snapshot_bytes` / `snapshot_rows` / `mean_entry_bytes` are updated.
    The compactor also advances `tail_hint` (monotone max). Compaction
-   folds are the primary durable advancer of the hint, and write-tick
-   maintenance may also rate-limit-refresh it when fold/GC work is
-   disabled or deferred. Ordinary writer commits never touch
+   folds are the primary durable advancer of the hint. Explicitly bounded
+   scheduled compaction can instead durably checkpoint an incomplete probe's
+   certified lower bound in `tail_hint` without publishing a snapshot; a
+   later pass resumes from that checkpoint. Write-tick maintenance may also
+   rate-limit-refresh the hint when fold/GC work is disabled or deferred.
+   Ordinary writer commits never touch
    `current.json` on the commit path. The fold CAS is therefore the
    only steady-state writer of the snapshot pointer, `log_seq_start`,
    and snapshot counters, which strengthens compaction-state atomicity.
@@ -399,14 +402,31 @@ commit (a winning `log/<seq>` create), the writer may dispatch
   raised via `BAERLY_MAINTENANCE_MAX_FOLD_BYTES`, whereas `E`
   (`MAINTENANCE_MAX_FOLD_ROWS`) is a hardcoded constant with no env
   override.
-- GC marks and sweeps bounded batches from `gc/pending.json`.
+- GC marks and sweeps bounded batches from `gc/pending.json`. A bounded
+  pass may checkpoint an inexact tail lower bound, or an exact tail that is
+  unaffordable for complete live-content classification, before deferring
+  orphan-content discovery. A malformed occupied slot also advances the safe
+  occupancy proof but makes the live-content set incomplete. An incomplete or
+  deferred live-content set disables both orphan-content marking and pending
+  orphan-content sweeping; the stored content cursor is preserved. With a
+  complete set, pending content candidates whose parsed hash is live are
+  resolved from the ledger without DELETE or sweep accounting.
+- Before any due snapshot candidate can be swept, GC re-reads `current.json`
+  and resolves every candidate named by the fresh `current.snapshot` pointer.
+  Stale-log classification continues to use the initial monotone
+  `log_seq_start`; a stale read can delay collection but cannot make a live log
+  stale.
+- Cloudflare Free schedules one collection and one phase per invocation,
+  alternating direct bounded `compact()` and `runGc()` calls. Fan-out must be
+  sharded or driven by a persisted collection cursor; the combined
+  `runScheduledMaintenance()` helper is for Cloudflare Paid or Node budgets.
 - Cloudflare can defer the tick past the response with
   `ctx.waitUntil`; Node runs inline unless the host wraps it
   differently.
 
 There is no daemon, lease service, scheduler, or background thread.
-`runScheduledMaintenance` is an exported convenience for teams that
-want an explicit maintenance window; it is not required for
+`runScheduledMaintenance` is an exported convenience for Cloudflare Paid or
+Node teams that want an explicit maintenance window; it is not required for
 correctness.
 
 The doctrine and trade-offs live in
@@ -449,13 +469,15 @@ These are the load-bearing rules.
 6. **`current.json` is compaction state; the commit path does not write
    it.** The compactor's fold CAS is the only steady-state writer of
    the snapshot pointer, `log_seq_start`, and snapshot counters.
-   `tail_hint` is a non-authoritative monotone lower bound, durably
-   advanced by compaction folds and by the write-tick runner's tail
-   refresh when fold/GC work defers or is disabled. Ordinary writer
-   commits never refresh it inline. Other non-commit-path writers are
-   explicit: the one-time `createCurrentJson` bootstrap, operator/import
-   paths such as `admin restore`, and the best-effort `last_warned_seq`
-   graduation stamp.
+   `tail_hint` is a non-authoritative monotone lower bound, durably advanced
+   by compaction folds, explicitly bounded scheduled-compaction probe
+   checkpoints, bounded-GC tail checkpoints, and by the write-tick runner's
+   tail refresh when fold/GC work defers or is disabled. Those durable
+   checkpoint writers use monotone CAS updates and never move `tail_hint`
+   past the true first missing log slot. Ordinary writer commits never refresh
+   it inline. Other non-commit-path writers are explicit: the one-time
+   `createCurrentJson` bootstrap, operator/import paths such as `admin
+   restore`, and the best-effort `last_warned_seq` graduation stamp.
 7. **An abandoned write cannot falsely unindex a committed doc.** New
    index keys are emitted _before_ the commit and stale keys deleted
    _after_, so a committed value is never de-indexed by a write that did

--- a/examples/minimal-cloudflare/AGENTS.md
+++ b/examples/minimal-cloudflare/AGENTS.md
@@ -533,8 +533,23 @@ not auto-compact and pays a small, bounded replay — fine at small scale, a sig
 graduate once a collection is large. See docs/about/graduation.md for the per-tier
 envelope and the `BAERLY_MAINTENANCE_*` operator env vars (you almost never need them).
 
-Operator opt-in: call runScheduledMaintenance from @gusto/baerly-storage/maintenance on
-your own schedule. Not required for steady-state operation.
+Operator opt-in is not required for steady-state operation. On Cloudflare Free, run
+exactly one collection and one phase per invocation, alternating the direct primitives:
+
+```ts
+import { CLOUDFLARE_FREE_TIER, compact, runGc } from "@gusto/baerly-storage/maintenance";
+
+const args = { storage, currentJsonKey };
+if (Math.floor(controller.scheduledTime / 60_000) % 2 === 0) {
+  await compact(args, CLOUDFLARE_FREE_TIER.compact);
+} else {
+  await runGc(args, CLOUDFLARE_FREE_TIER.gc);
+}
+```
+
+Do not loop tenants or collections in one Free invocation; shard the schedule or persist
+a collection cursor across invocations. Reserve `runScheduledMaintenance()` (both
+phases) for Cloudflare Paid or Node, within that host's invocation budget.
 
 <!-- pattern-d:end -->
 

--- a/examples/minimal-node/AGENTS.md
+++ b/examples/minimal-node/AGENTS.md
@@ -439,8 +439,23 @@ not auto-compact and pays a small, bounded replay — fine at small scale, a sig
 graduate once a collection is large. See docs/about/graduation.md for the per-tier
 envelope and the `BAERLY_MAINTENANCE_*` operator env vars (you almost never need them).
 
-Operator opt-in: call runScheduledMaintenance from @gusto/baerly-storage/maintenance on
-your own schedule. Not required for steady-state operation.
+Operator opt-in is not required for steady-state operation. On Cloudflare Free, run
+exactly one collection and one phase per invocation, alternating the direct primitives:
+
+```ts
+import { CLOUDFLARE_FREE_TIER, compact, runGc } from "@gusto/baerly-storage/maintenance";
+
+const args = { storage, currentJsonKey };
+if (Math.floor(controller.scheduledTime / 60_000) % 2 === 0) {
+  await compact(args, CLOUDFLARE_FREE_TIER.compact);
+} else {
+  await runGc(args, CLOUDFLARE_FREE_TIER.gc);
+}
+```
+
+Do not loop tenants or collections in one Free invocation; shard the schedule or persist
+a collection cursor across invocations. Reserve `runScheduledMaintenance()` (both
+phases) for Cloudflare Paid or Node, within that host's invocation budget.
 
 <!-- pattern-d:end -->
 

--- a/examples/react-cloudflare/AGENTS.md
+++ b/examples/react-cloudflare/AGENTS.md
@@ -538,8 +538,23 @@ not auto-compact and pays a small, bounded replay — fine at small scale, a sig
 graduate once a collection is large. See docs/about/graduation.md for the per-tier
 envelope and the `BAERLY_MAINTENANCE_*` operator env vars (you almost never need them).
 
-Operator opt-in: call runScheduledMaintenance from @gusto/baerly-storage/maintenance on
-your own schedule. Not required for steady-state operation.
+Operator opt-in is not required for steady-state operation. On Cloudflare Free, run
+exactly one collection and one phase per invocation, alternating the direct primitives:
+
+```ts
+import { CLOUDFLARE_FREE_TIER, compact, runGc } from "@gusto/baerly-storage/maintenance";
+
+const args = { storage, currentJsonKey };
+if (Math.floor(controller.scheduledTime / 60_000) % 2 === 0) {
+  await compact(args, CLOUDFLARE_FREE_TIER.compact);
+} else {
+  await runGc(args, CLOUDFLARE_FREE_TIER.gc);
+}
+```
+
+Do not loop tenants or collections in one Free invocation; shard the schedule or persist
+a collection cursor across invocations. Reserve `runScheduledMaintenance()` (both
+phases) for Cloudflare Paid or Node, within that host's invocation budget.
 <!-- pattern-d:end -->
 
 ## When to graduate

--- a/examples/react-node/AGENTS.md
+++ b/examples/react-node/AGENTS.md
@@ -482,8 +482,23 @@ not auto-compact and pays a small, bounded replay — fine at small scale, a sig
 graduate once a collection is large. See docs/about/graduation.md for the per-tier
 envelope and the `BAERLY_MAINTENANCE_*` operator env vars (you almost never need them).
 
-Operator opt-in: call runScheduledMaintenance from @gusto/baerly-storage/maintenance on
-your own schedule. Not required for steady-state operation.
+Operator opt-in is not required for steady-state operation. On Cloudflare Free, run
+exactly one collection and one phase per invocation, alternating the direct primitives:
+
+```ts
+import { CLOUDFLARE_FREE_TIER, compact, runGc } from "@gusto/baerly-storage/maintenance";
+
+const args = { storage, currentJsonKey };
+if (Math.floor(controller.scheduledTime / 60_000) % 2 === 0) {
+  await compact(args, CLOUDFLARE_FREE_TIER.compact);
+} else {
+  await runGc(args, CLOUDFLARE_FREE_TIER.gc);
+}
+```
+
+Do not loop tenants or collections in one Free invocation; shard the schedule or persist
+a collection cursor across invocations. Reserve `runScheduledMaintenance()` (both
+phases) for Cloudflare Paid or Node, within that host's invocation budget.
 <!-- pattern-d:end -->
 
 ## When to graduate

--- a/packages/adapter-cloudflare/src/worker.ts
+++ b/packages/adapter-cloudflare/src/worker.ts
@@ -188,9 +188,12 @@ export const cfMaintenanceDispatch = (
  * Cron Trigger handler. Called once per tick when the user has
  * declared `triggers.crons` in `wrangler.jsonc` AND passed this
  * option. The body owns its own subrequest budget — wrap any
- * outlasting work in `ctx.waitUntil(...)`. Multi-tenant deployments
- * typically iterate a list of `current.json` keys and call
- * {@link runScheduledMaintenance} per tenant.
+ * outlasting work in `ctx.waitUntil(...)`. On Cloudflare Free, one
+ * invocation must process only one `current.json` key and one direct
+ * `compact()` or `runGc()` phase; alternate phases and shard cron
+ * triggers or persist a collection cursor instead of looping tenants /
+ * collections. Cloudflare Paid may use {@link runScheduledMaintenance}
+ * within its larger invocation budget.
  */
 export type WorkerScheduledHandler = (
   event: ScheduledController,
@@ -563,12 +566,16 @@ export function baerlyWorker<E extends BaerlyEnv = BaerlyEnv>(
     async scheduled(event, env, ctx): Promise<void> {
       const { options } = await ensureResolved(env);
       if (options.scheduled !== undefined) {
-        // To honour BAERLY_MAINTENANCE_PROFILE on the cron path, call
-        // `runScheduledMaintenance(args, CLOUDFLARE_PAID_TIER)` when the
-        // profile is "cf-paid", or `CLOUDFLARE_FREE_TIER` (the default) —
-        // both imported from `@gusto/baerly-storage/maintenance`. Use
-        // `resolveCfMaintenanceProfile((k) => env[k])` (exported from this
-        // module) to read the env var inside your WorkerScheduledHandler.
+        // To honour BAERLY_MAINTENANCE_PROFILE on the cron path, reserve
+        // `runScheduledMaintenance(args, CLOUDFLARE_PAID_TIER)` for
+        // "cf-paid". On the Free default, alternate direct
+        // `compact(args, CLOUDFLARE_FREE_TIER.compact)` and
+        // `runGc(args, CLOUDFLARE_FREE_TIER.gc)` calls, with exactly one
+        // collection/phase per invocation; shard or persist a collection
+        // cursor instead of looping. Import those entry points from
+        // `@gusto/baerly-storage/maintenance`, and use
+        // `resolveCfMaintenanceProfile((k) => env[k])` here to select the
+        // paid recipe when configured.
         await options.scheduled(event, env, ctx);
       }
     },

--- a/packages/protocol/src/constants.ts
+++ b/packages/protocol/src/constants.ts
@@ -420,6 +420,19 @@ export const WRITE_TICK_GC_MAX_SWEEPS: number = 10;
 export const WRITE_TICK_FOLD_ENTRIES_PER_PASS: number = 20;
 
 /**
+ * Cloudflare Free scheduled-compactor tail-discovery budget (`P`). A
+ * prior-snapshot fold pass costs 1 GET current + P GETs tail probe +
+ * 1 GET prior snapshot + N GETs log + 1 PUT snapshot + 1 PUT current
+ * = 4 + N + P storage operations. With P=25 and the Free profile's
+ * N=20 slice, the worst pass is 49 operations, leaving one operation
+ * below the 50-subrequest invocation cap.
+ *
+ * @see packages/server/src/maintenance.ts
+ * @see packages/server/src/maintenance-budget.test.ts
+ */
+export const CF_FREE_COMPACT_TAIL_PROBE_GETS: number = 25;
+
+/**
  * compact()'s minEntriesToCompact, set EXPLICITLY by the runner so it agrees with Gate 1
  * rather than inheriting compact()'s silent default 100 (which would contradict the 64 KB
  * first-fold story — round-4 Tier-3). Adapter-overridable; CF-free value.

--- a/packages/protocol/src/metrics.ts
+++ b/packages/protocol/src/metrics.ts
@@ -26,9 +26,12 @@
  *   - `db.gc.swept_total` — counter (labelled by reason)
  *   - `db.gc.content_deferred_total` — counter (labelled by reason; emitted
  *     only when a pass skipped orphan-content discovery, so any sustained
- *     non-zero rate on a `snapshot-unreadable` / `live-log-unreadable`
- *     reason is alertable — a single occurrence may be transient, a
- *     repeating one does not self-clear)
+ *     non-zero rate on a DEGRADED reason is alertable — a single
+ *     occurrence may be transient, a repeating one does not self-clear.
+ *     `isDegradedContentDeferral` in `@baerly/server` owns which reasons
+ *     those are; do not re-enumerate them)
+ *   - `db.gc.cas_lost_total` — counter (GC lost its admission-checkpoint CAS
+ *     on `current.json`; the GC-side sibling of `db.compaction.cas_lost_total`)
  *
  * Names follow `db.<subsystem>.<metric>`, dot-separated, all-lowercase
  * snake_case segments. Labels are flat

--- a/packages/server/src/compactor.test.ts
+++ b/packages/server/src/compactor.test.ts
@@ -13,7 +13,9 @@ import {
   createCurrentJson,
   MemoryStorage,
   BaerlyError,
+  encodeJsonBytes,
   LOG_KEY_PREFIX,
+  LOG_FORWARD_PROBE_CAP,
   readCurrentJson,
   type Storage,
   type StoragePutOptions,
@@ -164,6 +166,11 @@ describe("compact", () => {
     ["maxEntriesPerRun", "fractional", { maxEntriesPerRun: 1.5 }, "non-negative"],
     ["knownTail", "NaN", { knownTail: Number.NaN }, "non-negative"],
     ["knownTail", "negative", { knownTail: -1 }, "non-negative"],
+    ["maxTailProbeGets", "zero", { maxTailProbeGets: 0 }, "positive"],
+    ["maxTailProbeGets", "negative", { maxTailProbeGets: -1 }, "positive"],
+    ["maxTailProbeGets", "NaN", { maxTailProbeGets: Number.NaN }, "positive"],
+    ["maxTailProbeGets", "Infinity", { maxTailProbeGets: Number.POSITIVE_INFINITY }, "positive"],
+    ["maxTailProbeGets", "fractional", { maxTailProbeGets: 1.5 }, "positive"],
   ])("rejects %s = %s at the seam", (option, _shape, overrides, integerContract) => {
     test("fails closed before invoking storage", async () => {
       const s = new MemoryStorage();
@@ -788,6 +795,145 @@ describe("compact", () => {
     expect(recording.logReadSeqs).toEqual([7, 0, 1, 2, 3, 4, 5, 6]);
     const after = await readCurrentJson(inner, KEY);
     expect(after).toEqual(before);
+  });
+
+  test("checkpoints an incomplete bounded tail probe without writing a snapshot", async () => {
+    const s = new MemoryStorage();
+    const collectionPrefix = KEY.slice(0, KEY.lastIndexOf("/"));
+    await bootstrap(s, KEY);
+    await seedLogEntries(s, collectionPrefix, 0, 100);
+
+    const res = await compact({ storage: s, currentJsonKey: KEY }, {
+      minEntriesToCompact: 50,
+      maxEntriesPerRun: 20,
+      maxTailProbeGets: 25,
+    } as InternalCompactOptions);
+
+    expect(res).toMatchObject({ written: false, skippedReason: "probe-budget-checkpointed" });
+    expect((await readCurrentJson(s, KEY))!.json).toMatchObject({
+      log_seq_start: 0,
+      tail_hint: 25,
+      snapshot: null,
+    });
+  });
+
+  test("the default tail probe rejects a full protocol-cap run without publishing", async () => {
+    // Replacing `probeTailFrom` with the chunk probe on the default path
+    // would accept its `at-least` result and fold a non-exact tail. The
+    // default safety contract must instead surface the runaway as Internal.
+    const inner = new MemoryStorage();
+    const collectionPrefix = KEY.slice(0, KEY.lastIndexOf("/"));
+    await bootstrap(inner, KEY);
+    const entry = encodeJsonBytes({
+      seq: 0,
+      op: "I",
+      collection: COLL,
+      doc_id: "d0",
+      after: { _id: "d0" },
+    });
+    let logGets = 0;
+    const putKeys: string[] = [];
+    const alwaysOccupied: Storage = {
+      async get(key, opts) {
+        if (key.startsWith(`${collectionPrefix}/${LOG_KEY_PREFIX}/`)) {
+          logGets++;
+          return { body: entry, etag: "always-occupied" };
+        }
+        return inner.get(key, opts);
+      },
+      async put(key, body, opts) {
+        putKeys.push(key);
+        return inner.put(key, body, opts);
+      },
+      delete: (key, opts) => inner.delete(key, opts),
+      list: (prefix, opts) => inner.list(prefix, opts),
+    };
+
+    await expect(
+      compact({ storage: alwaysOccupied, currentJsonKey: KEY }, { minEntriesToCompact: 1 }),
+    ).rejects.toMatchObject({ code: "Internal" });
+
+    expect(logGets).toBe(LOG_FORWARD_PROBE_CAP);
+    expect(putKeys).toEqual([]);
+  });
+
+  test("folds a certified probe lower bound without emitting an exact lag gauge", async () => {
+    const s = new MemoryStorage();
+    const collectionPrefix = KEY.slice(0, KEY.lastIndexOf("/"));
+    await bootstrap(s, KEY);
+    await seedLogEntries(s, collectionPrefix, 0, 100);
+    const ctx = createObservabilityContext();
+    let res!: Awaited<ReturnType<typeof compact>>;
+
+    await runWithContext(ctx, async () => {
+      res = await compact({ storage: s, currentJsonKey: KEY }, {
+        minEntriesToCompact: 20,
+        maxEntriesPerRun: 20,
+        maxTailProbeGets: 25,
+      } as InternalCompactOptions);
+    });
+
+    expect(res.entriesFolded).toBe(20);
+    expect((await readCurrentJson(s, KEY))!.json).toMatchObject({
+      log_seq_start: 20,
+      tail_hint: 25,
+    });
+    const metrics = ctx.recorder.snapshot();
+    expect(metrics.histograms).toContainEqual({
+      name: "db.compact.entries_folded",
+      value: 20,
+      labels: { collection: COLL },
+    });
+    expect(
+      metrics.gauges.find((gauge) => gauge.name === "db.manifest.lag_window_depth"),
+    ).toBeUndefined();
+  });
+
+  test("returns cas-lost when an incomplete-probe checkpoint loses its ETag", async () => {
+    const inner = new MemoryStorage();
+    const collectionPrefix = KEY.slice(0, KEY.lastIndexOf("/"));
+    await bootstrap(inner, KEY);
+    await seedLogEntries(inner, collectionPrefix, 0, 100);
+    let failedOnce = false;
+    const failingPut: Storage = {
+      get: inner.get.bind(inner),
+      delete: inner.delete.bind(inner),
+      list: inner.list.bind(inner),
+      async put(
+        key: string,
+        body: Uint8Array,
+        opts?: StoragePutOptions,
+      ): Promise<StoragePutResult> {
+        if (!failedOnce && key === KEY && opts?.ifMatch !== undefined) {
+          failedOnce = true;
+          throw new BaerlyError("Conflict", "simulated checkpoint CAS loss");
+        }
+        return inner.put(key, body, opts);
+      },
+    };
+    const ctx = createObservabilityContext();
+    let res!: Awaited<ReturnType<typeof compact>>;
+
+    await runWithContext(ctx, async () => {
+      res = await compact({ storage: failingPut, currentJsonKey: KEY }, {
+        minEntriesToCompact: 50,
+        maxEntriesPerRun: 20,
+        maxTailProbeGets: 25,
+      } as InternalCompactOptions);
+    });
+
+    expect(res.skippedReason).toBe("cas-lost");
+    expect((await readCurrentJson(inner, KEY))!.json.tail_hint).toBe(0);
+    const snapshots: string[] = [];
+    for await (const entry of inner.list(`${collectionPrefix}/snapshot/`)) {
+      snapshots.push(entry.key);
+    }
+    expect(snapshots).toEqual([]);
+    expect(
+      ctx.recorder
+        .snapshot()
+        .counters.filter((counter) => counter.name === "db.compaction.cas_lost_total"),
+    ).toEqual([{ name: "db.compaction.cas_lost_total", value: 1, labels: { collection: COLL } }]);
   });
 
   test("cas-lost: snapshot orphan stays pending until a later fold advances beyond it", async () => {

--- a/packages/server/src/compactor.test.ts
+++ b/packages/server/src/compactor.test.ts
@@ -153,14 +153,19 @@ describe("compact", () => {
   // the collection against every read path, `restore --force` included.
   // A negative value is the benign case (it would merely lower the floor).
   describe.each([
-    ["maxEntriesPerRun", "negative", { maxEntriesPerRun: -1 }],
-    ["maxEntriesPerRun", "NaN", { maxEntriesPerRun: Number.NaN }],
-    ["maxEntriesPerRun", "Infinity", { maxEntriesPerRun: Number.POSITIVE_INFINITY }],
-    ["maxEntriesPerRun", "fractional", { maxEntriesPerRun: 1.5 }],
-    ["knownTail", "NaN", { knownTail: Number.NaN }],
-    ["knownTail", "negative", { knownTail: -1 }],
-  ])("rejects %s = %s at the seam", (_option, _shape, overrides) => {
-    test("fails closed before touching storage", async () => {
+    ["maxEntriesPerRun", "negative", { maxEntriesPerRun: -1 }, "non-negative"],
+    ["maxEntriesPerRun", "NaN", { maxEntriesPerRun: Number.NaN }, "non-negative"],
+    [
+      "maxEntriesPerRun",
+      "Infinity",
+      { maxEntriesPerRun: Number.POSITIVE_INFINITY },
+      "non-negative",
+    ],
+    ["maxEntriesPerRun", "fractional", { maxEntriesPerRun: 1.5 }, "non-negative"],
+    ["knownTail", "NaN", { knownTail: Number.NaN }, "non-negative"],
+    ["knownTail", "negative", { knownTail: -1 }, "non-negative"],
+  ])("rejects %s = %s at the seam", (option, _shape, overrides, integerContract) => {
+    test("fails closed before invoking storage", async () => {
       const s = new MemoryStorage();
       await bootstrap(s, KEY);
       const writer = new Writer({ storage: s, currentJsonKey: KEY });
@@ -173,13 +178,25 @@ describe("compact", () => {
         });
       }
       const before = await readCurrentJson(s, KEY);
+      const failStorageOperation = (operation: keyof Storage): never => {
+        throw new Error(`compact must validate before storage.${operation}()`);
+      };
+      const storageThatFailsAllOperations: Storage = {
+        get: () => failStorageOperation("get"),
+        put: () => failStorageOperation("put"),
+        delete: () => failStorageOperation("delete"),
+        list: () => failStorageOperation("list"),
+      };
 
       await expect(
-        compact({ storage: s, currentJsonKey: KEY }, {
+        compact({ storage: storageThatFailsAllOperations, currentJsonKey: KEY }, {
           minEntriesToCompact: 1,
           ...overrides,
         } as InternalCompactOptions),
-      ).rejects.toMatchObject({ code: "InvalidConfig" });
+      ).rejects.toMatchObject({
+        code: "InvalidConfig",
+        message: expect.stringContaining(`${option} must be a ${integerContract} integer`),
+      });
 
       // Nothing moved: the floor is intact, no snapshot pointer, and no
       // orphan snapshot object was left on the bucket.

--- a/packages/server/src/compactor.ts
+++ b/packages/server/src/compactor.ts
@@ -50,7 +50,7 @@ import {
 } from "@baerly/protocol";
 import { requireIntegerOption } from "./option-guards.ts";
 import { walkLogRangeWithBytes } from "./log-walk.ts";
-import { probeTailFrom } from "./log-tail.ts";
+import { probeTailChunk, probeTailFrom, type TailProbeChunk } from "./log-tail.ts";
 import { getCurrentContext } from "./observability/context.ts";
 import {
   encodeSnapshotBody,
@@ -92,12 +92,23 @@ export interface InternalCompactOptions extends CompactOptions {
   /**
    * @internal Budget cap for the CF free-tier subrequest budget;
    * `CLOUDFLARE_FREE_TIER` sets it. Tests also set it to exercise
-   * the cap path. The compactor's I/O profile is
-   * `maxEntriesPerRun + 3` subrequests (N GETs + 1 PUT snapshot +
-   * 1 GET current + 1 PUT current). The default is effectively
-   * unbounded (`Number.MAX_SAFE_INTEGER`).
+   * the cap path. A snapshot-producing run's I/O profile includes the
+   * current read, bounded tail probe, optional prior snapshot read, folded
+   * log reads, and two writes (snapshot PUT plus `current.json` CAS). A
+   * probe-budget checkpoint instead writes only the `current.json` CAS.
+   * The default is effectively unbounded (`Number.MAX_SAFE_INTEGER`).
    */
   readonly maxEntriesPerRun?: number;
+
+  /**
+   * @internal Maximum consecutive log GETs spent discovering the tail
+   * during one compaction run. An exhausted budget checkpoints the
+   * certified lower bound in `current.json` so the next run resumes from
+   * there. Must be a positive integer. When omitted, the default path uses
+   * the strict protocol-capped probe, which throws rather than accepting a
+   * partial result.
+   */
+  readonly maxTailProbeGets?: number;
 
   /**
    * @internal SNAPSHOT-axis byte ceiling. The rebuilt snapshot body
@@ -126,10 +137,11 @@ export interface InternalCompactOptions extends CompactOptions {
    * `max(log_seq_start, tail_hint, knownTail)`, so on a stale-low stored
    * `tail_hint` the forward probe walks only "commits since this writer's
    * commit" instead of re-walking the whole gap from the stale hint
-   * (which could blow the CF subrequest budget — B4). The compactor still
-   * discovers the TRUE tail by probing UP from this floor (small gap).
-   * Absent on the scheduled path ⇒ probe from `max(log_seq_start,
-   * tail_hint)` as before.
+   * (which could blow the CF subrequest budget — B4). The compactor probes
+   * UP from this floor and, within `maxTailProbeGets`, either discovers the
+   * exact tail or certifies an exclusive lower bound that it checkpoints;
+   * the latter is not the exact tail. Absent on the scheduled path ⇒ probe
+   * from `max(log_seq_start, tail_hint)` as before.
    */
   readonly knownTail?: number;
 }
@@ -137,8 +149,19 @@ export interface InternalCompactOptions extends CompactOptions {
 export interface CompactResult {
   /** `true` iff a new snapshot landed and `current.json` was advanced. */
   readonly written: boolean;
-  /** Reason `written === false`. */
-  readonly skippedReason?: "below-min-threshold" | "current-json-missing" | "cas-lost" | "deferred";
+  /**
+   * Reason `written === false`. `"probe-budget-checkpointed"` means the
+   * explicitly budgeted tail probe could not finish: no snapshot was
+   * published, but the certified tail lower bound was durably checkpointed
+   * in `current.json`. A later scheduled `compact()` invocation resumes
+   * probing from that checkpoint.
+   */
+  readonly skippedReason?:
+    | "below-min-threshold"
+    | "current-json-missing"
+    | "cas-lost"
+    | "deferred"
+    | "probe-budget-checkpointed";
   /** `true` on the over-ceiling rebuild-defer path (`skippedReason === "deferred"`). */
   readonly deferred?: boolean;
   /** Prior snapshot key (`null` if no prior snapshot existed). */
@@ -170,9 +193,9 @@ const APPLICATION_JSON = "application/json";
  *
  * @throws BaerlyError code="InvalidConfig" — `maxEntriesPerRun` or
  *   `knownTail` (the `InternalCompactOptions` seam) is not a
- *   non-negative integer. Checked before any I/O: a non-finite value
- *   would otherwise slip the range guards and write an unreadable
- *   `current.json`.
+ *   non-negative integer, or `maxTailProbeGets` is not a positive
+ *   integer. Checked before any I/O: a non-finite value would otherwise
+ *   slip the range guards and write an unreadable `current.json`.
  * @throws BaerlyError code="InvalidResponse" — `current.json` is
  *   present but malformed, or a snapshot body fails its schema /
  *   collection cross-check.
@@ -207,6 +230,7 @@ export const compact = async (
   // narrowing — and keeps the public type honest.
   const internal = options as InternalCompactOptions;
   const maxPerRun = internal.maxEntriesPerRun ?? DEFAULT_MAX_PER_RUN;
+  const maxTailProbeGets = internal.maxTailProbeGets;
   const minToCompact = options.minEntriesToCompact ?? DEFAULT_MIN_TO_COMPACT;
   // Each ceiling: `undefined ⇒ no ceiling` (treated as `Infinity`).
   const ceilingBytes = internal.ceilingBytes ?? Number.POSITIVE_INFINITY;
@@ -237,6 +261,9 @@ export const compact = async (
     requireIntegerOption("compact", collectionName, name, value, 0);
   requireSeqOption("maxEntriesPerRun", maxPerRun);
   requireSeqOption("knownTail", internal.knownTail ?? 0);
+  if (maxTailProbeGets !== undefined) {
+    requireIntegerOption("compact", collectionName, "maxTailProbeGets", maxTailProbeGets, 1);
+  }
 
   // ── Step 1. Read current.json fresh. ────────────────────────────
   const read = await readCurrentJson(
@@ -257,26 +284,70 @@ export const compact = async (
   const current = read.json;
   const baseEtag = read.etag;
   const logSeqStartBefore = logSeqStartOf(current);
-  // Forward-probe the TRUE tail (uncapped) and stamp it as the new
-  // `tail_hint` (Step 7). Ordinary writer commits never advance
-  // `tail_hint` under single-write commit; compaction folds are the
-  // primary durable advancer, with maintenance defer/disable refreshes
-  // and explicit operator/import paths as the other writers. The
-  // compactor still discovers the true tail to keep the writer's
-  // per-commit tail-find cheap (a tracking hint ⇒ small gap). The
-  // compactor's O(gap) probe is amortized O(1) per write across the
-  // fold cadence; it's Class-A-active, not idle-reader-bound.
+  // Forward-probe a bounded chunk of the tail and stamp the certified
+  // lower bound (or exact tail) as the new `tail_hint` (Step 7).
+  // Ordinary writer commits never advance `tail_hint` under single-write
+  // commit; compaction folds are the primary durable advancer, with
+  // maintenance defer/disable refreshes and explicit operator/import paths
+  // as the other writers. An exhausted probe budget checkpoints its lower
+  // bound before a below-threshold return, so a future run resumes there.
   // Raise the probe floor to any fresh tail lower bound the caller passed
   // (the write-tick `knownTail` = writer's observed `seq + 1`) so a
   // stale-low stored `tail_hint` doesn't force an O(gap) re-walk (B4).
   const probeFloor = Math.max(logSeqStartBefore, current.tail_hint, internal.knownTail ?? 0);
-  const probe = await probeTailFrom(storage, collectionPrefix, probeFloor, {
-    ...(options.signal !== undefined && { signal: options.signal }),
-  });
-  const discoveredTail = probe.tail;
+  let probe: TailProbeChunk;
+  if (maxTailProbeGets === undefined) {
+    const exact = await probeTailFrom(storage, collectionPrefix, probeFloor, {
+      ...(options.signal !== undefined && { signal: options.signal }),
+    });
+    probe = { kind: "exact", ...exact, complete: true };
+  } else {
+    probe = await probeTailChunk(storage, collectionPrefix, probeFloor, {
+      ...(options.signal !== undefined && { signal: options.signal }),
+      cap: maxTailProbeGets,
+    });
+  }
+  const tailIsExact = probe.kind === "exact";
+  const discoveredTail = probe.kind === "exact" ? probe.tail : probe.lowerBound;
   const nextSeq = discoveredTail;
   const available = nextSeq - logSeqStartBefore;
   if (available < minToCompact) {
+    if (!tailIsExact) {
+      const checkpoint: CurrentJson = {
+        ...current,
+        tail_hint: Math.max(current.tail_hint, discoveredTail),
+      };
+      const checkpointBody = encodeJsonBytes(checkpoint);
+      const checkpointCasOpts: StoragePutOptions = {
+        ifMatch: baseEtag,
+        contentType: APPLICATION_JSON,
+        ...(options.signal !== undefined && { signal: options.signal }),
+      };
+      try {
+        await storage.put(currentJsonKey, checkpointBody, checkpointCasOpts);
+      } catch (error) {
+        if (isCasConflict(error)) {
+          ctxMetrics().counter("db.compaction.cas_lost_total", 1, { collection: collectionName });
+          return {
+            written: false,
+            skippedReason: "cas-lost",
+            previousSnapshotKey: current.snapshot,
+            logSeqStartBefore,
+            logSeqStartAfter: logSeqStartBefore,
+            entriesFolded: 0,
+          };
+        }
+        throw error;
+      }
+      return {
+        written: false,
+        skippedReason: "probe-budget-checkpointed",
+        previousSnapshotKey: current.snapshot,
+        logSeqStartBefore,
+        logSeqStartAfter: logSeqStartBefore,
+        entriesFolded: 0,
+      };
+    }
     return {
       written: false,
       skippedReason: "below-min-threshold",
@@ -471,9 +542,11 @@ export const compact = async (
   // add zero storage ops.
   const metrics = ctxMetrics();
   metrics.histogram("db.compact.entries_folded", entriesFolded, { collection: collectionName });
-  metrics.gauge("db.manifest.lag_window_depth", discoveredTail - foldEnd, {
-    collection: collectionName,
-  });
+  if (tailIsExact) {
+    metrics.gauge("db.manifest.lag_window_depth", discoveredTail - foldEnd, {
+      collection: collectionName,
+    });
+  }
 
   return {
     written: true,

--- a/packages/server/src/compactor.ts
+++ b/packages/server/src/compactor.ts
@@ -48,6 +48,7 @@ import {
   type Storage,
   type StoragePutOptions,
 } from "@baerly/protocol";
+import { requireIntegerOption } from "./option-guards.ts";
 import { walkLogRangeWithBytes } from "./log-walk.ts";
 import { probeTailFrom } from "./log-tail.ts";
 import { getCurrentContext } from "./observability/context.ts";
@@ -232,14 +233,8 @@ export const compact = async (
   // because nothing has been written yet. The ceilings are deliberately
   // not checked: a NaN there fails the viability comparisons closed
   // (defer), which is the safe direction.
-  const requireSeqOption = (name: string, value: number): void => {
-    if (!Number.isInteger(value) || value < 0) {
-      throw new BaerlyError(
-        "InvalidConfig",
-        `compact(${collectionName}): ${name} must be a non-negative integer, got ${String(value)}`,
-      );
-    }
-  };
+  const requireSeqOption = (name: string, value: number): void =>
+    requireIntegerOption("compact", collectionName, name, value, 0);
   requireSeqOption("maxEntriesPerRun", maxPerRun);
   requireSeqOption("knownTail", internal.knownTail ?? 0);
 

--- a/packages/server/src/gc.test.ts
+++ b/packages/server/src/gc.test.ts
@@ -17,8 +17,8 @@ import {
   GC_GRACE_PERIOD_MILLIS,
   GC_PENDING_SCHEMA_VERSION,
   MAX_PARALLEL_LOG_READS,
-  MemoryStorage,
   SNAPSHOT_SCHEMA_VERSION,
+  MemoryStorage,
   casUpdateCurrentJson,
   casUpdateGcPending,
   createCurrentJson,
@@ -34,7 +34,12 @@ import {
   seedLogEntry,
 } from "../../../tests/fixtures/log-state.ts";
 import { compact, type InternalCompactOptions } from "./compactor.ts";
-import { type InternalRunGcOptions, runGc } from "./gc.ts";
+import {
+  type ContentDeferralReason,
+  type InternalRunGcOptions,
+  isDegradedContentDeferral,
+  runGc,
+} from "./gc.ts";
 import { createObservabilityContext, runWithContext } from "./observability/index.ts";
 import { encodeSnapshotBody, snapshotKey } from "./snapshot.ts";
 import { Writer } from "./writer.ts";
@@ -122,6 +127,36 @@ describe("runGc", () => {
     expect(r.swept).toBe(0);
     // Nothing was bootstrapped either — pending.json is absent.
     await expect(readGcPending(s, PENDING_KEY)).resolves.toBeNull();
+  });
+
+  // Production mutation caught: allowing zero/fractional/negative admission
+  // caps into the probe arithmetic could either do no progress or silently
+  // admit a partial live set. Both internal seams must fail before the first
+  // storage call.
+  describe.each([
+    ["maxTailProbeGets", { maxTailProbeGets: 0 }, "positive"],
+    ["maxTailProbeGets", { maxTailProbeGets: 1.5 }, "positive"],
+    ["maxLiveLogEntriesPerRun", { maxLiveLogEntriesPerRun: -1 }, "non-negative"],
+    ["maxLiveLogEntriesPerRun", { maxLiveLogEntriesPerRun: 1.5 }, "non-negative"],
+  ])("rejects invalid %s before I/O", (option, overrides, contract) => {
+    test("fails closed at the internal seam", async () => {
+      const fail = (operation: keyof Storage): never => {
+        throw new Error(`runGc must validate before storage.${operation}()`);
+      };
+      const storage: Storage = {
+        get: () => fail("get"),
+        put: () => fail("put"),
+        delete: () => fail("delete"),
+        list: () => fail("list"),
+      };
+
+      await expect(
+        runGc({ storage, currentJsonKey: KEY }, overrides as InternalRunGcOptions),
+      ).rejects.toMatchObject({
+        code: "InvalidConfig",
+        message: expect.stringContaining(`${option} must be a ${contract} integer`),
+      });
+    });
   });
 
   test("marks stale log entries after compaction (no sweep at default grace)", async () => {
@@ -850,6 +885,578 @@ describe("runGc", () => {
     await expect(s.get("app/t/tenant/x/manifests/c/log/0.json")).resolves.toBeNull();
   });
 
+  // Production mutation caught: treating an occupied bounded probe as an
+  // exact tail would build an incomplete live set and LIST/mark content;
+  // returning before all other GC work would instead starve snapshot marks
+  // and due sweeps while the hint catches up.
+  test("defers only content GC after an inexact tail probe and checkpoints the certified lower bound", async () => {
+    const inner = new MemoryStorage();
+    await createCurrentJson(inner, KEY, logStateCurrentJson({ tail_hint: 0 }));
+    await seedDenseLog(inner, 0, 60);
+    const orphanSnapshot = `${PREFIX}/snapshot/L9/orphan.json`;
+    const orphanContent = `${PREFIX}/content/00000000000000000000000000000000.json`;
+    const dueKey = `${PREFIX}/gc/due-inexact.json`;
+    await inner.put(orphanSnapshot, new TextEncoder().encode("{}"));
+    await inner.put(orphanContent, new TextEncoder().encode("{}"));
+    await createGcPending(inner, PENDING_KEY, {
+      schema_version: GC_PENDING_SCHEMA_VERSION,
+      candidates: [{ key: dueKey, due_at: "2000-01-01T00:00:00.000Z", reason: "stale-log" }],
+      last_swept_at: "",
+      content_scan_cursor: `${PREFIX}/content/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json`,
+    });
+
+    const { storage, trace } = tracingStorage(inner);
+    const result = await runGc({ storage, currentJsonKey: KEY }, {
+      maxTailProbeGets: 25,
+      maxLiveLogEntriesPerRun: 20,
+      maxMarksPerRun: 20,
+      maxSweepsPerRun: 10,
+      now: () => new Date("2026-01-01T00:00:00.000Z"),
+    } as InternalRunGcOptions);
+
+    expect(result).toEqual({
+      marked: { stale_log: 0, orphan_snapshot: 1, orphan_content: 0 },
+      swept: 1,
+      pendingDepth: 1,
+      // Budget class: expected on Free, and the checkpoint below is what
+      // makes it self-clear.
+      contentDeferredReason: "probe-budget",
+    });
+    const checkpointedCurrent = await readCurrentJson(inner, KEY);
+    expect(checkpointedCurrent?.json.tail_hint).toBe(25);
+    expect(trace.lists).toContain(`${PREFIX}/snapshot/`);
+    expect(trace.lists).not.toContain(`${PREFIX}/content/`);
+    expect(trace.deletes).toEqual([dueKey]);
+    const pending = await readGcPending(inner, PENDING_KEY);
+    expect(pending?.json.candidates.map((candidate) => candidate.key)).toEqual([orphanSnapshot]);
+    expect(pending?.json.content_scan_cursor).toBe(
+      `${PREFIX}/content/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json`,
+    );
+  });
+
+  // Production mutation caught: an exact tail is not affordable merely
+  // because the suffix probe was short; admitting when the complete live
+  // range exceeds the cap would overspend, while returning immediately
+  // would starve stale-log/snapshot marking and due sweeps.
+  test("defers only content GC when the exact live tail exceeds the admission cap", async () => {
+    const inner = new MemoryStorage();
+    const liveSnapshot = `${PREFIX}/snapshot/L9/live.json`;
+    const orphanSnapshot = `${PREFIX}/snapshot/L9/orphan.json`;
+    const orphanContent = `${PREFIX}/content/00000000000000000000000000000000.json`;
+    const dueKey = `${PREFIX}/gc/due-oversized.json`;
+    await createCurrentJson(
+      inner,
+      KEY,
+      logStateCurrentJson({
+        snapshot: liveSnapshot,
+        log_seq_start: 20,
+        tail_hint: 50,
+      }),
+    );
+    await seedDenseLog(inner, 0, 60);
+    await inner.put(liveSnapshot, new TextEncoder().encode("{}"));
+    await inner.put(orphanSnapshot, new TextEncoder().encode("{}"));
+    await inner.put(orphanContent, new TextEncoder().encode("{}"));
+    await createGcPending(inner, PENDING_KEY, {
+      schema_version: GC_PENDING_SCHEMA_VERSION,
+      candidates: [{ key: dueKey, due_at: "2000-01-01T00:00:00.000Z", reason: "stale-log" }],
+      last_swept_at: "",
+      content_scan_cursor: `${PREFIX}/content/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.json`,
+    });
+
+    const { storage, trace } = tracingStorage(inner);
+    const result = await runGc({ storage, currentJsonKey: KEY }, {
+      maxTailProbeGets: 25,
+      maxLiveLogEntriesPerRun: 20,
+      maxMarksPerRun: 20,
+      maxSweepsPerRun: 10,
+      now: () => new Date("2026-01-01T00:00:00.000Z"),
+    } as InternalRunGcOptions);
+
+    expect(result.marked.stale_log).toBeGreaterThan(0);
+    expect(result.marked.orphan_snapshot).toBe(1);
+    expect(result.marked.orphan_content).toBe(0);
+    expect(result.swept).toBe(1);
+    const checkpointedCurrent = await readCurrentJson(inner, KEY);
+    expect(checkpointedCurrent?.json.tail_hint).toBe(60);
+    expect(trace.lists).toContain(`${PREFIX}/log/`);
+    expect(trace.lists).toContain(`${PREFIX}/snapshot/`);
+    expect(trace.lists).not.toContain(`${PREFIX}/content/`);
+    expect(trace.gets).not.toContain(liveSnapshot);
+    const pending = await readGcPending(inner, PENDING_KEY);
+    expect(pending?.json.content_scan_cursor).toBe(
+      `${PREFIX}/content/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.json`,
+    );
+  });
+
+  // Production mutation caught: probing the suffix and then scanning the
+  // entire live range from storage would GET entries 50..59 twice. The exact
+  // probe's decoded entries must feed the same liveness hash ingestion path.
+  test("reuses exact probe entries so every admitted live log key is read once", async () => {
+    const inner = new MemoryStorage();
+    await createCurrentJson(
+      inner,
+      KEY,
+      logStateCurrentJson({
+        log_seq_start: 40,
+        tail_hint: 50,
+      }),
+    );
+    await seedDenseLog(inner, 40, 60);
+    const orphanContent = `${PREFIX}/content/00000000000000000000000000000000.json`;
+    await inner.put(orphanContent, new TextEncoder().encode("{}"));
+
+    const { storage, trace } = tracingStorage(inner);
+    const result = await runGc({ storage, currentJsonKey: KEY }, {
+      maxTailProbeGets: 25,
+      maxLiveLogEntriesPerRun: 20,
+      maxMarksPerRun: 20,
+      maxSweepsPerRun: 10,
+    } as InternalRunGcOptions);
+
+    expect(result.marked.orphan_content).toBe(1);
+    for (let seq = 40; seq < 60; seq++) {
+      expect(trace.gets.filter((key) => key === `${PREFIX}/log/${seq}.json`)).toHaveLength(1);
+    }
+    expect(trace.gets.filter((key) => key === `${PREFIX}/log/60.json`)).toHaveLength(1);
+  });
+
+  test("a malformed bounded suffix checkpoints occupancy and defers only content work", async () => {
+    const inner = new MemoryStorage();
+    await createCurrentJson(
+      inner,
+      KEY,
+      logStateCurrentJson({
+        log_seq_start: 20,
+        tail_hint: 30,
+      }),
+    );
+    await seedLogEntry(inner, PREFIX, 0);
+    await seedDenseLog(inner, 20, 36);
+    await inner.put(`${PREFIX}/log/32.json`, new TextEncoder().encode("{"));
+    const orphanSnapshot = `${PREFIX}/snapshot/L9/orphan-malformed-probe.json`;
+    const dueSnapshot = snapshotKey(PREFIX, 0, 19, "e".repeat(64));
+    const orphanContent = `${PREFIX}/content/ffffffffffffffffffffffffffffffff.json`;
+    const dueStale = `${PREFIX}/gc/due-malformed-probe.json`;
+    const storedCursor = `${PREFIX}/content/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json`;
+    await inner.put(orphanSnapshot, new TextEncoder().encode("{}"));
+    await inner.put(dueSnapshot, new TextEncoder().encode("{}"));
+    await inner.put(orphanContent, new TextEncoder().encode("{}"));
+    await createGcPending(inner, PENDING_KEY, {
+      schema_version: GC_PENDING_SCHEMA_VERSION,
+      candidates: [
+        { key: dueStale, due_at: "2000-01-01T00:00:00.000Z", reason: "stale-log" },
+        {
+          key: dueSnapshot,
+          due_at: "2000-01-01T00:00:00.000Z",
+          reason: "orphan-snapshot",
+        },
+      ],
+      last_swept_at: "",
+      content_scan_cursor: storedCursor,
+    });
+    const { storage, trace } = tracingStorage(inner);
+
+    const result = await runGc({ storage, currentJsonKey: KEY }, {
+      maxTailProbeGets: 25,
+      maxLiveLogEntriesPerRun: 20,
+      maxMarksPerRun: 20,
+      maxSweepsPerRun: 10,
+      now: () => new Date("2026-01-01T00:00:00.000Z"),
+    } as InternalRunGcOptions);
+
+    expect(result).toEqual({
+      marked: { stale_log: 1, orphan_snapshot: 1, orphan_content: 0 },
+      swept: 2,
+      pendingDepth: 2,
+      // Degraded class. This probe reaches an exact tail (36 is missing),
+      // so only the malformed condition holds; the both-hold precedence
+      // case is pinned separately below.
+      contentDeferredReason: "probe-slot-malformed",
+    });
+    expect(trace.gets).toContain(`${PREFIX}/log/36.json`);
+    expect(trace.lists).toEqual([`${PREFIX}/log/`, `${PREFIX}/snapshot/`]);
+    expect(trace.deletes).toEqual([dueStale, dueSnapshot]);
+    await expect(inner.get(orphanContent)).resolves.not.toBeNull();
+    const current = await readCurrentJson(inner, KEY);
+    expect(current?.json.tail_hint).toBe(36);
+    const pending = await readGcPending(inner, PENDING_KEY);
+    expect(pending?.json.content_scan_cursor).toBe(storedCursor);
+    expect(pending?.json.candidates.map((candidate) => candidate.key).toSorted()).toEqual(
+      [`${PREFIX}/log/0.json`, orphanSnapshot].toSorted(),
+    );
+  });
+
+  // Production mutation caught: treating a missing or malformed live entry as
+  // an empty contribution produces a partial hash set. Content absent from that
+  // partial set must not be classified; only the content phase is deferred.
+  describe.each(["missing", "malformed"] as const)(
+    "when a pre-probe-floor live log entry is %s",
+    (failure) => {
+      test("defers content classification and preserves its cursor", async () => {
+        const inner = new MemoryStorage();
+        await createCurrentJson(
+          inner,
+          KEY,
+          logStateCurrentJson({
+            log_seq_start: 40,
+            tail_hint: 50,
+          }),
+        );
+        await seedLogEntry(inner, PREFIX, 0);
+        await seedDenseLog(inner, 40, 60);
+        if (failure === "missing") {
+          await inner.delete(`${PREFIX}/log/45.json`);
+        } else {
+          await inner.put(`${PREFIX}/log/45.json`, new TextEncoder().encode("not-json"));
+        }
+        const orphanSnapshot = `${PREFIX}/snapshot/L9/orphan-incomplete-log.json`;
+        const orphanContent = `${PREFIX}/content/ffffffffffffffffffffffffffffffff.json`;
+        const dueStaleKey = `${PREFIX}/gc/due-incomplete-log.json`;
+        const dueSnapshotKey = snapshotKey(PREFIX, 0, 39, "f".repeat(64));
+        const storedCursor = `${PREFIX}/content/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json`;
+        await inner.put(orphanSnapshot, new TextEncoder().encode("{}"));
+        await inner.put(dueSnapshotKey, new TextEncoder().encode("{}"));
+        await inner.put(orphanContent, new TextEncoder().encode("{}"));
+        await createGcPending(inner, PENDING_KEY, {
+          schema_version: GC_PENDING_SCHEMA_VERSION,
+          candidates: [
+            {
+              key: dueStaleKey,
+              due_at: "2000-01-01T00:00:00.000Z",
+              reason: "stale-log",
+            },
+            {
+              key: dueSnapshotKey,
+              due_at: "2000-01-01T00:00:00.000Z",
+              reason: "orphan-snapshot",
+            },
+            {
+              key: orphanContent,
+              due_at: "2000-01-01T00:00:00.000Z",
+              reason: "orphan-content",
+            },
+          ],
+          last_swept_at: "",
+          content_scan_cursor: storedCursor,
+        });
+
+        const { storage, trace } = tracingStorage(inner);
+        const result = await runGc({ storage, currentJsonKey: KEY }, {
+          maxTailProbeGets: 25,
+          maxLiveLogEntriesPerRun: 20,
+          maxMarksPerRun: 20,
+          maxSweepsPerRun: 10,
+          now: () => new Date("2026-01-01T00:00:00.000Z"),
+        } as InternalRunGcOptions);
+
+        expect(result).toEqual({
+          marked: { stale_log: 1, orphan_snapshot: 1, orphan_content: 0 },
+          swept: 2,
+          pendingDepth: 3,
+          contentDeferredReason: "live-log-unreadable",
+        });
+        expect(trace.lists).toContain(`${PREFIX}/log/`);
+        expect(trace.lists).toContain(`${PREFIX}/snapshot/`);
+        expect(trace.lists).not.toContain(`${PREFIX}/content/`);
+        expect(trace.deletes).toEqual([dueStaleKey, dueSnapshotKey]);
+        await expect(inner.get(orphanContent)).resolves.not.toBeNull();
+        const pending = await readGcPending(inner, PENDING_KEY);
+        expect(pending?.json.content_scan_cursor).toBe(storedCursor);
+        expect(pending?.json.candidates.map((candidate) => candidate.reason).toSorted()).toEqual([
+          "orphan-content",
+          "orphan-snapshot",
+          "stale-log",
+        ]);
+      });
+    },
+  );
+
+  // Production mutation caught: swallowing a current-snapshot read failure
+  // and returning the hashes collected so far makes every snapshot-only row
+  // look dead. All snapshot failure modes must defer content classification.
+  describe.each(["failed", "missing", "corrupt"] as const)(
+    "when the current snapshot is %s",
+    (failure) => {
+      test("defers content classification and preserves its cursor", async () => {
+        const inner = new MemoryStorage();
+        const currentSnapshot = `${PREFIX}/snapshot/L9/000000000000-000000000040-${"a".repeat(64)}.json`;
+        await createCurrentJson(
+          inner,
+          KEY,
+          logStateCurrentJson({
+            snapshot: currentSnapshot,
+            log_seq_start: 0,
+            tail_hint: 0,
+          }),
+        );
+        if (failure !== "missing") {
+          await inner.put(currentSnapshot, new TextEncoder().encode("not-a-valid-snapshot"));
+        }
+        const orphanSnapshot = `${PREFIX}/snapshot/L9/orphan-incomplete-snapshot.json`;
+        const orphanContent = `${PREFIX}/content/ffffffffffffffffffffffffffffffff.json`;
+        const dueKey = `${PREFIX}/gc/due-incomplete-snapshot.json`;
+        const storedCursor = `${PREFIX}/content/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.json`;
+        await inner.put(orphanSnapshot, new TextEncoder().encode("{}"));
+        await inner.put(orphanContent, new TextEncoder().encode("{}"));
+        await createGcPending(inner, PENDING_KEY, {
+          schema_version: GC_PENDING_SCHEMA_VERSION,
+          candidates: [{ key: dueKey, due_at: "2000-01-01T00:00:00.000Z", reason: "stale-log" }],
+          last_swept_at: "",
+          content_scan_cursor: storedCursor,
+        });
+        const subject: Storage =
+          failure === "failed"
+            ? {
+                get: (key, opts) => {
+                  if (key === currentSnapshot) {
+                    throw new BaerlyError("AccessDenied", "snapshot read denied");
+                  }
+                  return inner.get(key, opts);
+                },
+                put: (key, body, opts) => inner.put(key, body, opts),
+                delete: (key, opts) => inner.delete(key, opts),
+                list: (prefix, opts) => inner.list(prefix, opts),
+              }
+            : inner;
+
+        const { storage, trace } = tracingStorage(subject);
+        const result = await runGc({ storage, currentJsonKey: KEY }, {
+          maxTailProbeGets: 25,
+          maxLiveLogEntriesPerRun: 20,
+          maxMarksPerRun: 20,
+          maxSweepsPerRun: 10,
+          now: () => new Date("2026-01-01T00:00:00.000Z"),
+        } as InternalRunGcOptions);
+
+        expect(result).toEqual({
+          marked: { stale_log: 0, orphan_snapshot: 1, orphan_content: 0 },
+          swept: 1,
+          pendingDepth: 1,
+          // The reviewer-cited scenario: a persistent AccessDenied here
+          // parks orphan-content GC forever, so the pass must NOT look
+          // identical to an orphan-free one.
+          contentDeferredReason: "snapshot-unreadable",
+        });
+        expect(trace.lists).toContain(`${PREFIX}/snapshot/`);
+        expect(trace.lists).not.toContain(`${PREFIX}/content/`);
+        expect(trace.deletes).toEqual([dueKey]);
+        await expect(inner.get(orphanContent)).resolves.not.toBeNull();
+        const pending = await readGcPending(inner, PENDING_KEY);
+        expect(pending?.json.content_scan_cursor).toBe(storedCursor);
+        expect(pending?.json.candidates.map((candidate) => candidate.reason)).toEqual([
+          "orphan-snapshot",
+        ]);
+      });
+    },
+  );
+
+  // A degraded pass and a genuinely orphan-free one both mark zero content
+  // and sweep zero content. Without a signal that separates them, a
+  // persistent snapshot fault disables orphan-content GC silently and
+  // forever. Pin both directions of that discrimination.
+  describe("content-deferral signal", () => {
+    // The class, not the string, is what a cron caller branches on to
+    // decide whether to page. Pin every member so a reason that changes
+    // class — or a new one classified wrongly — fails here rather than in
+    // an operator's alerting rule.
+    test("classifies every deferral reason as budget or degraded", () => {
+      const byReason: Readonly<Record<ContentDeferralReason, boolean>> = {
+        "probe-budget": false,
+        "live-tail-over-cap": false,
+        "probe-slot-malformed": true,
+        "live-log-unreadable": true,
+        "snapshot-unreadable": true,
+      };
+      for (const [reason, degraded] of Object.entries(byReason)) {
+        expect(isDegradedContentDeferral(reason as ContentDeferralReason)).toBe(degraded);
+      }
+      // Total over the result field: no deferral is not a degraded one.
+      expect(isDegradedContentDeferral(undefined)).toBe(false);
+    });
+
+    test("counts a degraded pass under its reason label", async () => {
+      const inner = new MemoryStorage();
+      const currentSnapshot = `${PREFIX}/snapshot/L9/000000000000-000000000040-${"a".repeat(64)}.json`;
+      await createCurrentJson(
+        inner,
+        KEY,
+        logStateCurrentJson({ snapshot: currentSnapshot, log_seq_start: 0, tail_hint: 0 }),
+      );
+      await inner.put(currentSnapshot, new TextEncoder().encode("not-a-valid-snapshot"));
+      const denied: Storage = {
+        get: (key, opts) => {
+          if (key === currentSnapshot) {
+            throw new BaerlyError("AccessDenied", "snapshot read denied");
+          }
+          return inner.get(key, opts);
+        },
+        put: (key, body, opts) => inner.put(key, body, opts),
+        delete: (key, opts) => inner.delete(key, opts),
+        list: (prefix, opts) => inner.list(prefix, opts),
+      };
+
+      const ctx = createObservabilityContext();
+      let result!: Awaited<ReturnType<typeof runGc>>;
+      await runWithContext(ctx, async () => {
+        result = await runGc({ storage: denied, currentJsonKey: KEY }, {
+          maxMarksPerRun: 20,
+          maxSweepsPerRun: 10,
+        } as InternalRunGcOptions);
+      });
+
+      expect(result.contentDeferredReason).toBe("snapshot-unreadable");
+      expect(
+        ctx.recorder.snapshot().counters.filter((c) => c.name === "db.gc.content_deferred_total"),
+      ).toEqual([
+        {
+          name: "db.gc.content_deferred_total",
+          value: 1,
+          labels: { collection: COLL, reason: "snapshot-unreadable" },
+        },
+      ]);
+    });
+
+    test("emits nothing when a complete live set classified content", async () => {
+      const inner = new MemoryStorage();
+      await createCurrentJson(inner, KEY, logStateCurrentJson({ tail_hint: 0 }));
+
+      const ctx = createObservabilityContext();
+      let result!: Awaited<ReturnType<typeof runGc>>;
+      await runWithContext(ctx, async () => {
+        result = await runGc({ storage: inner, currentJsonKey: KEY }, {
+          maxMarksPerRun: 20,
+          maxSweepsPerRun: 10,
+        } as InternalRunGcOptions);
+      });
+
+      expect(result.contentDeferredReason).toBeUndefined();
+      expect(
+        ctx.recorder.snapshot().counters.find((c) => c.name === "db.gc.content_deferred_total"),
+      ).toBeUndefined();
+    });
+
+    // Precedence, not just labelling: a probe can exhaust its budget AND
+    // contain a malformed slot. Reporting the budget reason there would
+    // file an actionable corruption under the one outcome operators are
+    // told to expect on Free, so the degraded reason must win.
+    test("reports the degraded reason when a budget reason also holds", async () => {
+      const inner = new MemoryStorage();
+      await createCurrentJson(inner, KEY, logStateCurrentJson({ log_seq_start: 0, tail_hint: 0 }));
+      // Dense past the 25-GET cap, so the probe never sees a 404 and can
+      // only return `at-least` — and slot 5 inside that range is malformed.
+      await seedDenseLog(inner, 0, 40);
+      await inner.put(`${PREFIX}/log/5.json`, new TextEncoder().encode("{"));
+
+      const result = await runGc({ storage: inner, currentJsonKey: KEY }, {
+        maxTailProbeGets: 25,
+        maxLiveLogEntriesPerRun: 20,
+        maxMarksPerRun: 20,
+        maxSweepsPerRun: 10,
+      } as InternalRunGcOptions);
+
+      expect(result.contentDeferredReason).toBe("probe-slot-malformed");
+      // The budget half of the pass still happened: occupancy was
+      // certified up to the cap and checkpointed.
+      await expect(readCurrentJson(inner, KEY)).resolves.toMatchObject({
+        json: { tail_hint: 25 },
+      });
+    });
+  });
+
+  // Production mutation caught: a retrying current.json helper would spend
+  // extra budget and could run GC against a different admission snapshot.
+  // The captured-etag checkpoint is one attempt; Conflict returns zero work.
+  test("returns zero work after one admission checkpoint conflict", async () => {
+    const inner = new MemoryStorage();
+    await createCurrentJson(inner, KEY, logStateCurrentJson({ tail_hint: 0 }));
+    await seedDenseLog(inner, 0, 60);
+    const conflictOnCheckpoint: Storage = {
+      get: (key, opts) => inner.get(key, opts),
+      put: async (key, body, opts) => {
+        if (key === KEY && opts?.ifMatch !== undefined) {
+          throw new BaerlyError("Conflict", "checkpoint lost");
+        }
+        return inner.put(key, body, opts);
+      },
+      delete: (key, opts) => inner.delete(key, opts),
+      list: (prefix, opts) => inner.list(prefix, opts),
+    };
+    const { storage, trace } = tracingStorage(conflictOnCheckpoint);
+
+    const ctx = createObservabilityContext();
+    let result!: Awaited<ReturnType<typeof runGc>>;
+    await runWithContext(ctx, async () => {
+      result = await runGc({ storage, currentJsonKey: KEY }, {
+        maxTailProbeGets: 25,
+        maxLiveLogEntriesPerRun: 20,
+        maxMarksPerRun: 20,
+        maxSweepsPerRun: 10,
+      } as InternalRunGcOptions);
+    });
+
+    // A lost checkpoint is contention, not an idle collection. Counted the
+    // way `compact()` counts its own, and the deferral still reported, so
+    // the early return cannot swallow a DEGRADED reason.
+    const counters = ctx.recorder.snapshot().counters;
+    expect(counters.filter((c) => c.name === "db.gc.cas_lost_total")).toEqual([
+      { name: "db.gc.cas_lost_total", value: 1, labels: { collection: COLL } },
+    ]);
+    expect(counters.filter((c) => c.name === "db.gc.content_deferred_total")).toEqual([
+      {
+        name: "db.gc.content_deferred_total",
+        value: 1,
+        labels: { collection: COLL, reason: "probe-budget" },
+      },
+    ]);
+    // Zero work, but NOT an idle no-op: the pass deferred content
+    // classification, and that has to survive the lost checkpoint.
+    expect(result).toEqual({
+      marked: { stale_log: 0, orphan_snapshot: 0, orphan_content: 0 },
+      swept: 0,
+      pendingDepth: 0,
+      contentDeferredReason: "probe-budget",
+    });
+    const unchangedCurrent = await readCurrentJson(inner, KEY);
+    expect(unchangedCurrent?.json.tail_hint).toBe(0);
+    expect(trace.puts.filter((put) => put.key === KEY)).toHaveLength(1);
+    expect(trace.gets.filter((key) => key === PENDING_KEY)).toHaveLength(0);
+    expect(trace.puts.filter((put) => put.key === PENDING_KEY)).toHaveLength(0);
+    expect(trace.lists).toEqual([]);
+  });
+
+  // Production mutation caught: broad checkpoint error swallowing would hide
+  // access/transient failures and report a successful no-op. Only Conflict is
+  // the safe zero-work outcome.
+  test("propagates a non-Conflict admission checkpoint failure", async () => {
+    const inner = new MemoryStorage();
+    await createCurrentJson(inner, KEY, logStateCurrentJson({ tail_hint: 0 }));
+    await seedDenseLog(inner, 0, 60);
+    const deniedCheckpoint: Storage = {
+      get: (key, opts) => inner.get(key, opts),
+      put: async (key, body, opts) => {
+        if (key === KEY && opts?.ifMatch !== undefined) {
+          throw new BaerlyError("AccessDenied", "checkpoint denied");
+        }
+        return inner.put(key, body, opts);
+      },
+      delete: (key, opts) => inner.delete(key, opts),
+      list: (prefix, opts) => inner.list(prefix, opts),
+    };
+    const { storage, trace } = tracingStorage(deniedCheckpoint);
+
+    await expect(
+      runGc({ storage, currentJsonKey: KEY }, {
+        maxTailProbeGets: 25,
+        maxLiveLogEntriesPerRun: 20,
+        maxMarksPerRun: 20,
+        maxSweepsPerRun: 10,
+      } as InternalRunGcOptions),
+    ).rejects.toMatchObject({ code: "AccessDenied" });
+    expect(trace.gets.filter((key) => key === PENDING_KEY)).toHaveLength(0);
+    expect(trace.lists).toEqual([]);
+  });
+
   // ── orphan-content LIST rotation (Task 4.6) ──────────────────────
   // Seed N orphan content blobs (no live docs ⇒ every content key is
   // an orphan). With `maxMarksPerRun` < N the per-pass content LIST
@@ -1489,71 +2096,4 @@ describe("runGc", () => {
       });
     },
   );
-
-  // A degraded pass and a genuinely orphan-free one both mark zero content
-  // and sweep zero content. Without a signal that separates them, a
-  // persistent snapshot fault disables orphan-content GC silently and
-  // forever. Pin both directions of that discrimination.
-  describe("content-deferral signal", () => {
-    test("counts a degraded pass under its reason label", async () => {
-      const inner = new MemoryStorage();
-      const currentSnapshot = `${PREFIX}/snapshot/L9/000000000000-000000000040-${"a".repeat(64)}.json`;
-      await createCurrentJson(
-        inner,
-        KEY,
-        logStateCurrentJson({ snapshot: currentSnapshot, log_seq_start: 0, tail_hint: 0 }),
-      );
-      await inner.put(currentSnapshot, new TextEncoder().encode("not-a-valid-snapshot"));
-      const denied: Storage = {
-        get: (key, opts) => {
-          if (key === currentSnapshot) {
-            throw new BaerlyError("AccessDenied", "snapshot read denied");
-          }
-          return inner.get(key, opts);
-        },
-        put: (key, body, opts) => inner.put(key, body, opts),
-        delete: (key, opts) => inner.delete(key, opts),
-        list: (prefix, opts) => inner.list(prefix, opts),
-      };
-
-      const ctx = createObservabilityContext();
-      let result!: Awaited<ReturnType<typeof runGc>>;
-      await runWithContext(ctx, async () => {
-        result = await runGc({ storage: denied, currentJsonKey: KEY }, {
-          maxMarksPerRun: 20,
-          maxSweepsPerRun: 10,
-        } as InternalRunGcOptions);
-      });
-
-      expect(result.contentDeferredReason).toBe("snapshot-unreadable");
-      expect(
-        ctx.recorder.snapshot().counters.filter((c) => c.name === "db.gc.content_deferred_total"),
-      ).toEqual([
-        {
-          name: "db.gc.content_deferred_total",
-          value: 1,
-          labels: { collection: COLL, reason: "snapshot-unreadable" },
-        },
-      ]);
-    });
-
-    test("emits nothing when a complete live set classified content", async () => {
-      const inner = new MemoryStorage();
-      await createCurrentJson(inner, KEY, logStateCurrentJson({ tail_hint: 0 }));
-
-      const ctx = createObservabilityContext();
-      let result!: Awaited<ReturnType<typeof runGc>>;
-      await runWithContext(ctx, async () => {
-        result = await runGc({ storage: inner, currentJsonKey: KEY }, {
-          maxMarksPerRun: 20,
-          maxSweepsPerRun: 10,
-        } as InternalRunGcOptions);
-      });
-
-      expect(result.contentDeferredReason).toBeUndefined();
-      expect(
-        ctx.recorder.snapshot().counters.find((c) => c.name === "db.gc.content_deferred_total"),
-      ).toBeUndefined();
-    });
-  });
 });

--- a/packages/server/src/gc.ts
+++ b/packages/server/src/gc.ts
@@ -22,8 +22,10 @@
  * Unbounded by default — the run marks and sweeps the entire eligible
  * set in one pass. Callers on the Cloudflare 50-subrequest free-tier
  * budget opt INTO caps via the `CLOUDFLARE_FREE_TIER` profile's
- * `gc.maxMarksPerRun` / `maxSweepsPerRun` knobs (`InternalRunGcOptions`,
- * not on the public `RunGcOptions`).
+ * tail-admission, mark, and sweep knobs (`InternalRunGcOptions`, not on
+ * the public `RunGcOptions`). One Free invocation processes only this
+ * GC phase for one collection; alternate it with a direct bounded
+ * `compact()` invocation instead of composing both phases.
  *
  * **When a bounded pass needs a rotation cursor.** A budget-capped
  * LIST that always starts at the lexicographic beginning only makes
@@ -92,8 +94,10 @@ import {
   type CurrentJson,
   type GcCandidate,
   type GcPending,
+  type LogEntry,
   type MetricsRecorder,
   type Storage,
+  CURRENT_JSON_CONTENT_TYPE,
   GC_GRACE_PERIOD_MILLIS,
   GC_MAX_PENDING_CANDIDATES,
   GC_PENDING_SCHEMA_VERSION,
@@ -111,8 +115,9 @@ import {
   readGcPending,
   versionFromContent,
 } from "@baerly/protocol";
+import { requireIntegerOption } from "./option-guards.ts";
 import { loadSnapshotAsMap } from "./snapshot.ts";
-import { probeTailFrom } from "./log-tail.ts";
+import { probeTailChunk, probeTailFrom } from "./log-tail.ts";
 import { getCurrentContext } from "./observability/context.ts";
 
 const ctxMetrics = (): MetricsRecorder => getCurrentContext()?.recorder ?? noopMetricsRecorder;
@@ -138,6 +143,21 @@ export interface RunGcOptions {
  */
 export interface InternalRunGcOptions extends RunGcOptions {
   /**
+   * @internal Maximum GETs used to establish the tail admission proof.
+   * An occupied or malformed chunk defers only the content phase while
+   * preserving safe occupancy progress. Must be a positive integer when
+   * supplied; absent retains exact default probing.
+   */
+  readonly maxTailProbeGets?: number;
+
+  /**
+   * @internal Maximum complete live-log range affordable for content
+   * liveness hashing. Must be a non-negative integer when supplied;
+   * absent retains the exact/unbounded default behavior.
+   */
+  readonly maxLiveLogEntriesPerRun?: number;
+
+  /**
    * @internal Override grace-period for tests. Defaults to
    * {@link GC_GRACE_PERIOD_MILLIS} (7 days). Tests use `0` to bypass
    * the grace and exercise the sweep path in one pass.
@@ -154,9 +174,10 @@ export interface InternalRunGcOptions extends RunGcOptions {
 
   /**
    * @internal Budget cap on keys deleted per run.
-   * `CLOUDFLARE_FREE_TIER` sets it — CF free-tier safe when paired
-   * with `compact()` in the same scheduled handler. The default is
-   * effectively unbounded (`Number.MAX_SAFE_INTEGER`).
+   * `CLOUDFLARE_FREE_TIER` sets it — CF free-tier safe as one isolated
+   * GC phase for one collection, alternated with a separate direct
+   * `compact()` invocation. The default is effectively unbounded
+   * (`Number.MAX_SAFE_INTEGER`).
    */
   readonly maxSweepsPerRun?: number;
 
@@ -170,11 +191,22 @@ export interface InternalRunGcOptions extends RunGcOptions {
 }
 
 /**
- * Why a pass skipped orphan-content discovery entirely.
+ * Why a pass skipped orphan-content discovery entirely. Two classes,
+ * and an operator needs to tell them apart:
+ *
+ * BUDGET (expected on Cloudflare Free; self-clearing) — the pass could
+ * not afford to prove content liveness, checkpointed its progress, and a
+ * later pass finishes the job:
+ *   - `"probe-budget"`: the bounded tail probe hit `maxTailProbeGets`
+ *     without reaching the true tail.
+ *   - `"live-tail-over-cap"`: the tail is known exactly but the live
+ *     range exceeds `maxLiveLogEntriesPerRun`.
  *
  * DEGRADED (never expected) — an artifact that should be readable was
  * not, so no complete live set can be built while the fault persists.
  * Orphan content accumulates for as long as it does:
+ *   - `"probe-slot-malformed"`: an occupied log slot in the probe range
+ *     held a body that would not decode.
  *   - `"live-log-unreadable"`: a log entry inside `[log_seq_start, tail)`
  *     was missing or would not decode.
  *   - `"snapshot-unreadable"`: reading or hash-verifying the current
@@ -189,8 +221,55 @@ export interface InternalRunGcOptions extends RunGcOptions {
  * Consecutive passes reporting the same reason is the discriminator, and
  * the operator's signal to look at the named artifact; `admin fsck`
  * walks the same chain and surfaces the underlying error.
+ *
+ * The BUDGET/DEGRADED class is what callers actually branch on, and it is
+ * not readable off the string — use {@link isDegradedContentDeferral}
+ * rather than re-deriving it from a hardcoded list of members.
  */
-export type ContentDeferralReason = "live-log-unreadable" | "snapshot-unreadable";
+export type ContentDeferralReason =
+  | "probe-budget"
+  | "live-tail-over-cap"
+  | "probe-slot-malformed"
+  | "live-log-unreadable"
+  | "snapshot-unreadable";
+
+/**
+ * The BUDGET/DEGRADED split of {@link ContentDeferralReason}, in the one
+ * place that owns it. A `Record` over the union rather than a list of the
+ * degraded members: adding a sixth reason fails to typecheck until it is
+ * classified here, so a new reason cannot silently inherit the wrong class
+ * — false alerts for a budget reason, silence for a degraded one.
+ */
+const CONTENT_DEFERRAL_IS_DEGRADED: Readonly<Record<ContentDeferralReason, boolean>> = {
+  "probe-budget": false,
+  "live-tail-over-cap": false,
+  "probe-slot-malformed": true,
+  "live-log-unreadable": true,
+  "snapshot-unreadable": true,
+};
+
+/**
+ * Whether a deferral reason is DEGRADED — a fault that does not
+ * self-clear, so orphan-content GC stays parked until an operator acts on
+ * the named artifact. `false` for both a budget reason and `undefined`
+ * (no deferral), which makes it a total predicate over
+ * `RunGcResult.contentDeferredReason`.
+ *
+ * This is the alerting predicate for a cron caller, which runs outside any
+ * HTTP scope and therefore sees no metrics.
+ *
+ * @example
+ * ```ts
+ * import { isDegradedContentDeferral, runGc } from "@gusto/baerly-storage/maintenance";
+ *
+ * const gc = await runGc({ storage, currentJsonKey }, CLOUDFLARE_FREE_TIER.gc);
+ * if (isDegradedContentDeferral(gc.contentDeferredReason)) {
+ *   console.error("orphan-content GC is degraded:", gc.contentDeferredReason);
+ * }
+ * ```
+ */
+export const isDegradedContentDeferral = (reason: ContentDeferralReason | undefined): boolean =>
+  reason !== undefined && CONTENT_DEFERRAL_IS_DEGRADED[reason];
 
 /**
  * Return shape of {@link runGc}.
@@ -220,14 +299,19 @@ export interface RunGcResult {
    * Absent means content classification ran on a complete live set. Also
    * emitted as `db.gc.content_deferred_total` (labelled by reason), but a
    * cron caller outside any HTTP scope sees no metrics — read this field
-   * and log a reason (see {@link ContentDeferralReason}) that repeats
-   * across passes.
+   * and log a reason that {@link isDegradedContentDeferral} accepts when
+   * it repeats across passes.
    */
   readonly contentDeferredReason?: ContentDeferralReason;
 }
 
 const DEFAULT_MAX_MARKS = Number.MAX_SAFE_INTEGER;
 const DEFAULT_MAX_SWEEPS = Number.MAX_SAFE_INTEGER;
+const zeroGcResult = (): RunGcResult => ({
+  marked: { stale_log: 0, orphan_snapshot: 0, orphan_content: 0 },
+  swept: 0,
+  pendingDepth: 0,
+});
 
 /**
  * Single GC pass — mark new orphans, sweep due-elapsed candidates,
@@ -256,6 +340,8 @@ export const runGc = async (
   const grace = internal.graceMillis ?? GC_GRACE_PERIOD_MILLIS;
   const maxMarks = internal.maxMarksPerRun ?? DEFAULT_MAX_MARKS;
   const maxSweeps = internal.maxSweepsPerRun ?? DEFAULT_MAX_SWEEPS;
+  const maxTailProbeGets = internal.maxTailProbeGets;
+  const maxLiveLogEntries = internal.maxLiveLogEntriesPerRun;
   const now = internal.now ?? ((): Date => new Date());
   const collectionPrefix = currentJsonKey.slice(0, currentJsonKey.lastIndexOf("/"));
   const collectionName = collectionPrefix.slice(collectionPrefix.lastIndexOf("/") + 1);
@@ -263,17 +349,98 @@ export const runGc = async (
   const signal = options.signal;
   const signalOpts = signal !== undefined ? { signal } : undefined;
 
+  // These internal caps feed range arithmetic and must fail before the
+  // first storage operation. Their absence is meaningful: the public/default
+  // path keeps the exact, complete pre-admission behavior.
+  if (maxTailProbeGets !== undefined) {
+    requireIntegerOption("runGc", collectionName, "maxTailProbeGets", maxTailProbeGets, 1);
+  }
+  if (maxLiveLogEntries !== undefined) {
+    requireIntegerOption("runGc", collectionName, "maxLiveLogEntriesPerRun", maxLiveLogEntries, 0);
+  }
+
   // ── Step 1. Read current.json (skip silently if absent). ────────
   const cur = await readCurrentJson(storage, currentJsonKey, signalOpts);
   if (cur === null) {
-    return {
-      marked: { stale_log: 0, orphan_snapshot: 0, orphan_content: 0 },
-      swept: 0,
-      pendingDepth: 0,
-    };
+    return zeroGcResult();
   }
   const current = cur.json;
   const logSeqStart = logSeqStartOf(current);
+
+  // Bounded scheduled GC admits content liveness hashing only after an
+  // exact, affordable proof. Capture decoded suffix entries here so an
+  // admitted pass never pays for those GETs twice. This happens before the
+  // pending-ledger read so a deferred pass can checkpoint its certified
+  // progress without spending bootstrap/CAS budget first.
+  let admittedTailProbe:
+    | { readonly floor: number; readonly tail: number; readonly entries: LogEntry[] }
+    | undefined;
+  let preserveContentCursor = false;
+  // Why content discovery deferred, for the result field and the metric.
+  // Ordered DEGRADED-before-BUDGET where a pass qualifies for both: a
+  // malformed slot is the actionable fault, and a budget reason would bury
+  // it under an outcome operators are told to expect on Free.
+  let contentDeferredReason: ContentDeferralReason | undefined;
+  const boundedAdmission = maxTailProbeGets !== undefined || maxLiveLogEntries !== undefined;
+  if (boundedAdmission) {
+    const floor = Math.max(logSeqStart, current.tail_hint);
+    const probe = await probeTailChunk(storage, collectionPrefix, floor, {
+      ...(signal !== undefined && { signal }),
+      ...(maxTailProbeGets !== undefined && { cap: maxTailProbeGets }),
+      tolerateMalformed: true,
+    });
+    const exactTail = probe.kind === "exact" ? probe.tail : undefined;
+    const liveEntryCap = maxLiveLogEntries ?? Number.MAX_SAFE_INTEGER;
+    if (!probe.complete) {
+      contentDeferredReason = "probe-slot-malformed";
+    } else if (probe.kind === "at-least") {
+      contentDeferredReason = "probe-budget";
+    } else if (exactTail !== undefined && exactTail - logSeqStart > liveEntryCap) {
+      contentDeferredReason = "live-tail-over-cap";
+    }
+    preserveContentCursor = contentDeferredReason !== undefined;
+
+    // Tested against the reason rather than `preserveContentCursor` so the
+    // conflict return below narrows to a defined reason — the two are the
+    // same condition, assigned on the line above.
+    if (contentDeferredReason !== undefined) {
+      const certifiedTail = probe.kind === "exact" ? probe.tail : probe.lowerBound;
+      if (certifiedTail > current.tail_hint) {
+        try {
+          await storage.put(
+            currentJsonKey,
+            encodeJsonBytes({ ...current, tail_hint: certifiedTail }),
+            {
+              ifMatch: cur.etag,
+              contentType: CURRENT_JSON_CONTENT_TYPE,
+              ...(signal !== undefined && { signal }),
+            },
+          );
+        } catch (error) {
+          if (error instanceof BaerlyError && error.code === "Conflict") {
+            // One attempt only — a retry spends more budget and could admit
+            // against a different manifest. But the pass DID defer content
+            // classification, and on a DEGRADED reason that is the alertable
+            // fact; a bare zero result renders it as a healthy idle pass,
+            // indistinguishable from a missing `current.json`. Report the
+            // reason on both channels, and count the lost checkpoint the way
+            // `compact()` counts its own.
+            const casLostMetrics = ctxMetrics();
+            const casLostLabels = { collection: collectionName };
+            casLostMetrics.counter("db.gc.cas_lost_total", 1, casLostLabels);
+            casLostMetrics.counter("db.gc.content_deferred_total", 1, {
+              ...casLostLabels,
+              reason: contentDeferredReason,
+            });
+            return { ...zeroGcResult(), contentDeferredReason };
+          }
+          throw error;
+        }
+      }
+    } else if (probe.kind === "exact") {
+      admittedTailProbe = { floor, tail: probe.tail, entries: probe.entries };
+    }
+  }
 
   // ── Step 2. Read or create gc/pending.json. ─────────────────────
   // Race-tolerant create: a concurrent pass may have bootstrapped
@@ -379,26 +546,26 @@ export const runGc = async (
   // the writer used to mint the content key.
   let markedOrphanContent = 0;
   let nextContentCursor: string | undefined;
-  let preserveContentCursor = false;
-  // Why content discovery deferred, for the result field and the metric.
-  let contentDeferredReason: ContentDeferralReason | undefined;
   let completeLiveContentHashes: ReadonlySet<string> | undefined;
-  const liveContent = await collectLiveContentHashes(
-    storage,
-    collectionPrefix,
-    collectionName,
-    current,
-    logSeqStart,
-    signal,
-  );
-  if (!liveContent.complete) {
+  const liveContent = preserveContentCursor
+    ? undefined
+    : await collectLiveContentHashes(
+        storage,
+        collectionPrefix,
+        collectionName,
+        current,
+        logSeqStart,
+        signal,
+        admittedTailProbe,
+      );
+  if (liveContent !== undefined && !liveContent.complete) {
     // A partial live set cannot prove ANY content key dead — the missing
     // post-images are exactly the ones that would look orphan. Defer the
     // whole category (cursor held, nothing marked, nothing swept) rather
     // than classify against an incomplete set.
     preserveContentCursor = true;
     contentDeferredReason = liveContent.incompleteReason;
-  } else {
+  } else if (liveContent !== undefined) {
     completeLiveContentHashes = liveContent.hashes;
     const contentPass = await markOrphanContent({
       storage,
@@ -555,9 +722,9 @@ export const runGc = async (
     }
   }
   // Emitted only on a deferred pass, so a flat zero rate is the healthy
-  // signal and any non-zero reason is the alertable one. Without this, a
-  // pass that classified nothing because it COULDN'T is indistinguishable
-  // from one that found no orphans.
+  // signal and any non-zero DEGRADED reason is the alertable one. Without
+  // this, a pass that classified nothing because it COULDN'T is
+  // indistinguishable from one that found no orphans.
   if (contentDeferredReason !== undefined) {
     metrics.counter("db.gc.content_deferred_total", 1, {
       collection: collectionName,
@@ -756,6 +923,11 @@ type LiveContentScan =
  * post-image: every `entry.after` in `[logSeqStart, true tail)` plus
  * every row body in the current snapshot.
  *
+ * A bounded admitted caller supplies the exact probe it already paid for.
+ * Entries below `probe.floor` are fetched once; decoded entries from
+ * `[probe.floor, probe.tail)` are ingested directly. With no probe the
+ * original exact/unbounded probe + complete storage scan remains unchanged.
+ *
  * Missing or malformed live entries and snapshot read failures yield the
  * incomplete arm, which carries a reason and no hashes — the caller
  * cannot reach a partial set to classify against.
@@ -767,6 +939,11 @@ const collectLiveContentHashes = async (
   current: CurrentJson,
   logSeqStart: number,
   signal: AbortSignal | undefined,
+  exactProbe?: {
+    readonly floor: number;
+    readonly tail: number;
+    readonly entries: ReadonlyArray<LogEntry>;
+  },
 ): Promise<LiveContentScan> => {
   const hashes = new Set<string>();
   // First cause wins: the log walk runs before the snapshot read, and a
@@ -783,12 +960,18 @@ const collectLiveContentHashes = async (
   // probe at `max(log_seq_start, tail_hint)` — entries below
   // `log_seq_start` are folded and never scanned by the loop below. The
   // loop 404-tolerates misses, so over-bounding to `tail` is safe.
-  const { tail } = await probeTailFrom(
-    storage,
-    collectionPrefix,
-    Math.max(logSeqStart, current.tail_hint),
-    { signal },
-  );
+  let tail: number;
+  if (exactProbe !== undefined) {
+    tail = exactProbe.tail;
+  } else {
+    const tailProbe = await probeTailFrom(
+      storage,
+      collectionPrefix,
+      Math.max(logSeqStart, current.tail_hint),
+      { signal },
+    );
+    tail = tailProbe.tail;
+  }
   // Read every live entry in `[logSeqStart, tail)`, but cap the
   // simultaneous in-flight log GETs at MAX_PARALLEL_LOG_READS. A raw
   // `Promise.all` over the whole range fans out up to
@@ -800,33 +983,55 @@ const collectLiveContentHashes = async (
   // missing `log/<seq>` past a stale-low hint is skipped, not fatal)
   // and tolerant of a malformed entry, so it keeps its own bounded loop
   // rather than borrowing the throwing walker.
-  const ingestLogEntry = async (s: number): Promise<void> => {
-    const got = await storage.get(logObjectKey(collectionPrefix, s), getOpts);
-    if (got === null) {
-      markIncomplete("live-log-unreadable");
-      return;
-    }
-    let entry: { after?: unknown };
-    try {
-      entry = decodeJsonBytes<{ after?: unknown }>(got.body);
-    } catch {
-      markIncomplete("live-log-unreadable");
-      return;
-    }
+  const ingestDecodedLogEntry = async (entry: Pick<LogEntry, "after">): Promise<void> => {
     if (entry.after === undefined) {
       return;
     }
     const bodyBytes = encodeJsonBytes(entry.after);
     hashes.add(await versionFromContent(bodyBytes));
   };
-  for (let chunkStart = logSeqStart; chunkStart < tail; chunkStart += MAX_PARALLEL_LOG_READS) {
+  const ingestLogEntry = async (s: number): Promise<void> => {
+    const got = await storage.get(logObjectKey(collectionPrefix, s), getOpts);
+    if (got === null) {
+      markIncomplete("live-log-unreadable");
+      return;
+    }
+    let entry: LogEntry;
+    try {
+      entry = decodeJsonBytes<LogEntry>(got.body);
+    } catch {
+      markIncomplete("live-log-unreadable");
+      return;
+    }
+    await ingestDecodedLogEntry(entry);
+  };
+  const storageScanEnd = exactProbe?.floor ?? tail;
+  for (
+    let chunkStart = logSeqStart;
+    chunkStart < storageScanEnd;
+    chunkStart += MAX_PARALLEL_LOG_READS
+  ) {
     signal?.throwIfAborted();
-    const chunkEnd = Math.min(chunkStart + MAX_PARALLEL_LOG_READS, tail);
+    const chunkEnd = Math.min(chunkStart + MAX_PARALLEL_LOG_READS, storageScanEnd);
     const chunk: Array<Promise<void>> = [];
     for (let s = chunkStart; s < chunkEnd; s++) {
       chunk.push(ingestLogEntry(s));
     }
     await Promise.all(chunk);
+  }
+  if (exactProbe !== undefined) {
+    for (
+      let chunkStart = 0;
+      chunkStart < exactProbe.entries.length;
+      chunkStart += MAX_PARALLEL_LOG_READS
+    ) {
+      signal?.throwIfAborted();
+      await Promise.all(
+        exactProbe.entries
+          .slice(chunkStart, chunkStart + MAX_PARALLEL_LOG_READS)
+          .map(ingestDecodedLogEntry),
+      );
+    }
   }
 
   // Snapshot rows.

--- a/packages/server/src/log-tail.test.ts
+++ b/packages/server/src/log-tail.test.ts
@@ -15,7 +15,7 @@ import {
 } from "@baerly/protocol";
 import { describe, expect, test } from "vitest";
 import { seedLogEntries } from "../../../tests/fixtures/log-state.ts";
-import { findLogTail, probeTailFrom } from "./log-tail.ts";
+import { findLogTail, probeTailChunk, probeTailFrom } from "./log-tail.ts";
 
 const PREFIX = "app/t/tenant/x/manifests/c";
 
@@ -27,6 +27,24 @@ describe("probeTailFrom", () => {
     const { tail, entries } = await probeTailFrom(storage, PREFIX, 5);
     expect(tail).toBe(10);
     expect(entries.map((e) => e.seq)).toEqual([5, 6, 7, 8, 9]);
+  });
+
+  test("a bounded chunk returns an exact tail when its budget includes the miss", async () => {
+    const storage = new MemoryStorage();
+    await seedLogEntries(storage, PREFIX, 5, 10);
+    await expect(probeTailChunk(storage, PREFIX, 5, { cap: 6 })).resolves.toMatchObject({
+      kind: "exact",
+      tail: 10,
+      complete: true,
+    });
+  });
+
+  test("a full bounded chunk returns a certified exclusive lower bound", async () => {
+    const storage = new MemoryStorage();
+    await seedLogEntries(storage, PREFIX, 5, 11);
+    const result = await probeTailChunk(storage, PREFIX, 5, { cap: 5 });
+    expect(result).toMatchObject({ kind: "at-least", lowerBound: 10, complete: true });
+    expect(result.entries.map((entry) => entry.seq)).toEqual([5, 6, 7, 8, 9]);
   });
 
   test("hint already at the tail returns empty", async () => {
@@ -46,6 +64,10 @@ describe("probeTailFrom", () => {
     const { tail, entries } = await probeTailFrom(storage, PREFIX, 3);
     expect(tail).toBe(8);
     expect(entries.map((e) => e.seq)).toEqual([3, 4, 5, 6, 7]);
+
+    const result = await probeTailChunk(storage, PREFIX, 3, { cap: 10 });
+    expect(result).toMatchObject({ kind: "exact", tail: 8 });
+    expect(result.entries.map((entry) => entry.seq)).not.toContain(9);
   });
 
   test("cap exhausted: THROWS Internal instead of silently truncating", async () => {
@@ -93,6 +115,38 @@ describe("probeTailFrom", () => {
     await expect(probeTailFrom(storage, PREFIX, 5)).rejects.toMatchObject({
       code: "NetworkError",
     });
+  });
+
+  test("a malformed bounded entry identifies probeTailChunk in its error", async () => {
+    // Calling the chunk probe its former `probeTailFrom` name conceals which
+    // contract rejected the body when operators inspect an InvalidResponse.
+    const malformed: Storage = {
+      get: async () => ({ body: new TextEncoder().encode("{"), etag: "x" }),
+      put: async () => ({ etag: "x" }),
+      delete: async () => {},
+      list: () => {
+        throw new Error("list not used by probeTailChunk");
+      },
+    };
+
+    await expect(probeTailChunk(malformed, PREFIX, 0)).rejects.toMatchObject({
+      code: "InvalidResponse",
+      message: expect.stringContaining("probeTailChunk: malformed log entry"),
+    });
+  });
+
+  test("tolerant bounded mode records malformed occupancy as incomplete and keeps probing", async () => {
+    const storage = new MemoryStorage();
+    await seedLogEntries(storage, PREFIX, 5, 8);
+    await storage.put(logObjectKey(PREFIX, 6), new TextEncoder().encode("{"));
+
+    const result = await probeTailChunk(storage, PREFIX, 5, {
+      cap: 10,
+      tolerateMalformed: true,
+    });
+
+    expect(result).toMatchObject({ kind: "exact", tail: 8, complete: false });
+    expect(result.entries.map((entry) => entry.seq)).toEqual([5, 7]);
   });
 
   test("an aborted signal propagates — never silently read as the tail", async () => {

--- a/packages/server/src/log-tail.ts
+++ b/packages/server/src/log-tail.ts
@@ -14,6 +14,64 @@ import {
   logObjectKey,
 } from "@baerly/protocol";
 
+export type TailProbeChunk =
+  | {
+      readonly kind: "exact";
+      readonly tail: number;
+      readonly entries: LogEntry[];
+      readonly complete: boolean;
+    }
+  | {
+      readonly kind: "at-least";
+      readonly lowerBound: number;
+      readonly entries: LogEntry[];
+      readonly complete: boolean;
+    };
+
+/**
+ * Probe a bounded chunk of committed entries from `hint`. An occupied
+ * chunk certifies only that the tail is at or past its exclusive bound.
+ * Decode failures throw by default. GC alone opts into tolerant
+ * occupancy probing: malformed slots remain occupied, `complete` becomes
+ * false, and probing continues to the first missing slot or cap.
+ */
+export const probeTailChunk = async (
+  storage: Storage,
+  logPrefix: string,
+  hint: number,
+  opts?: { signal?: AbortSignal; cap?: number; tolerateMalformed?: boolean },
+): Promise<TailProbeChunk> => {
+  const cap = opts?.cap ?? LOG_FORWARD_PROBE_CAP;
+  const getOpts = opts?.signal !== undefined ? { signal: opts.signal } : undefined;
+  const entries: LogEntry[] = [];
+  let complete = true;
+  for (let i = 0; i < cap; i++) {
+    const seq = hint + i;
+    const key = logObjectKey(logPrefix, seq);
+    const got = await storage.get(key, getOpts);
+    if (got === null) {
+      return { kind: "exact", tail: seq, entries, complete };
+    }
+    try {
+      entries.push(decodeJsonBytes<LogEntry>(got.body));
+    } catch (error) {
+      if (opts?.tolerateMalformed === true) {
+        complete = false;
+        continue;
+      }
+      // A malformed body at an occupied slot is a protocol violation —
+      // surface it as InvalidResponse (the same code readLogEntry uses)
+      // rather than a raw SyntaxError leaking out of the probe.
+      throw new BaerlyError(
+        "InvalidResponse",
+        `probeTailChunk: malformed log entry at ${key}: ${(error as Error).message}`,
+        { cause: error },
+      );
+    }
+  }
+  return { kind: "at-least", lowerBound: hint + cap, entries, complete };
+};
+
 /**
  * Discover the true committed tail and fold entries in `[hint, tail)`.
  * `tail` is the first empty seq (>= hint); `entries` are the
@@ -27,28 +85,9 @@ export const probeTailFrom = async (
   hint: number,
   opts?: { signal?: AbortSignal; cap?: number },
 ): Promise<{ tail: number; entries: LogEntry[] }> => {
-  const cap = opts?.cap ?? LOG_FORWARD_PROBE_CAP;
-  const getOpts = opts?.signal !== undefined ? { signal: opts.signal } : undefined;
-  const entries: LogEntry[] = [];
-  for (let i = 0; i < cap; i++) {
-    const seq = hint + i;
-    const key = logObjectKey(logPrefix, seq);
-    const got = await storage.get(key, getOpts);
-    if (got === null) {
-      return { tail: seq, entries };
-    }
-    try {
-      entries.push(decodeJsonBytes<LogEntry>(got.body));
-    } catch (error) {
-      // A malformed body at an occupied slot is a protocol violation —
-      // surface it as InvalidResponse (the same code readLogEntry uses)
-      // rather than a raw SyntaxError leaking out of the probe.
-      throw new BaerlyError(
-        "InvalidResponse",
-        `probeTailFrom: malformed log entry at ${key}: ${(error as Error).message}`,
-        { cause: error },
-      );
-    }
+  const result = await probeTailChunk(storage, logPrefix, hint, opts);
+  if (result.kind === "exact") {
+    return { tail: result.tail, entries: result.entries };
   }
   // Cap exhausted without hitting a 404 — the true tail is past `cap`.
   // Returning `hint+cap` here would silently truncate every downstream
@@ -62,7 +101,7 @@ export const probeTailFrom = async (
   // needs to walk past the cap.
   throw new BaerlyError(
     "Internal",
-    `probeTailFrom: forward probe exceeded ${cap} from hint ${hint} on ${logPrefix}`,
+    `probeTailFrom: forward probe exceeded ${opts?.cap ?? LOG_FORWARD_PROBE_CAP} from hint ${hint} on ${logPrefix}`,
   );
 };
 

--- a/packages/server/src/maintenance-budget.test.ts
+++ b/packages/server/src/maintenance-budget.test.ts
@@ -6,26 +6,31 @@
  *
  * One scheduled Worker invocation is capped at 50 subrequests on the
  * free tier; this test wraps `MemoryStorage` in a counting proxy and
- * proves that a single {@link runScheduledMaintenance} tick under
+ * proves that every isolated scheduled phase under
  * {@link CLOUDFLARE_FREE_TIER} stays at or below that budget. R2
  * binding ops map 1:1 to subrequests, so the proxy counts `get` /
  * `put` / `delete` / `list` invocations as one each.
  *
  * The Cloudflare scheduled handler runs only one phase per tick
- * (even-minute compact, odd-minute GC) because `collectLiveContentHashes`
- * inside `runGc()` reads the full live log tail unconditionally —
- * combining both phases in a single tick can exceed 50 ops when the
- * tail is long. This test therefore checks each phase in isolation,
- * mirroring what production actually executes. If a future refactor
+ * (even-minute compact, odd-minute GC). GC admits the content phase only
+ * after a bounded exact probe proves the full live tail affordable; a
+ * partial GC still advances the hint and performs non-content cleanup.
+ * These tests check each phase in isolation, mirroring production. If a future refactor
  * inflates either phase's per-tick budget, this is the load-bearing
  * test that fails — do NOT relax the assertion. Tune
  * `CLOUDFLARE_FREE_TIER` or the underlying primitives instead.
  */
 
 import {
+  BaerlyError,
   CURRENT_JSON_SCHEMA_VERSION,
+  GC_PENDING_SCHEMA_VERSION,
+  SNAPSHOT_SCHEMA_VERSION,
   createCurrentJson,
+  createGcPending,
   MemoryStorage,
+  readCurrentJson,
+  snapshotHash,
   type Storage,
   type StorageGetOptions,
   type StorageGetResult,
@@ -34,9 +39,11 @@ import {
   type StoragePutResult,
 } from "@baerly/protocol";
 import { describe, expect, test } from "vitest";
+import { logStateCurrentJson, seedLogEntries } from "../../../tests/fixtures/log-state.ts";
 import { compact } from "./compactor.ts";
-import { runGc } from "./gc.ts";
+import { type InternalRunGcOptions, runGc } from "./gc.ts";
 import { CLOUDFLARE_FREE_TIER, runBoundedMaintenance } from "./maintenance.ts";
+import { encodeSnapshotBody, snapshotKey } from "./snapshot.ts";
 import { Writer } from "./writer.ts";
 
 const FREE_TIER_BUDGET = 50;
@@ -48,8 +55,14 @@ const FREE_TIER_BUDGET = 50;
  */
 const countingStorage = (
   inner: Storage,
-): { storage: Storage; getOps: () => number; report: () => Record<string, number> } => {
+): {
+  storage: Storage;
+  getOps: () => number;
+  report: () => Record<string, number>;
+  listedPrefixes: () => string[];
+} => {
   const counts = { get: 0, put: 0, delete: 0, list: 0 };
+  const prefixes: string[] = [];
   const wrapper: Storage = {
     async get(key: string, opts?: StorageGetOptions): Promise<StorageGetResult | null> {
       counts.get += 1;
@@ -68,6 +81,7 @@ const countingStorage = (
       opts?: { startAfter?: string; maxKeys?: number; signal?: AbortSignal },
     ): AsyncIterable<StorageListEntry> {
       counts.list += 1;
+      prefixes.push(prefix);
       return inner.list(prefix, opts);
     },
   };
@@ -75,6 +89,7 @@ const countingStorage = (
     storage: wrapper,
     getOps: (): number => counts.get + counts.put + counts.delete + counts.list,
     report: (): Record<string, number> => ({ ...counts }),
+    listedPrefixes: (): string[] => [...prefixes],
   };
 };
 
@@ -108,73 +123,286 @@ describe("CLOUDFLARE_FREE_TIER budget", () => {
   const KEY = "app/t/tenant/x/manifests/c/current.json";
   const COLL = "c";
 
-  test("compact-only tick stays at or below 50 storage ops", async () => {
-    // Even-minute branch of the scheduled handler: compact alone.
-    // Budget math: 1 GET current + 1 GET tail-probe 404 + N GETs log
-    // (N = maxEntriesPerRun = 20) + 1 PUT snapshot + 1 PUT current ≈ 24.
-    // (No prior snapshot on first compact ⇒ skip the snapshot-load GET.)
-    //
-    // Under single-write commit the writer doesn't advance tail_hint, so
-    // model steady state (a prior fold stamped it) by stamping the true
-    // tail. The compactor then probes from `max(log_seq_start, tail_hint)`
-    // — an immediate 404 — instead of walking O(minEntriesToCompact) to
-    // confirm the go/no-go gate, which is the budget-blowing cost on a
-    // never-yet-compacted backlog.
+  test("compact-only ticks converge from a stale-low tail_hint within the 50-op budget", async () => {
+    // Even-minute branch of the scheduled handler: compact alone. The
+    // writer deliberately leaves tail_hint stale, so each invocation must
+    // bound discovery, checkpoint progress, and let later ticks resume.
     const inner = new MemoryStorage();
-    await seed(inner, KEY, COLL, 200);
-    const { casUpdateCurrentJson } = await import("@baerly/protocol");
-    await casUpdateCurrentJson(inner, KEY, (c) => ({ ...c, tail_hint: 200 }));
-    const { storage, getOps, report } = countingStorage(inner);
+    await seed(inner, KEY, COLL, 100);
 
-    const r = await compact({ storage, currentJsonKey: KEY }, CLOUDFLARE_FREE_TIER.compact);
-    expect(r.written).toBe(true);
-    const ops = getOps();
-    expect(ops, `ops by category: ${JSON.stringify(report())}`).toBeLessThanOrEqual(
-      FREE_TIER_BUDGET,
-    );
+    const perPassOps: number[] = [];
+    const reasons: Array<string | undefined> = [];
+    const states: Array<{ log_seq_start: number; tail_hint: number }> = [];
+    const reports: Array<Record<string, number>> = [];
+    let reachedBelowMinThreshold = false;
+
+    for (let invocation = 0; invocation < 10; invocation++) {
+      const { storage, getOps, report } = countingStorage(inner);
+      const result = await compact({ storage, currentJsonKey: KEY }, CLOUDFLARE_FREE_TIER.compact);
+      const current = await readCurrentJson(inner, KEY);
+      expect(current).not.toBeNull();
+
+      perPassOps.push(getOps());
+      reasons.push(result.skippedReason);
+      reports.push(report());
+      states.push({
+        log_seq_start: current!.json.log_seq_start,
+        tail_hint: current!.json.tail_hint,
+      });
+
+      if (result.skippedReason === "below-min-threshold") {
+        reachedBelowMinThreshold = true;
+        break;
+      }
+    }
+
+    for (let i = 1; i < states.length; i++) {
+      expect(states[i]!.log_seq_start).toBeGreaterThanOrEqual(states[i - 1]!.log_seq_start);
+      expect(states[i]!.tail_hint).toBeGreaterThanOrEqual(states[i - 1]!.tail_hint);
+    }
+
+    expect(reachedBelowMinThreshold).toBe(true);
+    expect(perPassOps.length).toBeLessThan(10);
+    expect(
+      perPassOps.every((ops) => ops <= FREE_TIER_BUDGET),
+      `per-pass ops: ${JSON.stringify(perPassOps)}; reports: ${JSON.stringify(reports)}`,
+    ).toBe(true);
+    expect(perPassOps, `reports: ${JSON.stringify(reports)}`).toEqual([48, 49, 49, 49, 25, 2]);
+    expect(Math.max(...perPassOps)).toBe(49);
+    expect(reasons).not.toContain("probe-budget-checkpointed");
+
+    const finalCurrent = await readCurrentJson(inner, KEY);
+    expect(finalCurrent).not.toBeNull();
+    expect(finalCurrent!.json).toMatchObject({ log_seq_start: 100, tail_hint: 100 });
   });
 
-  test("gc-only tick stays at or below 50 storage ops at steady state", async () => {
-    // Odd-minute branch of the scheduled handler: GC alone. Steady
-    // state on free tier: compaction runs at the same cadence as GC
-    // and keeps the live log tail near `minEntriesToCompact = 50`,
-    // bounded by the M term in the GC budget docstring.
-    //
-    // To model the steady-state operating point we seed 60 entries
-    // and pre-compact: log_seq_start = 20, tail_hint = 60 ⇒ tail = 40,
-    // which is below the 50-entry compaction threshold (next compact
-    // tick will rerun). The GC pass then mark+sweeps stale-log
-    // candidates and computes live-content hashes over the 40-entry
-    // tail.
-    //
-    // Budget math (steady state): 1 GET current + 1 GET pending +
-    // 1 PUT create pending (first GC pass) + 3 LISTs + 1 GET snapshot
-    // + ≤40 GETs log + ≤20 DELETEs (mark-and-sweep bypass) + 1 PUT
-    // pending = ≤67 — over budget. The default 7-day grace means
-    // *zero* sweeps in any single pass, so the realistic GC ops are
-    // 1 GET current + 1 GET pending + 1 PUT create + 3 LISTs + 1 GET
-    // snapshot + 40 GETs log + 1 PUT pending = 48, fits.
+  // Production mutation caught: manual tail priming hid both the stale-hint
+  // catch-up cost and content-GC starvation. Real alternating scheduled
+  // phases must keep every invocation bounded, advance manifest positions
+  // monotonically, and eventually admit a complete content-marking pass.
+  test.each([60, 100])(
+    "real compact/GC alternation drains %i entries within budget and admits content marking",
+    async (entryCount) => {
+      const inner = new MemoryStorage();
+      await seed(inner, KEY, COLL, entryCount);
+      const orphanContent =
+        "app/t/tenant/x/manifests/c/content/00000000000000000000000000000000.json";
+      await inner.put(orphanContent, new TextEncoder().encode('{"_id":"orphan"}'));
+      const seededCurrent = await readCurrentJson(inner, KEY);
+      expect(seededCurrent?.json.tail_hint).toBe(0);
+
+      const states: Array<{ log_seq_start: number; tail_hint: number }> = [];
+      const invocations: Array<{
+        phase: "compact" | "gc";
+        ops: number;
+        report: Record<string, number>;
+      }> = [];
+      let fullContentPass = false;
+
+      for (let invocation = 0; invocation < 24 && !fullContentPass; invocation++) {
+        const counted = countingStorage(inner);
+        const phase = invocation % 2 === 0 ? "compact" : "gc";
+        if (phase === "compact") {
+          await compact(
+            { storage: counted.storage, currentJsonKey: KEY },
+            CLOUDFLARE_FREE_TIER.compact,
+          );
+        } else {
+          const result = await runGc(
+            { storage: counted.storage, currentJsonKey: KEY },
+            CLOUDFLARE_FREE_TIER.gc,
+          );
+          if (result.marked.orphan_content === 1) {
+            fullContentPass = true;
+            expect(counted.listedPrefixes()).toContain("app/t/tenant/x/manifests/c/content/");
+          }
+        }
+
+        const current = await readCurrentJson(inner, KEY);
+        expect(current).not.toBeNull();
+        states.push({
+          log_seq_start: current!.json.log_seq_start,
+          tail_hint: current!.json.tail_hint,
+        });
+        const report = counted.report();
+        const ops = counted.getOps();
+        invocations.push({ phase, ops, report });
+        expect(
+          ops,
+          `entries=${entryCount}; invocation=${invocation}; phase=${phase}; report=${JSON.stringify(report)}`,
+        ).toBeLessThanOrEqual(FREE_TIER_BUDGET);
+      }
+
+      for (let i = 1; i < states.length; i++) {
+        expect(states[i]!.log_seq_start).toBeGreaterThanOrEqual(states[i - 1]!.log_seq_start);
+        expect(states[i]!.tail_hint).toBeGreaterThanOrEqual(states[i - 1]!.tail_hint);
+      }
+      if (!fullContentPass) {
+        throw new Error(`content pass never admitted: ${JSON.stringify(invocations)}`);
+      }
+      expect(fullContentPass).toBe(true);
+      expect(states.at(-1)?.tail_hint).toBe(entryCount);
+      expect(entryCount - states.at(-1)!.log_seq_start).toBeLessThanOrEqual(20);
+    },
+  );
+
+  // Production mutation caught: forgetting any bootstrap/final-CAS retry
+  // cost can make the nominal Free profile exceed 50 under contention.
+  // Hand-derived maximum: 1 current GET + 21 live/probe GETs + 3 pending
+  // bootstrap ops + 3 LISTs + 1 snapshot GET + 10 DELETEs + 1 fresh
+  // current GET for a due snapshot + 6 final CAS ops = 46.
+  test("maximally contended admitted GC stays at 46 storage operations", async () => {
     const inner = new MemoryStorage();
-    await seed(inner, KEY, COLL, 60);
-
-    // Pre-compact to set up the steady-state shape; we measure GC alone,
-    // so we do compact outside the counting wrapper. Under single-write
-    // commit the writer doesn't advance tail_hint, so after a CAPPED
-    // compact the stored hint lags the true tail. Stamp the true tail
-    // (tail_hint=60) directly so GC's probe is a single immediate-404
-    // and the steady-state shape (log_seq_start=20, tail=60) holds — the
-    // operating point the budget math models.
-    await compact({ storage: inner, currentJsonKey: KEY }, CLOUDFLARE_FREE_TIER.compact);
-    const { casUpdateCurrentJson } = await import("@baerly/protocol");
-    await casUpdateCurrentJson(inner, KEY, (c) => ({ ...c, tail_hint: 60 }));
-
-    const { storage, getOps, report } = countingStorage(inner);
-    const r = await runGc({ storage, currentJsonKey: KEY }, CLOUDFLARE_FREE_TIER.gc);
-    expect(r).not.toBeNull();
-    const ops = getOps();
-    expect(ops, `ops by category: ${JSON.stringify(report())}`).toBeLessThanOrEqual(
-      FREE_TIER_BUDGET,
+    const prefix = "app/t/tenant/x/manifests/c";
+    const snapshotBody = encodeSnapshotBody({
+      schema_version: SNAPSHOT_SCHEMA_VERSION,
+      min_seq: 0,
+      max_seq: 40,
+      collection: COLL,
+      docs: [],
+    });
+    const liveSnapshot = snapshotKey(prefix, 0, 40, await snapshotHash(snapshotBody));
+    await inner.put(liveSnapshot, snapshotBody);
+    await createCurrentJson(
+      inner,
+      KEY,
+      logStateCurrentJson({
+        snapshot: liveSnapshot,
+        log_seq_start: 40,
+        tail_hint: 50,
+      }),
     );
+    await seedLogEntries(inner, prefix, 40, 60, (seq) => ({
+      after: { _id: `d${seq}`, n: seq },
+    }));
+    const dueCandidates = [
+      ...Array.from({ length: 9 }, (_, index) => ({
+        key: `${prefix}/gc/due-${index}.json`,
+        due_at: "2000-01-01T00:00:00.000Z",
+        reason: "stale-log" as const,
+      })),
+      {
+        key: snapshotKey(prefix, 0, 39, "b".repeat(64)),
+        due_at: "2000-01-01T00:00:00.000Z",
+        reason: "orphan-snapshot" as const,
+      },
+    ];
+    let firstPendingRead = true;
+    let injectedBootstrapWinner = false;
+    const contended: Storage = {
+      async get(key, opts) {
+        if (key === `${prefix}/gc/pending.json` && firstPendingRead) {
+          firstPendingRead = false;
+          return null;
+        }
+        return inner.get(key, opts);
+      },
+      async put(key, body, opts) {
+        if (
+          key === `${prefix}/gc/pending.json` &&
+          opts?.ifNoneMatch === "*" &&
+          !injectedBootstrapWinner
+        ) {
+          injectedBootstrapWinner = true;
+          await createGcPending(inner, key, {
+            schema_version: GC_PENDING_SCHEMA_VERSION,
+            candidates: dueCandidates,
+            last_swept_at: "",
+          });
+          return inner.put(key, body, opts);
+        }
+        if (key === `${prefix}/gc/pending.json` && opts?.ifMatch !== undefined) {
+          throw new BaerlyError("Conflict", "forced final pending CAS conflict");
+        }
+        return inner.put(key, body, opts);
+      },
+      delete: (key, opts) => inner.delete(key, opts),
+      list: (listPrefix, opts) => inner.list(listPrefix, opts),
+    };
+    const counted = countingStorage(contended);
+
+    const result = await runGc({ storage: counted.storage, currentJsonKey: KEY }, {
+      ...CLOUDFLARE_FREE_TIER.gc,
+      graceMillis: 0,
+      now: () => new Date("2026-01-01T00:00:00.000Z"),
+    } as InternalRunGcOptions);
+
+    expect(result.swept).toBe(10);
+    const totalOps = counted.getOps();
+    expect(totalOps).toBe(46);
+    expect(totalOps).toBeLessThanOrEqual(FREE_TIER_BUDGET);
+  });
+
+  test("maximally contended content-deferred GC stays at 49 storage operations", async () => {
+    const inner = new MemoryStorage();
+    const prefix = "app/t/tenant/x/manifests/c";
+    await createCurrentJson(
+      inner,
+      KEY,
+      logStateCurrentJson({
+        log_seq_start: 20,
+        tail_hint: 20,
+      }),
+    );
+    await seedLogEntries(inner, prefix, 20, 45);
+    const dueCandidates = [
+      ...Array.from({ length: 9 }, (_, index) => ({
+        key: `${prefix}/gc/deferred-due-${index}.json`,
+        due_at: "2000-01-01T00:00:00.000Z",
+        reason: "stale-log" as const,
+      })),
+      {
+        key: snapshotKey(prefix, 0, 19, "c".repeat(64)),
+        due_at: "2000-01-01T00:00:00.000Z",
+        reason: "orphan-snapshot" as const,
+      },
+    ];
+    let firstPendingRead = true;
+    let injectedBootstrapWinner = false;
+    const contended: Storage = {
+      async get(key, opts) {
+        if (key === `${prefix}/gc/pending.json` && firstPendingRead) {
+          firstPendingRead = false;
+          return null;
+        }
+        return inner.get(key, opts);
+      },
+      async put(key, body, opts) {
+        if (
+          key === `${prefix}/gc/pending.json` &&
+          opts?.ifNoneMatch === "*" &&
+          !injectedBootstrapWinner
+        ) {
+          injectedBootstrapWinner = true;
+          await createGcPending(inner, key, {
+            schema_version: GC_PENDING_SCHEMA_VERSION,
+            candidates: dueCandidates,
+            last_swept_at: "",
+          });
+          return inner.put(key, body, opts);
+        }
+        if (key === `${prefix}/gc/pending.json` && opts?.ifMatch !== undefined) {
+          throw new BaerlyError("Conflict", "forced final pending CAS conflict");
+        }
+        return inner.put(key, body, opts);
+      },
+      delete: (key, opts) => inner.delete(key, opts),
+      list: (listPrefix, opts) => inner.list(listPrefix, opts),
+    };
+    const counted = countingStorage(contended);
+
+    const result = await runGc({ storage: counted.storage, currentJsonKey: KEY }, {
+      ...CLOUDFLARE_FREE_TIER.gc,
+      graceMillis: 0,
+      now: () => new Date("2026-01-01T00:00:00.000Z"),
+    } as InternalRunGcOptions);
+
+    expect(result.swept).toBe(10);
+    expect(counted.listedPrefixes()).toEqual([`${prefix}/log/`, `${prefix}/snapshot/`]);
+    expect(counted.report()).toEqual({ get: 32, put: 5, delete: 10, list: 2 });
+    const totalOps = counted.getOps();
+    expect(totalOps).toBe(49);
+    expect(totalOps).toBeLessThanOrEqual(FREE_TIER_BUDGET);
   });
 
   test("B4: a write-tick fold with a STALE-LOW stored tail_hint stays within budget because observedTail bounds the probe", async () => {

--- a/packages/server/src/maintenance.test.ts
+++ b/packages/server/src/maintenance.test.ts
@@ -132,9 +132,30 @@ describe("runScheduledMaintenance", () => {
     const cfFree = CLOUDFLARE_FREE_TIER as InternalMaintenanceOptions;
 
     expect(cfFree.compact?.maxEntriesPerRun).toBe(20);
-    expect(cfFree.compact?.minEntriesToCompact).toBe(50);
+    expect(cfFree.compact?.minEntriesToCompact).toBe(20);
+    expect(cfFree.compact?.maxTailProbeGets).toBe(25);
+    expect(cfFree.gc?.maxTailProbeGets).toBe(25);
+    expect(cfFree.gc?.maxLiveLogEntriesPerRun).toBe(20);
     expect(cfFree.gc?.maxMarksPerRun).toBe(20);
     expect(cfFree.gc?.maxSweepsPerRun).toBe(10);
+  });
+
+  test("CLOUDFLARE_FREE_TIER keeps its fold threshold within one probe budget", () => {
+    // Not a restatement of the constants above: this is the RELATION
+    // between two of them. `compact()` derives `available` from a probe
+    // that certifies at most `probeFloor + maxTailProbeGets`, so a
+    // threshold above that budget cannot be met by a single pass — every
+    // pass would return `probe-budget-checkpointed` and fold nothing until
+    // enough passes had ratcheted `tail_hint` forward. Raising the
+    // threshold or lowering the probe budget in isolation reintroduces
+    // that stall, so bind them here.
+    const cfFree = CLOUDFLARE_FREE_TIER as InternalMaintenanceOptions;
+    const threshold = cfFree.compact?.minEntriesToCompact;
+    const probeBudget = cfFree.compact?.maxTailProbeGets;
+
+    expect(threshold).toBeDefined();
+    expect(probeBudget).toBeDefined();
+    expect(threshold as number).toBeLessThanOrEqual(probeBudget as number);
   });
 
   test("CLOUDFLARE_PAID_TIER carries the Node-derived per-pass bounds", () => {
@@ -145,6 +166,10 @@ describe("runScheduledMaintenance", () => {
     const cfPaid = CLOUDFLARE_PAID_TIER as InternalMaintenanceOptions;
 
     expect(cfPaid.compact?.maxEntriesPerRun).toBe(200);
+    expect(cfPaid.compact?.minEntriesToCompact).toBe(50);
+    expect(cfPaid.compact?.maxTailProbeGets).toBeUndefined();
+    expect(cfPaid.gc?.maxTailProbeGets).toBeUndefined();
+    expect(cfPaid.gc?.maxLiveLogEntriesPerRun).toBeUndefined();
     expect(cfPaid.gc?.maxMarksPerRun).toBe(200);
     expect(cfPaid.gc?.maxSweepsPerRun).toBe(100);
   });

--- a/packages/server/src/maintenance.ts
+++ b/packages/server/src/maintenance.ts
@@ -24,6 +24,7 @@ import {
   type Storage,
   BaerlyError,
   casUpdateCurrentJson,
+  CF_FREE_COMPACT_TAIL_PROBE_GETS,
   GC_STARVATION_GUARD,
   MAINTENANCE_COLD_START_ENTRY_BYTES,
   MAINTENANCE_MIN_LIVE_BYTES,
@@ -131,12 +132,24 @@ export {
 } from "@baerly/protocol";
 
 // Snapshot ceilings aren't part of the scheduled cap surface; omitted.
-const profileToScheduledOptions = (profile: MaintenanceProfile): InternalMaintenanceOptions => ({
+const profileToScheduledOptions = (
+  profile: MaintenanceProfile,
+  maxTailProbeGets?: number,
+  minEntriesToCompact: number = WRITE_TICK_MIN_ENTRIES_TO_COMPACT,
+): InternalMaintenanceOptions => ({
   compact: {
     maxEntriesPerRun: profile.maxFoldEntriesPerPass,
-    minEntriesToCompact: WRITE_TICK_MIN_ENTRIES_TO_COMPACT,
+    minEntriesToCompact,
+    ...(maxTailProbeGets !== undefined && { maxTailProbeGets }),
   },
-  gc: { maxMarksPerRun: profile.gcMaxMarks, maxSweepsPerRun: profile.gcMaxSweeps },
+  gc: {
+    maxMarksPerRun: profile.gcMaxMarks,
+    maxSweepsPerRun: profile.gcMaxSweeps,
+    ...(maxTailProbeGets !== undefined && {
+      maxTailProbeGets,
+      maxLiveLogEntriesPerRun: profile.maxFoldEntriesPerPass,
+    }),
+  },
 });
 
 /**
@@ -144,22 +157,44 @@ const profileToScheduledOptions = (profile: MaintenanceProfile): InternalMainten
  * derived from {@link MAINTENANCE_PROFILE_CF_FREE} (one source of truth).
  *
  * Budget arithmetic (worst case):
- *   compact: 1 GET current + 1 GET snapshot (if any) + N GETs log
- *     + 1 PUT snapshot + 1 PUT current = 3 + N (N = maxEntriesPerRun).
- *   runGc:   1 GET current + 1 GET pending + 3 LISTs (one page each)
- *     + M GETs log (live tail for content hashes) + S DELETEs + 1 PUT
- *     pending = 6 + M + S.
+ *   compact: 1 current GET + P tail-probe GETs + 1 optional prior-snapshot
+ *     GET + N folded-log GETs + 1 snapshot PUT + 1 `current.json` CAS PUT
+ *     = 4 + N + P (N = maxEntriesPerRun, P = 25).
+ *   full content-marking GC, maximally contended: 1 current GET + (M + 1)
+ *     live-log/probe GETs + 3 pending-bootstrap-conflict operations + 3 LIST
+ *     calls + 1 optional snapshot GET + 1 conditional fresh-current GET before
+ *     a due snapshot sweep + S DELETEs + all three final pending CAS attempts
+ *     (3 GETs + 3 PUTs).
+ *   content-deferred GC: 1 current GET + P tail-probe GETs + 1 `tail_hint`
+ *     checkpoint CAS PUT + 3 pending-bootstrap-conflict operations + 2 LIST
+ *     calls + 1 conditional fresh-current GET before a due snapshot sweep + S
+ *     DELETEs + all three final pending CAS attempts (3 GETs + 3 PUTs).
  *
- * With N=20, M=20, S=10 the totals are: compact ≈ 23, gc ≈ 36 — over
- * the 50 cap combined. The Cloudflare scheduled handler therefore
- * alternates phases per tick (even minute → compact, odd minute →
- * GC) by calling `compact()` / `runGc()` directly instead of
- * `runScheduledMaintenance`; the `maintenance-budget.test.ts`
+ * `minEntriesToCompact` drops to `maxFoldEntriesPerPass` (20) here, from the
+ * write-tick default of 50, because a bounded probe changes what "available"
+ * can even mean. `compact()` measures `available = discoveredTail −
+ * log_seq_start`, and a P-capped probe certifies at most `probeFloor + P`, so
+ * a threshold above P is only reachable after several passes have each spent
+ * P GETs to ratchet `tail_hint` forward — every one of them returning
+ * `probe-budget-checkpointed` without folding. Holding 50 against P=25 also
+ * pairs a threshold with a smaller per-pass fold cap (N=20), which folds 20
+ * of an accumulated 50 and then waits for the remainder to climb back to 50.
+ * Keeping the threshold at N makes a pass fold exactly when one pass's worth
+ * of work exists. Any future edit must keep `minEntriesToCompact <= P`.
+ *
+ * With N=20, P=25, M=20, S=10 the exact worst cases are: compaction ≤49,
+ * full content-marking GC ≤46, and content-deferred GC ≤49. Combining a
+ * compact and GC pass can exceed 50, so the Cloudflare scheduled handler
+ * processes one collection and alternates phases per invocation (even minute
+ * → compact, odd minute → GC) by calling `compact()` / `runGc()` directly
+ * instead of `runScheduledMaintenance`; the `maintenance-budget.test.ts`
  * worst-case test proves each phase in isolation sits under 50 ops
  * with these bounds.
  */
 export const CLOUDFLARE_FREE_TIER: MaintenanceOptions = profileToScheduledOptions(
   MAINTENANCE_PROFILE_CF_FREE,
+  CF_FREE_COMPACT_TAIL_PROBE_GETS,
+  MAINTENANCE_PROFILE_CF_FREE.maxFoldEntriesPerPass,
 );
 
 /**

--- a/packages/server/src/maintenance.ts
+++ b/packages/server/src/maintenance.ts
@@ -1,10 +1,9 @@
 /**
- * `runScheduledMaintenance` — single-pass compose of `compact()` and
- * `runGc()` over one collection. Designed to fit a single Cloudflare
- * Cron Trigger invocation's 50-subrequest free-tier budget when
- * called with the {@link CLOUDFLARE_FREE_TIER} profile (which the
- * caller pairs with even/odd-minute alternation between compact and
- * GC ticks); unbounded on Node.
+ * `runScheduledMaintenance` — single-pass composition of `compact()` and
+ * `runGc()` over one collection. It always runs both phases; therefore one
+ * invocation with {@link CLOUDFLARE_FREE_TIER} is **not** safe for
+ * Cloudflare Free's 50-subrequest limit. Free-tier schedulers alternate
+ * direct `compact()` and `runGc()` calls instead. Unbounded on Node.
  *
  * Single-attempt: returns the combined result. The caller (cron
  * handler) is responsible for scheduling the next invocation; this
@@ -75,11 +74,13 @@ export interface MaintenanceResult {
 }
 
 /**
- * Single maintenance pass for one collection. Runs `compact()` then
- * `runGc()` (in that order; the compactor's advance of
- * `log_seq_start` produces the stale-log candidates the GC then
- * marks). Callers wanting a single phase per tick invoke
- * `compact()` or `runGc()` directly instead.
+ * Single maintenance pass for one collection. Always runs `compact()` then
+ * `runGc()` (in that order; the compactor's advance of `log_seq_start`
+ * produces the stale-log candidates the GC then marks). It is not safe to
+ * call once with {@link CLOUDFLARE_FREE_TIER} on Cloudflare Free: the two
+ * individually bounded phases can exceed that invocation's combined
+ * 50-subrequest limit. Alternate direct `compact()` and `runGc()` calls for
+ * that profile.
  *
  * Errors propagate — the caller's cron handler is responsible for
  * logging them. The Cloudflare runtime ships uncaught Worker errors
@@ -88,7 +89,12 @@ export interface MaintenanceResult {
  *
  * @example
  * ```ts
- * import { runScheduledMaintenance, CLOUDFLARE_FREE_TIER } from "@gusto/baerly-storage/maintenance";
+ * import {
+ *   CLOUDFLARE_FREE_TIER,
+ *   compact,
+ *   runGc,
+ *   runScheduledMaintenance,
+ * } from "@gusto/baerly-storage/maintenance";
  *
  * // Node (unbounded — defaults fold the entire live tail):
  * const res = await runScheduledMaintenance(
@@ -96,8 +102,12 @@ export interface MaintenanceResult {
  * );
  * console.log("compacted:", res.compact.entriesFolded, "swept:", res.gc.swept);
  *
- * // Cloudflare free tier (50-subrequest cap, single phase per tick):
- * await runScheduledMaintenance({ storage, currentJsonKey }, CLOUDFLARE_FREE_TIER);
+ * // Cloudflare Free: alternate the individually bounded direct phases.
+ * if (Math.floor(controller.scheduledTime / 60_000) % 2 === 0) {
+ *   await compact({ storage, currentJsonKey }, CLOUDFLARE_FREE_TIER.compact);
+ * } else {
+ *   await runGc({ storage, currentJsonKey }, CLOUDFLARE_FREE_TIER.gc);
+ * }
  * ```
  */
 export const runScheduledMaintenance = async (
@@ -185,9 +195,9 @@ const profileToScheduledOptions = (
  * With N=20, P=25, M=20, S=10 the exact worst cases are: compaction ≤49,
  * full content-marking GC ≤46, and content-deferred GC ≤49. Combining a
  * compact and GC pass can exceed 50, so the Cloudflare scheduled handler
- * processes one collection and alternates phases per invocation (even minute
- * → compact, odd minute → GC) by calling `compact()` / `runGc()` directly
- * instead of `runScheduledMaintenance`; the `maintenance-budget.test.ts`
+ * processes one collection and alternates phases per invocation (even minute →
+ * compact, odd minute → GC) by calling `compact()` / `runGc()` directly instead of
+ * `runScheduledMaintenance`; the `maintenance-budget.test.ts`
  * worst-case test proves each phase in isolation sits under 50 ops
  * with these bounds.
  */

--- a/packages/server/src/maintenance.ts
+++ b/packages/server/src/maintenance.ts
@@ -45,7 +45,13 @@ import { getCurrentContext } from "./observability/context.ts";
 const ctxMetrics = (): MetricsRecorder => getCurrentContext()?.recorder ?? noopMetricsRecorder;
 
 export { type CompactOptions, type CompactResult, compact } from "./compactor.ts";
-export { type ContentDeferralReason, type RunGcOptions, type RunGcResult, runGc } from "./gc.ts";
+export {
+  type ContentDeferralReason,
+  isDegradedContentDeferral,
+  type RunGcOptions,
+  type RunGcResult,
+  runGc,
+} from "./gc.ts";
 export {
   type RebuildIndexOptions,
   type RebuildIndexResult,

--- a/packages/server/src/option-guards.ts
+++ b/packages/server/src/option-guards.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared pre-I/O validation for the internal maintenance option seams
+ * (`InternalCompactOptions`, `InternalRunGcOptions`).
+ *
+ * Those seams are unvalidated by construction — reached by JS callers,
+ * in-repo casts, and the `_internal/testing` subpath — yet their values
+ * feed seq arithmetic and range bounds. A non-finite value must fail
+ * before the first storage operation, so a rejected run costs nothing
+ * durable. `compactor.ts` explains the specific NaN corruption at stake.
+ *
+ * Zero-import leaf beyond `BaerlyError`: both maintenance entry points
+ * already carry that import, so consolidating here removes duplication
+ * without widening either closure.
+ */
+
+import { BaerlyError } from "@baerly/protocol";
+
+/**
+ * Throw `InvalidConfig` unless `value` is an integer at or above `min`.
+ * `min` is `0` for a seq-shaped or count-shaped option (zero is a
+ * meaningful "do nothing" bound) and `1` for one that must make at least
+ * one unit of progress to be well-defined.
+ *
+ * Callers own the `undefined ⇒ default` decision before calling; this
+ * guard rejects rather than defaults, so passing an absent option is a
+ * caller bug, not a silently-tolerated input.
+ */
+export const requireIntegerOption = (
+  fnName: string,
+  collectionName: string,
+  optionName: string,
+  value: number,
+  min: 0 | 1,
+): void => {
+  if (!Number.isInteger(value) || value < min) {
+    throw new BaerlyError(
+      "InvalidConfig",
+      `${fnName}(${collectionName}): ${optionName} must be a ${
+        min === 0 ? "non-negative" : "positive"
+      } integer, got ${String(value)}`,
+    );
+  }
+};


### PR DESCRIPTION
## What & why

A scheduled `compact()` or `runGc()` on Cloudflare Free had no bound on tail discovery: starting from a stale-low `tail_hint`, a pass could spend its whole 50-subrequest budget walking forward, reach nothing, record nothing, and have the next invocation repeat exactly the same walk. `CLOUDFLARE_FREE_TIER` now caps both probes and checkpoints certified progress, so successive invocations converge instead of restarting.

Separately, the docs were wrong: they claimed one `runScheduledMaintenance(…, CLOUDFLARE_FREE_TIER)` call fits the budget. The profile bounds each phase individually and the function always runs both, so it does not — that claim predates this branch and is corrected here.

## Key points

- Absence of `maxTailProbeGets` is meaningful. The default path keeps `probeTailFrom` and its throw-on-cap-exhaustion contract, so an exhausted protocol cap still fails closed rather than silently accepting a partial tail. Only an explicitly budgeted caller opts into partial results.
- `minEntriesToCompact` drops 50 → 20 on the Free profile, and this is load-bearing rather than cosmetic: `available` derives from a probe certifying at most `probeFloor + P`, so a threshold above P=25 is unreachable in one pass. A test binds `minEntriesToCompact <= maxTailProbeGets` so raising one without the other fails.
- The GC admission probe runs *before* the pending-ledger read, so a deferring pass spends no bootstrap or CAS budget before deciding it cannot afford the content phase.
- The admission checkpoint is a single attempt against a captured ETag. A `Conflict` returns zero work rather than retrying — a retry would spend more budget and could admit against a different manifest. It still reports the deferral it had already decided on, and counts the loss as `db.gc.cas_lost_total`, so a lost checkpoint is not indistinguishable from an idle collection.
- The BUDGET/DEGRADED split of `ContentDeferralReason` lives in exactly one `Record` over the union, behind the exported `isDegradedContentDeferral`. That is the alerting predicate for a cron caller, and a sixth reason cannot typecheck until it is classified.
- Where a pass qualifies for both a budget and a degraded deferral reason, the degraded one wins, so an actionable corruption is not filed under the outcome operators are told to expect on Free.
- `db.manifest.lag_window_depth` is suppressed on an inexact tail rather than reporting a depth measured from a lower bound.
- `CompactResult.skippedReason` gains a fifth member — breaking for an exhaustive switch. Migration snippet is in the changeset.
- `CLOUDFLARE_PAID_TIER` and the Node profile are untouched; both new parameters are optional and absent there.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3104 passed, 101 skipped |
| `pnpm bundle-sizes` | ok (14 entries) |
| `pnpm test:adapter-cloudflare` | 157 passed, 2 skipped |

Each of the six commits was also verified individually: `tsgo --noEmit`, `pnpm bundle-sizes`, and the six suites this branch touches (`gc`, `compactor`, `log-tail`, `maintenance-budget`, `maintenance`, `gc-pending`) — 198 → 232 tests as the series builds up.

Minio-gated and credentials-gated suites were not run (no local stack).

## Notes for reviewers

The exact per-phase op counts (compaction 49, admitted GC 46, content-deferred GC 49) are pinned in `maintenance-budget.test.ts` and derived in the `CLOUDFLARE_FREE_TIER` JSDoc; those two must stay in sync, and the convergence fixture is what proves a stale-low hint actually reaches the true tail rather than just staying under budget.

The `pattern-d` block is byte-identical across all four example AGENTS.md files and fenced by `tests/integration/agents-md-drift.test.ts`.

Four JSDoc and docs paragraphs were merged by hand where this branch's wording met the wording #107 landed on `main` — the `ContentDeferralReason` DEGRADED block and the `collectLiveContentHashes` contract in `gc.ts`, and the `db.gc.content_deferred_total` entry in both `metrics.ts` and `observability.md`. Worth a read on their own rather than as diff noise.
