### PR TITLE
fix(gc): never act on an unproven liveness set

### DIFF
--- a/.changeset/gc-snapshot-floor-proof.md
+++ b/.changeset/gc-snapshot-floor-proof.md
@@ -1,0 +1,15 @@
+---
+"@gusto/baerly-storage": patch
+---
+
+GC proves an orphan snapshot is obsolete before deleting it.
+
+A due `orphan-snapshot` candidate is now checked against a freshly read
+`current.json`: a candidate the fresh pointer names is rescued, and every
+other one must prove its `max_seq` is strictly below the observed
+`log_seq_start` before it is deleted. Previously a compactor that published
+a snapshot between GC's classification and its DELETE could have that live
+snapshot removed. Snapshot keys GC cannot parse — unknown levels,
+non-canonical names, inverted ranges — now stay pending instead of being
+swept. This is on the default path: it applies on every host, not only
+under a bounded maintenance profile.

--- a/.changeset/gc-unproven-content-liveness.md
+++ b/.changeset/gc-unproven-content-liveness.md
@@ -1,0 +1,29 @@
+---
+"@gusto/baerly-storage": minor
+---
+
+GC no longer classifies orphan content against an incomplete live set.
+
+A missing or malformed live log entry, or a `current.json` snapshot that
+will not read or hash-verify, previously left those post-images out of the
+live set and let the pass mark live content as orphan; the 7-day grace
+period was expected to absorb it. It does not, because a persistent fault
+recurs on every pass and the mark stands until the sweep deletes the blob.
+Such a pass now skips orphan-content discovery entirely: nothing marked, no
+pending content candidate swept, and `content_scan_cursor` held so the next
+pass resumes in place. Stale-log and orphan-snapshot marking and their
+sweeps are unaffected. A pending content candidate proven live by a
+complete set is now rescued rather than swept. This is on the default path:
+it applies on every host, not only under a bounded maintenance profile.
+
+**Operators should watch for this.** `RunGcResult` carries a new optional
+`contentDeferredReason` (`"live-log-unreadable"` or
+`"snapshot-unreadable"`, exported as `ContentDeferralReason`), also
+emitted as the `db.gc.content_deferred_total` counter labelled by reason.
+A reason names the unreadable artifact, not the fault class, so a single
+occurrence may be a transient storage error; a reason that REPEATS across
+passes does not self-clear, and orphan content accumulates for as long as
+the underlying artifact is unreadable. A cron handler runs outside any
+HTTP scope where metrics fall through to the noop recorder, so read the
+result field and log a reason that repeats across passes. `admin fsck`
+walks the same chain.

--- a/bundle-sizes.json
+++ b/bundle-sizes.json
@@ -16,9 +16,9 @@
   "entries": {
     "index.js": {
       "tier": "shipped",
-      "raw": 246012,
-      "gz": 77881,
-      "minGz": 20550,
+      "raw": 248548,
+      "gz": 78641,
+      "minGz": 20802,
       "note": "kernel barrel; every consumer pays. Must not pull the observability subgraph — see the dedicated test."
     },
     "client.js": {
@@ -37,9 +37,9 @@
     },
     "cloudflare.js": {
       "tier": "shipped",
-      "raw": 434921,
-      "gz": 131825,
-      "minGz": 44312,
+      "raw": 437457,
+      "gz": 132620,
+      "minGz": 44599,
       "note": "Worker isolate cold start. Aggregator: closure includes the index.js and http.js subgraphs, so growth that slips past those entries still surfaces here."
     },
     "s3.js": {
@@ -58,9 +58,9 @@
     },
     "http.js": {
       "tier": "shipped",
-      "raw": 374477,
-      "gz": 112426,
-      "minGz": 37055,
+      "raw": 377013,
+      "gz": 113218,
+      "minGz": 37343,
       "note": "server-side. Also inside the cloudflare.js closure, so growth here shows up on that entry too."
     },
     "auth.js": {
@@ -72,9 +72,9 @@
     },
     "maintenance.js": {
       "tier": "shipped",
-      "raw": 136813,
-      "gz": 42563,
-      "minGz": 11721,
+      "raw": 139349,
+      "gz": 43343,
+      "minGz": 11983,
       "note": "operator-side; reached from the cloudflare.js closure."
     },
     "observability.js": {
@@ -102,12 +102,12 @@
     },
     "node.js": {
       "tier": "tooling",
-      "raw": 599747,
+      "raw": 602283,
       "note": "server-only aggregator. Raw-only dep-creep tripwire; live-external-import creep is caught separately by the bare-specifier allowlist test."
     },
     "dev-vite.js": {
       "tier": "tooling",
-      "raw": 608660,
+      "raw": 611196,
       "note": "dev-only aggregator. Raw-only dep-creep tripwire; see node.js."
     }
   }

--- a/bundle-sizes.json
+++ b/bundle-sizes.json
@@ -16,9 +16,9 @@
   "entries": {
     "index.js": {
       "tier": "shipped",
-      "raw": 244545,
-      "gz": 77477,
-      "minGz": 20358,
+      "raw": 246012,
+      "gz": 77881,
+      "minGz": 20550,
       "note": "kernel barrel; every consumer pays. Must not pull the observability subgraph — see the dedicated test."
     },
     "client.js": {
@@ -37,9 +37,9 @@
     },
     "cloudflare.js": {
       "tier": "shipped",
-      "raw": 433454,
-      "gz": 131424,
-      "minGz": 44135,
+      "raw": 434921,
+      "gz": 131825,
+      "minGz": 44312,
       "note": "Worker isolate cold start. Aggregator: closure includes the index.js and http.js subgraphs, so growth that slips past those entries still surfaces here."
     },
     "s3.js": {
@@ -58,9 +58,9 @@
     },
     "http.js": {
       "tier": "shipped",
-      "raw": 373010,
-      "gz": 112018,
-      "minGz": 36883,
+      "raw": 374477,
+      "gz": 112426,
+      "minGz": 37055,
       "note": "server-side. Also inside the cloudflare.js closure, so growth here shows up on that entry too."
     },
     "auth.js": {
@@ -72,9 +72,9 @@
     },
     "maintenance.js": {
       "tier": "shipped",
-      "raw": 135346,
-      "gz": 42148,
-      "minGz": 11538,
+      "raw": 136813,
+      "gz": 42563,
+      "minGz": 11721,
       "note": "operator-side; reached from the cloudflare.js closure."
     },
     "observability.js": {
@@ -102,12 +102,12 @@
     },
     "node.js": {
       "tier": "tooling",
-      "raw": 598280,
+      "raw": 599747,
       "note": "server-only aggregator. Raw-only dep-creep tripwire; live-external-import creep is caught separately by the bare-specifier allowlist test."
     },
     "dev-vite.js": {
       "tier": "tooling",
-      "raw": 607193,
+      "raw": 608660,
       "note": "dev-only aggregator. Raw-only dep-creep tripwire; see node.js."
     }
   }

--- a/bundle-sizes.json
+++ b/bundle-sizes.json
@@ -16,9 +16,9 @@
   "entries": {
     "index.js": {
       "tier": "shipped",
-      "raw": 248548,
-      "gz": 78641,
-      "minGz": 20802,
+      "raw": 248865,
+      "gz": 78689,
+      "minGz": 20855,
       "note": "kernel barrel; every consumer pays. Must not pull the observability subgraph — see the dedicated test."
     },
     "client.js": {
@@ -37,9 +37,9 @@
     },
     "cloudflare.js": {
       "tier": "shipped",
-      "raw": 437457,
-      "gz": 132620,
-      "minGz": 44599,
+      "raw": 437774,
+      "gz": 132674,
+      "minGz": 44638,
       "note": "Worker isolate cold start. Aggregator: closure includes the index.js and http.js subgraphs, so growth that slips past those entries still surfaces here."
     },
     "s3.js": {
@@ -58,9 +58,9 @@
     },
     "http.js": {
       "tier": "shipped",
-      "raw": 377013,
-      "gz": 113218,
-      "minGz": 37343,
+      "raw": 377330,
+      "gz": 113265,
+      "minGz": 37380,
       "note": "server-side. Also inside the cloudflare.js closure, so growth here shows up on that entry too."
     },
     "auth.js": {
@@ -72,9 +72,9 @@
     },
     "maintenance.js": {
       "tier": "shipped",
-      "raw": 139349,
-      "gz": 43343,
-      "minGz": 11983,
+      "raw": 139666,
+      "gz": 43391,
+      "minGz": 12024,
       "note": "operator-side; reached from the cloudflare.js closure."
     },
     "observability.js": {
@@ -102,12 +102,12 @@
     },
     "node.js": {
       "tier": "tooling",
-      "raw": 602283,
+      "raw": 602600,
       "note": "server-only aggregator. Raw-only dep-creep tripwire; live-external-import creep is caught separately by the bare-specifier allowlist test."
     },
     "dev-vite.js": {
       "tier": "tooling",
-      "raw": 611196,
+      "raw": 611513,
       "note": "dev-only aggregator. Raw-only dep-creep tripwire; see node.js."
     }
   }

--- a/docs/contributing/conventions/observability.md
+++ b/docs/contributing/conventions/observability.md
@@ -163,6 +163,16 @@ The load-bearing kernel metrics today (canonical list in
 - `db.gc.entries_swept_per_second` — GC gauge (livelock indicator
   when below writes/s).
 - `db.gc.swept_total` — GC counter, labelled by reason.
+- `db.gc.content_deferred_total` — GC counter, labelled by the
+  `ContentDeferralReason` for a pass that skipped orphan-content
+  discovery. Emitted only on a deferred pass. The label names the
+  unreadable artifact, not the fault class, so a single occurrence can
+  be a transient storage error that clears on the next pass; a
+  SUSTAINED non-zero rate is the alertable signal, and means
+  orphan-content GC is parked for as long as the fault persists. Cron
+  callers see no metrics outside an HTTP scope —
+  `RunGcResult.contentDeferredReason` carries the same value for them
+  to log.
 - `db.orphan.candidate_count` — GC gauge (`gc/pending.json` depth).
 - `db.storage.<op>.calls_total` / `db.storage.<op>.errors_total` /
   `db.storage.<op>.duration_ms` — storage decorator counters +

--- a/packages/protocol/src/coordination/gc-pending.test.ts
+++ b/packages/protocol/src/coordination/gc-pending.test.ts
@@ -1234,6 +1234,77 @@ describe("gc-pending", () => {
     expect("log_scan_cursor" in merged).toBe(false);
   });
 
+  // Production mutation caught: treating a deliberately deferred content
+  // phase as an end-of-keyspace wrap would manufacture a cursor transition
+  // even when the latest ledger has never stored one.
+  test("mergeGcPending: deferred content preserves an absent cursor while log progress advances", () => {
+    const latest: GcPending = {
+      schema_version: GC_PENDING_SCHEMA_VERSION,
+      candidates: [],
+      last_swept_at: "",
+    };
+    const merged = mergeGcPending(latest, {
+      sweptKeys: new Set<string>(),
+      newCandidates: [],
+      lastSweptAt: "",
+      nextContentCursor: undefined,
+      nextLogCursor: "log/7.json",
+      preserveContentCursor: true,
+      maxCandidates: 1000,
+    });
+    expect("content_scan_cursor" in merged).toBe(false);
+    expect(merged.log_scan_cursor).toBe("log/7.json");
+  });
+
+  // Production mutation caught: interpreting deferred
+  // `nextContentCursor: undefined` as a wrap would clear a stored content
+  // cursor and restart the expensive content rotation from the beginning.
+  test("mergeGcPending: deferred content preserves a stored cursor while log progress wraps", () => {
+    const latest: GcPending = {
+      schema_version: GC_PENDING_SCHEMA_VERSION,
+      candidates: [],
+      last_swept_at: "",
+      content_scan_cursor: "content/mmm",
+      log_scan_cursor: "log/9.json",
+    };
+    const merged = mergeGcPending(latest, {
+      sweptKeys: new Set<string>(),
+      newCandidates: [],
+      lastSweptAt: "",
+      nextContentCursor: undefined,
+      nextLogCursor: undefined,
+      preserveContentCursor: true,
+      maxCandidates: 1000,
+    });
+    expect(merged.content_scan_cursor).toBe("content/mmm");
+    expect("log_scan_cursor" in merged).toBe(false);
+  });
+
+  // Production mutation caught: reusing the stale pass's proposed content
+  // position during a CAS retry would regress a concurrent pass's advance;
+  // preservation must copy the freshly-read ledger value verbatim while the
+  // independent log cursor still merges forward.
+  test("mergeGcPending: deferred content preserves a concurrent advance verbatim", () => {
+    const latest: GcPending = {
+      schema_version: GC_PENDING_SCHEMA_VERSION,
+      candidates: [],
+      last_swept_at: "",
+      content_scan_cursor: "content/zzz",
+      log_scan_cursor: "log/12.json",
+    };
+    const merged = mergeGcPending(latest, {
+      sweptKeys: new Set<string>(),
+      newCandidates: [],
+      lastSweptAt: "",
+      nextContentCursor: "content/aaa",
+      nextLogCursor: "log/9.json",
+      preserveContentCursor: true,
+      maxCandidates: 1000,
+    });
+    expect(merged.content_scan_cursor).toBe("content/zzz");
+    expect(merged.log_scan_cursor).toBe("log/9.json");
+  });
+
   test("mergeGcPending: returns the current schema_version", () => {
     const merged = mergeGcPending(initial(), {
       sweptKeys: new Set<string>(),

--- a/packages/protocol/src/coordination/gc-pending.ts
+++ b/packages/protocol/src/coordination/gc-pending.ts
@@ -267,6 +267,10 @@ export const casUpdateGcPending = async (
  *          - latest cursor defined ⇒ take the lexicographically GREATER
  *            (don't regress a concurrent pass's advance);
  *          - latest cursor absent ⇒ keep OUR advance (don't lose it).
+ *    When `pass.preserveContentCursor` is true the content phase was
+ *    deliberately deferred, not completed: copy the latest stored value
+ *    verbatim on every CAS retry. This third state is content-only; the log
+ *    cursor still follows its normal independent rotation semantics.
  *  - **log_scan_cursor**: the same rule, applied INDEPENDENTLY over the
  *    `log/` keyspace. The two rotations cover disjoint prefixes and
  *    consume their budgets at different rates, so one reaching the end
@@ -280,6 +284,7 @@ export const mergeGcPending = (
     readonly lastSweptAt: string;
     readonly nextContentCursor: string | undefined;
     readonly nextLogCursor: string | undefined;
+    readonly preserveContentCursor?: boolean;
     readonly maxCandidates: number;
   },
 ): GcPending => {
@@ -302,7 +307,9 @@ export const mergeGcPending = (
 
   // Both rotation cursors follow the same asymmetric rule, applied
   // independently over their own prefix — see {@link mergeRotationCursor}.
-  const contentCursor = mergeRotationCursor(latest.content_scan_cursor, pass.nextContentCursor);
+  const contentCursor = pass.preserveContentCursor
+    ? latest.content_scan_cursor
+    : mergeRotationCursor(latest.content_scan_cursor, pass.nextContentCursor);
   const logCursor = mergeRotationCursor(latest.log_scan_cursor, pass.nextLogCursor);
 
   return {

--- a/packages/protocol/src/metrics.ts
+++ b/packages/protocol/src/metrics.ts
@@ -24,6 +24,11 @@
  *   - `db.orphan.candidate_count` — gauge (`gc/pending.json` depth)
  *   - `db.compact.entries_folded` — histogram (entries folded per run)
  *   - `db.gc.swept_total` — counter (labelled by reason)
+ *   - `db.gc.content_deferred_total` — counter (labelled by reason; emitted
+ *     only when a pass skipped orphan-content discovery, so any sustained
+ *     non-zero rate on a `snapshot-unreadable` / `live-log-unreadable`
+ *     reason is alertable — a single occurrence may be transient, a
+ *     repeating one does not self-clear)
  *
  * Names follow `db.<subsystem>.<metric>`, dot-separated, all-lowercase
  * snake_case segments. Labels are flat

--- a/packages/server/src/compactor.test.ts
+++ b/packages/server/src/compactor.test.ts
@@ -773,7 +773,7 @@ describe("compact", () => {
     expect(after).toEqual(before);
   });
 
-  test("cas-lost: snapshot pointer unchanged, bumps cas_lost_total, orphan reclaimable by runGc", async () => {
+  test("cas-lost: snapshot orphan stays pending until a later fold advances beyond it", async () => {
     const inner = new MemoryStorage();
     const recording = recordingStorage(inner);
     const foldEnd = 30;
@@ -823,19 +823,43 @@ describe("compact", () => {
     expect(snap.counters.filter((c) => c.name === "db.compaction.cas_lost_total")).toEqual([
       { name: "db.compaction.cas_lost_total", value: 1, labels: { collection: COLL } },
     ]);
-    // The orphan snapshot it wrote is reclaimable by runGc. Two-phase:
-    // first pass marks it into gc/pending.json; with graceMillis:0 the
-    // second pass sweeps it.
+    // The orphan snapshot covers [0, 30), but the lost CAS leaves the fresh
+    // manifest floor at 0. GC must mark and retain it: a compactor could still
+    // publish this exact object until the monotone floor advances beyond 30.
     expect(res.newSnapshotKey).toBeDefined();
     const orphan = await inner.get(res.newSnapshotKey!);
     expect(orphan).not.toBeNull();
-    await runGc({ storage: inner, currentJsonKey: KEY }, {
+    const retained = await runGc({ storage: inner, currentJsonKey: KEY }, {
       graceMillis: 0,
     } as Parameters<typeof runGc>[1]);
-    await runGc({ storage: inner, currentJsonKey: KEY }, {
-      graceMillis: 0,
-    } as Parameters<typeof runGc>[1]);
+    expect(retained.marked.orphan_snapshot).toBe(1);
+    expect(retained.swept).toBe(0);
+    expect(retained.pendingDepth).toBe(1);
+    await expect(inner.get(res.newSnapshotKey!)).resolves.not.toBeNull();
+
+    // Commit one more entry, then perform a real successful fold through 31.
+    // The fresh floor is now strictly beyond the CAS-lost snapshot's max_seq,
+    // making that pending candidate safe to reclaim on the next GC pass.
+    await writer.commit({
+      op: "I",
+      collection: COLL,
+      docId: `d${foldEnd}`,
+      body: { _id: `d${foldEnd}` },
+    });
+    const advanced = await compact({ storage: inner, currentJsonKey: KEY }, {
+      minEntriesToCompact: 10,
+      maxEntriesPerRun: foldEnd + 1,
+    } as InternalCompactOptions);
+    expect(advanced.written).toBe(true);
+    expect(advanced.logSeqStartAfter).toBe(foldEnd + 1);
+    expect(advanced.newSnapshotKey).not.toBe(res.newSnapshotKey);
+
+    // Default grace keeps the newly marked stale logs pending, so this one
+    // sweep is specifically the older, already-due snapshot candidate.
+    const reclaimed = await runGc({ storage: inner, currentJsonKey: KEY });
+    expect(reclaimed.swept).toBe(1);
     const swept = await inner.get(res.newSnapshotKey!);
     expect(swept).toBeNull();
+    await expect(inner.get(advanced.newSnapshotKey!)).resolves.not.toBeNull();
   });
 });

--- a/packages/server/src/gc.test.ts
+++ b/packages/server/src/gc.test.ts
@@ -1392,6 +1392,7 @@ describe("runGc", () => {
           marked: { stale_log: 1, orphan_snapshot: 1, orphan_content: 0 },
           swept: 2,
           pendingDepth: 3,
+          contentDeferredReason: "live-log-unreadable",
         });
         // The content LIST never runs — nothing can be classified.
         expect(trace.lists).toContain(`${PREFIX}/log/`);
@@ -1471,6 +1472,10 @@ describe("runGc", () => {
           marked: { stale_log: 0, orphan_snapshot: 1, orphan_content: 0 },
           swept: 1,
           pendingDepth: 1,
+          // A persistent AccessDenied here parks orphan-content GC
+          // forever, so the pass must NOT look identical to an
+          // orphan-free one.
+          contentDeferredReason: "snapshot-unreadable",
         });
         expect(trace.lists).toContain(`${PREFIX}/snapshot/`);
         expect(trace.lists).not.toContain(`${PREFIX}/content/`);
@@ -1484,4 +1489,71 @@ describe("runGc", () => {
       });
     },
   );
+
+  // A degraded pass and a genuinely orphan-free one both mark zero content
+  // and sweep zero content. Without a signal that separates them, a
+  // persistent snapshot fault disables orphan-content GC silently and
+  // forever. Pin both directions of that discrimination.
+  describe("content-deferral signal", () => {
+    test("counts a degraded pass under its reason label", async () => {
+      const inner = new MemoryStorage();
+      const currentSnapshot = `${PREFIX}/snapshot/L9/000000000000-000000000040-${"a".repeat(64)}.json`;
+      await createCurrentJson(
+        inner,
+        KEY,
+        logStateCurrentJson({ snapshot: currentSnapshot, log_seq_start: 0, tail_hint: 0 }),
+      );
+      await inner.put(currentSnapshot, new TextEncoder().encode("not-a-valid-snapshot"));
+      const denied: Storage = {
+        get: (key, opts) => {
+          if (key === currentSnapshot) {
+            throw new BaerlyError("AccessDenied", "snapshot read denied");
+          }
+          return inner.get(key, opts);
+        },
+        put: (key, body, opts) => inner.put(key, body, opts),
+        delete: (key, opts) => inner.delete(key, opts),
+        list: (prefix, opts) => inner.list(prefix, opts),
+      };
+
+      const ctx = createObservabilityContext();
+      let result!: Awaited<ReturnType<typeof runGc>>;
+      await runWithContext(ctx, async () => {
+        result = await runGc({ storage: denied, currentJsonKey: KEY }, {
+          maxMarksPerRun: 20,
+          maxSweepsPerRun: 10,
+        } as InternalRunGcOptions);
+      });
+
+      expect(result.contentDeferredReason).toBe("snapshot-unreadable");
+      expect(
+        ctx.recorder.snapshot().counters.filter((c) => c.name === "db.gc.content_deferred_total"),
+      ).toEqual([
+        {
+          name: "db.gc.content_deferred_total",
+          value: 1,
+          labels: { collection: COLL, reason: "snapshot-unreadable" },
+        },
+      ]);
+    });
+
+    test("emits nothing when a complete live set classified content", async () => {
+      const inner = new MemoryStorage();
+      await createCurrentJson(inner, KEY, logStateCurrentJson({ tail_hint: 0 }));
+
+      const ctx = createObservabilityContext();
+      let result!: Awaited<ReturnType<typeof runGc>>;
+      await runWithContext(ctx, async () => {
+        result = await runGc({ storage: inner, currentJsonKey: KEY }, {
+          maxMarksPerRun: 20,
+          maxSweepsPerRun: 10,
+        } as InternalRunGcOptions);
+      });
+
+      expect(result.contentDeferredReason).toBeUndefined();
+      expect(
+        ctx.recorder.snapshot().counters.find((c) => c.name === "db.gc.content_deferred_total"),
+      ).toBeUndefined();
+    });
+  });
 });

--- a/packages/server/src/gc.test.ts
+++ b/packages/server/src/gc.test.ts
@@ -17,16 +17,21 @@ import {
   GC_PENDING_SCHEMA_VERSION,
   MAX_PARALLEL_LOG_READS,
   MemoryStorage,
+  SNAPSHOT_SCHEMA_VERSION,
+  casUpdateCurrentJson,
   casUpdateGcPending,
   createCurrentJson,
   createGcPending,
+  readCurrentJson,
   readGcPending,
+  snapshotHash,
 } from "@baerly/protocol";
 import { describe, expect, test } from "vitest";
 import { logStateCurrentJson, seedLogEntry } from "../../../tests/fixtures/log-state.ts";
 import { compact, type InternalCompactOptions } from "./compactor.ts";
 import { type InternalRunGcOptions, runGc } from "./gc.ts";
 import { createObservabilityContext, runWithContext } from "./observability/index.ts";
+import { encodeSnapshotBody, snapshotKey } from "./snapshot.ts";
 import { Writer } from "./writer.ts";
 
 const bootstrap = async (storage: MemoryStorage, key: string): Promise<void> => {
@@ -39,6 +44,7 @@ const bootstrap = async (storage: MemoryStorage, key: string): Promise<void> => 
 
 const KEY = "app/t/tenant/x/manifests/c/current.json";
 const PENDING_KEY = "app/t/tenant/x/manifests/c/gc/pending.json";
+const PREFIX = "app/t/tenant/x/manifests/c";
 const COLL = "c";
 
 describe("runGc", () => {
@@ -274,6 +280,236 @@ describe("runGc", () => {
       pending?.json.candidates.filter((c) => c.reason === "orphan-snapshot") ?? [];
     expect(snapCandidates).toHaveLength(1);
     expect(snapCandidates[0]?.key).toBe(first.newSnapshotKey);
+  });
+
+  test("rescues a snapshot that becomes current after the initial manifest read", async () => {
+    const inner = new MemoryStorage();
+    await bootstrap(inner, KEY);
+    const newSnapshot = `${PREFIX}/snapshot/L9/newly-current.json`;
+    const deleted: string[] = [];
+    let advanced = false;
+    const storage: Storage = {
+      get: (key, opts) => inner.get(key, opts),
+      put: (key, body, opts) => inner.put(key, body, opts),
+      async delete(key, opts) {
+        deleted.push(key);
+        await inner.delete(key, opts);
+      },
+      list(prefix, opts) {
+        if (prefix !== `${PREFIX}/snapshot/`) {
+          return inner.list(prefix, opts);
+        }
+        return (async function* (): AsyncIterable<StorageListEntry> {
+          if (!advanced) {
+            advanced = true;
+            await inner.put(newSnapshot, new TextEncoder().encode("{}"));
+            await casUpdateCurrentJson(inner, KEY, (current) => ({
+              ...current,
+              snapshot: newSnapshot,
+            }));
+          }
+          yield* inner.list(prefix, opts);
+        })();
+      },
+    };
+
+    const result = await runGc({ storage, currentJsonKey: KEY }, {
+      graceMillis: 0,
+      maxSweepsPerRun: 10,
+    } as InternalRunGcOptions);
+
+    expect(result.marked.orphan_snapshot).toBe(1);
+    expect(result.swept).toBe(0);
+    expect(deleted).not.toContain(newSnapshot);
+    await expect(inner.get(newSnapshot)).resolves.not.toBeNull();
+    const pending = await readGcPending(inner, PENDING_KEY);
+    expect(pending?.json.candidates.map((candidate) => candidate.key)).not.toContain(newSnapshot);
+  });
+
+  // Production mutation caught: admitting any due snapshot not named by the
+  // late manifest read lets a compactor publish that exact candidate after
+  // the GET linearizes but before DELETE, leaving a dangling pointer.
+  test("retains a due snapshot published after the fresh manifest read", async () => {
+    const inner = new MemoryStorage();
+    await createCurrentJson(
+      inner,
+      KEY,
+      logStateCurrentJson({
+        log_seq_start: 10,
+        tail_hint: 10,
+      }),
+    );
+    const candidateBody = encodeSnapshotBody({
+      schema_version: SNAPSHOT_SCHEMA_VERSION,
+      min_seq: 0,
+      max_seq: 20,
+      collection: COLL,
+      docs: [],
+    });
+    const candidate = snapshotKey(PREFIX, 0, 20, await snapshotHash(candidateBody));
+    await inner.put(candidate, candidateBody);
+    await createGcPending(inner, PENDING_KEY, {
+      schema_version: GC_PENDING_SCHEMA_VERSION,
+      candidates: [
+        {
+          key: candidate,
+          due_at: "2000-01-01T00:00:00.000Z",
+          reason: "orphan-snapshot",
+        },
+      ],
+      last_swept_at: "",
+    });
+
+    let currentReads = 0;
+    const deleted: string[] = [];
+    const storage: Storage = {
+      async get(key, opts) {
+        const result = await inner.get(key, opts);
+        if (key === KEY) {
+          currentReads++;
+          if (currentReads === 2) {
+            // The GET above linearized first. Publish the already-written
+            // snapshot and advance the manifest before GC can issue DELETE.
+            await inner.put(candidate, candidateBody);
+            await casUpdateCurrentJson(inner, KEY, (current) => ({
+              ...current,
+              snapshot: candidate,
+              log_seq_start: 20,
+              tail_hint: 20,
+            }));
+          }
+        }
+        return result;
+      },
+      put: (key, body, opts) => inner.put(key, body, opts),
+      async delete(key, opts) {
+        deleted.push(key);
+        await inner.delete(key, opts);
+      },
+      list: (prefix, opts) => inner.list(prefix, opts),
+    };
+
+    const result = await runGc({ storage, currentJsonKey: KEY }, {
+      graceMillis: 0,
+      maxSweepsPerRun: 10,
+    } as InternalRunGcOptions);
+
+    expect(currentReads).toBe(2);
+    expect(result.swept).toBe(0);
+    expect(deleted).not.toContain(candidate);
+    const current = await readCurrentJson(inner, KEY);
+    expect(current?.json.snapshot).toBe(candidate);
+    await expect(inner.get(candidate)).resolves.not.toBeNull();
+    const pending = await readGcPending(inner, PENDING_KEY);
+    expect(pending?.json.candidates.map((entry) => entry.key)).toContain(candidate);
+  });
+
+  test("sweeps a due canonical snapshot strictly below the fresh log floor", async () => {
+    const inner = new MemoryStorage();
+    await createCurrentJson(
+      inner,
+      KEY,
+      logStateCurrentJson({
+        log_seq_start: 20,
+        tail_hint: 20,
+      }),
+    );
+    const candidate = snapshotKey(PREFIX, 0, 19, "b".repeat(64));
+    await inner.put(candidate, new TextEncoder().encode("{}"));
+    await createGcPending(inner, PENDING_KEY, {
+      schema_version: GC_PENDING_SCHEMA_VERSION,
+      candidates: [
+        {
+          key: candidate,
+          due_at: "2000-01-01T00:00:00.000Z",
+          reason: "orphan-snapshot",
+        },
+      ],
+      last_swept_at: "",
+    });
+
+    const result = await runGc({ storage: inner, currentJsonKey: KEY }, {
+      graceMillis: 0,
+      maxSweepsPerRun: 10,
+    } as InternalRunGcOptions);
+
+    expect(result.swept).toBe(1);
+    await expect(inner.get(candidate)).resolves.toBeNull();
+    const pending = await readGcPending(inner, PENDING_KEY);
+    expect(pending?.json.candidates.map((entry) => entry.key)).not.toContain(candidate);
+  });
+
+  test("retains a due canonical snapshot equal to the fresh log floor", async () => {
+    const inner = new MemoryStorage();
+    await createCurrentJson(
+      inner,
+      KEY,
+      logStateCurrentJson({
+        log_seq_start: 20,
+        tail_hint: 20,
+      }),
+    );
+    const candidate = snapshotKey(PREFIX, 0, 20, "c".repeat(64));
+    await inner.put(candidate, new TextEncoder().encode("{}"));
+    await createGcPending(inner, PENDING_KEY, {
+      schema_version: GC_PENDING_SCHEMA_VERSION,
+      candidates: [
+        {
+          key: candidate,
+          due_at: "2000-01-01T00:00:00.000Z",
+          reason: "orphan-snapshot",
+        },
+      ],
+      last_swept_at: "",
+    });
+
+    const result = await runGc({ storage: inner, currentJsonKey: KEY }, {
+      graceMillis: 0,
+      maxSweepsPerRun: 10,
+    } as InternalRunGcOptions);
+
+    expect(result.swept).toBe(0);
+    await expect(inner.get(candidate)).resolves.not.toBeNull();
+    const pending = await readGcPending(inner, PENDING_KEY);
+    expect(pending?.json.candidates.map((entry) => entry.key)).toContain(candidate);
+  });
+
+  test("retains malformed and unknown-layout due snapshot candidates", async () => {
+    const inner = new MemoryStorage();
+    await createCurrentJson(
+      inner,
+      KEY,
+      logStateCurrentJson({
+        log_seq_start: 100,
+        tail_hint: 100,
+      }),
+    );
+    const malformed = `${PREFIX}/snapshot/L9/not-a-canonical-snapshot.json`;
+    const unknownLayout = `${PREFIX}/snapshot/L8/000000000000-000000000001-${"d".repeat(64)}.json`;
+    await inner.put(malformed, new TextEncoder().encode("{}"));
+    await inner.put(unknownLayout, new TextEncoder().encode("{}"));
+    await createGcPending(inner, PENDING_KEY, {
+      schema_version: GC_PENDING_SCHEMA_VERSION,
+      candidates: [malformed, unknownLayout].map((key) => ({
+        key,
+        due_at: "2000-01-01T00:00:00.000Z",
+        reason: "orphan-snapshot" as const,
+      })),
+      last_swept_at: "",
+    });
+
+    const result = await runGc({ storage: inner, currentJsonKey: KEY }, {
+      graceMillis: 0,
+      maxSweepsPerRun: 10,
+    } as InternalRunGcOptions);
+
+    expect(result.swept).toBe(0);
+    await expect(inner.get(malformed)).resolves.not.toBeNull();
+    await expect(inner.get(unknownLayout)).resolves.not.toBeNull();
+    const pending = await readGcPending(inner, PENDING_KEY);
+    expect(pending?.json.candidates.map((entry) => entry.key).toSorted()).toEqual(
+      [malformed, unknownLayout].toSorted(),
+    );
   });
 
   test("does NOT mark a live content blob as orphan", async () => {

--- a/packages/server/src/gc.test.ts
+++ b/packages/server/src/gc.test.ts
@@ -13,6 +13,7 @@ import {
   type Storage,
   type StorageGetOptions,
   type StorageListEntry,
+  BaerlyError,
   GC_GRACE_PERIOD_MILLIS,
   GC_PENDING_SCHEMA_VERSION,
   MAX_PARALLEL_LOG_READS,
@@ -27,7 +28,11 @@ import {
   snapshotHash,
 } from "@baerly/protocol";
 import { describe, expect, test } from "vitest";
-import { logStateCurrentJson, seedLogEntry } from "../../../tests/fixtures/log-state.ts";
+import {
+  logStateCurrentJson,
+  seedLogEntries,
+  seedLogEntry,
+} from "../../../tests/fixtures/log-state.ts";
 import { compact, type InternalCompactOptions } from "./compactor.ts";
 import { type InternalRunGcOptions, runGc } from "./gc.ts";
 import { createObservabilityContext, runWithContext } from "./observability/index.ts";
@@ -46,6 +51,53 @@ const KEY = "app/t/tenant/x/manifests/c/current.json";
 const PENDING_KEY = "app/t/tenant/x/manifests/c/gc/pending.json";
 const PREFIX = "app/t/tenant/x/manifests/c";
 const COLL = "c";
+
+interface StorageTrace {
+  readonly gets: string[];
+  readonly puts: Array<{
+    key: string;
+    ifMatch: string | undefined;
+    ifNoneMatch: string | undefined;
+  }>;
+  readonly deletes: string[];
+  readonly lists: string[];
+}
+
+const tracingStorage = (inner: Storage): { storage: Storage; trace: StorageTrace } => {
+  const trace: StorageTrace = { gets: [], puts: [], deletes: [], lists: [] };
+  const storage: Storage = {
+    async get(key, opts) {
+      trace.gets.push(key);
+      return inner.get(key, opts);
+    },
+    async put(key, body, opts) {
+      trace.puts.push({
+        key,
+        ifMatch: opts?.ifMatch,
+        ifNoneMatch: opts?.ifNoneMatch,
+      });
+      return inner.put(key, body, opts);
+    },
+    async delete(key, opts) {
+      trace.deletes.push(key);
+      return inner.delete(key, opts);
+    },
+    list(prefix, opts) {
+      trace.lists.push(prefix);
+      return inner.list(prefix, opts);
+    },
+  };
+  return { storage, trace };
+};
+
+const seedDenseLog = async (
+  storage: Storage,
+  fromSeq: number,
+  toExclusive: number,
+): Promise<void> =>
+  seedLogEntries(storage, PREFIX, fromSeq, toExclusive, (seq) => ({
+    after: { _id: `d${seq}`, n: seq },
+  }));
 
 describe("runGc", () => {
   test("returns zeros and bootstraps an empty pending.json on first run", async () => {
@@ -573,6 +625,68 @@ describe("runGc", () => {
     expect(r.marked.orphan_content).toBe(1);
     expect(r.swept).toBe(1);
     await expect(s.get(orphanKey)).resolves.toBeNull();
+  });
+
+  test("rescues a due pending content candidate once a complete live set references it", async () => {
+    const inner = new MemoryStorage();
+    await bootstrap(inner, KEY);
+    const writer = new Writer({ storage: inner, currentJsonKey: KEY });
+    await writer.commit({
+      op: "I",
+      collection: COLL,
+      docId: "live-again",
+      body: { _id: "live-again", n: 1 },
+    });
+    const liveContentKeys: string[] = [];
+    for await (const entry of inner.list(`${PREFIX}/content/`)) {
+      liveContentKeys.push(entry.key);
+    }
+    expect(liveContentKeys).toHaveLength(1);
+    const liveContent = liveContentKeys[0]!;
+    await createGcPending(inner, PENDING_KEY, {
+      schema_version: GC_PENDING_SCHEMA_VERSION,
+      candidates: [
+        {
+          key: liveContent,
+          due_at: "2000-01-01T00:00:00.000Z",
+          reason: "orphan-content",
+        },
+      ],
+      last_swept_at: "",
+    });
+    const concurrentCandidate = {
+      key: `${PREFIX}/gc/concurrent.json`,
+      due_at: "2099-01-01T00:00:00.000Z",
+      reason: "stale-log" as const,
+    };
+    let injectedConcurrentUpdate = false;
+    const subject: Storage = {
+      get: (key, opts) => inner.get(key, opts),
+      async put(key, body, opts) {
+        if (key === PENDING_KEY && opts?.ifMatch !== undefined && !injectedConcurrentUpdate) {
+          injectedConcurrentUpdate = true;
+          await casUpdateGcPending(inner, PENDING_KEY, (latest) => ({
+            ...latest,
+            candidates: [...latest.candidates, concurrentCandidate],
+          }));
+        }
+        return inner.put(key, body, opts);
+      },
+      delete: (key, opts) => inner.delete(key, opts),
+      list: (prefix, opts) => inner.list(prefix, opts),
+    };
+    const { storage, trace } = tracingStorage(subject);
+
+    const result = await runGc({ storage, currentJsonKey: KEY }, {
+      graceMillis: 0,
+      maxSweepsPerRun: 10,
+    } as InternalRunGcOptions);
+
+    expect(result).toMatchObject({ swept: 0, pendingDepth: 1 });
+    expect(trace.deletes).not.toContain(liveContent);
+    await expect(inner.get(liveContent)).resolves.not.toBeNull();
+    const pending = await readGcPending(inner, PENDING_KEY);
+    expect(pending?.json.candidates).toEqual([concurrentCandidate]);
   });
 
   test("bounds new marks per category at maxMarksPerRun", async () => {
@@ -1209,4 +1323,165 @@ describe("runGc", () => {
       await expect(inner.get(entry.key)).resolves.not.toBeNull();
     }
   });
+
+  // A partial live-content set cannot prove ANY content key dead — the
+  // post-images it is missing are exactly the ones that look orphan. These
+  // run the DEFAULT (unbounded) path, because the deferral is not a
+  // budget behaviour: a Node operator with an unreadable artifact gets it
+  // too. Only the content phase defers; stale-log and orphan-snapshot work
+  // and their due sweeps continue.
+  describe.each(["missing", "malformed"] as const)(
+    "when a live log entry is %s on the default path",
+    (failure) => {
+      test("defers content classification and preserves its cursor", async () => {
+        const inner = new MemoryStorage();
+        await createCurrentJson(
+          inner,
+          KEY,
+          logStateCurrentJson({
+            log_seq_start: 40,
+            tail_hint: 50,
+          }),
+        );
+        await seedLogEntry(inner, PREFIX, 0);
+        await seedDenseLog(inner, 40, 60);
+        if (failure === "missing") {
+          await inner.delete(`${PREFIX}/log/45.json`);
+        } else {
+          await inner.put(`${PREFIX}/log/45.json`, new TextEncoder().encode("not-json"));
+        }
+        const orphanSnapshot = `${PREFIX}/snapshot/L9/orphan-incomplete-log.json`;
+        const orphanContent = `${PREFIX}/content/ffffffffffffffffffffffffffffffff.json`;
+        const dueStaleKey = `${PREFIX}/gc/due-incomplete-log.json`;
+        const dueSnapshotKey = snapshotKey(PREFIX, 0, 39, "f".repeat(64));
+        const storedCursor = `${PREFIX}/content/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json`;
+        await inner.put(orphanSnapshot, new TextEncoder().encode("{}"));
+        await inner.put(dueSnapshotKey, new TextEncoder().encode("{}"));
+        await inner.put(orphanContent, new TextEncoder().encode("{}"));
+        await createGcPending(inner, PENDING_KEY, {
+          schema_version: GC_PENDING_SCHEMA_VERSION,
+          candidates: [
+            {
+              key: dueStaleKey,
+              due_at: "2000-01-01T00:00:00.000Z",
+              reason: "stale-log",
+            },
+            {
+              key: dueSnapshotKey,
+              due_at: "2000-01-01T00:00:00.000Z",
+              reason: "orphan-snapshot",
+            },
+            {
+              key: orphanContent,
+              due_at: "2000-01-01T00:00:00.000Z",
+              reason: "orphan-content",
+            },
+          ],
+          last_swept_at: "",
+          content_scan_cursor: storedCursor,
+        });
+
+        const { storage, trace } = tracingStorage(inner);
+        const result = await runGc({ storage, currentJsonKey: KEY }, {
+          maxMarksPerRun: 20,
+          maxSweepsPerRun: 10,
+          now: () => new Date("2026-01-01T00:00:00.000Z"),
+        } as InternalRunGcOptions);
+
+        expect(result).toEqual({
+          marked: { stale_log: 1, orphan_snapshot: 1, orphan_content: 0 },
+          swept: 2,
+          pendingDepth: 3,
+        });
+        // The content LIST never runs — nothing can be classified.
+        expect(trace.lists).toContain(`${PREFIX}/log/`);
+        expect(trace.lists).toContain(`${PREFIX}/snapshot/`);
+        expect(trace.lists).not.toContain(`${PREFIX}/content/`);
+        expect(trace.deletes).toEqual([dueStaleKey, dueSnapshotKey]);
+        // The pending orphan-content candidate is NOT swept on an
+        // unprovable pass, and the cursor does not move.
+        await expect(inner.get(orphanContent)).resolves.not.toBeNull();
+        const pending = await readGcPending(inner, PENDING_KEY);
+        expect(pending?.json.content_scan_cursor).toBe(storedCursor);
+        expect(pending?.json.candidates.map((candidate) => candidate.reason).toSorted()).toEqual([
+          "orphan-content",
+          "orphan-snapshot",
+          "stale-log",
+        ]);
+      });
+    },
+  );
+
+  // Swallowing a current-snapshot read failure and returning the hashes
+  // collected so far makes every snapshot-only row look dead. All snapshot
+  // failure modes must defer content classification, on every host.
+  describe.each(["failed", "missing", "corrupt"] as const)(
+    "when the current snapshot is %s on the default path",
+    (failure) => {
+      test("defers content classification and preserves its cursor", async () => {
+        const inner = new MemoryStorage();
+        const currentSnapshot = `${PREFIX}/snapshot/L9/000000000000-000000000040-${"a".repeat(64)}.json`;
+        await createCurrentJson(
+          inner,
+          KEY,
+          logStateCurrentJson({
+            snapshot: currentSnapshot,
+            log_seq_start: 0,
+            tail_hint: 0,
+          }),
+        );
+        if (failure !== "missing") {
+          await inner.put(currentSnapshot, new TextEncoder().encode("not-a-valid-snapshot"));
+        }
+        const orphanSnapshot = `${PREFIX}/snapshot/L9/orphan-incomplete-snapshot.json`;
+        const orphanContent = `${PREFIX}/content/ffffffffffffffffffffffffffffffff.json`;
+        const dueKey = `${PREFIX}/gc/due-incomplete-snapshot.json`;
+        const storedCursor = `${PREFIX}/content/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.json`;
+        await inner.put(orphanSnapshot, new TextEncoder().encode("{}"));
+        await inner.put(orphanContent, new TextEncoder().encode("{}"));
+        await createGcPending(inner, PENDING_KEY, {
+          schema_version: GC_PENDING_SCHEMA_VERSION,
+          candidates: [{ key: dueKey, due_at: "2000-01-01T00:00:00.000Z", reason: "stale-log" }],
+          last_swept_at: "",
+          content_scan_cursor: storedCursor,
+        });
+        const subject: Storage =
+          failure === "failed"
+            ? {
+                get: (key, opts) => {
+                  if (key === currentSnapshot) {
+                    throw new BaerlyError("AccessDenied", "snapshot read denied");
+                  }
+                  return inner.get(key, opts);
+                },
+                put: (key, body, opts) => inner.put(key, body, opts),
+                delete: (key, opts) => inner.delete(key, opts),
+                list: (prefix, opts) => inner.list(prefix, opts),
+              }
+            : inner;
+
+        const { storage, trace } = tracingStorage(subject);
+        const result = await runGc({ storage, currentJsonKey: KEY }, {
+          maxMarksPerRun: 20,
+          maxSweepsPerRun: 10,
+          now: () => new Date("2026-01-01T00:00:00.000Z"),
+        } as InternalRunGcOptions);
+
+        expect(result).toEqual({
+          marked: { stale_log: 0, orphan_snapshot: 1, orphan_content: 0 },
+          swept: 1,
+          pendingDepth: 1,
+        });
+        expect(trace.lists).toContain(`${PREFIX}/snapshot/`);
+        expect(trace.lists).not.toContain(`${PREFIX}/content/`);
+        expect(trace.deletes).toEqual([dueKey]);
+        await expect(inner.get(orphanContent)).resolves.not.toBeNull();
+        const pending = await readGcPending(inner, PENDING_KEY);
+        expect(pending?.json.content_scan_cursor).toBe(storedCursor);
+        expect(pending?.json.candidates.map((candidate) => candidate.reason)).toEqual([
+          "orphan-snapshot",
+        ]);
+      });
+    },
+  );
 });

--- a/packages/server/src/gc.ts
+++ b/packages/server/src/gc.ts
@@ -172,17 +172,23 @@ export interface InternalRunGcOptions extends RunGcOptions {
 /**
  * Why a pass skipped orphan-content discovery entirely.
  *
- * DEGRADED (never expected; does NOT self-clear) — an artifact that
- * should be readable was not, so no complete live set can be built while
- * the fault persists. Orphan content accumulates for as long as it does:
+ * DEGRADED (never expected) — an artifact that should be readable was
+ * not, so no complete live set can be built while the fault persists.
+ * Orphan content accumulates for as long as it does:
  *   - `"live-log-unreadable"`: a log entry inside `[log_seq_start, tail)`
  *     was missing or would not decode.
  *   - `"snapshot-unreadable"`: reading or hash-verifying the current
  *     snapshot failed (a persistent `AccessDenied` or a corrupt body
  *     parks orphan-content GC here indefinitely).
  *
- * A DEGRADED reason on consecutive passes is the operator's signal to
- * look at the named artifact; `admin fsck` walks the same chain.
+ * A reason names the ARTIFACT that could not be read, not the fault
+ * class: a one-off transient storage error and a persistent
+ * `AccessDenied` on the same object both report
+ * `"snapshot-unreadable"`. So a single occurrence does NOT imply a fault
+ * that fails to self-clear — a transient one clears on the next pass.
+ * Consecutive passes reporting the same reason is the discriminator, and
+ * the operator's signal to look at the named artifact; `admin fsck`
+ * walks the same chain and surfaces the underlying error.
  */
 export type ContentDeferralReason = "live-log-unreadable" | "snapshot-unreadable";
 
@@ -204,6 +210,20 @@ export interface RunGcResult {
    * see module JSDoc.
    */
   readonly pendingDepth: number;
+  /**
+   * Set iff this pass skipped orphan-content discovery: no content was
+   * marked, no pending content candidate was swept, and
+   * `content_scan_cursor` was held so the next pass resumes in place.
+   * `marked.stale_log` / `marked.orphan_snapshot` and their sweeps are
+   * unaffected — only the content category defers.
+   *
+   * Absent means content classification ran on a complete live set. Also
+   * emitted as `db.gc.content_deferred_total` (labelled by reason), but a
+   * cron caller outside any HTTP scope sees no metrics — read this field
+   * and log a reason (see {@link ContentDeferralReason}) that repeats
+   * across passes.
+   */
+  readonly contentDeferredReason?: ContentDeferralReason;
 }
 
 const DEFAULT_MAX_MARKS = Number.MAX_SAFE_INTEGER;
@@ -360,6 +380,8 @@ export const runGc = async (
   let markedOrphanContent = 0;
   let nextContentCursor: string | undefined;
   let preserveContentCursor = false;
+  // Why content discovery deferred, for the result field and the metric.
+  let contentDeferredReason: ContentDeferralReason | undefined;
   let completeLiveContentHashes: ReadonlySet<string> | undefined;
   const liveContent = await collectLiveContentHashes(
     storage,
@@ -375,6 +397,7 @@ export const runGc = async (
     // whole category (cursor held, nothing marked, nothing swept) rather
     // than classify against an incomplete set.
     preserveContentCursor = true;
+    contentDeferredReason = liveContent.incompleteReason;
   } else {
     completeLiveContentHashes = liveContent.hashes;
     const contentPass = await markOrphanContent({
@@ -531,11 +554,22 @@ export const runGc = async (
       metrics.counter("db.gc.swept_total", count, { collection: collectionName, reason });
     }
   }
+  // Emitted only on a deferred pass, so a flat zero rate is the healthy
+  // signal and any non-zero reason is the alertable one. Without this, a
+  // pass that classified nothing because it COULDN'T is indistinguishable
+  // from one that found no orphans.
+  if (contentDeferredReason !== undefined) {
+    metrics.counter("db.gc.content_deferred_total", 1, {
+      collection: collectionName,
+      reason: contentDeferredReason,
+    });
+  }
 
   return {
     marked: markedSummary,
     swept: toSweep.length,
     pendingDepth,
+    ...(contentDeferredReason !== undefined && { contentDeferredReason }),
   };
 };
 

--- a/packages/server/src/gc.ts
+++ b/packages/server/src/gc.ts
@@ -6,7 +6,8 @@
  *      run).
  *   2. Marks new orphan candidates by LISTing the three artifact
  *      prefixes — log, snapshot, content — and classifying each key.
- *   3. Sweeps any already-pending candidate whose `due_at` has passed.
+ *   3. Rescues candidates proven live, then sweeps due candidates that
+ *      are safe to classify.
  *   4. CAS-writes the updated `gc/pending.json`.
  *
  * Two-phase by design: every candidate sits in `gc/pending.json` for a
@@ -395,7 +396,7 @@ export const runGc = async (
   const reachedEnd = examinedThisPass < maxMarks;
   const nextContentCursor = reachedEnd ? undefined : lastExaminedKey;
 
-  // ── Step 6. Sweep candidates whose due_at is in the past. ───────
+  // ── Step 6. Rescue live candidates, then sweep due candidates. ──
   // Eligible set = previously-pending entries PLUS this pass's freshly
   // marked entries. Including the new marks lets `runGc({graceMillis:0})`
   // mark-and-sweep in a single pass — useful for tests and for
@@ -403,10 +404,42 @@ export const runGc = async (
   // (they've been waiting longer), then new marks.
   const nowMs = now().getTime();
   const sweepCandidates: GcCandidate[] = [...pending.json.candidates, ...newCandidates];
+  // Snapshot classification used the initial manifest so stale work remains
+  // monotone and deterministic. Re-read only when a due snapshot could be
+  // deleted, as late as possible before DELETE. The fresh pointer rescues a
+  // candidate it names; every other due snapshot still needs a strict
+  // generation-floor proof below before it may enter `toSweep`.
+  const hasDueSnapshot = sweepCandidates.some(
+    (candidate) => candidate.reason === "orphan-snapshot" && Date.parse(candidate.due_at) <= nowMs,
+  );
+  const freshCurrent = hasDueSnapshot
+    ? await readCurrentJson(storage, currentJsonKey, signalOpts)
+    : undefined;
+  const rescuedKeys = new Set<string>();
+  for (const candidate of sweepCandidates) {
+    if (candidate.reason === "orphan-snapshot" && candidate.key === freshCurrent?.json.snapshot) {
+      rescuedKeys.add(candidate.key);
+    }
+  }
   const toSweep: GcCandidate[] = [];
   const remaining: GcCandidate[] = [];
   for (const cand of sweepCandidates) {
+    if (rescuedKeys.has(cand.key)) {
+      continue;
+    }
     if (toSweep.length < maxSweeps && Date.parse(cand.due_at) <= nowMs) {
+      if (cand.reason === "orphan-snapshot") {
+        const maxSeq = parseMaxSeqFromCanonicalSnapshotKey(cand.key, collectionPrefix);
+        // A compactor may publish this candidate after the fresh manifest GET
+        // but before DELETE. The manifest floor is monotone, so only a
+        // canonical snapshot wholly below that observed floor is already
+        // obsolete in every later generation. Equality stays pending: the
+        // internal zero-entry fold seam may publish `[floor, floor)`.
+        if (maxSeq === null || maxSeq >= (freshCurrent?.json.log_seq_start ?? 0)) {
+          remaining.push(cand);
+          continue;
+        }
+      }
       toSweep.push(cand);
     } else {
       remaining.push(cand);
@@ -426,7 +459,10 @@ export const runGc = async (
   // would succeed (fresh etag), so NO conflict is raised and the marks
   // are lost. The mutator is pure + the DELETEs are idempotent + already
   // performed, so the helper safely retries the merge on conflict.
-  const sweptKeys = new Set(toSweep.map((c) => c.key));
+  // `mergeGcPending` drops terminal keys via its existing `sweptKeys`
+  // merge input. Positively-live rescues are terminal ledger resolutions too,
+  // but only `toSweep` drives DELETEs, result counts, timestamps, and metrics.
+  const sweptKeys = new Set([...toSweep.map((candidate) => candidate.key), ...rescuedKeys]);
   // `""` when this pass swept nothing — sourcing the no-sweep truth from
   // `latest` (via the merge's "take later" rule) rather than our stale
   // read. With no contention this is observably identical: `latest`
@@ -529,6 +565,29 @@ const parseSeqFromLogKey = (key: string): number | null => {
   }
   const n = Number.parseInt(match[1]!, 10);
   return Number.isFinite(n) && n >= 0 ? n : null;
+};
+
+/**
+ * Parse the exclusive `max_seq` from the exact key shape emitted by
+ * `snapshotKey`. Unknown levels/layouts and invalid ranges stay opaque so GC
+ * retains them rather than guessing at a generation boundary.
+ */
+const parseMaxSeqFromCanonicalSnapshotKey = (
+  key: string,
+  collectionPrefix: string,
+): number | null => {
+  const snapshotPrefix = `${collectionPrefix}/snapshot/L9/`;
+  if (!key.startsWith(snapshotPrefix)) {
+    return null;
+  }
+  const match = /^(\d{12})-(\d{12})-[0-9a-f]{64}\.json$/.exec(key.slice(snapshotPrefix.length));
+  if (match === null) {
+    return null;
+  }
+  const minSeq = Number(match[1]);
+  const maxSeq = Number(match[2]);
+  // Twelve decimal digits are always safely below MAX_SAFE_INTEGER.
+  return minSeq <= maxSeq ? maxSeq : null;
 };
 
 /**

--- a/packages/server/src/gc.ts
+++ b/packages/server/src/gc.ts
@@ -348,53 +348,20 @@ export const runGc = async (
     logSeqStart,
     signal,
   );
-  // Rotation cursor: resume the content LIST after the last key we
-  // examined last pass. Bounded passes (`maxMarks` < keyspace) thus
-  // sweep the whole `content/` keyspace over a rotation instead of
-  // re-scanning the same lexicographic-first window forever — content
-  // keys are hash-named (random lex order) and live content is never
-  // deleted, so a fixed first-`maxMarks` window can be all-live and
-  // never reach orphan content past it. See `content_scan_cursor`.
-  const contentPrefix = `${collectionPrefix}/content/`;
-  let markedOrphanContent = 0;
-  let examinedThisPass = 0;
-  let lastExaminedKey: string | undefined;
-  for await (const entry of storage.list(
-    contentPrefix,
-    listWindow(maxMarks, pending.json.content_scan_cursor, signal),
-  )) {
-    // The cursor advances by EXAMINED keys (not marked), so an
-    // all-live window still moves the window forward to fresh keys
-    // next pass.
-    examinedThisPass++;
-    lastExaminedKey = entry.key;
-    const hash = parseHashFromContentKey(entry.key);
-    if (hash === null || liveHashes.has(hash)) {
-      continue;
-    }
-    if (known.has(entry.key)) {
-      continue;
-    }
-    newCandidates.push({
-      key: entry.key,
-      due_at: computeDueAt(now, grace),
-      reason: "orphan-content",
-    });
-    markedOrphanContent++;
-  }
-  // New cursor: if the LIST yielded FEWER than `maxKeys` keys it
-  // reached the end of the keyspace ⇒ WRAP (next pass starts from the
-  // beginning, cursor cleared). The unbounded reconcile path
-  // (maxMarks ≈ MAX_SAFE_INTEGER) always yields < maxKeys, so it always
-  // WRAPS — but it does not necessarily scan the whole keyspace first.
-  // Bounded and cursored are INDEPENDENT axes: `listWindow` applies
-  // `startAfter` whenever the ledger carries a cursor, whatever
-  // `maxKeys` is, so an unbounded pass that finds a cursor left by a
-  // bounded one covers only cursor→end. Liveness-only and self-healing
-  // — that pass wraps, so the next starts from the beginning and marks
-  // the remainder. Otherwise carry the last examined key.
-  const reachedEnd = examinedThisPass < maxMarks;
-  const nextContentCursor = reachedEnd ? undefined : lastExaminedKey;
+  const contentPass = await markOrphanContent({
+    storage,
+    collectionPrefix,
+    liveHashes,
+    known,
+    maxMarks,
+    cursor: pending.json.content_scan_cursor,
+    now,
+    grace,
+    signal,
+  });
+  newCandidates.push(...contentPass.candidates);
+  const markedOrphanContent = contentPass.candidates.length;
+  const nextContentCursor = contentPass.nextContentCursor;
 
   // ── Step 6. Rescue live candidates, then sweep due candidates. ──
   // Eligible set = previously-pending entries PLUS this pass's freshly
@@ -618,6 +585,72 @@ const parseHashFromContentKey = (key: string): string | null => {
  */
 const computeDueAt = (now: () => Date, graceMs: number): string =>
   new Date(now().getTime() + graceMs).toISOString();
+
+/**
+ * One bounded rotation window over `content/`: LIST at most `maxMarks`
+ * keys resuming after `cursor`, mark every key whose content hash is
+ * absent from `liveHashes` and not already pending, and report where the
+ * next pass resumes.
+ *
+ * Rotation cursor: bounded passes (`maxMarks` < keyspace) sweep the whole
+ * `content/` keyspace over a rotation instead of re-scanning the same
+ * lexicographic-first window forever — content keys are hash-named
+ * (random lex order) and live content is never deleted, so a fixed
+ * first-`maxMarks` window can be all-live and never reach orphan content
+ * past it. See `content_scan_cursor`.
+ */
+const markOrphanContent = async (opts: {
+  readonly storage: Storage;
+  readonly collectionPrefix: string;
+  readonly liveHashes: ReadonlySet<string>;
+  readonly known: ReadonlySet<string>;
+  readonly maxMarks: number;
+  readonly cursor: string | undefined;
+  readonly now: () => Date;
+  readonly grace: number;
+  readonly signal: AbortSignal | undefined;
+}): Promise<{
+  readonly candidates: GcCandidate[];
+  readonly nextContentCursor: string | undefined;
+}> => {
+  const candidates: GcCandidate[] = [];
+  let examinedThisPass = 0;
+  let lastExaminedKey: string | undefined;
+  for await (const entry of opts.storage.list(
+    `${opts.collectionPrefix}/content/`,
+    listWindow(opts.maxMarks, opts.cursor, opts.signal),
+  )) {
+    // The cursor advances by EXAMINED keys (not marked), so an all-live
+    // window still moves the window forward to fresh keys next pass.
+    examinedThisPass++;
+    lastExaminedKey = entry.key;
+    const hash = parseHashFromContentKey(entry.key);
+    if (hash === null || opts.liveHashes.has(hash)) {
+      continue;
+    }
+    if (opts.known.has(entry.key)) {
+      continue;
+    }
+    candidates.push({
+      key: entry.key,
+      due_at: computeDueAt(opts.now, opts.grace),
+      reason: "orphan-content",
+    });
+  }
+  // New cursor: if the LIST yielded FEWER than `maxKeys` keys it reached
+  // the end of the keyspace ⇒ WRAP (next pass starts from the beginning,
+  // cursor cleared). The unbounded reconcile path (maxMarks ≈
+  // MAX_SAFE_INTEGER) always yields < maxKeys, so it always WRAPS — but it
+  // does not necessarily scan the whole keyspace first. Bounded and
+  // cursored are INDEPENDENT axes: `listWindow` applies `startAfter`
+  // whenever the ledger carries a cursor, whatever `maxKeys` is, so an
+  // unbounded pass that finds a cursor left by a bounded one covers only
+  // cursor→end. Liveness-only and self-healing — that pass wraps, so the
+  // next starts from the beginning and marks the remainder. Otherwise
+  // carry the last examined key.
+  const reachedEnd = examinedThisPass < opts.maxMarks;
+  return { candidates, nextContentCursor: reachedEnd ? undefined : lastExaminedKey };
+};
 
 /**
  * Build the live content-hash set. The set covers every live

--- a/packages/server/src/gc.ts
+++ b/packages/server/src/gc.ts
@@ -170,6 +170,23 @@ export interface InternalRunGcOptions extends RunGcOptions {
 }
 
 /**
+ * Why a pass skipped orphan-content discovery entirely.
+ *
+ * DEGRADED (never expected; does NOT self-clear) — an artifact that
+ * should be readable was not, so no complete live set can be built while
+ * the fault persists. Orphan content accumulates for as long as it does:
+ *   - `"live-log-unreadable"`: a log entry inside `[log_seq_start, tail)`
+ *     was missing or would not decode.
+ *   - `"snapshot-unreadable"`: reading or hash-verifying the current
+ *     snapshot failed (a persistent `AccessDenied` or a corrupt body
+ *     parks orphan-content GC here indefinitely).
+ *
+ * A DEGRADED reason on consecutive passes is the operator's signal to
+ * look at the named artifact; `admin fsck` walks the same chain.
+ */
+export type ContentDeferralReason = "live-log-unreadable" | "snapshot-unreadable";
+
+/**
  * Return shape of {@link runGc}.
  */
 export interface RunGcResult {
@@ -335,12 +352,16 @@ export const runGc = async (
 
   // ── Step 5. Mark orphan content. ────────────────────────────────
   // Build the live content-hash set by hashing every live post-image:
-  //   - log entries [log_seq_start, tail_hint)
+  //   - log entries [log_seq_start, true tail)
   //   - snapshot rows (via `loadSnapshotAsMap` so the hash check
   //     defends against a tampered snapshot)
   // Hash with the same `versionFromContent` (32-hex truncated SHA-256)
   // the writer used to mint the content key.
-  const liveHashes = await collectLiveContentHashes(
+  let markedOrphanContent = 0;
+  let nextContentCursor: string | undefined;
+  let preserveContentCursor = false;
+  let completeLiveContentHashes: ReadonlySet<string> | undefined;
+  const liveContent = await collectLiveContentHashes(
     storage,
     collectionPrefix,
     collectionName,
@@ -348,20 +369,29 @@ export const runGc = async (
     logSeqStart,
     signal,
   );
-  const contentPass = await markOrphanContent({
-    storage,
-    collectionPrefix,
-    liveHashes,
-    known,
-    maxMarks,
-    cursor: pending.json.content_scan_cursor,
-    now,
-    grace,
-    signal,
-  });
-  newCandidates.push(...contentPass.candidates);
-  const markedOrphanContent = contentPass.candidates.length;
-  const nextContentCursor = contentPass.nextContentCursor;
+  if (!liveContent.complete) {
+    // A partial live set cannot prove ANY content key dead — the missing
+    // post-images are exactly the ones that would look orphan. Defer the
+    // whole category (cursor held, nothing marked, nothing swept) rather
+    // than classify against an incomplete set.
+    preserveContentCursor = true;
+  } else {
+    completeLiveContentHashes = liveContent.hashes;
+    const contentPass = await markOrphanContent({
+      storage,
+      collectionPrefix,
+      liveHashes: liveContent.hashes,
+      known,
+      maxMarks,
+      cursor: pending.json.content_scan_cursor,
+      now,
+      grace,
+      signal,
+    });
+    newCandidates.push(...contentPass.candidates);
+    markedOrphanContent = contentPass.candidates.length;
+    nextContentCursor = contentPass.nextContentCursor;
+  }
 
   // ── Step 6. Rescue live candidates, then sweep due candidates. ──
   // Eligible set = previously-pending entries PLUS this pass's freshly
@@ -386,6 +416,13 @@ export const runGc = async (
   for (const candidate of sweepCandidates) {
     if (candidate.reason === "orphan-snapshot" && candidate.key === freshCurrent?.json.snapshot) {
       rescuedKeys.add(candidate.key);
+      continue;
+    }
+    if (candidate.reason === "orphan-content" && completeLiveContentHashes !== undefined) {
+      const hash = parseHashFromContentKey(candidate.key);
+      if (hash !== null && completeLiveContentHashes.has(hash)) {
+        rescuedKeys.add(candidate.key);
+      }
     }
   }
   const toSweep: GcCandidate[] = [];
@@ -394,7 +431,12 @@ export const runGc = async (
     if (rescuedKeys.has(cand.key)) {
       continue;
     }
-    if (toSweep.length < maxSweeps && Date.parse(cand.due_at) <= nowMs) {
+    // Without a complete live hash set, an orphan-content candidate cannot
+    // be proven dead. Keep it pending while independent stale-log/snapshot
+    // candidates continue through the same bounded sweep.
+    if (cand.reason === "orphan-content" && completeLiveContentHashes === undefined) {
+      remaining.push(cand);
+    } else if (toSweep.length < maxSweeps && Date.parse(cand.due_at) <= nowMs) {
       if (cand.reason === "orphan-snapshot") {
         const maxSeq = parseMaxSeqFromCanonicalSnapshotKey(cand.key, collectionPrefix);
         // A compactor may publish this candidate after the fresh manifest GET
@@ -452,6 +494,7 @@ export const runGc = async (
           lastSweptAt,
           nextContentCursor,
           nextLogCursor,
+          ...(preserveContentCursor && { preserveContentCursor: true }),
           maxCandidates: GC_MAX_PENDING_CANDIDATES,
         }),
       signalOpts,
@@ -592,6 +635,11 @@ const computeDueAt = (now: () => Date, graceMs: number): string =>
  * absent from `liveHashes` and not already pending, and report where the
  * next pass resumes.
  *
+ * `liveHashes` MUST be complete. A partial set marks live content as
+ * orphan, and the grace period does not save it — a marked live key is
+ * only rescued if a LATER pass builds a complete set before the due date.
+ * `runGc` owns that gate; this helper trusts it.
+ *
  * Rotation cursor: bounded passes (`maxMarks` < keyspace) sweep the whole
  * `content/` keyspace over a rotation instead of re-scanning the same
  * lexicographic-first window forever — content keys are hash-named
@@ -653,15 +701,30 @@ const markOrphanContent = async (opts: {
 };
 
 /**
+ * Outcome of one live-content-set build — a discriminated union on
+ * `complete`, so the two invariants are the compiler's to keep rather
+ * than a runtime convention's:
+ *
+ *   - Only the `false` arm exists without a reason, so a deferral can
+ *     never be silent. Independent `complete` + `incompleteReason?`
+ *     fields would admit `{ complete: false }` with no reason, which
+ *     holds the cursor and reports nothing — the exact silent deferral
+ *     {@link ContentDeferralReason} exists to remove.
+ *   - Only the `true` arm carries `hashes`, so a partial set is not
+ *     merely unsafe to classify against, it is unreachable.
+ */
+type LiveContentScan =
+  | { readonly complete: true; readonly hashes: ReadonlySet<string> }
+  | { readonly complete: false; readonly incompleteReason: ContentDeferralReason };
+
+/**
  * Build the live content-hash set. The set covers every live
- * post-image: every `entry.after` in `[logSeqStart, tail_hint)` plus
+ * post-image: every `entry.after` in `[logSeqStart, true tail)` plus
  * every row body in the current snapshot.
  *
- * A snapshot read that throws (corrupt body, hash mismatch) is
- * tolerated — the worst-case effect is missing some live hashes,
- * which could mark a live content blob as orphan. The grace period
- * absorbs the false-positive: a retry that re-PUTs the same hash
- * recreates the key before the sweep deletes it.
+ * Missing or malformed live entries and snapshot read failures yield the
+ * incomplete arm, which carries a reason and no hashes — the caller
+ * cannot reach a partial set to classify against.
  */
 const collectLiveContentHashes = async (
   storage: Storage,
@@ -670,8 +733,15 @@ const collectLiveContentHashes = async (
   current: CurrentJson,
   logSeqStart: number,
   signal: AbortSignal | undefined,
-): Promise<Set<string>> => {
+): Promise<LiveContentScan> => {
   const hashes = new Set<string>();
+  // First cause wins: the log walk runs before the snapshot read, and a
+  // log fault is the earlier link in the same chain. Set ⇒ incomplete;
+  // there is no separate `complete` flag to disagree with it.
+  let incompleteReason: ContentDeferralReason | undefined;
+  const markIncomplete = (reason: ContentDeferralReason): void => {
+    incompleteReason ??= reason;
+  };
   const getOpts = signal !== undefined ? { signal } : undefined;
 
   // Live log tail, bounded to the TRUE tail (probe past a stale-low
@@ -699,14 +769,14 @@ const collectLiveContentHashes = async (
   const ingestLogEntry = async (s: number): Promise<void> => {
     const got = await storage.get(logObjectKey(collectionPrefix, s), getOpts);
     if (got === null) {
+      markIncomplete("live-log-unreadable");
       return;
     }
     let entry: { after?: unknown };
     try {
       entry = decodeJsonBytes<{ after?: unknown }>(got.body);
     } catch {
-      // A malformed log entry is the writer's concern, not GC's.
-      // Skip and let other invariants catch it.
+      markIncomplete("live-log-unreadable");
       return;
     }
     if (entry.after === undefined) {
@@ -740,9 +810,16 @@ const collectLiveContentHashes = async (
       }
       await Promise.all(rowReads);
     } catch {
-      // Snapshot read failure is non-fatal — see the docstring.
+      // Swallowed deliberately: throwing here would abort the stale-log
+      // and orphan-snapshot categories, which need no snapshot read. The
+      // caller defers only content classification — but a persistent fault
+      // (AccessDenied, corrupt body) parks that category indefinitely, so
+      // the reason must reach the caller rather than die here.
+      markIncomplete("snapshot-unreadable");
     }
   }
 
-  return hashes;
+  return incompleteReason !== undefined
+    ? { complete: false, incompleteReason }
+    : { complete: true, hashes };
 };

--- a/packages/server/src/maintenance.ts
+++ b/packages/server/src/maintenance.ts
@@ -45,7 +45,7 @@ import { getCurrentContext } from "./observability/context.ts";
 const ctxMetrics = (): MetricsRecorder => getCurrentContext()?.recorder ?? noopMetricsRecorder;
 
 export { type CompactOptions, type CompactResult, compact } from "./compactor.ts";
-export { type RunGcOptions, type RunGcResult, runGc } from "./gc.ts";
+export { type ContentDeferralReason, type RunGcOptions, type RunGcResult, runGc } from "./gc.ts";
 export {
   type RebuildIndexOptions,
   type RebuildIndexResult,


### PR DESCRIPTION
## What & why

GC could delete live objects. Two independent paths: a due `orphan-snapshot` candidate was deleted without rechecking whether a compactor had published it in the meantime, and orphan-content classification ran against a live-content set that silently tolerated missing log entries and unreadable snapshots. Both are fixed by refusing to act on liveness that hasn't been proven — a candidate must be provably dead at DELETE time, or it stays pending.

This is default-path behavior, not a Cloudflare-Free budget concern: a Node operator with a persistently unreadable snapshot is affected too. #105 stacks the bounded-maintenance work on top of this.

The two defects are independent and land as separate stacks: commit 1 is the snapshot guard on its own, commits 2–5 are the content-liveness work. Each carries its own changeset, so they produce two changelog entries under one minor bump.

## Key points

- The snapshot guard is a strict generation-floor proof (`max_seq <` freshly observed `log_seq_start`), not a pointer comparison: the fresh pointer only rescues the one candidate it names, while any other due snapshot has to prove it is obsolete in every later generation. Equality stays pending because the internal zero-entry fold seam can publish `[floor, floor)`.
- Snapshot keys GC cannot parse — unknown levels, non-canonical names, inverted ranges — are retained rather than guessed at.
- The fresh `current.json` GET is conditional on a due snapshot candidate existing, so passes with no snapshot work pay nothing for it.
- Replaces the "grace period absorbs the false positive" doctrine that `collectLiveContentHashes` documented. Grace only helps if a *later* pass builds a complete set before the due date, which a persistent fault guarantees will not happen.
- `collectLiveContentHashes` returns a discriminated union, so the deferral arm cannot omit its reason and only the complete arm carries `hashes`. Classifying against a partial set is a type error, not a convention the caller has to honor.
- Only the content category defers. Stale-log and orphan-snapshot marking and their sweeps need no liveness proof and continue.
- `contentDeferredReason` on `RunGcResult` is the load-bearing half of the new signal, not the metric: a cron handler runs outside any HTTP scope, where metrics fall through to the noop recorder. A reason names the unreadable artifact, not the fault class, so the discriminator between a transient blip and an incident is the same reason repeating across passes.
- Three `bundle-sizes.json` rebaselines (min-gz +183 / +262 / +41), each on the commit that added the bytes and each with its delta in the commit message. The two refactor commits are byte-neutral against the gate and rebaseline nothing.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3063 passed, 101 skipped |
| `pnpm bundle-sizes` | ok (14 entries) |
| `pnpm test:adapter-cloudflare` | 157 passed |

Each of the five commits was also verified individually: commits 1, 4, and 5 through the full lefthook gate at commit time, commits 2 and 3 with `tsgo -b --noEmit` plus the `packages/server` + `packages/protocol` suites. `pnpm bundle-sizes` was run at every commit, so no intermediate commit fails the delta gate.

The new tests were re-run against the pre-change code to confirm they fail: 5 of 6 red for the snapshot guard (the sixth is the positive sweep case old code also allowed), 6 of 6 red for the content-deferral change.

Minio-gated and credentials-gated suites were not run (no local stack).

## Notes for reviewers

Start with `packages/server/src/gc.ts` Step 6 — the rescue pass and the generation-floor gate are the risky part. `parseMaxSeqFromCanonicalSnapshotKey` deliberately accepts only the exact shape `snapshotKey` emits.

The two `refactor` commits (`mergeGcPending.preserveContentCursor`, then the `markOrphanContent` extraction) are behavior-preserving and exist so the deferral gate reads as a flat guard rather than a five-level nest. The extraction commit changes no tests, which is the evidence for it.
