### PR TITLE
fix(maintenance): refresh tail_hint after a GC-only write tick

### DIFF
--- a/.changeset/stop-writing-content-objects.md
+++ b/.changeset/stop-writing-content-objects.md
@@ -26,4 +26,6 @@ New insert and update commits no longer create `content/<sha>.json` side objects
 
 Normal `@gusto/baerly-storage` API consumers and existing v0.6.0 buckets require no migration. Do not delete legacy content objects manually; retained legacy GC preserves its grace and revalidation protections, while content-free passes can now skip legacy liveness work.
 
+A content-free GC tick also refreshes a stale `tail_hint` afterwards, so a collection that GCs without ever folding keeps its read and write forward-probes bounded instead of re-walking a growing live tail. A tick that deferred legacy-content work keeps the tail its bounded probe certified. Any one maintenance tick now publishes `tail_hint` at most once, so a fold or a deferral that already stamped it never costs a second, byte-identical `current.json` write.
+
 baerly cost now keeps the exact 1M-Class-A/month R2 boundary inside the inclusive free tier instead of reporting a zero-dollar overage.

--- a/docs/spec/attachments/amortized-write-cost-baseline.json
+++ b/docs/spec/attachments/amortized-write-cost-baseline.json
@@ -12,19 +12,19 @@
     "profile": "cf-free",
     "workload": "update-heavy/50-docs/200B",
     "writes": 2000,
-    "puts": 2671,
+    "puts": 2673,
     "lists": 1377,
     "deletesFree": 1921,
-    "billableClassAPerWrite": 2.024
+    "billableClassAPerWrite": 2.025
   },
   {
     "profile": "cf-free",
     "workload": "insert-only/growing/200B",
     "writes": 1500,
-    "puts": 1959,
+    "puts": 1961,
     "lists": 1017,
     "deletesFree": 925,
-    "billableClassAPerWrite": 1.984
+    "billableClassAPerWrite": 1.985
   },
   {
     "profile": "node",
@@ -39,18 +39,18 @@
     "profile": "node",
     "workload": "update-heavy/50-docs/200B",
     "writes": 2000,
-    "puts": 3023,
+    "puts": 3035,
     "lists": 2837,
     "deletesFree": 1877,
-    "billableClassAPerWrite": 2.93
+    "billableClassAPerWrite": 2.936
   },
   {
     "profile": "node",
     "workload": "insert-only/growing/200B",
     "writes": 1500,
-    "puts": 2261,
+    "puts": 2269,
     "lists": 2087,
     "deletesFree": 971,
-    "billableClassAPerWrite": 2.899
+    "billableClassAPerWrite": 2.904
   }
 ]

--- a/docs/spec/attachments/amortized-write-cost-stress-baseline.json
+++ b/docs/spec/attachments/amortized-write-cost-stress-baseline.json
@@ -16,23 +16,23 @@
       "profile": "cf-free",
       "workload": "insert-burst/growing/2KB",
       "writes": 3000,
-      "puts": 3298,
+      "puts": 3318,
       "lists": 807,
       "deletesFree": 251,
-      "putsPerWrite": 1.099,
+      "putsPerWrite": 1.106,
       "listsPerWrite": 0.269,
-      "billableClassAPerWrite": 1.368
+      "billableClassAPerWrite": 1.375
     },
     {
       "profile": "cf-free",
       "workload": "rewrite-all/500-docs/2KB",
       "writes": 4000,
-      "puts": 4361,
+      "puts": 4388,
       "lists": 996,
       "deletesFree": 251,
-      "putsPerWrite": 1.09,
+      "putsPerWrite": 1.097,
       "listsPerWrite": 0.249,
-      "billableClassAPerWrite": 1.339
+      "billableClassAPerWrite": 1.346
     },
     {
       "profile": "node",
@@ -49,23 +49,23 @@
       "profile": "node",
       "workload": "insert-burst/growing/2KB",
       "writes": 3000,
-      "puts": 4507,
+      "puts": 4528,
       "lists": 4476,
       "deletesFree": 196,
-      "putsPerWrite": 1.502,
+      "putsPerWrite": 1.509,
       "listsPerWrite": 1.492,
-      "billableClassAPerWrite": 2.994
+      "billableClassAPerWrite": 3.001
     },
     {
       "profile": "node",
       "workload": "rewrite-all/500-docs/2KB",
       "writes": 4000,
-      "puts": 6007,
+      "puts": 6036,
       "lists": 5976,
       "deletesFree": 196,
-      "putsPerWrite": 1.502,
+      "putsPerWrite": 1.509,
       "listsPerWrite": 1.494,
-      "billableClassAPerWrite": 2.996
+      "billableClassAPerWrite": 3.003
     }
   ]
 }

--- a/docs/spec/sync-protocol.md
+++ b/docs/spec/sync-protocol.md
@@ -377,8 +377,13 @@ snapshot:
    folds are the primary durable advancer of the hint. Explicitly bounded
    scheduled compaction can instead durably checkpoint an incomplete probe's
    certified lower bound in `tail_hint` without publishing a snapshot; a
-   later pass resumes from that checkpoint. Write-tick maintenance may also
-   rate-limit-refresh the hint when fold/GC work is disabled or deferred.
+   later pass resumes from that checkpoint. Bounded GC checkpoints the
+   tail its own capped probe certified when it defers legacy-content
+   classification. Write-tick maintenance rate-limit-refreshes the hint
+   when fold/GC work is disabled or deferred, and after a GC slice that
+   neither deferred nor followed a landed fold in the same tick — a
+   landed fold has already published a hint at or past the observed
+   tail, so refreshing again would rewrite identical bytes.
    Ordinary writer commits never touch
    `current.json` on the commit path. The fold CAS is therefore the
    only steady-state writer of the snapshot pointer, `log_seq_start`,
@@ -483,7 +488,9 @@ These are the load-bearing rules.
    `tail_hint` is a non-authoritative monotone lower bound, durably advanced
    by compaction folds, explicitly bounded scheduled-compaction probe
    checkpoints, bounded-GC tail checkpoints, and by the write-tick runner's
-   tail refresh when fold/GC work defers or is disabled. Those durable
+   rate-limited tail refresh — which fires when fold/GC work defers or is
+   disabled, and after a non-deferring GC slice whose tick did not already
+   land a fold that published the hint. Those durable
    checkpoint writers use monotone CAS updates and never move `tail_hint`
    past the true first missing log slot. Ordinary writer commits never refresh
    it inline. Other non-commit-path writers are explicit: the one-time

--- a/packages/protocol/src/constants.ts
+++ b/packages/protocol/src/constants.ts
@@ -601,15 +601,30 @@ export const MAINTENANCE_PROFILE_CF_PAID: MaintenanceProfileShape = {
 export const MAINTENANCE_WARN_INTERVAL_WRITES: number = 1000;
 
 /**
- * Rate-limit for the maintenance tick's `tail_hint` advance on the
- * DEFER path (HR-2). When the fold defers (snapshot over the CF-CPU-kill
- * ceiling) the compactor never stamps `tail_hint` via its Step-7 fold
- * CAS, so the gap `(true_tail − tail_hint)` would grow without bound and
- * every read would re-walk the whole live tail via `probeTailFrom`. The
- * runner therefore advances `tail_hint` toward the observed tail with a
- * best-effort `current.json` CAS — but only once per this many writes,
- * so it is NOT a per-commit `current.json` write (which is exactly what
- * single-write commit removed).
+ * Rate-limit for the maintenance tick's `tail_hint` advance on every
+ * path where no fold published the hint (originally HR-2, the DEFER
+ * path). When the fold defers (snapshot over the CF-CPU-kill ceiling),
+ * when `BAERLY_MAINTENANCE_DISABLE` suppresses both phases, or when a
+ * tick runs only GC, the compactor never stamps `tail_hint` via its
+ * Step-7 fold CAS — so the gap `(true_tail − tail_hint)` would grow
+ * without bound and every read would re-walk the whole live tail via
+ * `probeTailFrom`. The runner therefore advances `tail_hint` toward the
+ * observed tail with a best-effort `current.json` CAS — but only once
+ * per this many writes, so it is NOT a per-commit `current.json` write
+ * (which is exactly what single-write commit removed).
+ *
+ * This interval is a floor on the rate, not a licence to publish more
+ * than once per tick. A tick publishes `tail_hint` AT MOST ONCE, by
+ * whichever party gets there first, because the interval is measured
+ * against the tick's in-memory `current.json` — which no CAS writes back,
+ * so a repeat call still reads as due and would rewrite identical bytes.
+ * Three parties can publish: the runner's own refresh, a fold that
+ * returned `written` (Step-7 stamped `max(stored, discoveredTail)` with
+ * `discoveredTail >= observedTail`), and a GC pass that deferred
+ * legacy-content classification (its bounded admission already
+ * CAS-checkpointed the tail its capped probe certified — an extra
+ * GET+PUT there would breach the Cloudflare-Free 50-subrequest worst
+ * case that pass is proven at).
  *
  * Sized at 128: it bounds a deferring collection's worst-case
  * read-walk to ≤128 forward GETs (≈one extra read-page sweep — a

--- a/packages/server/src/maintenance-budget.test.ts
+++ b/packages/server/src/maintenance-budget.test.ts
@@ -23,9 +23,15 @@
 
 import {
   BaerlyError,
+  CF_FREE_GC_TAIL_PROBE_GETS,
   CURRENT_JSON_SCHEMA_VERSION,
   GC_PENDING_SCHEMA_VERSION,
+  GC_STARVATION_GUARD,
+  MAINTENANCE_MAX_FOLD_ROWS,
+  MAINTENANCE_PROFILE_CF_FREE,
+  MAINTENANCE_TAIL_HINT_REFRESH_WRITES,
   SNAPSHOT_SCHEMA_VERSION,
+  WRITE_TICK_FOLD_ENTRIES_PER_PASS,
   createCurrentJson,
   createGcPending,
   MemoryStorage,
@@ -47,7 +53,7 @@ import {
 import { seedLegacyContentForBody } from "../../../tests/fixtures/legacy-content.ts";
 import { compact } from "./compactor.ts";
 import { type InternalRunGcOptions, runGc } from "./gc.ts";
-import { CLOUDFLARE_FREE_TIER, runBoundedMaintenance } from "./maintenance.ts";
+import { CLOUDFLARE_FREE_TIER, crossesGcBoundary, runBoundedMaintenance } from "./maintenance.ts";
 import { encodeSnapshotBody, snapshotKey } from "./snapshot.ts";
 import { Writer } from "./writer.ts";
 
@@ -158,6 +164,46 @@ describe("CLOUDFLARE_FREE_TIER budget", () => {
     ).toBeLessThanOrEqual(FREE_TIER_BUDGET);
     await expect(inner.get(liveContent)).resolves.not.toBeNull();
   });
+
+  test.each([
+    { name: "hard-GC guard", phasesPerTick: "single" as const },
+    { name: "cadence GC", phasesPerTick: "both" as const },
+  ])(
+    "content-free $name refreshes a 128-entry stale tail_hint within budget",
+    async ({ phasesPerTick }) => {
+      const inner = new MemoryStorage();
+      const prefix = "app/t/tenant/x/manifests/c";
+      await createCurrentJson(
+        inner,
+        KEY,
+        logStateCurrentJson({
+          log_seq_start: 0,
+          tail_hint: 0,
+          snapshot_bytes: 10_000_000,
+        }),
+      );
+      await seedLogEntries(inner, prefix, 0, 128);
+      const counted = countingStorage(inner);
+
+      await runBoundedMaintenance(
+        {
+          storage: counted.storage,
+          currentJsonKey: KEY,
+          prevSeq: 127,
+          observedTail: 128,
+        },
+        { phasesPerTick },
+      );
+
+      const current = await readCurrentJson(inner, KEY);
+      expect(current?.json.tail_hint).toBe(128);
+      expect(
+        counted.getOps(),
+        `ops by category: ${JSON.stringify(counted.report())}`,
+      ).toBeLessThanOrEqual(FREE_TIER_BUDGET);
+      expect(counted.listedPrefixes()).toContain(`${prefix}/content/`);
+    },
+  );
 
   test("compact-only ticks converge from a stale-low tail_hint within the 50-op budget", async () => {
     // Even-minute branch of the scheduled handler: compact alone. The
@@ -374,18 +420,33 @@ describe("CLOUDFLARE_FREE_TIER budget", () => {
     expect(totalOps).toBeLessThanOrEqual(FREE_TIER_BUDGET);
   });
 
-  test("maximally contended write-tick content deferral stays at 50 storage operations", async () => {
+  // A deferring pass keeps the tail hint it CERTIFIED and no more. The
+  // outer write-tick refresh is deliberately suppressed here even though
+  // its rate limit is satisfied (gap === MAINTENANCE_TAIL_HINT_REFRESH_WRITES
+  // below): GC already CAS-checkpointed `floor + CF_FREE_GC_TAIL_PROBE_GETS`
+  // from inside the bounded admission, and an unconditional outer GET+PUT
+  // would push this proven worst case to 52 — over the invocation cap. The
+  // hint still converges, because GC recurs at most every
+  // `gcInterval * GC_STARVATION_GUARD` writes while each pass certifies
+  // another `CF_FREE_GC_TAIL_PROBE_GETS` entries.
+  test("maximally contended write-tick content deferral keeps its certified checkpoint at 50 storage operations", async () => {
     const inner = new MemoryStorage();
     const prefix = "app/t/tenant/x/manifests/c";
+    const logFloor = 20;
+    // Make the outer refresh ELIGIBLE, so this case discriminates the
+    // deferral guard rather than the rate limit. Asserted, not assumed: a
+    // raised interval must fail here instead of silently defanging the test.
+    const observedTail = logFloor + MAINTENANCE_TAIL_HINT_REFRESH_WRITES;
+    expect(observedTail - logFloor).toBeGreaterThanOrEqual(MAINTENANCE_TAIL_HINT_REFRESH_WRITES);
     await createCurrentJson(
       inner,
       KEY,
       logStateCurrentJson({
-        log_seq_start: 20,
-        tail_hint: 20,
+        log_seq_start: logFloor,
+        tail_hint: logFloor,
       }),
     );
-    await seedLogEntries(inner, prefix, 20, 45);
+    await seedLogEntries(inner, prefix, logFloor, observedTail);
     await seedLegacyContentForBody(inner, prefix, { _id: "needs-liveness", n: 1 });
     const dueCandidates = [
       ...Array.from({ length: 9 }, (_, index) => ({
@@ -439,8 +500,10 @@ describe("CLOUDFLARE_FREE_TIER budget", () => {
       {
         storage: counted.storage,
         currentJsonKey: KEY,
-        prevSeq: 31,
-        observedTail: 45,
+        // 143 → 148 crosses the hard-GC boundary (gcInterval *
+        // GC_STARVATION_GUARD = 16), so this tick's one phase is GC.
+        prevSeq: 143,
+        observedTail,
       },
       {
         gcGraceMillis: 0,
@@ -453,10 +516,109 @@ describe("CLOUDFLARE_FREE_TIER budget", () => {
       `${prefix}/snapshot/`,
       `${prefix}/content/`,
     ]);
+    // The bounded admission's own CAS, and only it: the hint advances to the
+    // occupancy the capped probe certified, NOT to `observedTail`.
+    const current = await readCurrentJson(inner, KEY);
+    expect(current?.json.tail_hint).toBe(logFloor + CF_FREE_GC_TAIL_PROBE_GETS);
     expect(counted.report()).toEqual({ get: 32, put: 5, delete: 10, list: 3 });
     const totalOps = counted.getOps();
     expect(totalOps).toBe(50);
     expect(totalOps).toBeLessThanOrEqual(FREE_TIER_BUDGET);
+  });
+
+  test("a deferring pass certifies more tail than the hard-GC cadence lets accrue", () => {
+    // The test above proves a deferring tick advances `tail_hint` by exactly
+    // CF_FREE_GC_TAIL_PROBE_GETS and suppresses the outer refresh, so that
+    // checkpoint is the ONLY hint advance a never-folding deferring
+    // collection gets. It is sufficient only while one pass certifies more
+    // entries than the worst-case cadence lets accrue between passes: the
+    // hard-GC starvation guard fires at least every
+    // `gcInterval * GC_STARVATION_GUARD` writes, so below that bound the gap
+    // shrinks every pass and converges to an exact stamp. Invert the
+    // relation and `(true_tail − tail_hint)` grows without bound instead,
+    // until every read throws at LOG_FORWARD_PROBE_CAP — retune the outer
+    // guard, do not relax this.
+    const worstCaseWritesBetweenGcPasses =
+      MAINTENANCE_PROFILE_CF_FREE.gcInterval * GC_STARVATION_GUARD;
+    expect(CF_FREE_GC_TAIL_PROBE_GETS).toBeGreaterThan(worstCaseWritesBetweenGcPasses);
+  });
+
+  // A DEFER refreshes `tail_hint` at Step 3 and then falls through to GC,
+  // so the tick has two call sites for one publication. The rate limit
+  // cannot catch the second: it reads the in-memory `current`, which
+  // `casUpdateCurrentJson` never writes back, so an unguarded second call
+  // still evaluates as due and rewrites byte-identical bytes.
+  //
+  // Content-free is the ONLY shape that reaches this. A legacy-content pass
+  // with a due refresh always defers, because admission needs a live range
+  // <= `gcMaxLiveLogEntriesPerRun` while the refresh needs a gap >=
+  // MAINTENANCE_TAIL_HINT_REFRESH_WRITES, and `log_seq_start <= tail_hint`
+  // makes the gap a lower bound on that range. So the redundant write costs
+  // 2 ops on a cheap pass, never on the 46-op admitted one — it is a
+  // correctness-of-op-count pin, NOT a rescue of the 50-op cap.
+  test("a deferring fold that falls through to GC refreshes tail_hint exactly once", async () => {
+    const inner = new MemoryStorage();
+    const prefix = "app/t/tenant/x/manifests/c";
+    const logFloor = 40;
+    // Exactly at the rate limit, so this case discriminates the publication
+    // guard rather than the interval.
+    const observedTail = logFloor + MAINTENANCE_TAIL_HINT_REFRESH_WRITES;
+    // Crosses the gcInterval boundary (Step 4 opens) but NOT the hard-GC one
+    // (Step 2 must not early-return, or we never reach the DEFER branch).
+    const prevSeq = 164;
+    expect(crossesGcBoundary(prevSeq, observedTail, MAINTENANCE_PROFILE_CF_FREE.gcInterval)).toBe(
+      true,
+    );
+    expect(
+      crossesGcBoundary(
+        prevSeq,
+        observedTail,
+        MAINTENANCE_PROFILE_CF_FREE.gcInterval * GC_STARVATION_GUARD,
+      ),
+    ).toBe(false);
+
+    await createCurrentJson(
+      inner,
+      KEY,
+      logStateCurrentJson({
+        log_seq_start: logFloor,
+        tail_hint: logFloor,
+        // Rows arm trips the fold ceiling -> foldViable false -> DEFER.
+        snapshot_rows: MAINTENANCE_MAX_FOLD_ROWS - WRITE_TICK_FOLD_ENTRIES_PER_PASS + 1,
+        // Bytes arm stays under C, and keeps the ratio denominator pinned to
+        // MAINTENANCE_MIN_LIVE_BYTES so gate1 trips on the mean alone.
+        snapshot_bytes: 1024,
+        mean_entry_bytes: 1024,
+      }),
+    );
+    await seedLogEntries(inner, prefix, logFloor, observedTail);
+    // No legacy content: GC short-circuits before admission and never
+    // checkpoints, which is what exposes the second refresh.
+
+    let currentJsonPuts = 0;
+    const keyCounting: Storage = {
+      get: (key, opts) => inner.get(key, opts),
+      put: (key, body, opts) => {
+        if (key === KEY) {
+          currentJsonPuts += 1;
+        }
+        return inner.put(key, body, opts);
+      },
+      delete: (key, opts) => inner.delete(key, opts),
+      list: (listPrefix, opts) => inner.list(listPrefix, opts),
+    };
+    const counted = countingStorage(keyCounting);
+
+    await runBoundedMaintenance(
+      { storage: counted.storage, currentJsonKey: KEY, prevSeq, observedTail },
+      { gcGraceMillis: 0, now: () => new Date("2026-01-01T00:00:00.000Z") },
+    );
+
+    // One publication, and it lands the observed tail.
+    expect(currentJsonPuts).toBe(1);
+    const current = await readCurrentJson(inner, KEY);
+    expect(current?.json.tail_hint).toBe(observedTail);
+    expect(counted.getOps()).toBeLessThanOrEqual(FREE_TIER_BUDGET);
   });
 
   test("B4: a write-tick fold with a STALE-LOW stored tail_hint stays within budget because observedTail bounds the probe", async () => {

--- a/packages/server/src/maintenance.test.ts
+++ b/packages/server/src/maintenance.test.ts
@@ -300,10 +300,13 @@ interface Counting {
   readonly storage: Storage;
   readonly total: () => number;
   readonly report: () => Record<string, number>;
+  /** PUT keys in call order — the seam for asserting WRITE SHAPE, not just volume. */
+  readonly putKeys: () => string[];
 }
 
 const countingStorage = (inner: Storage): Counting => {
   const counts = { get: 0, put: 0, delete: 0, list: 0 };
+  const putKeys: string[] = [];
   const wrapper: Storage = {
     async get(key: string, opts?: StorageGetOptions): Promise<StorageGetResult | null> {
       counts.get += 1;
@@ -311,6 +314,7 @@ const countingStorage = (inner: Storage): Counting => {
     },
     async put(key: string, body: Uint8Array, opts?: StoragePutOptions): Promise<StoragePutResult> {
       counts.put += 1;
+      putKeys.push(key);
       return inner.put(key, body, opts);
     },
     async delete(key: string, opts?: { signal?: AbortSignal }): Promise<void> {
@@ -329,6 +333,7 @@ const countingStorage = (inner: Storage): Counting => {
     storage: wrapper,
     total: (): number => counts.get + counts.put + counts.delete + counts.list,
     report: (): Record<string, number> => ({ ...counts }),
+    putKeys: (): string[] => [...putKeys],
   };
 };
 
@@ -543,6 +548,7 @@ describe("runBoundedMaintenance", () => {
     // Force the defer: snapshot over E rows, ratio-tripping mean.
     await casUpdateCurrentJson(inner, KEY, (cur) => ({
       ...cur,
+      tail_hint: 0,
       mean_entry_bytes: RATIO_TRIPPING_MEAN,
       snapshot_bytes: 0,
       snapshot_rows: 1_000_000, // > MAINTENANCE_MAX_FOLD_ROWS ⇒ defer
@@ -767,6 +773,41 @@ describe("runBoundedMaintenance", () => {
     // GC also ran ⇒ pending.json exists.
     const pending = await inner.get("app/t/tenant/x/manifests/c/gc/pending.json");
     expect(pending).not.toBeNull();
+  });
+
+  test('phasesPerTick "both": a successful fold publishes the hint, so GC does NOT re-CAS it', async () => {
+    // The compactor's Step-7 fold CAS stamps `tail_hint = max(stored,
+    // discoveredTail)` and `discoveredTail >= knownTail === the runner's
+    // nextSeq`, so the hint is already published when GC returns. The outer
+    // refresh evaluates its rate limit against the STALE pre-fold manifest,
+    // which on a >= REFRESH_INTERVAL gap still reads as "due" — and would
+    // spend a second GET+PUT writing back byte-identical bytes.
+    const inner = new MemoryStorage();
+    const observedTail = MAINTENANCE_TAIL_HINT_REFRESH_WRITES + 2;
+    await bootstrap(inner, KEY); // tail_hint = 0 ⇒ the gap is `observedTail`
+    await seedLogEntries(inner, COLLECTION_PREFIX, 0, observedTail);
+    await patchCurrent(inner, KEY, {
+      mean_entry_bytes: RATIO_TRIPPING_MEAN, // ratio >= 1 ⇒ gate1 trips
+      snapshot_bytes: 0,
+      snapshot_rows: 0, // under C and E ⇒ fold-viable
+    });
+    const c = countingStorage(inner);
+
+    await runBoundedMaintenance(
+      {
+        storage: c.storage,
+        currentJsonKey: KEY,
+        prevSeq: 0, // crosses the GC cadence boundary
+        observedTail,
+      },
+      { phasesPerTick: "both", profile: MAINTENANCE_PROFILE_CF_FREE },
+    );
+
+    // Exactly one current.json write this tick: the fold's publication.
+    expect(c.putKeys().filter((key) => key === KEY)).toEqual([KEY]);
+    // The fold both advanced the floor and published the discovered hint.
+    await expect(readSeqStart(inner, KEY)).resolves.toBe(WRITE_TICK_FOLD_ENTRIES_PER_PASS);
+    await expect(readTailHint(inner, KEY)).resolves.toBe(observedTail);
   });
 
   test("hard-GC starvation guard fires on single: runs GC, skips fold on the hard boundary", async () => {

--- a/packages/server/src/maintenance.ts
+++ b/packages/server/src/maintenance.ts
@@ -349,6 +349,14 @@ export interface BoundedMaintenanceOptions {
  *      defer (and metric); on `"single"` a successful fold attempt is
  *      this tick's one phase.
  *   4. Otherwise (or on `"both"`) → GC iff the cadence boundary crossed.
+ *
+ * Steps 0, 2, 3-defer, and 4 all take the rate-limited `tail_hint`
+ * refresh, but the tick publishes the hint AT MOST ONCE — a landed fold
+ * (Step-7 CAS), GC's legacy-content checkpoint, and the refresh itself
+ * all count as that publication. Ordering matters: Step 3's defer
+ * refreshes and then falls through to Step 4, so without the shared
+ * guard that one tick would CAS `current.json` twice with identical
+ * bytes.
  */
 export const runBoundedMaintenance = async (
   args: {
@@ -457,10 +465,33 @@ export const runBoundedMaintenance = async (
     const foldViable = snapshotBytes <= C && snapshotRows + maxFoldEntriesPerPass <= E;
     const gcDue = crossesGcBoundary(prevSeq, nextSeq, gcInterval);
 
+    // ONE `tail_hint` publication per tick, whoever performs it: this
+    // helper's own CAS, a fold that landed (compact()'s Step-7 stamps
+    // `max(stored, discoveredTail)` with a probe floor including
+    // `knownTail = nextSeq`), or GC's bounded-admission checkpoint.
+    //
+    // The rate limit alone cannot enforce this. It tests the in-memory
+    // `current`, which `casUpdateCurrentJson` never writes back, so a
+    // second call on a >= REFRESH_INTERVAL gap still reads as due and
+    // rewrites byte-identical bytes. Every path that reaches GC after
+    // already publishing — a landed fold on `"both"`, and the Step-3
+    // DEFER refresh that falls through — would otherwise spend a second
+    // GET+PUT for no state change.
+    let tailHintPublished = false;
+
     const refreshTailHintIfNeeded = async (): Promise<void> => {
+      if (tailHintPublished) {
+        return;
+      }
       if (nextSeq - current.tail_hint < MAINTENANCE_TAIL_HINT_REFRESH_WRITES) {
         return;
       }
+      // Set before the CAS, so this counts publication ATTEMPTS: a lost
+      // CAS means a peer advanced the hint (the stamp is monotone, so it
+      // is published either way) and a transient error is caught by the
+      // next tick. Retrying inside one tick would reintroduce the extra
+      // ops this guard exists to bound.
+      tailHintPublished = true;
       try {
         await casUpdateCurrentJson(
           storage,
@@ -473,6 +504,31 @@ export const runBoundedMaintenance = async (
         // any transient error. A missed advance just means the next tick
         // catches up; never throw out of write-tick maintenance.
       }
+    };
+
+    const runGcAndRefreshTailHint = async (): Promise<void> => {
+      const result = await runGc({ storage, currentJsonKey }, gcOpts);
+      if (result.contentDeferredReason !== undefined) {
+        // A content deferral raised by GC's BOUNDED ADMISSION already
+        // CAS-checkpointed the tail its capped probe certified, so refreshing
+        // to `nextSeq` on top of it would add a GET+PUT to the proven
+        // Cloudflare-Free 50-op worst case. The checkpoint is not a lossy
+        // stand-in: one pass certifies `CF_FREE_GC_TAIL_PROBE_GETS` entries
+        // while the hard-GC cadence recurs at most every
+        // `gcInterval * GC_STARVATION_GUARD` writes, so on that profile
+        // `(true_tail − tail_hint)` SHRINKS every deferring pass until the
+        // probe reaches the tail and stamps it exactly. Both the per-pass
+        // advance and that constant relation are pinned in
+        // `maintenance-budget.test.ts`.
+        //
+        // Known gap: the two DEGRADED reasons raised downstream of admission
+        // (`live-log-unreadable` / `snapshot-unreadable`) carry NO checkpoint,
+        // so they claim publication without performing it. Still strictly
+        // narrower than the no-refresh-on-any-GC-tick behavior this replaced;
+        // closing it needs a subrequest re-proof on a degraded pass.
+        tailHintPublished = true;
+      }
+      await refreshTailHintIfNeeded();
     };
 
     // ── Step 0. Phase disable. ───────────────────────────────────────
@@ -492,7 +548,7 @@ export const runBoundedMaintenance = async (
     // guarantees ~1 GC tick per GC_STARVATION_GUARD intervals.
     const hardGc = crossesGcBoundary(prevSeq, nextSeq, gcInterval * GC_STARVATION_GUARD);
     if (phasesPerTick === "single" && hardGc) {
-      await runGc({ storage, currentJsonKey }, gcOpts);
+      await runGcAndRefreshTailHint();
       return;
     }
 
@@ -503,7 +559,7 @@ export const runBoundedMaintenance = async (
         // above used into compact() as a Node-side belt-and-suspenders.
         // compact() emits `db.compaction.cas_lost_total` itself on a
         // lost CAS, so the runner does NOT (avoids double-count).
-        await compact({ storage, currentJsonKey }, {
+        const foldRes = await compact({ storage, currentJsonKey }, {
           maxEntriesPerRun: maxFoldEntriesPerPass,
           minEntriesToCompact,
           ceilingBytes: C,
@@ -518,6 +574,12 @@ export const runBoundedMaintenance = async (
           knownTail: nextSeq,
           ...(signal !== undefined && { signal }),
         } as InternalCompactOptions);
+        // A `written` fold stamped `max(stored, discoveredTail)` at or past
+        // `nextSeq` via Step-7. A failed, skipped, deferred, or CAS-lost
+        // attempt published nothing, so those still take the refresh below.
+        if (foldRes.written) {
+          tailHintPublished = true;
+        }
         if (phasesPerTick === "single") {
           return; // this tick's one phase was the fold (attempt)
         }
@@ -584,7 +646,7 @@ export const runBoundedMaintenance = async (
     // Reaching here on "single" means we did NOT fold (gate1 false, or
     // deferred). Run GC iff the cadence boundary was crossed.
     if (gcDue) {
-      await runGc({ storage, currentJsonKey }, gcOpts);
+      await runGcAndRefreshTailHint();
     }
   } catch (error) {
     // CAS contention (Conflict) thrown by compact()/runGc() is an


### PR DESCRIPTION
## What & why

A write tick that ran only GC returned without touching `tail_hint`, so a collection that GCs but never folds grew an unbounded `(true_tail − tail_hint)` gap — every read re-walked the whole live tail via `probeTailFrom`, eventually throwing at the forward-probe cap. The hard-GC and cadence-GC slices now take the same rate-limited refresh the defer and disable paths already used.

## Key points

- A tick publishes `tail_hint` at most once, whoever gets there first: the runner's rate-limited refresh, a landed fold's Step-7 CAS, or GC's bounded-admission checkpoint. A single `tailHintPublished` flag enforces it inside `refreshTailHintIfNeeded` — the rate limit alone cannot, because it tests the in-memory `current`, which no CAS writes back, so a second call on a due gap would rewrite byte-identical bytes.
- The flag counts publication *attempts*, not successes: it is set before the CAS, because a lost CAS means a peer advanced the hint and the stamp is monotone, while a transient error is caught by the next tick. Retrying inside one tick would spend the ops the guard exists to bound.
- GC's bounded-admission checkpoint is not a lossy stand-in for the refresh — it converges, because one pass certifies more entries than the hard-GC cadence can add between passes. Refreshing on top of it instead would take the proven Cloudflare-Free worst case from 50 subrequests to 52. The constant relation lives in the `MAINTENANCE_TAIL_HINT_REFRESH_WRITES` JSDoc and is pinned in `maintenance-budget.test.ts`.
- Known gap, accepted: the suppression keys off `contentDeferredReason !== undefined`, which also catches the two reasons raised downstream of admission (`live-log-unreadable`, `snapshot-unreadable`). Those carry no checkpoint, so they claim the tick's one publication without performing it — strictly narrower than the no-refresh-on-any-GC-tick behavior this replaces. Closing it means gating on `isDegradedContentDeferral` instead, which needs a subrequest re-proof because a degraded pass's worst case was never bounded.
- No new configuration, scheduler, resident process, or author-facing API. Reads stay pure and do no maintenance work.

## Verification

| Command | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3331 passed; 101 skipped |
| `pnpm test:adapter-cloudflare` | 157 passed; 2 skipped |
| `pnpm bundle-sizes` | ok (14 entries) |

`pnpm bench:amortized-write-cost` and `pnpm bench:write-amp-stress` regenerated the two baseline attachments: the extra hint CAS moves cf-free update-heavy from 2.024 to 2.025 billable Class A per write and node update-heavy from 2.93 to 2.936; stress peak stays 3.032.

## Notes for reviewers

Start with the `runGcAndRefreshTailHint` comment block — it carries the subrequest reasoning for both suppressions. The exactly-once property is a design constraint of routing more call sites into the refresh, not a bug being repaired: `main` already satisfies it, and `maintenance-budget.test.ts` pins it so it survives the new call sites.

Restore-cutover hardening for `docs/guide/backups.md`, previously in this branch, is now split out into its own PR — no file overlap with this one.
