### PR TITLE
docs: record the unpadded log-key ordering and scope the positioning rules

### DIFF
--- a/docs/contributing/conventions/docs.md
+++ b/docs/contributing/conventions/docs.md
@@ -82,6 +82,23 @@ update every occurrence so they don't silently drift:
   may use the same content without the `Built like git:` lead when the
   sentence is embedded in explanatory prose.
 
+Two positioning constraints apply to **product positioning and
+graduation copy** — the prose that says what baerly-storage is for,
+how far it scales, and when to leave it. They do not reach ordinary
+explanatory or reference prose, and they say nothing about how a doc
+characterizes the reader's _own_ software.
+
+- **Production-grade within an envelope.** Describe the ceiling in
+  terms of workload scale and shape, never maturity. Do not call
+  baerly-storage "between toy and production," "prototype-tier," "not
+  a real database," or a stepping stone to a "serious" database.
+  Internal tools are production systems; the small surface is
+  deliberate.
+- **Do not invent scale numbers.** `docs/about/workload-fit.md`,
+  `docs/about/graduation.md`, and `docs/about/cost-model.md` are the
+  canonical owners of throughput, size, and cost figures. Front-door
+  copy links to those sources instead of restating their figures.
+
 Consistency is of the _wording_, not byte-identical formatting: the
 copies are not identical today (e.g. some are bold and standalone,
 others are embedded in a longer sentence or soft-wrapped). Keep the

--- a/packages/protocol/src/log-key.ts
+++ b/packages/protocol/src/log-key.ts
@@ -16,6 +16,10 @@ export const LOG_KEY_PREFIX = "log";
  * The single constructor for a log-object key:
  * `<manifestPrefix>/log/<seq>.json`. `manifestPrefix` is the
  * `<…>/manifests/<collection>` segment — this helper adds `/log/`.
+ * `<seq>` is unpadded decimal, so lexicographic LIST order is not numeric
+ * order (`log/10.json` precedes `log/2.json`). The descending base-32 LSN
+ * encoding applies to LSN values and the LSN half of `/v1/since` cursors,
+ * not these keys.
  * Route all callers here so the key shape lives in one place.
  */
 export const logObjectKey = (manifestPrefix: string, seq: number): string =>


### PR DESCRIPTION
## What & why

Two documentation facts that were previously only discoverable by reading the code.

Log object keys are unpadded decimal, so lexicographic LIST order is not numeric order — `log/10.json` precedes `log/2.json`. That has bitten the GC and long-poll paths before; `logObjectKey`'s JSDoc now says it at the constructor.

Separately, `docs/contributing/conventions/docs.md` gains two positioning constraints for product and graduation copy: describe the ceiling by workload scale and shape rather than by maturity, and source throughput/size/cost figures from `docs/about/` rather than restating them inline.

## Key points

- The positioning rule is scoped to product positioning and graduation copy, not all prose, and says explicitly that it does not govern how a doc characterises the reader's *own* software. That carve-out is what keeps `docs/README.md`'s existing "real enough to need shared state" line in bounds — it describes the user's application, not baerly-storage, and needs no correction.
- The log-key note says the descending base-32 encoding applies to LSN values and to the **LSN half** of a `/v1/since` cursor. The generation half is lowercase hex. The canonical long-form already lives at `log.ts:35-37` and is not duplicated here.
- This supersedes `docs/record-implicit-invariants`, which is stale against `main` and carried a third commit whose `gc.ts` comment collided with a concurrent rewrite of that mark site. That comment lands on the GC fencing branch instead, with "swept" corrected to "marked" — it annotates the mark predicate, not the sweep.

## Verification

| `pnpm verify:agent` | clean |
