### PR TITLE
fix(gc): fence deletion candidates to the collection generation that marked them

### DIFF
--- a/.changeset/gc-candidate-generation-fence.md
+++ b/.changeset/gc-candidate-generation-fence.md
@@ -1,0 +1,93 @@
+---
+"@gusto/baerly-storage": patch
+---
+
+Fence GC deletion candidates to the collection generation that marked
+them, re-validate `stale-log` liveness at sweep time, and clear the GC
+ledger on `baerly admin restore`.
+
+**The bug.** A `GcCandidate` was a bare key with no identity. The sweep
+already re-checked a due orphan-snapshot against a freshly-read
+`current.snapshot`, and an orphan-content key against the live
+content-hash set, but nothing tied a candidate to the collection it was
+judged against and nothing re-checked a `stale-log` candidate at all. A
+mark decision taken under one view of the bucket could therefore
+execute up to seven days later against a different one.
+
+The reachable consequence involved no crash. `runGc` sweeps `log/K` and
+then loses the `gc/pending.json` CAS; it catches that `Conflict` and
+reports success, so the swept candidate stays in the ledger. `baerly
+admin restore --force` reseeds `log_seq_start` from the surviving log
+objects — the deliberate floor exemption, which can land the floor
+BELOW where it was — and re-creates `log/K`. The sticky candidate
+deletes it, and the resulting hole inside `[log_seq_start, tail)` makes
+every read and every fold throw `BaerlyError{code:"Internal"}` from
+`walkLogRangeWithBytes`. The collection is unreadable and cannot heal
+itself.
+
+**The fix.** `GcCandidate` now carries an optional `generation`,
+stamped from `current.json` at mark time. The sweep drops — never
+deletes — a candidate whose generation no longer matches the live
+manifest, and a `stale-log` candidate whose seq now sits at or above the
+floor. Dropping resolves a candidate out of the ledger without deleting
+anything, which also closes a latent starvation path: `mergeGcPending`
+keeps the FIRST `GC_MAX_PENDING_CANDIDATES`, so a permanently-live
+candidate at the head previously blocked the ledger forever. Liveness is
+re-derived from the manifest and floor the pass already holds, so this
+adds no storage operations.
+
+Both reseed branches of `baerly admin restore` now also delete
+`gc/pending.json` before the writer's first commit, so a reseed no
+longer leaves behind a ledger describing the previous incarnation — one
+whose candidates name keys from the truncated log and whose rotation
+cursors and pending depth describe a keyspace that is gone. The delete
+lands before the first commit rather than after, because those commits
+tick maintenance in-band and so can run `runGc` inside the restore
+itself.
+
+Relatedly, `casUpdateGcPending` now reports a missing `gc/pending.json`
+as `Conflict` rather than `InvalidResponse`. Nothing in the system
+deleted that object before this change, so the branch was unreachable;
+the restore clear above makes it routine. It is a CAS precondition
+failure rather than a separate class of fault — the pre-read is an
+optimisation, and the `If-Match` PUT it short-circuits would have
+returned 412 against a deleted key and been translated to `Conflict`
+anyway. Without the reclassification, a GC pass that read the ledger
+before a concurrent restore and reached its CAS afterwards would throw
+out of `runGc`: the write tick would count an alert-grade
+`db.maintenance.unexpected_error_total`, and `runScheduledMaintenance`
+(documented "Errors propagate") would surface a corrupt-data code to an
+operator's cron during a routine restore. `InvalidResponse` stays
+reserved for a ledger body that is present but unparseable or
+shape-invalid — a failure that never self-heals and must keep escaping.
+
+**What this closes, and what it does not.** The persistent hazard is
+gone: a candidate that outlived the collection it was judged against is
+dropped by the next pass, which reads the replacement manifest and sees
+the generation mismatch. A pass already **in flight** when a restore
+lands still holds the pre-restore manifest, and the gate can only be as
+fresh as the manifest that pass holds — so a residual window remains,
+bounded by the duration of one pass rather than by the seven-day grace.
+Invariant 14 in `docs/spec/sync-protocol.md` states that freshness
+bound. A restore whose outcome matters is still best run without a
+maintenance pass racing it.
+
+**New metric.** `db.gc.dropped_total`, labelled by cause
+(`stale-generation` / `still-live`), counts candidates resolved out of
+the ledger without a DELETE. Deliberately not folded into
+`db.gc.swept_total`: a drop frees no bytes, and a pass that reclaimed
+nothing must not read as productive. A sustained `still-live` rate means
+the mark phase is misjudging liveness.
+
+**On upgrade.** No migration and no configuration change. The
+`generation` field is additive and optional, so
+`GC_PENDING_SCHEMA_VERSION` stays at 1 and a ledger written by an older
+build remains valid; absent compares equal to absent, so a bucket whose
+manifest carries no generation keeps reclaiming normally. Expect one
+`stale-generation` drop spike on the first pass after upgrading — every
+pre-upgrade candidate is dropped for want of a generation and re-marked
+next pass, which delays reclamation of anything already pending by one
+grace period — and one more per `baerly admin restore`. Both are
+self-healing. Operators who alert on
+`db.maintenance.unexpected_error_total` may see one fewer spurious
+source of it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,7 @@ Pure-unit tests that always pass: `packages/protocol/src/hashing.test.ts`,
 `tests/integration/bundle-size.test.ts`,
 `tests/integration/log-emit.test.ts`,
 `tests/integration/put-all-partial-failure.test.ts`,
-`tests/regressions.test.ts`,
+`tests/integration/gc-restore-fencing.test.ts`,
 `tests/integration/write-amp.test.ts`.
 Pattern A/B/C drift across `examples/*/AGENTS.md` is fenced by
 `tests/integration/agents-md-drift.test.ts`. The Node example servers'

--- a/bundle-sizes.json
+++ b/bundle-sizes.json
@@ -16,9 +16,9 @@
   "entries": {
     "index.js": {
       "tier": "shipped",
-      "raw": 259578,
-      "gz": 81858,
-      "minGz": 21748,
+      "raw": 262611,
+      "gz": 82812,
+      "minGz": 22007,
       "note": "kernel barrel; every consumer pays. Must not pull the observability subgraph — see the dedicated test."
     },
     "client.js": {
@@ -37,9 +37,9 @@
     },
     "cloudflare.js": {
       "tier": "shipped",
-      "raw": 448487,
-      "gz": 135804,
-      "minGz": 45543,
+      "raw": 451591,
+      "gz": 136748,
+      "minGz": 45794,
       "note": "Worker isolate cold start. Aggregator: closure includes the index.js and http.js subgraphs, so growth that slips past those entries still surfaces here."
     },
     "s3.js": {
@@ -58,9 +58,9 @@
     },
     "http.js": {
       "tier": "shipped",
-      "raw": 388043,
-      "gz": 116436,
-      "minGz": 38244,
+      "raw": 391147,
+      "gz": 117375,
+      "minGz": 38495,
       "note": "server-side. Also inside the cloudflare.js closure, so growth here shows up on that entry too."
     },
     "auth.js": {
@@ -72,9 +72,9 @@
     },
     "maintenance.js": {
       "tier": "shipped",
-      "raw": 150438,
-      "gz": 46533,
-      "minGz": 12849,
+      "raw": 153471,
+      "gz": 47468,
+      "minGz": 13099,
       "note": "operator-side; reached from the cloudflare.js closure."
     },
     "observability.js": {
@@ -102,12 +102,12 @@
     },
     "node.js": {
       "tier": "tooling",
-      "raw": 613313,
+      "raw": 616417,
       "note": "server-only aggregator. Raw-only dep-creep tripwire; live-external-import creep is caught separately by the bare-specifier allowlist test."
     },
     "dev-vite.js": {
       "tier": "tooling",
-      "raw": 622226,
+      "raw": 625330,
       "note": "dev-only aggregator. Raw-only dep-creep tripwire; see node.js."
     }
   }

--- a/docs/contributing/conventions/observability.md
+++ b/docs/contributing/conventions/observability.md
@@ -182,6 +182,24 @@ The load-bearing kernel metrics today (canonical list in
   CAS on `current.json` (per-collection label). The GC-side sibling of
   the compactor's `db.compaction.cas_lost_total`; sustained non-zero on
   either is write contention above the envelope.
+- `db.gc.dropped_total` — GC counter, labelled by `cause`
+  (`stale-generation` / `still-live`). A candidate the sweep gate
+  resolved out of the ledger without deleting anything, because its
+  `generation` no longer matches the live manifest or because the key
+  reads live again. Deliberately separate from `db.gc.swept_total`: a
+  drop frees no bytes, and folding the two would make a pass that
+  reclaimed nothing look productive. Expect one `stale-generation`
+  spike per `baerly admin restore` and one on the first pass after
+  upgrading to a build that stamps generations (every pre-upgrade
+  candidate is dropped for want of one and re-marked next pass, so
+  reclamation of anything already pending is delayed by one grace
+  period). Both are self-healing. A `stale-generation` rate that does
+  NOT subside means something is re-minting `generation` repeatedly; a
+  sustained `still-live` rate means the mark phase is misjudging
+  liveness, which is the failure the gate exists to contain rather
+  than to hide — check it against `db.gc.swept_total` before assuming
+  GC is healthy, since a collection can drop steadily while
+  reclaiming nothing.
 - `db.orphan.candidate_count` — GC gauge (`gc/pending.json` depth).
 - `db.storage.<op>.calls_total` / `db.storage.<op>.errors_total` /
   `db.storage.<op>.duration_ms` — storage decorator counters +

--- a/docs/spec/sync-protocol.md
+++ b/docs/spec/sync-protocol.md
@@ -568,6 +568,98 @@ These are the load-bearing rules.
     | nonce `A`     | `A`     | pass   | Same generation.                                            |
     | nonce `B`     | `A`     | reject | Truncated.                                                  |
 
+14. **A publication window is assumed shorter than the GC grace.** Two
+    paths PUT an artifact before the object that makes it reachable
+    exists, and are therefore observable by a concurrent GC mark:
+
+    - `Writer.commit` probes its `log/<seq>` slot
+      (`packages/server/src/writer.ts`, step 3), PUTs the content bodies
+      for that commit (step 4), and only then creates the slot (step 5).
+      Between the probe and the create, the content object is on the
+      bucket and no live log entry or snapshot references it, so
+      `runGc` classifies it `orphan-content`.
+    - The compactor PUTs a snapshot (`packages/server/src/compactor.ts`,
+      step 6) before it CASes `current.json` to point at it (step 7).
+      In between, the snapshot key is not `current.snapshot`, so `runGc`
+      classifies it `orphan-snapshot`.
+
+    The protocol assumes neither window stays open longer than
+    `GC_GRACE_PERIOD_MILLIS` (`packages/protocol/src/constants.ts`, 7
+    days), which is the delay GC imposes between a mark and the DELETE
+    it authorises. `packages/server/src/gc.ts`'s module JSDoc states the
+    same bound from the GC side — "The grace bounds the worst plausible
+    writer-retry window". Request-bounded runtimes (a Worker invocation,
+    a Lambda, an HTTP handler) enforce the assumption in practice.
+    Nothing in the kernel checks it, and no error is raised if it is
+    violated.
+
+    **The grace alone does not cover these two windows.** Its stated
+    rationale is about a writer that will _retry_: "a paused-process
+    writer that resumes hours later still finds its idempotency anchor
+    on the bucket". A content PUT and a snapshot PUT have already
+    **succeeded**; what is outstanding is the next step, not a repeat of
+    that one, so an argument about retry latency does not bound them.
+    What covers them is `runGc`'s sweep-time revalidation: the sweep
+    gate re-derives liveness from the `current.json`, floor, and
+    live-content-hash set that same pass already read, and drops — never
+    deletes — a candidate that now reads live or whose `generation` no
+    longer matches the live manifest. An artifact that became reachable
+    after it was marked is therefore dropped unswept — as far as the
+    freshest manifest that pass holds can see, which is the freshness
+    bound stated in the second limitation below.
+
+    **Known limitation: the grace is wall-clock, with no cross-node
+    backstop.** `computeDueAt` stamps `due_at` as the marking node's
+    `Date.now()` plus the grace, and the sweep gate compares that
+    against the sweeping node's `Date.now()`. There is no lease, no
+    bucket-side clock, and no skew tolerance on this path
+    (`LAG_WINDOW_MILLIS` covers log timestamps, not GC due dates). A
+    node whose clock runs more than the grace ahead of the node that did
+    the marking sees every candidate as already due on the first pass
+    that observes it. The consequence is that the grace stops bounding
+    anything, and the sweep-time revalidation above becomes the only
+    check standing between a mark and its DELETE.
+
+    **Known limitation: the revalidation is only as fresh as the
+    freshest manifest the pass already holds.** `runGc` reads
+    `current.json` at step 1
+    ([`packages/server/src/gc.ts`](../../packages/server/src/gc.ts)) and
+    re-reads it at step 6 only when a due `orphan-snapshot` candidate
+    could actually be deleted. The fence and the floor re-check use
+    whichever of the two is newer, so a pass that re-read for the
+    snapshot arm gets the fresher answer for the log and content arms
+    for free — but a pass with no due snapshot never re-reads at all.
+    That is deliberate: an unconditional second read would add a Class B
+    op to every pass, and costing nothing extra is what lets GC ride the
+    write tick. So on such a pass the fence detects "the collection was
+    replaced since this candidate was MARKED", not "since this pass
+    started reading", and the difference is a real window. The worked
+    case below is exactly that shape — `stale-log` candidates, no due
+    snapshot, therefore no re-read.
+
+    Pass `P` reads generation `G1` and floor 12 and loads
+    the due candidates naming `log/10` and `log/11`. `P` then spends
+    seconds on LISTs and log GETs. Meanwhile `baerly admin restore
+    --force` reseeds the collection to generation `G2` at floor 10,
+    clears `gc/pending.json`, and re-creates `log/10` and `log/11` as
+    live entries of the new generation. `P` reaches step 6 still holding
+    its stale `current`: the fence compares `G1` against `G1` and passes,
+    `10 < 12` reads dead, and both live keys are deleted. The restore's
+    ledger clear does not help — `P` loaded those candidates into memory
+    before the clear landed. Read together with the wall-clock limitation
+    above, this window is the entire safety margin: on a node clocked far
+    enough ahead the grace collapses to nothing, and all that stands
+    between a mark and its DELETE is one read of `current.json` taken an
+    unbounded time earlier. The mitigation is operational and is the one
+    [`packages/cli/src/admin/restore.ts`](../../packages/cli/src/admin/restore.ts)
+    already states — do not run `admin restore` against a collection
+    taking live traffic, where "traffic" includes GC passes, since
+    `runScheduledMaintenance` fires them on a cron independent of writes.
+    Re-reading or CASing the manifest immediately before the DELETEs
+    would close the window, and is deliberately not done: it would trade
+    a window that operational exclusivity already covers for a permanent
+    key leak on any pass that dies between the check and the DELETE.
+
 ## LSNs, wall clocks, and downstream consumers
 
 Each `LogEntry` carries a kernel sequence and an external cursor:

--- a/packages/cli/src/admin/restore.test.ts
+++ b/packages/cli/src/admin/restore.test.ts
@@ -16,7 +16,14 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { casUpdateCurrentJson, readCurrentJson } from "@baerly/protocol";
+import {
+  casUpdateCurrentJson,
+  createGcPending,
+  gcPendingKey,
+  type GcPending,
+  readCurrentJson,
+  readGcPending,
+} from "@baerly/protocol";
 import { LocalFsStorage } from "@baerly/dev";
 import { runRestore } from "./restore.ts";
 import { captureStream } from "../_internal/testing.ts";
@@ -26,6 +33,22 @@ const TENANT = "tenant";
 const COLL = "tickets";
 const CURRENT_JSON_KEY = `app/${APP}/tenant/${TENANT}/manifests/${COLL}/current.json`;
 const TABLE_PREFIX = `app/${APP}/tenant/${TENANT}/manifests/${COLL}`;
+const GC_PENDING_KEY = gcPendingKey(TABLE_PREFIX);
+
+/** A populated `gc/pending.json` body, shaped like a real post-mark ledger. */
+const STALE_GC_PENDING: GcPending = {
+  schema_version: 1,
+  candidates: [
+    {
+      key: `${TABLE_PREFIX}/log/0.json`,
+      due_at: "2020-01-01T00:00:00.000Z",
+      reason: "stale-log",
+    },
+  ],
+  last_swept_at: "2020-01-01T00:00:00.000Z",
+  content_scan_cursor: "deadbeef",
+  log_scan_cursor: "3",
+};
 
 const CANONICAL_NDJSON =
   `{"_id":"t-1","status":"open","title":"first"}\n` +
@@ -263,6 +286,68 @@ describe("baerly admin restore", () => {
     const truncated = await readCurrentJson(storage, CURRENT_JSON_KEY);
     expect(truncated?.json.generation).toMatch(/^[0-9a-f]{12}$/);
     expect(truncated?.json.generation).not.toBe(seeded?.json.generation);
+  });
+
+  test("--force clears a populated gc/pending.json ledger as part of the reseed", async () => {
+    // A ledger left behind by the reseed names keys from the truncated
+    // log — which the restore's own commits may re-create at the same
+    // seq — and carries rotation cursors and a pending depth that no
+    // longer describe this collection. The reseed must delete the
+    // ledger object outright, not merely stop referencing it.
+    await writeFile(stdinPath, CANONICAL_NDJSON, "utf8");
+    const first = await runRestore(
+      [`--bucket=file://${root}`, `--app=${APP}`, `--tenant=${TENANT}`, `--collection=${COLL}`],
+      { streams: { stdin: createReadStream(stdinPath) } },
+    );
+    expect(first).toBe(0);
+
+    await createGcPending(storage, GC_PENDING_KEY, STALE_GC_PENDING);
+    await expect(readGcPending(storage, GC_PENDING_KEY)).resolves.not.toBeNull();
+
+    await writeFile(stdinPath, `{"_id":"u-1","x":1}\n`, "utf8");
+    const second = await runRestore(
+      [
+        `--bucket=file://${root}`,
+        `--app=${APP}`,
+        `--tenant=${TENANT}`,
+        `--collection=${COLL}`,
+        "--force",
+      ],
+      { streams: { stdin: createReadStream(stdinPath) } },
+    );
+    expect(second).toBe(0);
+    await expect(readGcPending(storage, GC_PENDING_KEY)).resolves.toBeNull();
+  });
+
+  test("fresh-target restore clears a leftover gc/pending.json ledger", async () => {
+    // `current.json` absent while a ledger is present. No CLI path
+    // produces this — there is no `admin drop` — so it comes from
+    // operator surgery (deleting `current.json` by hand, or restoring
+    // into a prefix a previous collection used) or a half-finished
+    // reseed. The fresh-target branch must clear it too.
+    await createGcPending(storage, GC_PENDING_KEY, STALE_GC_PENDING);
+    await expect(readGcPending(storage, GC_PENDING_KEY)).resolves.not.toBeNull();
+
+    await writeFile(stdinPath, CANONICAL_NDJSON, "utf8");
+    const exitCode = await runRestore(
+      [`--bucket=file://${root}`, `--app=${APP}`, `--tenant=${TENANT}`, `--collection=${COLL}`],
+      { streams: { stdin: createReadStream(stdinPath) } },
+    );
+    expect(exitCode).toBe(0);
+    await expect(readGcPending(storage, GC_PENDING_KEY)).resolves.toBeNull();
+  });
+
+  test("restore succeeds when no gc/pending.json ledger exists", async () => {
+    // The ledger-clear must be a no-op, not an error, when GC has never
+    // run for this collection (the common case).
+    await expect(readGcPending(storage, GC_PENDING_KEY)).resolves.toBeNull();
+    await writeFile(stdinPath, CANONICAL_NDJSON, "utf8");
+    const exitCode = await runRestore(
+      [`--bucket=file://${root}`, `--app=${APP}`, `--tenant=${TENANT}`, `--collection=${COLL}`],
+      { streams: { stdin: createReadStream(stdinPath) } },
+    );
+    expect(exitCode).toBe(0);
+    await expect(readGcPending(storage, GC_PENDING_KEY)).resolves.toBeNull();
   });
 
   test("--force chooses old tail from log keys without decoding malformed old entries", async () => {

--- a/packages/cli/src/admin/restore.ts
+++ b/packages/cli/src/admin/restore.ts
@@ -21,6 +21,13 @@
  * stdin: NDJSON, one `{_id, ...}` row per line. Empty lines tolerated.
  *        EOF terminates.
  *
+ * Side effect: both reseed branches also delete any leftover
+ * `gc/pending.json` for the collection before the first row commits. A
+ * candidate marked before the reseed names a key from the old
+ * incarnation of the log, which the commits below may re-create at the
+ * same seq; the stale ledger's rotation cursors and pending depth no
+ * longer describe this collection either. A missing ledger is a no-op.
+ *
  * Cost shape: under single-write commit each `Writer.commit` is 2 Class
  *   A PUTs (content + the committing `log/<seq>` create — no per-row
  *   `current.json` write). So: 1 PUT current.json (initial seed) + N × 2
@@ -52,6 +59,7 @@ import {
   type CurrentJson,
   type DocumentData,
   encodeJsonBytes,
+  gcPendingKey,
   mintGeneration,
   readCurrentJson,
   type Storage,
@@ -66,6 +74,7 @@ import {
   JSON_ARG,
   TENANT_ARG,
 } from "../subcommand.ts";
+import { collectionPrefixOf } from "./usage.ts";
 
 const RESTORE_OWNER = "baerly-restore";
 
@@ -122,6 +131,8 @@ const bundle = defineBaerlySubcommand({
     const { app, tenant } = await ctx.resolveAppTenant({ app: args.app, tenant: args.tenant });
     assertCollectionArg(args.collection, "baerly admin restore");
     const currentJsonKey = `${bucket.keyPrefix}app/${app}/tenant/${tenant}/manifests/${args.collection}/current.json`;
+    const collectionPrefix = collectionPrefixOf(currentJsonKey);
+    const pendingKey = gcPendingKey(collectionPrefix);
 
     let baseSeq = 0;
     const head = await readCurrentJson(bucket.storage, currentJsonKey);
@@ -149,6 +160,17 @@ const bundle = defineBaerlySubcommand({
       // writes. (We still bump the fence epoch to keep the field
       // monotone, but nothing reads it.)
       //
+      // That contract covers concurrent GC PASSES too, not only
+      // concurrent writers, and `runScheduledMaintenance` fires GC on a
+      // cron independent of writes — so "no live writes" is not by
+      // itself enough. A pass reads `current.json` once at its top and
+      // never re-reads it before issuing its sweep DELETEs, so a pass
+      // that started before this reseed carries the pre-reseed floor
+      // all the way through and can delete log objects the reseed
+      // below re-creates. The ledger clear does not close that window:
+      // such a pass loaded its candidates into memory before the clear
+      // landed.
+      //
       // CRITICAL: stale log entries from the old generation still
       // live on disk under `log/<seq>.json` paths. The writer's
       // `If-None-Match: "*"` log PUT will 412 if we restart `tail_hint`
@@ -160,7 +182,6 @@ const bundle = defineBaerlySubcommand({
       // by folding the old log bodies: `--force` must be able to recover
       // from malformed old entries, and a hole must not make us
       // under-shoot a later old entry.
-      const collectionPrefix = currentJsonKey.slice(0, currentJsonKey.lastIndexOf("/"));
       const truncatedNext = await tailFromListedLogKeys(bucket.storage, collectionPrefix);
       baseSeq = truncatedNext;
       // FLOOR EXEMPTION — deliberate. `casUpdateCurrentJson` rejects any
@@ -234,6 +255,17 @@ const bundle = defineBaerlySubcommand({
           `baerly admin restore: failed to reseed current.json: ${(error as Error).message}`,
         );
       }
+      // Clear the GC ledger the old incarnation left behind. A
+      // candidate marked before this reseed names a key from the
+      // truncated log, which the commits below may re-create at the
+      // same seq; the ledger's rotation cursors and pending depth no
+      // longer describe this collection either. Clear it before the
+      // writer's first commit below — write-tick maintenance runs
+      // `runGc` inline (CF-free profile, `gcInterval = 4`), so a GC
+      // pass can happen during the restore itself. `Storage.delete` is
+      // idempotent (404 ⇒ no-op) per the `Storage` contract, so this is
+      // safe whether or not a ledger exists.
+      await bucket.storage.delete(pendingKey);
     } else {
       // Fresh target: seed `current.json` with `tail_hint=0`.
       const seed: CurrentJson = {
@@ -253,6 +285,15 @@ const bundle = defineBaerlySubcommand({
         generation: mintGeneration(),
       };
       await createCurrentJson(bucket.storage, currentJsonKey, seed);
+      // Same clear as the `--force` branch above, for the case where
+      // `current.json` is absent but a ledger is not. There is no
+      // `admin drop` subcommand, so this is not a product path — it is
+      // reachable by operator surgery (deleting `current.json` by hand,
+      // or restoring into a prefix a previous collection used) and by a
+      // partially-completed reseed. Cheap insurance rather than a case
+      // the CLI can produce on its own; must land before the writer's
+      // first commit either way.
+      await bucket.storage.delete(pendingKey);
     }
 
     const writer = new Writer({ storage: bucket.storage, currentJsonKey });

--- a/packages/protocol/src/constants.ts
+++ b/packages/protocol/src/constants.ts
@@ -691,3 +691,26 @@ export const NO_AUTH_CONFIGURED_MESSAGE: string =
  */
 export const SHARED_SECRET_MISSING_MESSAGE: string =
   'baerly: auth="shared-secret" but SHARED_SECRET env is empty/unset. Cloudflare: `wrangler secret put SHARED_SECRET`, or add to .dev.vars for local dev. Node: set in process env.';
+
+/**
+ * Stands in for "this manifest has no `generation`". Both spellings of
+ * that state — a `current.json` predating the field, and a bare-LSN
+ * cursor minted before this build — decode to this value, so an
+ * ordinary string comparison handles them without a fail-open branch.
+ * See the truth table in `docs/spec/sync-protocol.md`.
+ *
+ * `"-"` is safe as the sentinel because a real generation is a minted
+ * lowercase-hex nonce (`mintGeneration`), and hex contains no `-`. So
+ * the sentinel can never collide with a value a manifest actually
+ * carries, in either the `/v1/since` cursor codec or the GC candidate
+ * fence.
+ *
+ * Sited HERE rather than next to the cursor codec that first needed
+ * it: `constants.ts` is a zero-import leaf, and `runGc` imports this
+ * sentinel. Re-exported from `cursor.ts` so existing importers are
+ * unaffected. Importing it from `cursor.ts` instead would drag
+ * `parseCursor` + `formatCursor` into the `index.js` and
+ * `maintenance.js` closures — every consumer paying for a `/v1/since`
+ * codec to get one `"-"`.
+ */
+export const NO_GENERATION = "-";

--- a/packages/protocol/src/coordination/gc-pending.test.ts
+++ b/packages/protocol/src/coordination/gc-pending.test.ts
@@ -154,6 +154,45 @@ describe("gc-pending", () => {
     await expect(readGcPending(s, KEY)).rejects.toThrow(BaerlyError);
   });
 
+  test("accepts a candidate with no generation (legacy ledger)", async () => {
+    // The field is optional and additive, which is the whole reason
+    // `GC_PENDING_SCHEMA_VERSION` does not move: a ledger written by a
+    // build that predates the generation fence must stay READABLE, or
+    // upgrading bricks GC for every collection with pending candidates
+    // instead of costing them one grace period.
+    const s = new MemoryStorage();
+    const legacy = new TextEncoder().encode(
+      JSON.stringify({
+        schema_version: 1,
+        candidates: [{ key: "a", due_at: "x", reason: "stale-log" }],
+        last_swept_at: "",
+      }),
+    );
+    await s.put(KEY, legacy, { contentType: "application/json" });
+    const read = await readGcPending(s, KEY);
+    expect(read?.json.candidates[0]?.generation).toBeUndefined();
+  });
+
+  test("rejects a non-string generation on read", async () => {
+    // A producer bug, not a race — and it must surface at the READ
+    // rather than at the sweep gate. A non-string would compare unequal
+    // to every real generation, so the candidate would be silently
+    // dropped on every pass and its key never reclaimed; the same
+    // reasoning is why `reason` and the rotation cursors are validated.
+    const s = new MemoryStorage();
+    const bad = new TextEncoder().encode(
+      JSON.stringify({
+        schema_version: 1,
+        candidates: [{ key: "a", due_at: "x", reason: "stale-log", generation: 7 }],
+        last_swept_at: "",
+      }),
+    );
+    await s.put(KEY, bad, { contentType: "application/json" });
+    await expect(readGcPending(s, KEY)).rejects.toMatchObject({
+      code: "InvalidResponse",
+    });
+  });
+
   test("rejects malformed shape on create", async () => {
     const s = new MemoryStorage();
     const bad = { schema_version: 1, candidates: "no", last_swept_at: "" } as unknown as GcPending;

--- a/packages/protocol/src/coordination/gc-pending.test.ts
+++ b/packages/protocol/src/coordination/gc-pending.test.ts
@@ -17,6 +17,7 @@ import {
   type GcPending,
   casUpdateGcPending,
   createGcPending,
+  gcPendingKey,
   mergeGcPending,
   readGcPending,
 } from "./gc-pending.ts";
@@ -1384,6 +1385,35 @@ describe("gc-pending", () => {
     // Bounded: exactly GC_PENDING_CAS_MAX_ATTEMPTS puts (one per retry),
     // then Conflict. Pinned to the constant so a bump is caught.
     expect(putCount).toBe(GC_PENDING_CAS_MAX_ATTEMPTS);
+  });
+});
+
+describe("gcPendingKey", () => {
+  // Byte-identical guarantee: this literal is the key shape that every
+  // caller (gc / admin restore / the collection-api cascade fixture)
+  // must produce. Mirrors the `logObjectKey` pin in `log.test.ts` for the
+  // sibling `log/<seq>.json` shape.
+  //
+  // Scope, honestly: this is cheap self-documentation, not the guard that
+  // catches a real rename. Because every caller now routes through this
+  // helper, a CONSISTENT rename stays coherent end to end and is caught
+  // loudly elsewhere — ~28 tests across the suite redden on one. What
+  // this block adds is a single place that says what the shape IS, so the
+  // literal has to be changed deliberately rather than drifted into.
+  test("composes <collectionPrefix>/gc/pending.json", () => {
+    expect(gcPendingKey("apps/_/tenants/_/manifests/users")).toBe(
+      "apps/_/tenants/_/manifests/users/gc/pending.json",
+    );
+  });
+
+  // The helper is a pure suffix append: it neither normalises nor
+  // validates its input. Pinned so nobody "helpfully" trims a trailing
+  // slash here — every caller passes a `current.json`-derived prefix
+  // that already has none, and a silent normalisation would mask a
+  // caller that started passing the wrong thing.
+  test("appends without normalising the caller's prefix", () => {
+    expect(gcPendingKey("a/b")).toBe("a/b/gc/pending.json");
+    expect(gcPendingKey("")).toBe("/gc/pending.json");
   });
 });
 

--- a/packages/protocol/src/coordination/gc-pending.test.ts
+++ b/packages/protocol/src/coordination/gc-pending.test.ts
@@ -107,10 +107,16 @@ describe("gc-pending", () => {
     ).rejects.toMatchObject({ code: "Conflict" });
   });
 
-  test("cas-update on a missing key throws InvalidResponse", async () => {
+  test("cas-update on a missing key throws Conflict, not InvalidResponse", async () => {
+    // The code is load-bearing, not cosmetic. `runGc` tolerates
+    // `Conflict` from its step-7 CAS as a benign lost race and rethrows
+    // everything else, and `admin restore` deletes this very key on both
+    // reseed branches — so a ledger that vanishes mid-pass MUST arrive
+    // as the tolerated code. `InvalidResponse` stays reserved for a body
+    // that is present but broken, which must keep escaping.
     const s = new MemoryStorage();
     await expect(casUpdateGcPending(s, KEY, (cur) => cur)).rejects.toMatchObject({
-      code: "InvalidResponse",
+      code: "Conflict",
     });
   });
 
@@ -634,9 +640,12 @@ describe("gc-pending", () => {
   test("cas-update on missing key error message mentions 'does not exist'", async () => {
     const s = new MemoryStorage();
     const err = await casUpdateGcPending(s, KEY, (cur) => cur).catch((error: unknown) => error);
-    expect((err as BaerlyError).code).toBe("InvalidResponse");
+    expect((err as BaerlyError).code).toBe("Conflict");
     // L173: message must contain the 'does not exist' explanation
     expect((err as BaerlyError).message).toContain("does not exist");
+    // …and must not read as a pure programming error, since the
+    // dominant cause in production is a concurrent `admin restore`.
+    expect((err as BaerlyError).message).toContain("deleted concurrently");
   });
 
   // ---- casUpdateGcPending: encode and store new state (L179) ----

--- a/packages/protocol/src/coordination/gc-pending.ts
+++ b/packages/protocol/src/coordination/gc-pending.ts
@@ -201,10 +201,22 @@ export const createGcPending = async (
  *
  * @throws BaerlyError{code:"Conflict"} — another writer kept landing a
  *         write between this function's read and write for every
- *         attempt.
- * @throws BaerlyError{code:"InvalidResponse"} — `key` does not exist
- *         (use {@link createGcPending} instead) or body doesn't
- *         parse / fails the shape guard.
+ *         attempt, OR `key` does not exist. The missing-key case is a
+ *         CAS precondition failure, not a separate class of fault: the
+ *         pre-read is an optimisation, and a bare
+ *         `If-Match: <etag>` PUT against a key another actor deleted
+ *         would have surfaced `412` → `Conflict` from the storage layer
+ *         anyway. It is deliberately NOT retried — a deleted ledger
+ *         stays deleted until someone calls {@link createGcPending},
+ *         which the next `runGc` pass does. `baerly admin restore`
+ *         deletes `gc/pending.json` on both reseed branches, so a
+ *         concurrent pass reaches this routinely; `runGc` treats
+ *         `Conflict` as benign best-effort.
+ * @throws BaerlyError{code:"InvalidResponse"} — the stored body doesn't
+ *         parse or fails the shape guard. Kept distinct from the
+ *         missing-key case on purpose: a caller that tolerates
+ *         `Conflict` as a race must not thereby swallow a corrupt
+ *         ledger, which fails identically on every future pass.
  */
 export const casUpdateGcPending = async (
   storage: Storage,
@@ -216,9 +228,17 @@ export const casUpdateGcPending = async (
   for (let attempt = 0; attempt < GC_PENDING_CAS_MAX_ATTEMPTS; attempt++) {
     const existing = await readGcPending(storage, key, opts);
     if (existing === null) {
+      // `Conflict`, not `InvalidResponse`: the object was there when the
+      // caller decided to update it and is not there now, which is the
+      // If-Match precondition failing — the same 412 the storage layer
+      // would have raised had this helper skipped its pre-read. Callers
+      // that already tolerate a lost CAS therefore tolerate a ledger
+      // deleted out from under them (`baerly admin restore`) without
+      // also having to tolerate `InvalidResponse`, which stays reserved
+      // for a body that is present but broken.
       throw new BaerlyError(
-        "InvalidResponse",
-        `gc/pending.json at ${key} does not exist; use createGcPending first`,
+        "Conflict",
+        `gc/pending.json at ${key} does not exist; it was deleted concurrently, or was never created — see createGcPending`,
       );
     }
     const next = mutator(structuredClone(existing.json));

--- a/packages/protocol/src/coordination/gc-pending.ts
+++ b/packages/protocol/src/coordination/gc-pending.ts
@@ -111,6 +111,17 @@ export interface GcPendingRead {
 }
 
 /**
+ * The single constructor for a `gc/pending.json` key:
+ * `<collectionPrefix>/gc/pending.json`. `collectionPrefix` is the
+ * `<…>/manifests/<collection>` segment — this helper adds the ledger's
+ * relative path. Route all callers here so the key shape lives in one
+ * place, mirroring {@link logObjectKey} in `log-key.ts` for the sibling
+ * `log/<seq>.json` shape.
+ */
+export const gcPendingKey = (collectionPrefix: string): string =>
+  `${collectionPrefix}/gc/pending.json`;
+
+/**
  * Read + parse `gc/pending.json` at `key`. Returns `null` on
  * not-found.
  *

--- a/packages/protocol/src/coordination/gc-pending.ts
+++ b/packages/protocol/src/coordination/gc-pending.ts
@@ -99,6 +99,22 @@ export interface GcCandidate {
   due_at: string;
   /** Why the key is a candidate. */
   reason: "stale-log" | "orphan-snapshot" | "orphan-content";
+  /**
+   * The `current.json` `generation` this candidate was marked under, if
+   * the manifest carried one. The sweep drops — never deletes — a
+   * candidate whose generation no longer matches the live manifest,
+   * which is what stops a mark decision taken under one incarnation of
+   * a collection from executing against a different one up to
+   * `GC_GRACE_PERIOD_MILLIS` later.
+   *
+   * Optional and additive on the same terms as the rotation cursors, so
+   * {@link GC_PENDING_SCHEMA_VERSION} is unchanged and a ledger written
+   * by an older build stays valid. Absent decodes to `NO_GENERATION` on
+   * both sides of the comparison, so a bucket whose manifest carries no
+   * generation keeps reclaiming normally rather than fencing everything
+   * off.
+   */
+  generation?: string;
 }
 
 /**
@@ -450,6 +466,19 @@ const assertGcPending = (parsed: unknown, key: string): GcPending => {
       throw new BaerlyError(
         "InvalidResponse",
         `gc/pending.json at ${key}: candidates[${String(i)}].reason must be one of stale-log|orphan-snapshot|orphan-content`,
+      );
+    }
+    // Optional, like the rotation cursors: absent is valid and means
+    // "marked under a manifest with no generation". Present-but-not-a-
+    // string is a producer bug, and this guard runs inside
+    // `readGcPending` — GC's step-2 read — so rejecting here stalls the
+    // collection's GC rather than letting a malformed candidate reach
+    // the sweep gate, where a non-string would compare unequal to every
+    // real generation and be silently dropped forever.
+    if (cr["generation"] !== undefined && typeof cr["generation"] !== "string") {
+      throw new BaerlyError(
+        "InvalidResponse",
+        `gc/pending.json at ${key}: candidates[${String(i)}].generation must be a string when present`,
       );
     }
   }

--- a/packages/protocol/src/cursor.ts
+++ b/packages/protocol/src/cursor.ts
@@ -5,7 +5,8 @@
  * Kept separate from `log.ts` for the same reason as `log-key.ts`:
  * `log.ts` carries the heavier `lsn` parsing runtime, and consumers that
  * only need to split a cursor shouldn't drag it into their bundle
- * closure. This module imports only `BaerlyError`.
+ * closure. This module imports only `BaerlyError` and the
+ * `NO_GENERATION` sentinel from the zero-import `constants.ts`.
  *
  * ## Why the cursor is not just the LSN
  *
@@ -27,6 +28,7 @@
  * `/v1/since` boundary.
  */
 
+import { NO_GENERATION } from "./constants.ts";
 import { BaerlyError } from "./errors.ts";
 
 /**
@@ -37,14 +39,12 @@ import { BaerlyError } from "./errors.ts";
 const CURSOR_SEPARATOR = ".";
 
 /**
- * Stands in for "this manifest has no `generation`". Both spellings of
- * that state — a `current.json` predating the field, and a bare-LSN
- * cursor minted before this build — decode to this value, so the
- * ordinary string comparison in `/v1/since` handles them without a
- * fail-open branch. See the truth table in
- * `docs/spec/sync-protocol.md`.
+ * Re-exported from the zero-import `constants.ts`, where the sentinel
+ * now lives so `runGc` can reach it without dragging this module's
+ * codec into the `index.js` / `maintenance.js` closures. Kept exported
+ * here because `/v1/since` is still its primary consumer.
  */
-export const NO_GENERATION = "-";
+export { NO_GENERATION };
 
 /**
  * Build the wire cursor for an entry's `lsn` under a manifest's

--- a/packages/protocol/src/metrics.ts
+++ b/packages/protocol/src/metrics.ts
@@ -32,6 +32,14 @@
  *     those are; do not re-enumerate them)
  *   - `db.gc.cas_lost_total` — counter (GC lost its admission-checkpoint CAS
  *     on `current.json`; the GC-side sibling of `db.compaction.cas_lost_total`)
+ *   - `db.gc.dropped_total` — counter (labelled by cause: `stale-generation`
+ *     / `still-live`). Candidates resolved out of the ledger WITHOUT a
+ *     DELETE because the sweep gate re-checked them and found them no
+ *     longer eligible. A drop frees no bytes, so this is deliberately
+ *     not folded into `db.gc.swept_total` — a pass that reclaimed
+ *     nothing must not read as productive. One `stale-generation` spike
+ *     per restore or upgrade is expected; a sustained `still-live` rate
+ *     means the mark phase is misjudging liveness
  *
  * Names follow `db.<subsystem>.<metric>`, dot-separated, all-lowercase
  * snake_case segments. Labels are flat

--- a/packages/server/src/gc.test.ts
+++ b/packages/server/src/gc.test.ts
@@ -23,12 +23,14 @@ import {
   casUpdateGcPending,
   createCurrentJson,
   createGcPending,
+  encodeJsonBytes,
   readCurrentJson,
   readGcPending,
   snapshotHash,
 } from "@baerly/protocol";
 import { describe, expect, test } from "vitest";
 import {
+  LOG_STATE_GENERATION,
   logStateCurrentJson,
   seedLogEntries,
   seedLogEntry,
@@ -112,6 +114,7 @@ describe("runGc", () => {
     expect(r).toEqual({
       marked: { stale_log: 0, orphan_snapshot: 0, orphan_content: 0 },
       swept: 0,
+      dropped: { stale_generation: 0, still_live: 0 },
       pendingDepth: 0,
     });
     const pending = await readGcPending(s, PENDING_KEY);
@@ -442,6 +445,7 @@ describe("runGc", () => {
           key: candidate,
           due_at: "2000-01-01T00:00:00.000Z",
           reason: "orphan-snapshot",
+          generation: LOG_STATE_GENERATION,
         },
       ],
       last_swept_at: "",
@@ -510,6 +514,7 @@ describe("runGc", () => {
           key: candidate,
           due_at: "2000-01-01T00:00:00.000Z",
           reason: "orphan-snapshot",
+          generation: LOG_STATE_GENERATION,
         },
       ],
       last_swept_at: "",
@@ -545,6 +550,7 @@ describe("runGc", () => {
           key: candidate,
           due_at: "2000-01-01T00:00:00.000Z",
           reason: "orphan-snapshot",
+          generation: LOG_STATE_GENERATION,
         },
       ],
       last_swept_at: "",
@@ -581,6 +587,7 @@ describe("runGc", () => {
         key,
         due_at: "2000-01-01T00:00:00.000Z",
         reason: "orphan-snapshot" as const,
+        generation: LOG_STATE_GENERATION,
       })),
       last_swept_at: "",
     });
@@ -685,6 +692,7 @@ describe("runGc", () => {
           key: liveContent,
           due_at: "2000-01-01T00:00:00.000Z",
           reason: "orphan-content",
+          generation: LOG_STATE_GENERATION,
         },
       ],
       last_swept_at: "",
@@ -693,6 +701,7 @@ describe("runGc", () => {
       key: `${PREFIX}/gc/concurrent.json`,
       due_at: "2099-01-01T00:00:00.000Z",
       reason: "stale-log" as const,
+      generation: LOG_STATE_GENERATION,
     };
     let injectedConcurrentUpdate = false;
     const subject: Storage = {
@@ -836,7 +845,21 @@ describe("runGc", () => {
 
   test("returns success on CAS-lost on pending.json (best-effort pendingDepth)", async () => {
     const s = new MemoryStorage();
-    await bootstrap(s, KEY);
+    // Floor at 1, not the bootstrap default of 0, so the seeded
+    // candidate below names a key that is genuinely BENEATH the floor.
+    // With a floor of 0 the sweep gate re-derives `log/0.json` as live
+    // and drops the candidate instead of deleting it — correctly, since
+    // readers walk from 0 — and this test would be asserting a sweep the
+    // mark phase could never have authorised in the first place.
+    await createCurrentJson(
+      s,
+      KEY,
+      logStateCurrentJson({
+        writer_fence: { epoch: 0, owner: "gc-test", claimed_at: "" },
+        log_seq_start: 1,
+        tail_hint: 1,
+      }),
+    );
     // Pre-seed pending.json with an entry due-for-sweep so the run
     // has work to do.
     const pre: GcPending = {
@@ -846,6 +869,7 @@ describe("runGc", () => {
           key: "app/t/tenant/x/manifests/c/log/0.json",
           due_at: "2000-01-01T00:00:00.000Z",
           reason: "stale-log",
+          generation: LOG_STATE_GENERATION,
         },
       ],
       last_swept_at: "",
@@ -900,7 +924,14 @@ describe("runGc", () => {
     await inner.put(orphanContent, new TextEncoder().encode("{}"));
     await createGcPending(inner, PENDING_KEY, {
       schema_version: GC_PENDING_SCHEMA_VERSION,
-      candidates: [{ key: dueKey, due_at: "2000-01-01T00:00:00.000Z", reason: "stale-log" }],
+      candidates: [
+        {
+          key: dueKey,
+          due_at: "2000-01-01T00:00:00.000Z",
+          reason: "stale-log",
+          generation: LOG_STATE_GENERATION,
+        },
+      ],
       last_swept_at: "",
       content_scan_cursor: `${PREFIX}/content/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json`,
     });
@@ -917,6 +948,7 @@ describe("runGc", () => {
     expect(result).toEqual({
       marked: { stale_log: 0, orphan_snapshot: 1, orphan_content: 0 },
       swept: 1,
+      dropped: { stale_generation: 0, still_live: 0 },
       pendingDepth: 1,
       // Budget class: expected on Free, and the checkpoint below is what
       // makes it self-clear.
@@ -959,7 +991,14 @@ describe("runGc", () => {
     await inner.put(orphanContent, new TextEncoder().encode("{}"));
     await createGcPending(inner, PENDING_KEY, {
       schema_version: GC_PENDING_SCHEMA_VERSION,
-      candidates: [{ key: dueKey, due_at: "2000-01-01T00:00:00.000Z", reason: "stale-log" }],
+      candidates: [
+        {
+          key: dueKey,
+          due_at: "2000-01-01T00:00:00.000Z",
+          reason: "stale-log",
+          generation: LOG_STATE_GENERATION,
+        },
+      ],
       last_swept_at: "",
       content_scan_cursor: `${PREFIX}/content/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.json`,
     });
@@ -1045,11 +1084,17 @@ describe("runGc", () => {
     await createGcPending(inner, PENDING_KEY, {
       schema_version: GC_PENDING_SCHEMA_VERSION,
       candidates: [
-        { key: dueStale, due_at: "2000-01-01T00:00:00.000Z", reason: "stale-log" },
+        {
+          key: dueStale,
+          due_at: "2000-01-01T00:00:00.000Z",
+          reason: "stale-log",
+          generation: LOG_STATE_GENERATION,
+        },
         {
           key: dueSnapshot,
           due_at: "2000-01-01T00:00:00.000Z",
           reason: "orphan-snapshot",
+          generation: LOG_STATE_GENERATION,
         },
       ],
       last_swept_at: "",
@@ -1068,6 +1113,7 @@ describe("runGc", () => {
     expect(result).toEqual({
       marked: { stale_log: 1, orphan_snapshot: 1, orphan_content: 0 },
       swept: 2,
+      dropped: { stale_generation: 0, still_live: 0 },
       pendingDepth: 2,
       // Degraded class. This probe reaches an exact tail (36 is missing),
       // so only the malformed condition holds; the both-hold precedence
@@ -1125,16 +1171,19 @@ describe("runGc", () => {
               key: dueStaleKey,
               due_at: "2000-01-01T00:00:00.000Z",
               reason: "stale-log",
+              generation: LOG_STATE_GENERATION,
             },
             {
               key: dueSnapshotKey,
               due_at: "2000-01-01T00:00:00.000Z",
               reason: "orphan-snapshot",
+              generation: LOG_STATE_GENERATION,
             },
             {
               key: orphanContent,
               due_at: "2000-01-01T00:00:00.000Z",
               reason: "orphan-content",
+              generation: LOG_STATE_GENERATION,
             },
           ],
           last_swept_at: "",
@@ -1153,6 +1202,7 @@ describe("runGc", () => {
         expect(result).toEqual({
           marked: { stale_log: 1, orphan_snapshot: 1, orphan_content: 0 },
           swept: 2,
+          dropped: { stale_generation: 0, still_live: 0 },
           pendingDepth: 3,
           contentDeferredReason: "live-log-unreadable",
         });
@@ -1201,7 +1251,14 @@ describe("runGc", () => {
         await inner.put(orphanContent, new TextEncoder().encode("{}"));
         await createGcPending(inner, PENDING_KEY, {
           schema_version: GC_PENDING_SCHEMA_VERSION,
-          candidates: [{ key: dueKey, due_at: "2000-01-01T00:00:00.000Z", reason: "stale-log" }],
+          candidates: [
+            {
+              key: dueKey,
+              due_at: "2000-01-01T00:00:00.000Z",
+              reason: "stale-log",
+              generation: LOG_STATE_GENERATION,
+            },
+          ],
           last_swept_at: "",
           content_scan_cursor: storedCursor,
         });
@@ -1232,6 +1289,7 @@ describe("runGc", () => {
         expect(result).toEqual({
           marked: { stale_log: 0, orphan_snapshot: 1, orphan_content: 0 },
           swept: 1,
+          dropped: { stale_generation: 0, still_live: 0 },
           pendingDepth: 1,
           // The reviewer-cited scenario: a persistent AccessDenied here
           // parks orphan-content GC forever, so the pass must NOT look
@@ -1414,6 +1472,7 @@ describe("runGc", () => {
     expect(result).toEqual({
       marked: { stale_log: 0, orphan_snapshot: 0, orphan_content: 0 },
       swept: 0,
+      dropped: { stale_generation: 0, still_live: 0 },
       pendingDepth: 0,
       contentDeferredReason: "probe-budget",
     });
@@ -1972,16 +2031,19 @@ describe("runGc", () => {
               key: dueStaleKey,
               due_at: "2000-01-01T00:00:00.000Z",
               reason: "stale-log",
+              generation: LOG_STATE_GENERATION,
             },
             {
               key: dueSnapshotKey,
               due_at: "2000-01-01T00:00:00.000Z",
               reason: "orphan-snapshot",
+              generation: LOG_STATE_GENERATION,
             },
             {
               key: orphanContent,
               due_at: "2000-01-01T00:00:00.000Z",
               reason: "orphan-content",
+              generation: LOG_STATE_GENERATION,
             },
           ],
           last_swept_at: "",
@@ -1998,6 +2060,7 @@ describe("runGc", () => {
         expect(result).toEqual({
           marked: { stale_log: 1, orphan_snapshot: 1, orphan_content: 0 },
           swept: 2,
+          dropped: { stale_generation: 0, still_live: 0 },
           pendingDepth: 3,
           contentDeferredReason: "live-log-unreadable",
         });
@@ -2049,7 +2112,14 @@ describe("runGc", () => {
         await inner.put(orphanContent, new TextEncoder().encode("{}"));
         await createGcPending(inner, PENDING_KEY, {
           schema_version: GC_PENDING_SCHEMA_VERSION,
-          candidates: [{ key: dueKey, due_at: "2000-01-01T00:00:00.000Z", reason: "stale-log" }],
+          candidates: [
+            {
+              key: dueKey,
+              due_at: "2000-01-01T00:00:00.000Z",
+              reason: "stale-log",
+              generation: LOG_STATE_GENERATION,
+            },
+          ],
           last_swept_at: "",
           content_scan_cursor: storedCursor,
         });
@@ -2078,6 +2148,7 @@ describe("runGc", () => {
         expect(result).toEqual({
           marked: { stale_log: 0, orphan_snapshot: 1, orphan_content: 0 },
           swept: 1,
+          dropped: { stale_generation: 0, still_live: 0 },
           pendingDepth: 1,
           // A persistent AccessDenied here parks orphan-content GC
           // forever, so the pass must NOT look identical to an
@@ -2096,4 +2167,216 @@ describe("runGc", () => {
       });
     },
   );
+});
+
+// ---------------------------------------------------------------------
+// The sweep-time revalidation gate.
+//
+// Before this gate the sweep had exactly two conjuncts: a budget counter
+// and `due_at <= now`. A mark decision taken under one view of the
+// bucket therefore executed up to `GC_GRACE_PERIOD_MILLIS` later under a
+// different one, with no liveness re-check. These tests pin the four
+// outcomes the gate now distinguishes, and each is written so that
+// removing the arm under test turns it RED rather than merely changing a
+// count — the object's continued existence is the assertion, not the
+// tally.
+// ---------------------------------------------------------------------
+describe("runGc — sweep-time revalidation", () => {
+  const OTHER_GENERATION = "ffffffffffff";
+
+  /** Seed a manifest + a due `stale-log` candidate naming `log/<seq>`. */
+  const seedDueStaleLog = async (
+    storage: MemoryStorage,
+    opts: { floor: number; seq: number; manifestGeneration?: string; candidateGeneration?: string },
+  ): Promise<string> => {
+    await createCurrentJson(
+      storage,
+      KEY,
+      logStateCurrentJson({
+        log_seq_start: opts.floor,
+        tail_hint: opts.floor,
+        ...(opts.manifestGeneration !== undefined && { generation: opts.manifestGeneration }),
+      }),
+    );
+    const key = `${PREFIX}/log/${String(opts.seq)}.json`;
+    await storage.put(key, new TextEncoder().encode("{}"));
+    await createGcPending(storage, PENDING_KEY, {
+      schema_version: GC_PENDING_SCHEMA_VERSION,
+      candidates: [
+        {
+          key,
+          due_at: "2000-01-01T00:00:00.000Z",
+          reason: "stale-log",
+          ...(opts.candidateGeneration !== undefined && {
+            generation: opts.candidateGeneration,
+          }),
+        },
+      ],
+      last_swept_at: "",
+    });
+    return key;
+  };
+
+  const sweep = async (storage: MemoryStorage): ReturnType<typeof runGc> =>
+    runGc({ storage, currentJsonKey: KEY }, {
+      graceMillis: 0,
+      maxSweepsPerRun: 10,
+    } as InternalRunGcOptions);
+
+  test("drops a due candidate whose generation no longer matches the manifest", async () => {
+    // The reachable data-loss schedule, reduced to its gate. A candidate
+    // was marked against generation A; `admin restore --force` has since
+    // re-minted the manifest to generation B and re-created `log/5` as a
+    // LIVE entry of the new incarnation. Without the fence this DELETEs
+    // a live log object, putting a hole inside `[log_seq_start, tail)` —
+    // after which every read and every fold throws `Internal` from
+    // `walkLogRangeWithBytes` and the collection cannot heal itself.
+    const s = new MemoryStorage();
+    const key = await seedDueStaleLog(s, {
+      floor: 9,
+      seq: 5,
+      manifestGeneration: OTHER_GENERATION,
+      candidateGeneration: LOG_STATE_GENERATION,
+    });
+
+    const r = await sweep(s);
+
+    // The load-bearing assertion: the object SURVIVES. A drop resolves a
+    // candidate out of the ledger; it never deletes.
+    await expect(s.get(key)).resolves.not.toBeNull();
+    expect(r.swept).toBe(0);
+    expect(r.dropped).toEqual({ stale_generation: 1, still_live: 0 });
+    // …and it really left the ledger, rather than being retained and
+    // re-examined (and re-dropped) on every future pass.
+    const pending = await readGcPending(s, PENDING_KEY);
+    expect(pending?.json.candidates).toEqual([]);
+  });
+
+  test("sweeps a due candidate whose generation still matches", async () => {
+    // The control for the test above: the fence must not swallow the
+    // ordinary case. Same fixture, same floor, same due date — only the
+    // manifest generation agrees.
+    const s = new MemoryStorage();
+    const key = await seedDueStaleLog(s, {
+      floor: 9,
+      seq: 5,
+      candidateGeneration: LOG_STATE_GENERATION,
+    });
+
+    const r = await sweep(s);
+
+    await expect(s.get(key)).resolves.toBeNull();
+    expect(r.swept).toBe(1);
+    expect(r.dropped).toEqual({ stale_generation: 0, still_live: 0 });
+  });
+
+  test("drops a candidate marked before the build began stamping generations", async () => {
+    // The upgrade path. A ledger written by an older build carries no
+    // `generation` at all, and absent cannot be proven to match a
+    // manifest that has one — so the whole pre-upgrade ledger is dropped
+    // on the first pass and re-marked on the next with a fresh grace
+    // period. One-time, self-healing, and visible as a single
+    // `stale-generation` spike.
+    const s = new MemoryStorage();
+    const key = await seedDueStaleLog(s, { floor: 9, seq: 5 });
+
+    const r = await sweep(s);
+
+    await expect(s.get(key)).resolves.not.toBeNull();
+    expect(r.dropped.stale_generation).toBe(1);
+  });
+
+  test("keeps reclaiming on a bucket whose manifest carries no generation", async () => {
+    // Legacy compatibility, and the reason the field is optional on BOTH
+    // sides rather than defaulted at the writer. Absent compares equal to
+    // absent, so a collection predating `generation` entirely is not
+    // fenced off from GC forever.
+    const s = new MemoryStorage();
+    const key = await seedDueStaleLog(s, {
+      floor: 9,
+      seq: 5,
+      manifestGeneration: undefined,
+    });
+    // `logStateCurrentJson` always stamps a generation, so strip it to
+    // build the pre-`generation` manifest shape this test is about.
+    const cur = await readCurrentJson(s, KEY);
+    const { generation: _dropped, ...withoutGeneration } = cur!.json;
+    await s.put(KEY, encodeJsonBytes(withoutGeneration), { ifMatch: cur!.etag });
+
+    const r = await sweep(s);
+
+    await expect(s.get(key)).resolves.toBeNull();
+    expect(r.swept).toBe(1);
+    expect(r.dropped).toEqual({ stale_generation: 0, still_live: 0 });
+  });
+
+  test("drops a due stale-log candidate that the floor has made live again", async () => {
+    // The second arm, independent of the first: same generation
+    // throughout, but the floor has moved DOWN beneath the candidate.
+    // Only `admin restore --force` writes that shape — its deliberate
+    // floor exemption reseeds `log_seq_start` from the surviving log
+    // objects. `log/5` was dead under a floor of 9; under a floor of 3 it
+    // is a live entry readers walk.
+    const s = new MemoryStorage();
+    const key = await seedDueStaleLog(s, {
+      floor: 3,
+      seq: 5,
+      candidateGeneration: LOG_STATE_GENERATION,
+    });
+
+    const r = await sweep(s);
+
+    await expect(s.get(key)).resolves.not.toBeNull();
+    expect(r.swept).toBe(0);
+    expect(r.dropped).toEqual({ stale_generation: 0, still_live: 1 });
+  });
+
+  test("a drop advances neither last_swept_at nor db.gc.swept_total", async () => {
+    // A drop frees no bytes. Folding it into the sweep counters would
+    // make a pass that reclaimed nothing read as productive, and would
+    // move a timestamp whose whole purpose is to say when bytes last came
+    // back.
+    const s = new MemoryStorage();
+    await seedDueStaleLog(s, {
+      floor: 9,
+      seq: 5,
+      manifestGeneration: OTHER_GENERATION,
+      candidateGeneration: LOG_STATE_GENERATION,
+    });
+
+    const ctx = createObservabilityContext();
+    await runWithContext(ctx, async () => sweep(s));
+
+    const pending = await readGcPending(s, PENDING_KEY);
+    expect(pending?.json.last_swept_at).toBe("");
+    const snap = ctx.recorder.snapshot();
+    expect(snap.counters.find((c) => c.name === "db.gc.swept_total")).toBeUndefined();
+    const dropped = snap.counters.filter((c) => c.name === "db.gc.dropped_total");
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0]?.value).toBe(1);
+    expect(dropped[0]?.labels).toMatchObject({ cause: "stale-generation" });
+  });
+
+  test("stamps the marking manifest's generation onto every new candidate", async () => {
+    // The other half of the fence: a candidate with no generation is
+    // fenced against nothing on the next pass. Marks must carry it, or
+    // the sweep arm above degenerates into the upgrade path forever.
+    const s = new MemoryStorage();
+    await createCurrentJson(s, KEY, logStateCurrentJson({ log_seq_start: 4, tail_hint: 4 }));
+    for (let seq = 0; seq < 3; seq++) {
+      await s.put(`${PREFIX}/log/${String(seq)}.json`, new TextEncoder().encode("{}"));
+    }
+
+    await runGc({ storage: s, currentJsonKey: KEY }, {
+      // A grace far in the future, so everything marked stays pending
+      // and this test reads marks rather than sweeps.
+      graceMillis: 60 * 60 * 1000,
+    } as InternalRunGcOptions);
+
+    const pending = await readGcPending(s, PENDING_KEY);
+    expect(pending?.json.candidates.length).toBeGreaterThan(0);
+    for (const candidate of pending!.json.candidates) {
+      expect(candidate.generation).toBe(LOG_STATE_GENERATION);
+    }
+  });
 });

--- a/packages/server/src/gc.test.ts
+++ b/packages/server/src/gc.test.ts
@@ -15,6 +15,7 @@ import {
   type StorageListEntry,
   BaerlyError,
   GC_GRACE_PERIOD_MILLIS,
+  GC_PENDING_CAS_MAX_ATTEMPTS,
   GC_PENDING_SCHEMA_VERSION,
   MAX_PARALLEL_LOG_READS,
   SNAPSHOT_SCHEMA_VERSION,
@@ -907,6 +908,101 @@ describe("runGc", () => {
     // is non-fatal.
     expect(r.swept).toBe(1);
     await expect(s.get("app/t/tenant/x/manifests/c/log/0.json")).resolves.toBeNull();
+    // The retry loop CONVERGED: the interceptor above fires once, so
+    // `casUpdateGcPending`'s attempt 2 re-reads the rival's body, re-merges,
+    // and lands. The candidate therefore LEAVES the ledger and nothing is
+    // sticky. Pinned so the contrast with the exhausted-budget test below
+    // is explicit rather than incidental — that test is the one that
+    // reaches `gc.ts`'s `Conflict` catch, and this one never does.
+    const converged = await readGcPending(s, PENDING_KEY);
+    expect(converged?.json.candidates).toEqual([]);
+  });
+
+  test("sticky CAS-loss: candidate survives the ledger when every CAS attempt loses", async () => {
+    // The genuinely dangerous shape, and the one the sibling test above
+    // does NOT reach. A pass that DELETES a key and then fails to persist
+    // the removal leaves a candidate in `gc/pending.json` naming a key
+    // that is already gone — and a `GcCandidate` is a bare key with no
+    // identity. `baerly admin restore --force` can later re-create that
+    // exact key inside the NEW live range, at which point the surviving
+    // candidate authorises a DELETE of live data. That is the ABA the
+    // integration suite (`tests/integration/gc-restore-fencing.test.ts`)
+    // drives end to end; this test pins the state it starts from.
+    //
+    // `runGc` must still report SUCCESS here: the DELETEs it issued are
+    // durable, and re-throwing would mask the work that did complete.
+    const s = new MemoryStorage();
+    // Same fixture as the sibling: floor at 1 so `log/0.json` is genuinely
+    // sub-floor and the sweep gate re-derives it as dead.
+    await createCurrentJson(
+      s,
+      KEY,
+      logStateCurrentJson({
+        log_seq_start: 1,
+        tail_hint: 1,
+        writer_fence: { epoch: 0, owner: "gc-test", claimed_at: "" },
+      }),
+    );
+    const staleLogKey = "app/t/tenant/x/manifests/c/log/0.json";
+    const pre: GcPending = {
+      schema_version: GC_PENDING_SCHEMA_VERSION,
+      candidates: [
+        {
+          key: staleLogKey,
+          due_at: "2000-01-01T00:00:00.000Z",
+          reason: "stale-log",
+          generation: LOG_STATE_GENERATION,
+        },
+      ],
+      last_swept_at: "",
+    };
+    await createGcPending(s, PENDING_KEY, pre);
+    // Exhaust the budget: land a rival CAS before EVERY guarded PUT, not
+    // just the first, so all `GC_PENDING_CAS_MAX_ATTEMPTS` attempts lose
+    // and `casUpdateGcPending` surfaces `Conflict`. `inRival` is the
+    // re-entrancy guard — the rival's own guarded PUT re-enters this
+    // wrapper and would otherwise recurse forever.
+    const origPut = s.put.bind(s);
+    let guardedPuts = 0;
+    let inRival = false;
+    s.put = (async (key, body, opts) => {
+      if (key === PENDING_KEY && opts?.ifMatch !== undefined && !inRival) {
+        guardedPuts++;
+        inRival = true;
+        try {
+          await casUpdateGcPending(s, PENDING_KEY, (cur) => ({
+            ...cur,
+            last_swept_at: `rival-${String(guardedPuts)}`,
+          }));
+        } finally {
+          inRival = false;
+        }
+      }
+      return origPut(key, body, opts);
+    }) as typeof s.put;
+
+    const r = await runGc({ storage: s, currentJsonKey: KEY }, {
+      graceMillis: 0,
+      maxSweepsPerRun: 10,
+    } as InternalRunGcOptions);
+
+    // Every attempt was made, and every one lost.
+    expect(guardedPuts).toBe(GC_PENDING_CAS_MAX_ATTEMPTS);
+    // `runGc` still reports success — the DELETE is durable, so the pass
+    // is not a failure.
+    expect(r.swept).toBe(1);
+    await expect(s.get(staleLogKey)).resolves.toBeNull();
+    // …and the candidate is STICKY: it names a key that no longer exists,
+    // and it will be re-evaluated by the next pass against whatever the
+    // bucket looks like then.
+    const stuck = await readGcPending(s, PENDING_KEY);
+    expect(stuck?.json.candidates.map((c) => c.key)).toEqual([staleLogKey]);
+    // `pendingDepth` is best-effort on this path and deliberately does NOT
+    // agree with the ledger: it reports our post-sweep view (0), while the
+    // durable ledger still holds 1. Pinned because that divergence is the
+    // documented contract of the `Conflict` catch, not a bug to "fix".
+    expect(r.pendingDepth).toBe(0);
+    expect(stuck?.json.candidates).toHaveLength(1);
   });
 
   // Production mutation caught: treating an occupied bounded probe as an

--- a/packages/server/src/gc.ts
+++ b/packages/server/src/gc.ts
@@ -102,6 +102,7 @@ import {
   GC_MAX_PENDING_CANDIDATES,
   GC_PENDING_SCHEMA_VERSION,
   MAX_PARALLEL_LOG_READS,
+  NO_GENERATION,
   BaerlyError,
   casUpdateGcPending,
   createGcPending,
@@ -285,6 +286,23 @@ export interface RunGcResult {
   /** Number of keys deleted in this pass. */
   readonly swept: number;
   /**
+   * Per-cause counts of candidates RESOLVED OUT of the ledger without
+   * being deleted, because the sweep gate re-checked them and found
+   * them no longer eligible: `stale_generation` when the manifest that
+   * authorised the mark has been replaced, `still_live` when the key
+   * reads live now.
+   *
+   * A drop frees no bytes, so it drives neither {@link swept} nor
+   * `last_swept_at`. It is nonetheless the healthy outcome — dropping
+   * is what keeps a permanently-live candidate from wedging the ledger
+   * against `GC_MAX_PENDING_CANDIDATES`, which keeps the FIRST N
+   * entries. Also emitted as `db.gc.dropped_total`, labelled by cause.
+   */
+  readonly dropped: {
+    readonly stale_generation: number;
+    readonly still_live: number;
+  };
+  /**
    * Depth of `gc/pending.json` after this pass. Drives the
    * `db.orphan.candidate_count` metric. Best-effort on `cas-lost` —
    * see module JSDoc.
@@ -311,6 +329,7 @@ const DEFAULT_MAX_SWEEPS = Number.MAX_SAFE_INTEGER;
 const zeroGcResult = (): RunGcResult => ({
   marked: { stale_log: 0, orphan_snapshot: 0, orphan_content: 0 },
   swept: 0,
+  dropped: { stale_generation: 0, still_live: 0 },
   pendingDepth: 0,
 });
 
@@ -470,6 +489,15 @@ export const runGc = async (
   // Set of keys already pending — don't re-mark.
   const known = new Set(pending.json.candidates.map((c) => c.key));
 
+  // Stamped onto every candidate this pass marks, so the sweep gate can
+  // tell "still the collection I judged this against" from "a different
+  // incarnation wearing the same key". Spread rather than assigned so a
+  // manifest with no generation writes no field at all — absent is the
+  // legacy-compatible spelling, and it decodes to `NO_GENERATION` on
+  // both sides of the later comparison.
+  const markGeneration: { generation?: string } =
+    current.generation !== undefined ? { generation: current.generation } : {};
+
   // ── Step 3. Mark stale log entries (seq < log_seq_start). ───────
   // A LEXICOGRAPHIC window of the whole `log/` prefix, filtered
   // NUMERICALLY. The two orders disagree — log keys are unpadded
@@ -501,6 +529,7 @@ export const runGc = async (
         key: entry.key,
         due_at: computeDueAt(now, grace),
         reason: "stale-log",
+        ...markGeneration,
       });
       markedStaleLog++;
     }
@@ -524,6 +553,19 @@ export const runGc = async (
     `${collectionPrefix}/snapshot/`,
     listWindow(maxMarks, undefined, signal),
   )) {
+    // Liveness HERE is exact key equality with the active pointer,
+    // never a parsed key range — a snapshot installed directly by
+    // `admin restore` or by a replacement fold is live whatever its seq
+    // fields say, and one whose name parses as "current-looking" is
+    // still dead if `current.snapshot` does not name it.
+    //
+    // That is not in tension with `parseMaxSeqFromCanonicalSnapshotKey`
+    // in the sweep below, which answers a different question. The mark
+    // asks "is this the live snapshot?"; the sweep asks "can this
+    // already-marked, already-graced candidate still become live in a
+    // later generation?" — and only there is a canonical key range
+    // sound, because it is used to RETAIN on doubt rather than to
+    // authorise a DELETE.
     if (entry.key === current.snapshot) {
       continue;
     }
@@ -534,6 +576,7 @@ export const runGc = async (
       key: entry.key,
       due_at: computeDueAt(now, grace),
       reason: "orphan-snapshot",
+      ...markGeneration,
     });
     markedOrphanSnapshot++;
   }
@@ -577,6 +620,7 @@ export const runGc = async (
       cursor: pending.json.content_scan_cursor,
       now,
       grace,
+      markGeneration,
       signal,
     });
     newCandidates.push(...contentPass.candidates);
@@ -603,10 +647,46 @@ export const runGc = async (
   const freshCurrent = hasDueSnapshot
     ? await readCurrentJson(storage, currentJsonKey, signalOpts)
     : undefined;
+  // The freshest manifest this pass holds. `freshCurrent` exists only
+  // when a due snapshot forced the re-read above; otherwise this is the
+  // step-1 read. Either way it costs no additional op, and preferring
+  // the fresher one narrows — never widens — the window between the
+  // read a decision rests on and the DELETE it authorises.
+  const fenceCurrent = freshCurrent?.json ?? current;
+  const fenceGeneration = fenceCurrent.generation ?? NO_GENERATION;
+  const fenceFloor = logSeqStartOf(fenceCurrent);
   const rescuedKeys = new Set<string>();
+  const staleGenerationKeys = new Set<string>();
   for (const candidate of sweepCandidates) {
+    // Arm 1 — the generation fence, checked before liveness and for
+    // every reason. A candidate marked under a manifest that has since
+    // been replaced was judged against a keyspace that no longer
+    // exists: `baerly admin restore --force` truncates the log, reseeds
+    // `log_seq_start` from the surviving objects (which can move the
+    // floor DOWN), and re-mints `generation`. A `log/K` that was
+    // provably dead under the old floor can be a live entry of the new
+    // incarnation, at the same key. Absent compares equal to absent, so
+    // a bucket whose manifest never carried a generation is unaffected.
+    if ((candidate.generation ?? NO_GENERATION) !== fenceGeneration) {
+      staleGenerationKeys.add(candidate.key);
+      continue;
+    }
     if (candidate.reason === "orphan-snapshot" && candidate.key === freshCurrent?.json.snapshot) {
       rescuedKeys.add(candidate.key);
+      continue;
+    }
+    // Arm 2 — a stale-log candidate that reads live again. Same
+    // generation, so this is not a reseed; the floor can still have
+    // been rewound by a `--force` that reused the nonce, and a mark
+    // taken `GC_GRACE_PERIOD_MILLIS` ago is stale enough to be worth
+    // re-deriving from the floor rather than trusted. An unparseable
+    // key stays sweepable: it was marked as one, and `parseSeqFromLogKey`
+    // returning `null` says nothing about liveness.
+    if (candidate.reason === "stale-log") {
+      const seq = parseSeqFromLogKey(candidate.key);
+      if (seq !== null && seq >= fenceFloor) {
+        rescuedKeys.add(candidate.key);
+      }
       continue;
     }
     if (candidate.reason === "orphan-content" && completeLiveContentHashes !== undefined) {
@@ -616,10 +696,16 @@ export const runGc = async (
       }
     }
   }
+  // Both arms resolve a candidate OUT of the ledger without deleting
+  // anything. That is what stops the ledger starving: `mergeGcPending`
+  // keeps the FIRST `GC_MAX_PENDING_CANDIDATES` entries, so a
+  // permanently-live candidate at the head would otherwise wedge it
+  // forever and silently discard every later mark.
+  const droppedKeys = new Set([...staleGenerationKeys, ...rescuedKeys]);
   const toSweep: GcCandidate[] = [];
   const remaining: GcCandidate[] = [];
   for (const cand of sweepCandidates) {
-    if (rescuedKeys.has(cand.key)) {
+    if (droppedKeys.has(cand.key)) {
       continue;
     }
     // Without a complete live hash set, an orphan-content candidate cannot
@@ -662,7 +748,7 @@ export const runGc = async (
   // `mergeGcPending` drops terminal keys via its existing `sweptKeys`
   // merge input. Positively-live rescues are terminal ledger resolutions too,
   // but only `toSweep` drives DELETEs, result counts, timestamps, and metrics.
-  const sweptKeys = new Set([...toSweep.map((candidate) => candidate.key), ...rescuedKeys]);
+  const sweptKeys = new Set([...toSweep.map((candidate) => candidate.key), ...droppedKeys]);
   // `""` when this pass swept nothing — sourcing the no-sweep truth from
   // `latest` (via the merge's "take later" rule) rather than our stale
   // read. With no contention this is observably identical: `latest`
@@ -744,10 +830,32 @@ export const runGc = async (
       reason: contentDeferredReason,
     });
   }
+  // Separate from `db.gc.swept_total` on purpose: a drop frees no bytes,
+  // so folding the two would make a pass that reclaimed nothing look
+  // productive. A `stale-generation` spike is expected exactly once
+  // after a restore or an upgrade and is alertable if it persists; a
+  // sustained `still-live` rate means the mark phase is misjudging
+  // liveness, which is the failure this gate exists to contain.
+  if (staleGenerationKeys.size > 0) {
+    metrics.counter("db.gc.dropped_total", staleGenerationKeys.size, {
+      collection: collectionName,
+      cause: "stale-generation",
+    });
+  }
+  if (rescuedKeys.size > 0) {
+    metrics.counter("db.gc.dropped_total", rescuedKeys.size, {
+      collection: collectionName,
+      cause: "still-live",
+    });
+  }
 
   return {
     marked: markedSummary,
     swept: toSweep.length,
+    dropped: {
+      stale_generation: staleGenerationKeys.size,
+      still_live: rescuedKeys.size,
+    },
     pendingDepth,
     ...(contentDeferredReason !== undefined && { contentDeferredReason }),
   };
@@ -870,6 +978,13 @@ const markOrphanContent = async (opts: {
   readonly cursor: string | undefined;
   readonly now: () => Date;
   readonly grace: number;
+  /**
+   * The manifest generation to stamp on each candidate, pre-spread by
+   * the caller so an absent generation writes no field. Passed in
+   * rather than derived here because this helper never reads
+   * `current.json` — see `GcCandidate.generation`.
+   */
+  readonly markGeneration: { generation?: string };
   readonly signal: AbortSignal | undefined;
 }): Promise<{
   readonly candidates: GcCandidate[];
@@ -897,6 +1012,7 @@ const markOrphanContent = async (opts: {
       key: entry.key,
       due_at: computeDueAt(opts.now, opts.grace),
       reason: "orphan-content",
+      ...opts.markGeneration,
     });
   }
   // New cursor: if the LIST yielded FEWER than `maxKeys` keys it reached

--- a/packages/server/src/gc.ts
+++ b/packages/server/src/gc.ts
@@ -692,11 +692,23 @@ export const runGc = async (
     );
     pendingDepth = updated.json.candidates.length;
   } catch (error) {
-    // CAS-lost on pending.json after exhausting the bounded retry:
-    // another GC pass kept landing concurrently. The DELETEs we issued
-    // are durable; the next pass picks up any marks we couldn't persist.
-    // Surface success — re-throwing here would mask the work we DID
-    // complete.
+    // `Conflict` covers two benign races, and the DELETEs we issued are
+    // durable in both:
+    //   - CAS-lost on pending.json after exhausting the bounded retry —
+    //     another GC pass kept landing concurrently;
+    //   - the ledger VANISHED between step 2 and here. `baerly admin
+    //     restore` deletes `gc/pending.json` on both reseed branches, so
+    //     this is routine rather than exceptional.
+    //     `casUpdateGcPending` reports it as `Conflict` because it IS a
+    //     CAS precondition failure — an `If-Match` PUT against the
+    //     deleted key would have 412'd.
+    // Either way the next pass re-marks whatever we couldn't persist,
+    // bootstrapping a fresh ledger if there isn't one. Surface success —
+    // re-throwing would mask the work we DID complete, and on the
+    // `runScheduledMaintenance` path (documented "Errors propagate")
+    // would surface a routine restore to an operator's cron.
+    // `InvalidResponse` — a ledger body that is present but corrupt — is
+    // deliberately NOT in this arm and still escapes.
     if (error instanceof BaerlyError && error.code === "Conflict") {
       // Best-effort: we know `remaining.length` is at least the
       // post-sweep depth; concurrent passes may have moved it.

--- a/packages/server/src/gc.ts
+++ b/packages/server/src/gc.ts
@@ -539,9 +539,17 @@ export const runGc = async (
   // intended reading: with no floor the candidate set is empty, so we
   // trivially examined all of it and the next pass should start from
   // the beginning. The pass record has no third state for "phase did
-  // not run", and inventing one would buy nothing — the floor is
-  // monotonic, so a collection only passes through `0` before its
-  // first fold, when there is no stale key to strand.
+  // not run", and inventing one would buy nothing.
+  //
+  // Do NOT justify that by calling the floor monotonic. It is not:
+  // `admin restore --force` reseeds `log_seq_start` from the surviving
+  // log objects and can move it DOWN (invariant 12, and the read-to-
+  // delete window in invariant 14). The argument that actually holds is
+  // narrower and does not need monotonicity — a `0` floor has no key
+  // beneath it, so there is no stale key for a wrap to strand, and the
+  // only writer that reseeds `0` is `tailFromListedLogKeys` returning
+  // `maxSeq + 1 == 0`, which happens exactly when the log prefix listed
+  // empty.
   const nextLogCursor = logExaminedThisPass < maxMarks ? undefined : lastExaminedLogKey;
 
   // ── Step 4. Mark orphan snapshots. ──────────────────────────────

--- a/packages/server/src/gc.ts
+++ b/packages/server/src/gc.ts
@@ -107,6 +107,7 @@ import {
   createGcPending,
   decodeJsonBytes,
   encodeJsonBytes,
+  gcPendingKey,
   logObjectKey,
   logSeqStartOf,
   mergeGcPending,
@@ -345,7 +346,7 @@ export const runGc = async (
   const now = internal.now ?? ((): Date => new Date());
   const collectionPrefix = currentJsonKey.slice(0, currentJsonKey.lastIndexOf("/"));
   const collectionName = collectionPrefix.slice(collectionPrefix.lastIndexOf("/") + 1);
-  const gcPendingKey = `${collectionPrefix}/gc/pending.json`;
+  const pendingKey = gcPendingKey(collectionPrefix);
   const signal = options.signal;
   const signalOpts = signal !== undefined ? { signal } : undefined;
 
@@ -445,7 +446,7 @@ export const runGc = async (
   // ── Step 2. Read or create gc/pending.json. ─────────────────────
   // Race-tolerant create: a concurrent pass may have bootstrapped
   // between our read and our create. Re-read on Conflict.
-  let pending = await readGcPending(storage, gcPendingKey, signalOpts);
+  let pending = await readGcPending(storage, pendingKey, signalOpts);
   if (pending === null) {
     const initial: GcPending = {
       schema_version: GC_PENDING_SCHEMA_VERSION,
@@ -453,10 +454,10 @@ export const runGc = async (
       last_swept_at: "",
     };
     try {
-      pending = await createGcPending(storage, gcPendingKey, initial, signalOpts);
+      pending = await createGcPending(storage, pendingKey, initial, signalOpts);
     } catch (error) {
       if (error instanceof BaerlyError && error.code === "Conflict") {
-        pending = await readGcPending(storage, gcPendingKey, signalOpts);
+        pending = await readGcPending(storage, pendingKey, signalOpts);
         if (pending === null) {
           throw error;
         }
@@ -676,7 +677,7 @@ export const runGc = async (
   try {
     const updated = await casUpdateGcPending(
       storage,
-      gcPendingKey,
+      pendingKey,
       (latest) =>
         mergeGcPending(latest, {
           sweptKeys,

--- a/packages/server/src/maintenance-budget.test.ts
+++ b/packages/server/src/maintenance-budget.test.ts
@@ -39,7 +39,11 @@ import {
   type StoragePutResult,
 } from "@baerly/protocol";
 import { describe, expect, test } from "vitest";
-import { logStateCurrentJson, seedLogEntries } from "../../../tests/fixtures/log-state.ts";
+import {
+  LOG_STATE_GENERATION,
+  logStateCurrentJson,
+  seedLogEntries,
+} from "../../../tests/fixtures/log-state.ts";
 import { compact } from "./compactor.ts";
 import { type InternalRunGcOptions, runGc } from "./gc.ts";
 import { CLOUDFLARE_FREE_TIER, runBoundedMaintenance } from "./maintenance.ts";
@@ -280,11 +284,13 @@ describe("CLOUDFLARE_FREE_TIER budget", () => {
         key: `${prefix}/gc/due-${index}.json`,
         due_at: "2000-01-01T00:00:00.000Z",
         reason: "stale-log" as const,
+        generation: LOG_STATE_GENERATION,
       })),
       {
         key: snapshotKey(prefix, 0, 39, "b".repeat(64)),
         due_at: "2000-01-01T00:00:00.000Z",
         reason: "orphan-snapshot" as const,
+        generation: LOG_STATE_GENERATION,
       },
     ];
     let firstPendingRead = true;
@@ -350,11 +356,13 @@ describe("CLOUDFLARE_FREE_TIER budget", () => {
         key: `${prefix}/gc/deferred-due-${index}.json`,
         due_at: "2000-01-01T00:00:00.000Z",
         reason: "stale-log" as const,
+        generation: LOG_STATE_GENERATION,
       })),
       {
         key: snapshotKey(prefix, 0, 19, "c".repeat(64)),
         due_at: "2000-01-01T00:00:00.000Z",
         reason: "orphan-snapshot" as const,
+        generation: LOG_STATE_GENERATION,
       },
     ];
     let firstPendingRead = true;

--- a/packages/server/src/writer.test.ts
+++ b/packages/server/src/writer.test.ts
@@ -681,6 +681,83 @@ describe("Writer", () => {
     });
     expect(r.attempts).toBe(1);
   });
+
+  test("a commit never lands below the log_seq_start observed after it", async () => {
+    // Every other seq assertion in this file is an exact literal
+    // (`toBe(0)`, `toBe(1)`, …) against a collection whose floor is 0 and
+    // never moves, so none of them can see a commit landing BENEATH the
+    // floor. This states the relation instead, against the one manifest
+    // shape in the system where the floor has moved DOWN.
+    //
+    // That shape is what `baerly admin restore --force` writes: its
+    // deliberate floor exemption reseeds `log_seq_start` from the
+    // surviving log objects, which can land below the old floor, and it
+    // resets `snapshot` to null. `CurrentJson.log_seq_start`'s own docs
+    // name the trap — `log_seq_start > 0` implies `snapshot !== null`,
+    // "except after a `--force`". A writer that reads `snapshot: null` as
+    // "nothing has been folded, so there is no floor to respect" probes
+    // from zero, finds a swept slot beneath the floor, and commits there.
+    // Nothing collides, nothing errors, the write is acknowledged — and
+    // readers walk from the floor, so the row is invisible forever.
+    //
+    // HONEST FRAMING, do not overstate this test: `assertCurrentJson`
+    // enforces `0 <= log_seq_start <= tail_hint`, so today `probeFloor`'s
+    // `Math.max` is a defensive no-op and this invariant holds by
+    // construction. This is a TRIPWIRE on the floor exemption, not
+    // coverage of a live defect. It exists because the exemption is the
+    // only write in the system that lowers the floor, and because no
+    // other assertion here is relative to a floor that has moved.
+    const storage = new MemoryStorage();
+    // The post-`--force` manifest, in the fields this test turns on:
+    // floor and hint both reseeded to 10, snapshot dropped. Ten, not
+    // zero, is what makes the assertion non-trivial. It is NOT byte-
+    // identical to what `restore.ts` writes — the real reseed bumps
+    // `writer_fence.epoch` and stamps `RESTORE_OWNER`, and re-mints
+    // `generation` rather than reusing the fixture's fixed nonce.
+    // `commit()` reads neither field, so neither difference reaches the
+    // behaviour under test; the shared shape is `snapshot: null` over a
+    // positive floor.
+    const RESEEDED_FLOOR = 10;
+    await createCurrentJson(
+      storage,
+      CURRENT_KEY,
+      logStateCurrentJson({
+        snapshot: null,
+        log_seq_start: RESEEDED_FLOOR,
+        tail_hint: RESEEDED_FLOOR,
+      }),
+    );
+    // Sub-floor survivors GC has not reached yet — the objects whose
+    // presence set `truncatedNext` to 10 in the first place. Seqs 0 and 1
+    // are absent because GC swept them: `log/` is walked in LEX order
+    // (`0, 1, 10, 11, 2, …`), so a budget-bounded pass deletes the
+    // numerically-highest keys before the middle of the range.
+    for (let seq = 2; seq <= 9; seq++) {
+      await seedLogEntry(storage, `app/test/tenant/t/manifests/${COLL}`, seq);
+    }
+    // The precondition that makes a probe-too-low writer silently wrong
+    // rather than loudly wrong: the slot it would pick is FREE.
+    await expect(storage.get(`${LOG_PREFIX}/0.json`)).resolves.toBeNull();
+
+    const writer = new Writer({ storage, currentJsonKey: CURRENT_KEY });
+    const result = await writer.commit({
+      op: "I",
+      collection: COLL,
+      docId: "post-restore",
+      body: { _id: "post-restore", title: "after a --force reseed" },
+    });
+
+    const stored = await storage.get(CURRENT_KEY);
+    const floor = decodeJson<CurrentJson>(stored!.body).log_seq_start;
+    // The invariant, as a relation against the floor observed AFTER the
+    // commit — never against a literal.
+    expect(result.entry.seq).toBeGreaterThanOrEqual(floor);
+    // …and the row really is where the result says it is, so the
+    // assertion above is about a durable object and not just a number.
+    await expect(
+      storage.get(`${LOG_PREFIX}/${String(result.entry.seq)}.json`),
+    ).resolves.not.toBeNull();
+  });
 });
 
 describe("Writer — writer fence", () => {

--- a/tests/fixtures/collection-api-cascade.ts
+++ b/tests/fixtures/collection-api-cascade.ts
@@ -31,6 +31,7 @@ import {
   type SchemaValidator,
   type Storage,
   createCurrentJson,
+  gcPendingKey,
   uuid,
 } from "@baerly/protocol";
 import { Db } from "@baerly/server";
@@ -493,8 +494,8 @@ const runGcCascade = async (
   const t = freshTableName("gc");
   await provision(storage, app, tenant, t);
   const currentJsonKey = `app/${app}/tenant/${tenant}/manifests/${t}/current.json`;
-  const pendingKey = `app/${app}/tenant/${tenant}/manifests/${t}/gc/pending.json`;
   const collectionPrefix = `app/${app}/tenant/${tenant}/manifests/${t}`;
+  const pendingKey = gcPendingKey(collectionPrefix);
 
   for (let i = 0; i < 30; i++) {
     await db.collection(t).insert({ _id: `r-${i}`, k: "row", n: i });

--- a/tests/integration/gc-restore-fencing.test.ts
+++ b/tests/integration/gc-restore-fencing.test.ts
@@ -1,0 +1,438 @@
+/* eslint-disable no-underscore-dangle -- `_id` is the locked primary-key
+   field on document shapes; this suite threads it through the restore CLI
+   and reads it back through the collection API. */
+
+/**
+ * GC ↔ `baerly admin restore` fencing — the regression suite for a
+ * reachable data-loss defect that shipped because **no file in this repo
+ * imported both `runGc` and the restore path**. Each half was covered;
+ * their interaction was not, and the defect lives exactly in the seam.
+ *
+ * The hazard, end to end and with no crash anywhere in it:
+ *
+ *   1. A collection is folded, so `log_seq_start` moves up and the
+ *      sub-floor `log/<seq>` objects become stale-log GC candidates.
+ *   2. A budget-bounded `runGc` pass sweeps some of them and then LOSES
+ *      the `gc/pending.json` CAS. That path returns success by design —
+ *      the DELETEs are durable — so the candidates stay in the ledger
+ *      naming keys that are already gone. (Pinned on its own in
+ *      `packages/server/src/gc.test.ts`, "sticky CAS-loss".)
+ *   3. `baerly admin restore --force` reseeds `log_seq_start` from the
+ *      SURVIVING log objects. That is the deliberate floor exemption
+ *      documented in `restore.ts`, and it can land the new floor BELOW
+ *      the old one, because GC walks `log/` in lex order (`0,1,10,11,2,…`)
+ *      and therefore sweeps the top of the numeric range before the
+ *      middle of it.
+ *   4. The restore's own commits now re-create those exact keys INSIDE
+ *      the new live range `[log_seq_start, tail)`.
+ *   5. The surviving candidates are still bare keys with no identity. The
+ *      next pass deletes them — now live — and every read and every fold
+ *      throws `Internal` from `walkLogRangeWithBytes`. The collection is
+ *      unreadable.
+ *
+ * THREE independent mechanisms now block that, and knowing this matters
+ * before you conclude anything from a green run here:
+ *
+ *   - the `generation` fence on every `GcCandidate`;
+ *   - the sweep gate's re-derived liveness check — these two are the two
+ *     conjuncts of `runGc`'s revalidation gate, and **each one closes
+ *     this scenario on its own**;
+ *   - `admin restore` deleting `gc/pending.json` in both reseed branches.
+ *
+ * Because any one of the three alone closes the hazard, no single test
+ * here can fail when only one is reverted — it would pass for the wrong
+ * reason. So `1a` pins the revalidation gate **as a unit** (deleting
+ * either conjunct alone leaves `1a` green; deleting both reddens it) and
+ * `1b` pins the restore-side clear. The two conjuncts are discriminated
+ * separately by the unit tests in `packages/server/src/gc.test.ts` —
+ * that is where to look if you need to know which one is carrying a
+ * given case, and it is why `1a` does not try to.
+ *
+ * Backends: `memory://` via the CLI's own bucket-URI parser, so the
+ * suite drives the real `runRestore` entry point rather than a
+ * re-implementation of it. No infrastructure.
+ */
+
+import { Readable } from "node:stream";
+import {
+  type Collection,
+  type DocumentData,
+  type GcPending,
+  type Storage,
+  createGcPending,
+  gcPendingKey,
+  logObjectKey,
+  logSeqStartOf,
+  readCurrentJson,
+  readGcPending,
+} from "@baerly/protocol";
+import { Db } from "@baerly/server";
+import { compact, runGc } from "@baerly/server/maintenance";
+import {
+  type InternalCompactOptions,
+  type InternalRunGcOptions,
+} from "@baerly/server/_internal/testing";
+import { describe, expect, test } from "vitest";
+import { captureStream } from "../../packages/cli/src/_internal/testing.ts";
+import { runRestore } from "../../packages/cli/src/admin/restore.ts";
+import { parseBucketUri } from "../../packages/cli/src/bucket-uri.ts";
+
+const APP = "app";
+const TENANT = "tenant";
+const COLL = "tickets";
+const PREFIX = `app/${APP}/tenant/${TENANT}/manifests/${COLL}`;
+const CURRENT_JSON_KEY = `${PREFIX}/current.json`;
+const PENDING_KEY = gcPendingKey(PREFIX);
+
+interface Row extends DocumentData {
+  _id: string;
+}
+
+/**
+ * 12 seed rows, chosen so the lex order of the resulting `log/<seq>.json`
+ * keys (`0, 1, 10, 11, 2, 3, …, 9`) diverges from their numeric order.
+ * That divergence is load-bearing: it is what lets a budget-bounded sweep
+ * delete the numerically-HIGHEST keys first and leave the middle of the
+ * range behind, which is what drops the restore's reseeded floor below
+ * the old one.
+ */
+const SEED_IDS = Array.from({ length: 12 }, (_, i) => `seed-${String(i)}`);
+const RESTORE_IDS = ["restored-a", "restored-b", "restored-c"];
+
+const ndjson = (ids: readonly string[]): string =>
+  ids.length === 0 ? "" : `${ids.map((id) => JSON.stringify({ _id: id, label: id })).join("\n")}\n`;
+
+let bucketSerial = 0;
+
+/** A fresh `memory://` bucket plus a direct `Storage` handle on it. */
+const freshBucket = async (): Promise<{ uri: string; storage: Storage }> => {
+  bucketSerial += 1;
+  const uri = `memory://gc-restore-fencing-${String(bucketSerial)}`;
+  const { storage } = await parseBucketUri(uri);
+  return { uri, storage };
+};
+
+/**
+ * Drive the real `baerly admin restore` entry point. stdout/stderr are
+ * captured so the CLI's success envelope doesn't pollute the run.
+ */
+const restore = async (
+  uri: string,
+  rows: readonly string[],
+  opts: { force: boolean },
+): Promise<number> => {
+  const stdout = captureStream(process.stdout);
+  const stderr = captureStream(process.stderr);
+  try {
+    return await runRestore(
+      [
+        `--bucket=${uri}`,
+        `--app=${APP}`,
+        `--tenant=${TENANT}`,
+        `--collection=${COLL}`,
+        ...(opts.force ? ["--force"] : []),
+      ],
+      { streams: { stdin: Readable.from([Buffer.from(ndjson(rows), "utf8")]) } },
+    );
+  } finally {
+    stderr.restore();
+    stdout.restore();
+  }
+};
+
+/** Every `_id` visible through the locked collection API, sorted. */
+const readAllRowIds = async (storage: Storage): Promise<string[]> => {
+  const db = Db.create({ storage, app: APP, tenant: TENANT });
+  const rows = await (db.collection(COLL) as Collection<Row>).where({}).all();
+  return [...rows].map((r) => r._id).toSorted();
+};
+
+/** Which `log/<seq>.json` objects are currently on the bucket, ascending. */
+const listLogSeqs = async (storage: Storage): Promise<number[]> => {
+  const seqs: number[] = [];
+  for await (const entry of storage.list(`${PREFIX}/log/`)) {
+    const match = /\/log\/(\d+)\.json$/.exec(entry.key);
+    if (match !== null) {
+      seqs.push(Number.parseInt(match[1]!, 10));
+    }
+  }
+  return seqs.toSorted((a, b) => a - b);
+};
+
+/**
+ * Build the pre-restore bucket state: a folded collection whose ledger
+ * carries STICKY candidates naming keys a budget-bounded sweep has
+ * already deleted.
+ *
+ * Two GC passes, because the sticky state needs a candidate that was
+ * already durable in the ledger before the pass that swept it:
+ *   - pass 1 marks under `maxSweepsPerRun: 0`, so the marks persist and
+ *     nothing is deleted;
+ *   - pass 2 sweeps them and loses every `gc/pending.json` CAS, so the
+ *     DELETEs land but the removals never do.
+ */
+const buildStickyLedger = async (): Promise<{
+  uri: string;
+  storage: Storage;
+  sticky: GcPending;
+}> => {
+  const { uri, storage } = await freshBucket();
+  await expect(restore(uri, SEED_IDS, { force: false })).resolves.toBe(0);
+
+  // Fold everything, so every `log/<seq>` below the new floor is stale.
+  await compact({ storage, currentJsonKey: CURRENT_JSON_KEY }, {
+    minEntriesToCompact: 1,
+    maxEntriesPerRun: 100,
+  } as InternalCompactOptions);
+
+  // Pass 1 — mark the lex-first window, sweep nothing.
+  await runGc({ storage, currentJsonKey: CURRENT_JSON_KEY }, {
+    graceMillis: 0,
+    maxMarksPerRun: 4,
+    maxSweepsPerRun: 0,
+  } as InternalRunGcOptions);
+
+  // Pass 2 — sweep them, and lose every CAS on the ledger so the removal
+  // never persists. Same rival-CAS interception the unit-level sticky
+  // test uses, with the same `inRival` re-entrancy guard.
+  const origPut = storage.put.bind(storage);
+  let inRival = false;
+  storage.put = (async (key, body, putOpts) => {
+    if (key === PENDING_KEY && putOpts?.ifMatch !== undefined && !inRival) {
+      inRival = true;
+      try {
+        const latest = await readGcPending(storage, PENDING_KEY);
+        if (latest !== null) {
+          await origPut(
+            PENDING_KEY,
+            new TextEncoder().encode(JSON.stringify({ ...latest.json, last_swept_at: "rival" })),
+            { ifMatch: latest.etag, contentType: "application/json" },
+          );
+        }
+      } finally {
+        inRival = false;
+      }
+    }
+    return origPut(key, body, putOpts);
+  }) as typeof storage.put;
+
+  try {
+    await runGc({ storage, currentJsonKey: CURRENT_JSON_KEY }, {
+      graceMillis: 0,
+      maxSweepsPerRun: 4,
+    } as InternalRunGcOptions);
+  } finally {
+    // `MemoryStorage` handles are shared per bucket via the registry, so
+    // leaving the rival-CAS interceptor installed after a throw would
+    // leak it into every later use of this bucket.
+    storage.put = origPut;
+  }
+
+  const ledger = await readGcPending(storage, PENDING_KEY);
+  expect(ledger).not.toBeNull();
+  return { uri, storage, sticky: ledger!.json };
+};
+
+describe("GC candidates across `baerly admin restore`", () => {
+  test("the pre-restore fixture really is the hazardous state", async () => {
+    // Not a fix test — a fixture test. Every assertion below is a
+    // precondition the two ABA tests depend on, and each one is a thing
+    // that could quietly stop being true (a change to GC's lex-order
+    // walk, to the mark budget, to `tailFromListedLogKeys`). If this
+    // drifts, the ABA tests would still pass while no longer exercising
+    // the ABA — the exact failure mode the brief warns about.
+    const { storage, sticky } = await buildStickyLedger();
+
+    const stickyKeys = sticky.candidates.map((c) => c.key);
+    // The lex-first window is `0, 1, 10, 11` — note 10 and 11 are the
+    // numerically-highest keys in the collection, and they are swept
+    // while 2..9 survive. That inversion is the whole mechanism.
+    expect(stickyKeys).toEqual([
+      logObjectKey(PREFIX, 0),
+      logObjectKey(PREFIX, 1),
+      logObjectKey(PREFIX, 10),
+      logObjectKey(PREFIX, 11),
+    ]);
+    // The DELETEs landed…
+    await expect(listLogSeqs(storage)).resolves.toEqual([2, 3, 4, 5, 6, 7, 8, 9]);
+    // …so the candidates are sticky: they name keys that no longer exist.
+    for (const key of stickyKeys) {
+      await expect(storage.get(key)).resolves.toBeNull();
+    }
+    // Every candidate is due, and carries the pre-restore generation.
+    const before = await readCurrentJson(storage, CURRENT_JSON_KEY);
+    for (const cand of sticky.candidates) {
+      expect(Date.parse(cand.due_at)).toBeLessThanOrEqual(Date.now());
+      expect(cand.generation).toBe(before?.json.generation);
+    }
+  });
+
+  test("1a — the sweep gate refuses a candidate that outlived its collection", async () => {
+    // Pins `runGc`'s revalidation gate AS A UNIT, not either conjunct.
+    //
+    // Do not read a green run here as evidence that the `generation`
+    // fence is load-bearing: delete the fence and keep the liveness
+    // check and this test still passes, because the re-created `log/10`
+    // is now at/above the floor and reads as LIVE. Delete the liveness
+    // check and keep the fence and it also passes. Only removing BOTH —
+    // the pre-change two-way gate of a budget counter and
+    // `due_at <= now` — reddens it. The two conjuncts are discriminated
+    // individually in `packages/server/src/gc.test.ts`.
+    //
+    // The ledger is re-planted after the restore, byte for byte as GC
+    // left it. That is not a contrivance to force a failure — it is the
+    // state of any bucket reseeded without the ledger clear: an older
+    // `baerly` binary, or a future reseed path that forgets it. The
+    // clear is defence in depth (its own JSDoc says so); the sweep gate
+    // is the invariant, and this is what proves the invariant carries
+    // the weight alone. Reverting the clear therefore leaves this test
+    // GREEN, correctly — test 1b covers that fix.
+    const { uri, storage, sticky } = await buildStickyLedger();
+
+    await expect(restore(uri, RESTORE_IDS, { force: true })).resolves.toBe(0);
+
+    // The floor DROPPED: the surviving log objects were 2..9, so the
+    // reseed lands at 10 — below the old floor of 12. The restore's own
+    // commits then re-create log/10 and log/11, the very keys two sticky
+    // candidates still name.
+    const after = await readCurrentJson(storage, CURRENT_JSON_KEY);
+    expect(logSeqStartOf(after!.json)).toBe(10);
+
+    // Re-plant the ledger exactly as GC left it, then run GC again. The
+    // delete first is not incidental: the restore's own row commits tick
+    // in-band maintenance, which runs `runGc` inline and bootstraps a
+    // FRESH ledger against the new generation. So "the sticky ledger
+    // survived the reseed" has to be re-established explicitly.
+    //
+    // Not byte-fidelity with a bucket whose reseed never cleared the
+    // ledger: in that bucket the restore's own in-band pass would have
+    // merged into the surviving ledger, resolving some candidates on the
+    // way through. What is re-planted here is the pre-restore ledger
+    // untouched, which is the same candidate set that bucket would have
+    // started from and strictly more adversarial than what it would have
+    // been left holding.
+    await storage.delete(PENDING_KEY);
+    await createGcPending(storage, PENDING_KEY, sticky);
+    const r = await runGc({ storage, currentJsonKey: CURRENT_JSON_KEY }, {
+      graceMillis: 0,
+    } as InternalRunGcOptions);
+
+    // The harm this whole change exists to prevent, asserted first: every
+    // restored row is still readable, and no `Internal` escapes
+    // `walkLogRangeWithBytes`. Against the pre-change two-way sweep gate
+    // this rejects with `Internal: log/10.json missing`.
+    //
+    // Attribution warning for a future debugger: this assertion is a
+    // full read-back through `Db` + the collection API, so it also
+    // reddens on any write-path, log-walk, or restore regression that
+    // has nothing to do with GC. A red 1a is not on its own evidence
+    // about the sweep gate — check `packages/server/src/gc.test.ts` and
+    // the writer suites first, and read the two assertions below, which
+    // name the deleted-vs-surviving key sets directly.
+    await expect(readAllRowIds(storage)).resolves.toEqual([...RESTORE_IDS].toSorted());
+    // The mechanism behind it: nothing inside the live range `[10, 13)`
+    // was deleted…
+    await expect(listLogSeqs(storage)).resolves.toEqual([10, 11, 12]);
+    // …while the pass still did real work — the genuinely dead sub-floor
+    // keys 2..9 went away. The gate refused the live range specifically,
+    // it did not simply stop sweeping.
+    expect(r.swept).toBeGreaterThan(0);
+  });
+
+  test("1b — `restore --force` clears the sticky ledger a real GC pass left behind", async () => {
+    // Pins the SECOND fix, in isolation. The discriminating assertion is
+    // that the ledger object is GONE after the reseed — not that the rows
+    // survive, because the generation fence makes them survive either
+    // way. Reverting the fence leaves this test green; test 1a covers it.
+    //
+    // On its own assertion this overlaps `packages/cli/src/admin/restore.test.ts`:
+    // its two ledger-clear cases redden under the same mutation, and they
+    // already derive their key through `gcPendingKey`. The marginal value
+    // here is KEY COHERENCE between the two components, and it comes from
+    // `buildStickyLedger` rather than from the assertion below — the
+    // ledger is whatever a real `runGc` pass wrote, at whatever key `gc.ts`
+    // chose. Point `gc.ts`'s `pendingKey` somewhere else and every test in
+    // this file reddens while `restore.test.ts` stays green, because that
+    // file writes the ledger itself.
+    //
+    // The reseed carries NO rows, and that is deliberate. The restore's
+    // row commits tick in-band maintenance, which runs `runGc` inline and
+    // bootstraps a fresh ledger — so a reseed that carries rows cannot
+    // distinguish "the clear happened" from "the clear did not happen and
+    // the generation fence dropped the stale candidates instead". An
+    // empty reseed observes the clear directly, with nothing in between.
+    const { uri, storage, sticky } = await buildStickyLedger();
+    expect(sticky.candidates.length).toBeGreaterThan(0);
+    // The rotation cursor is part of why a surviving ledger is not
+    // harmless even once its candidates are fenced: it would resume the
+    // next scan mid-keyspace of a collection that no longer exists.
+    expect(sticky.log_scan_cursor).toBe(logObjectKey(PREFIX, 11));
+
+    await expect(restore(uri, [], { force: true })).resolves.toBe(0);
+
+    // The reseed happened…
+    const after = await readCurrentJson(storage, CURRENT_JSON_KEY);
+    expect(logSeqStartOf(after!.json)).toBe(10);
+    // …and took the ledger — candidates, rotation cursor and all — with it.
+    await expect(readGcPending(storage, PENDING_KEY)).resolves.toBeNull();
+  });
+
+  test("1c — a GC pass in flight when the ledger is cleared still returns", async () => {
+    // The cost of 1b's fix, and the reason it needs one. Before this
+    // branch nothing in the system ever deleted `gc/pending.json`, so
+    // "the ledger vanished mid-pass" was unreachable; the clear makes it
+    // routine, and `runGc` holds the ledger only as an in-memory read
+    // between step 2 and its step-7 CAS.
+    //
+    // Schedule, all of it steady-state: a pass reads the ledger, the
+    // operator's `admin restore` deletes it, the pass issues its sweep
+    // DELETEs, then the pass CASes. `casUpdateGcPending` reports the
+    // missing key as `Conflict` — a failed If-Match precondition, the
+    // same code the storage layer would raise on a bare conditional PUT
+    // — which `runGc`'s step-7 arm already tolerates as a lost race.
+    //
+    // Against the pre-fix `InvalidResponse` this throws out of `runGc`:
+    // on the write-tick path `runBoundedMaintenance` counts an
+    // alert-grade `db.maintenance.unexpected_error_total`, and on the
+    // `runScheduledMaintenance` path (documented "Errors propagate") an
+    // operator's cron reports a corrupt-data code during a routine
+    // restore.
+    //
+    // The interceptor stands in for the restore rather than running one
+    // concurrently: `runGc` is a single `await` chain from the test's
+    // point of view, so the delete has to be driven from inside it to
+    // land in the window deterministically. Hooking the sweep DELETE is
+    // the schedule above, at the point the brief describes.
+    const { storage } = await buildStickyLedger();
+    const origDelete = storage.delete.bind(storage);
+    let ledgerCleared = false;
+    storage.delete = (async (key, opts) => {
+      const result = await origDelete(key, opts);
+      if (!ledgerCleared && key !== PENDING_KEY) {
+        ledgerCleared = true;
+        await origDelete(PENDING_KEY);
+      }
+      return result;
+    }) as typeof storage.delete;
+
+    try {
+      const r = await runGc({ storage, currentJsonKey: CURRENT_JSON_KEY }, {
+        graceMillis: 0,
+      } as InternalRunGcOptions);
+      // The window was actually entered — a pass that swept nothing
+      // would never have called `storage.delete` and would prove
+      // nothing.
+      expect(ledgerCleared).toBe(true);
+      expect(r.swept).toBeGreaterThan(0);
+    } finally {
+      // `MemoryStorage` handles are shared per bucket via the registry;
+      // an interceptor left installed leaks into every later use.
+      storage.delete = origDelete;
+    }
+
+    // The pass did NOT resurrect the ledger the restore deleted — the
+    // step-7 arm is best-effort, not a re-create. The next pass
+    // bootstraps a fresh one against the new generation.
+    await expect(readGcPending(storage, PENDING_KEY)).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## What & why

A `gc/pending.json` candidate was a bare key with no identity, and the sweep gate was a budget counter plus a `due_at` comparison. A mark decision made under one view of the bucket executed up to seven days later under a different one, with no re-check that the candidate still belonged to the collection it was judged against.

That is reachable without a crash. `runGc` sweeps `log/K` and then loses the ledger CAS; it catches that `Conflict` and reports success, so the swept candidate stays in the ledger. `admin restore --force` reseeds `log_seq_start` from `tailFromListedLogKeys`, which counts surviving objects only — the deliberate floor exemption, and it can land the floor BELOW where it was. The restore re-creates `log/K`, the sticky candidate deletes it, and the hole inside `[log_seq_start, tail)` makes every read and every fold throw `Internal` from `walkLogRangeWithBytes`. The collection is unreadable and cannot heal itself.

`GcCandidate` now carries an optional `generation` stamped at mark time, and the sweep gains two arms ahead of its existing checks: a generation mismatch drops the candidate whatever its reason, and a `stale-log` candidate whose seq now sits at or above the floor reads live and is dropped. `admin restore` clears the ledger on both reseed branches.

## Key points

- Liveness is re-derived from the `current.json`, floor, and live-hash set the same pass already read, so this adds **zero storage operations** to `runGc` — pinned by an op-count test.
- `generation` is additive and optional: `GC_PENDING_SCHEMA_VERSION` stays at 1, an older ledger stays valid, and absent-compares-equal-to-absent keeps pre-generation buckets reclaiming normally.
- Dropping resolves a candidate out of the ledger instead of deleting it. That also closes a latent starvation path: `mergeGcPending` keeps the *first* `GC_MAX_PENDING_CANDIDATES`, so a permanently-live candidate at the head previously wedged the ledger forever and silently discarded every later mark.
- The fence compares against `freshCurrent ?? current` — the freshest manifest the pass already holds — which narrows the read-to-delete window at no extra op. The residual window is real and is recorded as `sync-protocol.md` invariant 14.
- `casUpdateGcPending` reports a vanished ledger as `Conflict`, not `InvalidResponse`. Widening `runGc`'s catch instead would have swallowed unparseable bodies and failed shape guards, which never self-heal.
- The restore-side clear lands before the writer's first commit, because those commits tick maintenance in-band and can run `runGc` inside the restore itself.
- The other three publication races need a writer suspended mid-commit for longer than the seven-day grace. Rather than engineer against them, the assumption is now invariant 14, with the two gaps it does not close stated plainly: the grace is wall-clock with no cross-node backstop, and the sweep revalidates against a pass-start snapshot rather than immediately before each DELETE.
- Not carried over from an earlier draft: rescuing a still-live content candidate from an *incomplete* live-hash set. `main` encodes completeness as a discriminated union, so a partial set has no `hashes` to consult and already retains rather than deletes; the rescue bought only marginal ledger pressure at the cost of making a partial set reachable again.
- Rejected: per-artifact acquire/release pins. Two extra Class A PUTs on every non-delete write doubles the documented commit floor to fix races that require a week-long pause.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3311 passed, 101 skipped, 0 failed |
| `pnpm test:adapter-cloudflare` | 157 passed, 2 skipped |
| `pnpm test:fuzz-maintenance` | 17 passed (`FC_NUM_RUNS=10000`, ~11 min) |
| `pnpm bundle-sizes` | 14/14 |

Also run per-commit rather than at the tip only: the five GC-relevant suites (`gc`, `maintenance-budget`, `writer`, `gc-pending`, `admin/restore`) pass at each of the ten commits.

Not run, no local stack: `test:minio`, `test:conformance`, `test:export-smoke`, `test:adapter-node`. Everything changed here is backend-agnostic, and the R2/workerd side of the changed fixture is covered by `test:adapter-cloudflare`.

Bundle rebaseline covers six entries: min-gz +259 on `index.js`, +251 on `cloudflare.js` and `http.js`, +250 on `maintenance.js`, plus raw-only moves on `node.js` and `dev-vite.js`. The min-gz figures are the revalidation gate itself, the only part a consumer's minifier keeps; the larger raw delta is mostly the JSDoc recording why the gate exists. Uniform growth across every shipped entry is what distinguishes this from a dragged-in subgraph — reason in the fence commit message, which also records why `NO_GENERATION` moves to `constants.ts`.

## Notes for reviewers

Start at the two new sweep arms in `gc.ts` and the `generation` stamp at mark time; everything else follows. `tests/integration/gc-restore-fencing.test.ts` is new and is the first file in the repo to exercise `runGc` and the restore path together — that structural gap is why this shipped.

Test 1a there pins the sweep gate as a unit, not the generation fence alone: the fence and the liveness re-check each independently block the scenario, so deleting either one leaves it green. The file says so, and the two halves are discriminated separately in `gc.test.ts`.

`writer.test.ts` gains a deliberate tripwire, not coverage of a live defect: `assertCurrentJson` already enforces `0 <= log_seq_start <= tail_hint`, so `probeFloor`'s `Math.max` is a defensive no-op today. It earns its place because the `--force` exemption is the only write in the system that lowers the floor, and because this branch makes that exemption load-bearing.

On upgrade, every pre-existing candidate is dropped for want of a generation and re-marked next pass. Reclamation of anything already pending is delayed by one grace period and `db.gc.dropped_total{cause="stale-generation"}` spikes once. Both expected, both self-healing.
