### PR TITLE
docs(model): clarify multilevel study boundaries

### DIFF
--- a/tests/model/multilevel/README.md
+++ b/tests/model/multilevel/README.md
@@ -21,6 +21,18 @@ The tests live under `tests/` and run under plain `pnpm test` for one reason:
 so the model keeps compiling and keeps passing as the repo moves around it.
 That is bit-rot protection, not a regression gate.
 
+**A green report authorizes nothing.** Specifically, it does not license
+building a multilevel manifest format, a decoder for one, a query path over
+one, a compactor change, or an oracle adapter. Each of those needs its own
+design and its own ratification; "the model admits no counterexample" is an
+input to that decision, not the decision.
+
+**Keep this model semantically independent of `tests/model/fold-boundary/`.**
+Do not share modeled state, transitions, generators, reconstruction logic, or
+invariants between them: the two models test different hypotheses, and shared
+semantics could give them the same blind spot. If shared reporting
+infrastructure is introduced, include it in each report's source-hash closure.
+
 ## What it checks
 
 Eight safety properties, evaluated over prefixes of each selected derived


### PR DESCRIPTION
## What & why

Clarify that the executable multilevel fold model is research evidence, not authorization to implement a production protocol. Preserve semantic independence from the fold-boundary model so the two studies do not acquire correlated blind spots.

## Key points

- Allows shared reporting infrastructure only when each report includes it in its source-hash closure.
- Keeps the durable boundary beside the model after the scratch implementation plan was retired.

## Verification

| Command | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false pnpm test:agent` | 3,311 passed; 101 skipped |

