### PR TITLE
test(gc): pin revalidation's zero-op cost, and correct the floor tripwire's header

### DIFF
--- a/packages/server/src/gc.test.ts
+++ b/packages/server/src/gc.test.ts
@@ -2406,6 +2406,49 @@ describe("runGc — sweep-time revalidation", () => {
     expect(r.dropped).toEqual({ stale_generation: 0, still_live: 0 });
   });
 
+  test("revalidation adds ZERO storage ops — a dropping pass costs a sweeping pass minus the DELETE", async () => {
+    // The gate's cost argument, pinned. Every value it consults is
+    // already in lexical scope — `current` and `logSeqStart` from step 1,
+    // the live-hash set from step 5 — so it issues no probe, no HEAD and
+    // no extra LIST. Nothing else in the suite counts operations, so
+    // without this test that claim rests on inspection alone.
+    //
+    // Two arms, byte-identical but for the candidate's `generation`, so
+    // any difference in the op trace IS revalidation cost. Both halves
+    // matter: comparing the arms catches an op added on the drop path,
+    // and pinning the absolute trace catches one added to BOTH paths,
+    // which a comparison alone would let through.
+    const traceFor = async (candidateGeneration: string): Promise<StorageTrace> => {
+      const inner = new MemoryStorage();
+      // Seed on the raw storage so fixture writes are not traced.
+      await seedDueStaleLog(inner, { floor: 9, seq: 5, candidateGeneration });
+      const { storage, trace } = tracingStorage(inner);
+      await runGc({ storage, currentJsonKey: KEY }, {
+        graceMillis: 0,
+        maxSweepsPerRun: 10,
+      } as InternalRunGcOptions);
+      return trace;
+    };
+
+    const swept = await traceFor(LOG_STATE_GENERATION);
+    const dropped = await traceFor(OTHER_GENERATION);
+
+    // Identical reads, writes and listings — the whole difference is the
+    // DELETE the fenced pass correctly declined to issue.
+    expect(dropped.gets).toEqual(swept.gets);
+    expect(dropped.puts).toEqual(swept.puts);
+    expect(dropped.lists).toEqual(swept.lists);
+    expect(swept.deletes).toEqual([`${PREFIX}/log/5.json`]);
+    expect(dropped.deletes).toEqual([]);
+
+    // The absolute shape, so an op added to both arms cannot hide behind
+    // the equality above. Keys rather than counts: a changed op is then
+    // legible in the diff instead of arriving as an off-by-one.
+    expect(swept.gets).toEqual([KEY, PENDING_KEY, `${PREFIX}/log/9.json`, PENDING_KEY]);
+    expect(swept.lists).toEqual([`${PREFIX}/log/`, `${PREFIX}/snapshot/`, `${PREFIX}/content/`]);
+    expect(swept.puts.map((p) => p.key)).toEqual([PENDING_KEY]);
+  });
+
   test("drops a due stale-log candidate that the floor has made live again", async () => {
     // The second arm, independent of the first: same generation
     // throughout, but the floor has moved DOWN beneath the candidate.

--- a/packages/server/src/writer.test.ts
+++ b/packages/server/src/writer.test.ts
@@ -684,10 +684,14 @@ describe("Writer", () => {
 
   test("a commit never lands below the log_seq_start observed after it", async () => {
     // Every other seq assertion in this file is an exact literal
-    // (`toBe(0)`, `toBe(1)`, …) against a collection whose floor is 0 and
-    // never moves, so none of them can see a commit landing BENEATH the
-    // floor. This states the relation instead, against the one manifest
-    // shape in the system where the floor has moved DOWN.
+    // (`toBe(0)`, `toBe(1)`, …) against a floor that never moves DOWN. Not
+    // "a floor of 0" — the `[log_seq_start, tail_hint)` walk test asserts
+    // a seq under a static floor of 2, and the `FLOOR = 300` tests further
+    // down assert index keys rather than seqs. The point is narrower: in
+    // all of them the commit lands at or above a floor that only ever rose,
+    // so none can observe a commit landing BENEATH the floor. This states
+    // the relation instead, against the one manifest shape in the system
+    // where the floor has moved DOWN.
     //
     // That shape is what `baerly admin restore --force` writes: its
     // deliberate floor exemption reseeds `log_seq_start` from the
@@ -704,9 +708,13 @@ describe("Writer", () => {
     // enforces `0 <= log_seq_start <= tail_hint`, so today `probeFloor`'s
     // `Math.max` is a defensive no-op and this invariant holds by
     // construction. This is a TRIPWIRE on the floor exemption, not
-    // coverage of a live defect. It exists because the exemption is the
-    // only write in the system that lowers the floor, and because no
-    // other assertion here is relative to a floor that has moved.
+    // coverage of a live defect — mutating `probeFloor` reddens other
+    // tests too, though none of them NAMES this invariant. It exists
+    // because the exemption is the only write in the system that lowers
+    // the floor. The read-side counterpart is `http/since.test.ts`, which
+    // pins cursor REJECTION across the same post-`--force` shape; its only
+    // commit happens before the truncation, so it does not cover the write
+    // path this test does.
     const storage = new MemoryStorage();
     // The post-`--force` manifest, in the fields this test turns on:
     // floor and hint both reseeded to 10, snapshot dropped. Ten, not


### PR DESCRIPTION
## What & why

Two follow-ups to #108, both confined to test files.

`gc.test.ts` gains an op-count test for the sweep-time revalidation gate. #108's body claimed the gate "adds zero storage operations to `runGc` — pinned by an op-count test", but the test that pinned it directly was lost when that branch's review-fix commits were squashed, and `gc.test.ts` had no op counting at all. The claim was still true and indirectly held — `maintenance-budget.test.ts` asserts exact op totals on paths the fence runs through — but nothing isolated revalidation as the only variable.

`writer.test.ts`'s floor tripwire had a false inventory claim in its header, which is corrected.

## Key points

- The op-count test runs two arms that are byte-identical but for the candidate's `generation`, so any trace difference is revalidation cost. Comparing the arms catches an op added on the drop path; pinning the sweeping arm's absolute trace catches one added to **both** paths, which the comparison alone would let through.
- Traces are asserted as key sequences, not counts, so a changed op is legible in the diff rather than arriving as an off-by-one.
- Reuses the suite's existing `tracingStorage` helper instead of restoring the original's separate counting wrapper — one tracing mechanism per suite.
- The tripwire's header said every other seq assertion in the file runs against "a collection whose floor is 0 and never moves". Two counterexamples: the `[log_seq_start, tail_hint)` walk test asserts a seq under a static floor of 2, and the `FLOOR = 300` tests assert index keys rather than seqs. The conclusion survives on a narrower statement — in all of them the commit lands at or above a floor that only ever rose.
- The tripwire also now names `http/since.test.ts` as the read-side counterpart and says why it is not coverage of the same thing: it pins cursor rejection across the same post-`--force` manifest shape, but its only commit happens before the truncation.
- No changeset: no user-facing behaviour changes.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3312 passed, 101 skipped, 0 failed |

Both halves of the new test are mutation-checked rather than assumed:

- Replacing the fence predicate with `if (false)` makes the dropped arm issue a DELETE, reddening the arm comparison.
- Injecting a redundant `storage.get(currentJsonKey)` into `runGc` reddens the absolute trace, and the failure names the duplicated key.

Not run, no local stack: `test:minio`, `test:conformance`, `test:export-smoke`, `test:adapter-node`. Both changes are test-only and backend-agnostic.

## Notes for reviewers

The op-count test's absolute assertions are the brittle-looking part and are deliberate — a comparison-only test would pass if someone added a probe to both arms, which is precisely the regression the gate's cost argument rules out.
