### PR TITLE
fix(maintenance): calibrate per-host snapshot fold ceilings

### DIFF
--- a/.changeset/per-host-snapshot-fold-ceiling.md
+++ b/.changeset/per-host-snapshot-fold-ceiling.md
@@ -36,3 +36,9 @@ configuration.
 Bytes now bind before rows on every host for documents of ~512 B and up, so
 `E` acts as the tiny-document backstop it was designed to be rather than as
 the effective ceiling.
+
+The Cloudflare adapter's init-time over-raised-ceiling warning is now scoped to
+the free profile. It reports free's ~10 ms CPU wall and its first stated remedy
+is "run on CF PAID" — an operator on `BAERLY_MAINTENANCE_PROFILE=cf-paid` has
+already taken that remedy, and the paid profile's own ceiling is 8x the bound
+being warned about.

--- a/.changeset/per-host-snapshot-fold-ceiling.md
+++ b/.changeset/per-host-snapshot-fold-ceiling.md
@@ -1,0 +1,38 @@
+---
+"@gusto/baerly-storage": minor
+---
+
+Give each host profile its own snapshot fold ceiling.
+
+All three maintenance profiles shared `C = 512 KiB` (`maxFoldBytes`) and
+`E = 2048` (`maxFoldRows`), both calibrated for a Cloudflare free isolate's
+~10 ms CPU budget. Serverful Node and Cloudflare paid inherited them. Because
+the fold gate is `snapshot_rows + maxFoldEntriesPerPass <= E`, and those two
+profiles fold a 200-entry slice against free's 20, the bigger host capped
+*lower*: ~1,848 live documents against free's ~2,028.
+
+Each profile now carries a ceiling measured against its own wall:
+
+| Profile | `C` | `E` | Documents at 1-5 KB/doc |
+| --- | --- | --- | --- |
+| cf-free | 512 KiB | 2,048 | ~100-500 (unchanged) |
+| cf-paid | 8 MiB | 32,768 | ~1,600-8,200 |
+| node | 32 MiB | 65,536 | ~6,500-32,800 |
+
+**Behaviour change.** A collection on serverful Node or Cloudflare paid that
+was deferring its fold against the old shared ceiling starts folding again on
+the next write tick, and its log tail begins collapsing into the snapshot
+again. Nothing else moves: a read already folded snapshot plus live tail, so
+the materialized view is unchanged either way, and the per-pass rate caps are
+untouched.
+
+Cloudflare paid takes its ceiling only when `BAERLY_MAINTENANCE_PROFILE=cf-paid`
+is set — a paid Worker runs the free-tier profile by default. The Node adapter
+selects its profile automatically. `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` still
+overrides `C` on any host; there is still no override for `E`, so a row-arm
+defer is cleared by moving to a larger host profile rather than by
+configuration.
+
+Bytes now bind before rows on every host for documents of ~512 B and up, so
+`E` acts as the tiny-document backstop it was designed to be rather than as
+the effective ceiling.

--- a/bundle-sizes.json
+++ b/bundle-sizes.json
@@ -16,9 +16,9 @@
   "entries": {
     "index.js": {
       "tier": "shipped",
-      "raw": 264485,
-      "gz": 83529,
-      "minGz": 22321,
+      "raw": 268296,
+      "gz": 84862,
+      "minGz": 22370,
       "note": "kernel barrel; every consumer pays. Must not pull the observability subgraph — see the dedicated test."
     },
     "client.js": {
@@ -37,30 +37,30 @@
     },
     "cloudflare.js": {
       "tier": "shipped",
-      "raw": 453465,
-      "gz": 137441,
-      "minGz": 46078,
+      "raw": 457276,
+      "gz": 138830,
+      "minGz": 46124,
       "note": "Worker isolate cold start. Aggregator: closure includes the index.js and http.js subgraphs, so growth that slips past those entries still surfaces here."
     },
     "s3.js": {
       "tier": "shipped",
-      "raw": 81965,
-      "gz": 26253,
-      "minGz": 11476,
+      "raw": 86067,
+      "gz": 27751,
+      "minGz": 11524,
       "note": "Worker-safe S3 entry, so consumer-facing. Demonstrated catch: fast-xml-parser is pinned at 5.8.0 because 5.9.3 inflated this closure ~25%."
     },
     "gcs.js": {
       "tier": "shipped",
-      "raw": 76582,
-      "gz": 24935,
-      "minGz": 9674,
+      "raw": 80684,
+      "gz": 26366,
+      "minGz": 9715,
       "note": "Worker-safe GCS entry, so consumer-facing. Smaller than s3.js because the GOOG4 signer is lighter than aws4fetch."
     },
     "http.js": {
       "tier": "shipped",
-      "raw": 393021,
-      "gz": 118064,
-      "minGz": 38778,
+      "raw": 396832,
+      "gz": 119411,
+      "minGz": 38827,
       "note": "server-side. Also inside the cloudflare.js closure, so growth here shows up on that entry too."
     },
     "auth.js": {
@@ -72,9 +72,9 @@
     },
     "maintenance.js": {
       "tier": "shipped",
-      "raw": 156303,
-      "gz": 48391,
-      "minGz": 13439,
+      "raw": 160332,
+      "gz": 49803,
+      "minGz": 13487,
       "note": "operator-side; reached from the cloudflare.js closure."
     },
     "observability.js": {
@@ -97,17 +97,17 @@
     },
     "dev.js": {
       "tier": "tooling",
-      "raw": 51911,
+      "raw": 56013,
       "note": "dev-only; never enters a consumer bundle. At the 2% shipped rate it produced 12 of 32 historical trips for no safety benefit."
     },
     "node.js": {
       "tier": "tooling",
-      "raw": 618291,
+      "raw": 621724,
       "note": "server-only aggregator. Raw-only dep-creep tripwire; live-external-import creep is caught separately by the bare-specifier allowlist test."
     },
     "dev-vite.js": {
       "tier": "tooling",
-      "raw": 627204,
+      "raw": 630637,
       "note": "dev-only aggregator. Raw-only dep-creep tripwire; see node.js."
     }
   }

--- a/docs/about/graduation.md
+++ b/docs/about/graduation.md
@@ -486,10 +486,12 @@ can create a killed-rebuild loop: the gate passes, the rebuild runs in
 `ctx.waitUntil`, the isolate is killed by CPU or memory, no in-band
 backoff fires, and the next write tries again.
 
-The CF adapter `console.warn`s once at handler init when
-`BAERLY_MAINTENANCE_MAX_FOLD_BYTES > CF_FREE_MAX_SAFE_FOLD_BYTES`
+On the free profile, the CF adapter `console.warn`s once at handler init
+when `BAERLY_MAINTENANCE_MAX_FOLD_BYTES > CF_FREE_MAX_SAFE_FOLD_BYTES`
 (1 MiB), the largest snapshot a free isolate can one-shot rebuild under
-the ~10 ms budget. There is still no runtime metric for the kill itself.
+the ~10 ms budget. It stays silent on `cf-paid`, whose own ceiling is
+already 8x that bound and whose wall is memory rather than CPU. There is
+still no runtime metric for the kill itself.
 Watch the snapshot key and object count from `baerly inspect`; a
 snapshot key that never advances while `live_log_tail` grows is a
 rebuild that keeps not landing.

--- a/docs/about/graduation.md
+++ b/docs/about/graduation.md
@@ -2,7 +2,7 @@
 title: Graduation thresholds
 audience: operator
 summary: The CPU and memory bounds that tell you when a collection has outgrown its deployment tier, and what to do about it.
-last-reviewed: 2026-06-28
+last-reviewed: 2026-08-08
 tags: [operations, cost, capacity, graduation]
 related: [cost-model.md, workload-fit.md, thesis.md, "../adr/002-ephemeral-coordination.md"]
 ---
@@ -66,8 +66,8 @@ baerly admin usage \
 
 | Symptom | Check | Threshold | Action |
 | --- | --- | --- | --- |
-| `db.compaction.deferred_total` or defer `console.warn` on Cloudflare free | Warning names bytes vs. rows; `baerly inspect` reports `snapshot_bytes` / `snapshot_rows` | `snapshot_bytes > C` or `snapshot_rows + maxFoldEntriesPerPass > E` | If bytes tripped, upgrade to Workers Paid, then raise `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` only to a cap the isolate can rebuild. If rows tripped, split or graduate the collection; `E` is not operator-tunable. |
-| Same defer on Node | Warning text plus `snapshot_bytes` / `snapshot_rows` from `baerly inspect` | Host has RAM for old snapshot + new snapshot + tail, and the row ceiling did not trip | If bytes tripped, raise `BAERLY_MAINTENANCE_MAX_FOLD_BYTES`; expect one inline write-latency spike. If rows tripped, split or graduate the collection. |
+| `db.compaction.deferred_total` or defer `console.warn` on Cloudflare free | Warning names bytes vs. rows; `baerly inspect` reports `snapshot_bytes` / `snapshot_rows` | `snapshot_bytes > C` or `snapshot_rows + maxFoldEntriesPerPass > E` (cf-free: `C = 512 KB`, `E = 2048`) | If bytes tripped, upgrade to Workers Paid and set `BAERLY_MAINTENANCE_PROFILE=cf-paid`, which moves `C` to 8 MiB; raise `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` past that only to a cap the isolate can rebuild. If rows tripped, the same profile switch moves `E` to 32,768. `E` has no env override, but it is per host profile, so moving to a larger profile raises it. |
+| Same defer on Node | Warning text plus `snapshot_bytes` / `snapshot_rows` from `baerly inspect` | Node ships `C = 32 MiB`, `E = 65,536`; check the host has RAM for old snapshot + new snapshot + tail | If bytes tripped, raise `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` above 32 MiB, sized by `C ≈ heap / 10`; expect one inline write-latency spike. If rows tripped, Node already has the largest shipped `E` and there is no env override — split or graduate the collection. |
 | Object count grows while writes are steady | Logs + `admin fsck` | GC sweep throughput no longer keeps up with orphan production | Reduce contention, split the hot collection, or graduate the workload. |
 | Sustained hot collection | `admin usage` | ~30 logical writes/min/collection | Graduate to D1/Postgres; this is the workload ceiling. |
 | Tenant data keeps growing | `admin usage` / bucket inventory | >10 GB/tenant (R2 free-tier storage line; see [cost-model.md](cost-model.md)) or ~100 collections/tenant (soft fan-out guideline; see [workload-fit.md](workload-fit.md#scale-at-a-glance)) | Review graduation cost; neither line is enforced by the protocol. |
@@ -87,6 +87,11 @@ For compaction, compare the **snapshot**, not the tail:
 - `db.compaction.deferred_total` plus the rate-limited `console.warn`
   for the portable operator signal.
 
+`C` and `E` are not one shared pair of numbers: each host profile ships
+its own, sized to that host's measured wall. Look up the values for the
+host you are on in [the per-tier table](#per-tier-bounds) before
+comparing.
+
 Some metric sinks preserve the byte-vs-row label on
 `db.compaction.deferred_total`; the warning text always names it. A
 large tail alone is not a graduation signal because it drains in slices.
@@ -96,19 +101,54 @@ and [the per-tier table](#per-tier-bounds).
 
 ### What is shipped vs. estimated
 
-**Shipped:** write-triggered folding, `C`
-(`MAINTENANCE_MAX_FOLD_BYTES_DEFAULT`), `E`
-(`MAINTENANCE_MAX_FOLD_ROWS`), `MAINTENANCE_TARGET_RATIO`, `S_max`, the
-`BAERLY_MAINTENANCE_*` env vars, and the defer/warn signals. These are
-defined in code and dispatched on the write path by
+**Shipped:** write-triggered folding, a per-profile `C`/`E` pair
+(cf-free `MAINTENANCE_MAX_FOLD_BYTES_DEFAULT` / `MAINTENANCE_MAX_FOLD_ROWS`,
+cf-paid `CF_PAID_MAINTENANCE_MAX_FOLD_BYTES` /
+`CF_PAID_MAINTENANCE_MAX_FOLD_ROWS`, node
+`NODE_MAINTENANCE_MAX_FOLD_BYTES` / `NODE_MAINTENANCE_MAX_FOLD_ROWS`),
+`MAINTENANCE_TARGET_RATIO`, `S_max`, the `BAERLY_MAINTENANCE_*` env
+vars, and the defer/warn signals. These are defined in code and
+dispatched on the write path by
 [`runBoundedMaintenance`](../../packages/server/src/maintenance.ts).
 
-**Estimated:** the per-tier CPU/memory envelope numbers, including the
-~10 ms-CPU-to-bytes conversion, the chosen `E = 2048` row ceiling, and
-the graduation snapshot sizes. The fold-cost bench has landed
-(`docs/spec/attachments/fold-cost-baseline.json`), but recalibrating
-`C`/`E` to where the paid envelope actually binds is deferred until
-there is demonstrated need.
+**Measured:** the per-host ceilings are no longer chosen. They come from
+`pnpm bench:fold-ceiling`
+([`bench/measurement/fold-ceiling-probe.ts`](../../bench/measurement/fold-ceiling-probe.ts)),
+run unconstrained and at `--max-old-space-size` 512/1024/2048 (actual
+`heap_size_limit` 704/1216/2240 MB). Two results hold across that whole
+range and are what fix `C` and `E`:
+
+- peak heap is **~2.4x the snapshot** on the byte axis, and
+- peak heap costs **~600 B per row** on the row axis.
+
+Both are invariant to heap size (verified 704 MB - 4.3 GB), so the
+memory-bound verdicts behind cf-paid's 8 MiB / 32,768 and node's
+32 MiB / 65,536 are portable.
+
+Those two constants and one rule fix every memory-bound ceiling: **a
+fold is sized to occupy at most a quarter of the memory budget**, so
+`peak heap × 4 ≤ budget`. At ~2.4x that works out to `C ≈ budget / 10`,
+which is where node's `C ≈ heap / 10` comes from, and why cf-paid stops
+at 8 MiB — 8 MiB peaks at ~19.5 MB and 19.5 × 4 = 78 MB fits under the
+~128 MB Worker limit, while the next grid cell (16 MiB ⇒ 37.3 MB ⇒
+149 MB) does not. Where a per-tier cell below cites "the 4x margin",
+this is the rule it means.
+
+cf-free is the exception, because its wall is CPU rather than memory:
+2048 rows measures ~1.5 ms and the row axis does not reach ~10 ms until
+~16,384 rows, but that margin was measured off workerd and so does not
+transfer. The value stays deliberately far inside it, because a
+free-isolate overrun is CPU-killed mid-rebuild and strands the
+`current.json` CAS.
+
+**Still estimated:** the CPU column below and anything derived from it.
+CPU was measured on Node v24 / darwin-arm64, which is not workerd, and
+the bench host ran 1.05-1.30x slower than the host behind the frozen
+June baseline — the probe itself reports CPU-bound verdicts as
+non-portable. Also estimated: the `≈ 11 ms/MB` upper-bound model, the
+graduation snapshot sizes in documents (they assume 1-5 KB/doc), and
+node's 32 MiB, which is the top of the measured grid rather than a
+measured wall.
 
 ## What costs CPU: compaction
 
@@ -121,20 +161,15 @@ A fold (`compact` in
 does this work:
 
 1. Read `current.json`.
-2. Load the previous snapshot with `loadSnapshotAsMap`
-   (`compactor.ts:265`).
-3. Fetch the bounded log slice with `walkLogRangeWithBytes`
-   (`compactor.ts:271`).
-4. Apply entries in memory: `I`/`U` overwrite, `D` tombstones
-   (`compactor.ts:287`-`314`).
-5. Sort docs by `_id` for deterministic output
-   (`compactor.ts:316`-`329`).
-6. Serialize the new snapshot with `encodeSnapshotBody`
-   (`compactor.ts:337`).
+2. Load the previous snapshot with `loadSnapshotAsMap`.
+3. Fetch the bounded log slice with `walkLogRangeWithBytes`.
+4. Apply entries in memory: `I`/`U` overwrite, `D` tombstones.
+5. Sort docs by `_id` for deterministic output.
+6. Serialize the new snapshot with `encodeSnapshotBody`.
 7. SHA-256 the snapshot bytes with `snapshotHash` to derive the
-   filename (`compactor.ts:364`).
-8. PUT the snapshot (`compactor.ts:375`) and CAS-advance
-   (conditional compare-and-swap) `current.json` (`compactor.ts:402`).
+   filename.
+8. PUT the snapshot and CAS-advance (conditional compare-and-swap)
+   `current.json`.
 
 The GETs and PUTs are I/O. They do not count against a Cloudflare
 Worker's CPU budget. CPU is spent on the in-memory JSON parse, merge,
@@ -142,7 +177,7 @@ sort, stringify, and SHA-256 work.
 
 Compaction is all-or-nothing. Snapshot filenames embed the SHA-256 of
 their body, and the atomic moment is the single conditional PUT that
-swaps `current.json.snapshot` (`compactor.ts:5`-`20`). If a write is
+swaps `current.json.snapshot`. If a write is
 interrupted before the body is complete, readers reject the hash
 mismatch. If the snapshot body lands but the `current.json` CAS does
 not, the snapshot is a correct but unreferenced orphan for GC. The
@@ -173,34 +208,80 @@ So the ceiling is on the snapshot, not on `snapshot + tail`:
 Using order-of-magnitude engine assumptions, JSON parse/stringify at
 roughly 300 MB/s and SHA-256 at roughly 2 GB/s, snapshot rebuild cost is:
 
-> **≈ 11 ms CPU per MB of snapshot rebuilt.**
+> **≈ 11 ms CPU per MB of snapshot rebuilt** — a deliberate *upper
+> bound*, not a prediction. `C` was derived from it, and that derivation
+> still stands.
 
-Treat that as an envelope model, not a benchmark. A 2-3x swing in the
-JSON assumption moves the free-tier ceiling between roughly 0.4 MB and
-1.5 MB of snapshot. The shape stays linear in the snapshot, dominated
-by JSON, around 10 ms/MB.
+Measurement has since overtaken it, and the model is pessimistic where
+that is safe. A 1 MB rebuild measures 2.6-3.2 ms, so the model overstates
+small folds by roughly 3x; at 5 MB (53.6-55.4 ms measured against 55 ms
+modelled) it is about right. Cost is not linear across that range, so
+"around 10 ms/MB" is not the shape: it is roughly **3.3 ms/MB below
+4 MB**, rising to **~7-10 ms/MB above 5 MB**. Because `C` is a safety
+ceiling, an upper bound that is 3x pessimistic at the small end errs the
+right way. A 2-3x swing in the JSON assumption still moves the modelled
+free-tier CPU ceiling between roughly 0.4 MB and 1.5 MB of snapshot, and
+that is the arm measurement has *not* closed, because the numbers below
+were not taken on workerd.
 
 ### Snapshot size → CPU per fold
 
-| Snapshot size | CPU per rebuild (order-of-magnitude) | Note |
+Measured by `pnpm bench:fold-ceiling`
+([`bench/measurement/fold-ceiling-probe.ts`](../../bench/measurement/fold-ceiling-probe.ts))
+on the byte axis at 2048 B/doc; median CPU and peak heap over the two
+clean runs (unconstrained 4288 MB heap, and 2240 MB).
+
+> **The CPU column is not portable.** It was taken on Node v24 /
+> darwin-arm64, not workerd, and that host ran 1.05-1.30x slower than
+> the one behind the frozen June baseline. The probe reports
+> memory-bound verdicts as portable and CPU-bound ones as not. Use the
+> peak-heap column to reason about a host's wall; use CPU only for shape.
+
+| Snapshot size | CPU per rebuild (bench host) | Peak heap | Peak / snapshot |
+| --- | --- | --- | --- |
+| 512 KB | 1.6-1.7 ms | 2.37 MB | 4.67x |
+| 1 MB | 2.6-3.2 ms | 3.02 MB | 2.97x |
+| 2 MB | 5.1 ms | 5.11 MB | 2.52x |
+| 3 MB | 7.2-9.4 ms | 7.38 MB | 2.42x |
+| 4 MB | 15.6 ms | 9.60 MB | 2.37x |
+| 5 MB | 53.6-55.4 ms | 12.0 MB | 2.36x |
+| 8 MB | 63.3-83.1 ms | 18.6-19.5 MB | 2.29-2.41x |
+| 16 MB | 112-117 ms | 37.3 MB | 2.30x |
+| 32 MB | 268-281 ms | (unusable — all samples lost to the GC floor) | — |
+
+The knee sits between 4 MB and 5 MB. Below it a fold is single-digit
+milliseconds on this host; above it per-MB cost roughly triples and then
+settles. The peak/snapshot ratio converges to ~2.4x once the snapshot is
+large enough to dominate fixed overhead, which is the number the
+memory-bound ceilings are sized against.
+
+A ~512 KB snapshot is roughly **100-500 documents** at 1-5 KB/doc, and
+it is the smallest cell measured — at ~1.6 ms, anything smaller is
+effectively free everywhere.
+
+On the row axis (64 B/doc), where per-entry work rather than bytes
+dominates:
+
+| Snapshot rows | CPU per rebuild (bench host) | Peak heap |
 | --- | --- | --- |
-| 64 KB | ~0.7 ms | trivial |
-| 256 KB | ~2.8 ms | trivial; under the free-tier line by 3-4x |
-| 512 KB | ~5.5 ms | conservative default snapshot ceiling `C` |
-| 1 MB | ~11 ms | ≈ Cloudflare free-tier CPU line (`CF_FREE_MAX_SAFE_FOLD_BYTES`) |
-| 5 MB | ~55 ms | fine on paid |
-| 40 MB | ~440 ms | CPU fine on paid, but near the memory wall |
+| 2,048 | 1.45-1.51 ms | 1.66 MB |
+| 8,192 | 5.0-5.3 ms | 6.0 MB |
+| 16,384 | 10.4-10.9 ms | 9.9 MB |
+| 32,768 | 22.2-22.6 ms | 19.7 MB |
+| 65,536 | 54.4-57.6 ms | 39.4 MB |
 
-A ~512 KB snapshot is roughly **100-500 documents** at 1-5 KB/doc. Below
-~256 KB, a rebuild is 1-3 ms and effectively free everywhere.
+Peak heap per row is ~600 B and stable, which is what lets the row
+ceilings be sized against a memory wall rather than a CPU one on the
+hosts where memory is the wall.
 
-The row ceiling catches tiny-doc snapshots that bytes can miss:
-`E = MAINTENANCE_MAX_FOLD_ROWS = 2048`. This value is
-**PROVISIONAL**. The fold-cost bench shows 2048 rows is well under the
-CF-free CPU budget, but recalibrating `E` and `C` to where the paid
-envelope binds is deferred pending need. Treat 2048 rows as the order of
-magnitude where per-entry CPU starts to rival the byte budget on CF free,
-not as a final measured limit.
+The row ceiling catches tiny-doc snapshots that bytes can miss, and like
+`C` it is now per host: `E = 2048` on cf-free
+(`MAINTENANCE_MAX_FOLD_ROWS`), `32,768` on cf-paid, `65,536` on node.
+cf-free stays at 2048 even though the row axis does not reach the ~10 ms
+free budget until ~16,384 rows, because a free-isolate overrun is
+CPU-killed mid-rebuild and strands the `current.json` CAS; the larger
+hosts fail by running slow, not by stranding, so they are sized to
+memory.
 
 ### When a fold fires, and when it defers
 
@@ -216,17 +297,18 @@ pure and never trigger maintenance. For folding, three gates matter:
   `MAINTENANCE_TARGET_RATIO = 1.0`, so the ratio arm starts when the
   estimated tail equals the snapshot.
 - **Static byte ceiling (`C`).** Once dispatched, the rebuild defers if
-  `snapshot_bytes > C`. Default
-  `C = MAINTENANCE_MAX_FOLD_BYTES_DEFAULT = 512 KB`. Operators can raise
-  it out-of-band with `BAERLY_MAINTENANCE_MAX_FOLD_BYTES`; see
+  `snapshot_bytes > C`. `C` is per host profile: 512 KB on cf-free
+  (`MAINTENANCE_MAX_FOLD_BYTES_DEFAULT`), 8 MiB on cf-paid, 32 MiB on
+  node. Operators can raise it out-of-band with
+  `BAERLY_MAINTENANCE_MAX_FOLD_BYTES`; see
   [Operations plane](#operations-plane-env-vars).
 - **Static row ceiling (`E`).** The rebuild also defers if
-  `snapshot_rows + maxFoldEntriesPerPass > E`, with `E = 2048`
-  provisional.
+  `snapshot_rows + maxFoldEntriesPerPass > E`. `E` is likewise per host
+  profile: 2048 on cf-free, 32,768 on cf-paid, 65,536 on node.
 
-`C` is conservative because there is no adaptive backoff for a killed
-rebuild. Cloudflare free's ~10 ms CPU budget can rebuild roughly a 1 MB
-snapshot; `C = 512 KB` leaves margin. On CF free, setting
+`C` is conservative *on cf-free* because there is no adaptive backoff for
+a killed rebuild. Cloudflare free's ~10 ms CPU budget can rebuild roughly
+a 1 MB snapshot; `C = 512 KB` leaves margin. On CF free, setting
 `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` above
 `CF_FREE_MAX_SAFE_FOLD_BYTES = 1 MiB` emits an init-time
 `console.warn`.
@@ -238,14 +320,29 @@ Because the tail is sliced and the snapshot rebuild is the unsliced work:
 > **`S_max = C`** (subject to
 > `snapshot_rows + maxFoldEntriesPerPass <= E`).
 
-At the defaults, `S_max = 512 KB` of snapshot: about **100-500
-documents** at 1-5 KB/doc on Cloudflare free, or fewer if tiny docs hit
-the 2048-row ceiling first. Past `C` bytes or `E` rows, folds defer. A
-byte defer can be cleared by raising
+`S_max` is therefore whatever `C` is on the host you are running, and
+that differs per profile:
+
+| Profile | `C` (`S_max`) | `E` | Documents at 1-5 KB/doc |
+| --- | --- | --- | --- |
+| cf-free | 512 KB | 2,048 | ~100-500 |
+| cf-paid | 8 MiB | 32,768 | ~1,600-8,200 |
+| node | 32 MiB | 65,536 | ~6,500-32,800 |
+
+For documents that size, bytes bind first on every host — the row
+ceiling is the backstop for snapshots made of many tiny documents, where
+`E` trips while `snapshot_bytes` is still small.
+
+Past `C` bytes or `E` rows, folds defer and the live log stops
+collapsing into the snapshot. A byte defer can be cleared by raising
 `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` on a host that can rebuild the
-snapshot. A row defer cannot; split or graduate the collection until
-`E` is recalibrated. Until then, the live log stops collapsing into the
-snapshot.
+snapshot. A row defer cannot be cleared that way — there is no env
+override for `E` — but `E` is not one fixed number any more, so moving
+to a larger host profile raises it: 2,048 → 32,768 → 65,536. On a paid
+Worker that means setting `BAERLY_MAINTENANCE_PROFILE=cf-paid`, which is
+what selects the paid ceilings; the Node adapter selects its profile
+automatically. Once you are on node's `E = 65,536`, splitting or
+graduating the collection is the remaining move.
 
 The old estimate-based model divided the ceiling by `(1 + R)` because it
 treated snapshot plus estimated tail as one unsliceable pass. With a
@@ -279,8 +376,10 @@ See
 
 Read this table on the snapshot axis: `snapshot_bytes` against `C`, and
 `snapshot_rows` against `E`. The sliced tail does not enter the per-pass
-ceiling. The default `C = 512 KB` sits below the CF-free hardware wall;
-after you raise `C`, the host's hardware wall binds.
+ceiling. Each profile ships its own `C`/`E`, sized to that host's
+measured wall rather than inherited from cf-free, so the shipped ceiling
+is already near the hardware wall on every tier; raising `C` further is
+an override, not the normal path.
 
 Cloudflare free has two binding walls:
 
@@ -292,17 +391,18 @@ Cloudflare free has two binding walls:
 
 | Tier | Hardware walls | Binds on | What can actually fold |
 | --- | --- | --- | --- |
-| **Cloudflare free** | ~10 ms CPU/request and 50 subrequests/request | CPU + subrequests | default `C = 512 KB` ⇒ ~512 KB snapshot (`S_max = C`), `E = 2048` rows; tail drains ≈ 20 entries/tick; raising `C` past ~1 MB (`CF_FREE_MAX_SAFE_FOLD_BYTES`) hits the CPU wall and `console.warn`s |
-| **Cloudflare paid** | 30 s CPU default (up to 5 min); ~128 MB Worker memory; 10,000 subrequests/request default, raisable to 10M, changed 2026-02-11; free wall stays 50 | memory | raise `C` and fold to ~tens of MB snapshot (~40 MB); CPU is not the wall; opt in to higher per-pass throughput with `BAERLY_MAINTENANCE_PROFILE=cf-paid` |
-| **Serverful Node** | no per-request cap; process RAM; a fold blocks the event loop | host memory | raise `C` and fold up to host memory; per-pass caps are `NODE_MAINTENANCE_*` (moderate, latency-budgeted) |
-| **AWS Lambda** _(adapter pending — not yet shipped)_ | 3-10 GB RAM selectable; up to 15 min timeout; `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` self-reported | host memory, same shape as Node | between the Workers tiers and serverful Node in practice; raise `C` once the adapter ships |
+| **Cloudflare free** | ~10 ms CPU/request and 50 subrequests/request | CPU + subrequests | profile `C = 512 KB` ⇒ ~512 KB snapshot (`S_max = C`), `E = 2048` rows; tail drains ≈ 20 entries/tick; raising `C` past ~1 MB (`CF_FREE_MAX_SAFE_FOLD_BYTES`) hits the CPU wall and `console.warn`s |
+| **Cloudflare paid** | 30 s CPU default (up to 5 min); ~128 MB Worker memory; 10,000 subrequests/request default, raisable to 10M, changed 2026-02-11; free wall stays 50 | memory | `C = 8 MiB` (`CF_PAID_MAINTENANCE_MAX_FOLD_BYTES`), `E = 32,768` rows (`CF_PAID_MAINTENANCE_MAX_FOLD_ROWS`), selected by `BAERLY_MAINTENANCE_PROFILE=cf-paid` — no `C` override needed to get there. CPU is not the wall; memory is: 8 MiB peaks at ~19.5 MB, which fits the 4x margin under ~128 MB; the next grid cell (16 MiB ⇒ 37.3 MB) does not. That margin is why the ceiling is not "tens of MB" |
+| **Serverful Node** | no per-request cap; process RAM; a fold blocks the event loop | host memory | `C = 32 MiB` (`NODE_MAINTENANCE_MAX_FOLD_BYTES`), `E = 65,536` rows (`NODE_MAINTENANCE_MAX_FOLD_ROWS`), selected automatically by the Node adapter. 32 MiB is the top of the measured grid, **not** the measured wall — the probe reports `grid-exhausted` for this profile at every margin and every heap from 704 MB up. Past the grid, scale by `C ≈ heap / 10`. Per-pass caps are `NODE_MAINTENANCE_*` (moderate, latency-budgeted) |
 
 Implications: on Cloudflare free, a ~1 MB snapshot is near the ~10 ms
 CPU wall, and the 50-subrequest wall makes a large tail drain over many
 write ticks. On Cloudflare paid, CPU could rebuild a multi-GB snapshot,
 but Worker memory (~128 MB) is the wall because a fold holds the old
-snapshot, new snapshot, and log tail at once, roughly 2-3x the snapshot.
-On Node, process RAM and event-loop blocking bind.
+snapshot, new snapshot, and log tail at once — measured at ~2.4x the
+snapshot in peak heap. On Node, process RAM and event-loop blocking
+bind, and the shipped 32 MiB is a floor set by where the bench grid
+stopped, not by where Node stops.
 
 ## Graduation triggers
 
@@ -360,9 +460,14 @@ signal; the protocol does not silently lose data.
 
 Map the signal before acting:
 
-- **Cloudflare free byte defer:** upgrade tier, then size `C` to memory.
-- **Node byte defer:** raise `BAERLY_MAINTENANCE_MAX_FOLD_BYTES`.
-- **Any row defer:** split or graduate; `E` is not operator-tunable.
+- **Cloudflare free byte defer:** upgrade tier and set
+  `BAERLY_MAINTENANCE_PROFILE=cf-paid`, which moves `C` to 8 MiB. Only
+  override `C` beyond that if you have sized it to memory.
+- **Node byte defer:** raise `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` above
+  the 32 MiB node default, sized by `C ≈ heap / 10`.
+- **Row defer:** `E` has no env override, but it is per host profile —
+  move to a larger profile (2,048 → 32,768 → 65,536) to raise it. At
+  node's 65,536, split or graduate.
 - **Hot collection or tenant-scale signal:** graduate the workload to
   D1/Postgres.
 
@@ -376,45 +481,53 @@ A deferred fold alone does not mean "move to Postgres."
 
 ### 1. Off Cloudflare free → Cloudflare paid
 
-**Threshold:** the auto-maintained snapshot ceiling:
-~512 KB snapshot / ~100-500 docs, or `E = 2048` rows, whichever trips
-first at the `C = 512 KB` defaults:
+**Threshold:** the auto-maintained snapshot ceiling at the cf-free
+values: ~512 KB snapshot / ~100-500 docs, or `E = 2048` rows, whichever
+trips first —
 `snapshot_bytes > C` or `snapshot_rows + maxFoldEntriesPerPass > E`.
 
 **What you'll observe:** slower reads, a growing bucket, and a
 `console.warn` naming bytes vs. rows.
 
 **What to do:** upgrade to Cloudflare Workers Paid (about $5/mo; 30 s
-CPU vs. free's ~10 ms). Then raise
-`BAERLY_MAINTENANCE_MAX_FOLD_BYTES` above the 512 KB default so
-compaction resumes. On paid, CPU stops being the practical wall; Worker
-memory (~128 MB) becomes the limit, which is roughly tens of MB of
-snapshot. Size the cap to memory, not CPU; see
+CPU vs. free's ~10 ms), then set `BAERLY_MAINTENANCE_PROFILE=cf-paid`.
+That alone moves `C` to 8 MiB and `E` to 32,768 and compaction resumes;
+there is no env override to set for the common case. On paid, CPU stops
+being the practical wall and Worker memory (~128 MB) becomes the limit,
+which is what fixes 8 MiB rather than "tens of MB": peak heap runs
+~2.4x the snapshot, so 8 MiB peaks at ~19.5 MB and the next step up
+(16 MiB ⇒ 37.3 MB) overruns the 4x margin. If you override `C` past the
+profile value, size it to memory, not CPU; see
 [Operations plane](#operations-plane-env-vars).
 
 ### 2. On serverful Node: raise the env var
 
 When the warning names bytes, this is not a tier graduation. A Node host
-has no per-request CPU wall; the ceiling is host RAM, and the static
-`C = 512 KB` default is holding back work the host can run. Raise
-`BAERLY_MAINTENANCE_MAX_FOLD_BYTES`; the fold completes on the next
-write, with one inline write-latency spike. If the warning names rows,
-the env var will not help because `E` is not operator-tunable.
+has no per-request CPU wall; the ceiling is host RAM, and the node
+profile already ships `C = 32 MiB` — the top of the measured grid, not
+a measured wall, so a host with headroom can go further. Raise
+`BAERLY_MAINTENANCE_MAX_FOLD_BYTES`, scaling by `C ≈ heap / 10` (peak
+heap ≈ 2.4x snapshot, keeping a 4x margin); the fold completes on the
+next write, with one inline write-latency spike. If the warning names
+rows, the env var will not help: `E` has no override, and node already
+runs the largest shipped value (65,536).
 
 ### 3. Paid serverless → serverful Node
 
-**Threshold:** a snapshot approaches **tens of MB**.
+**Threshold:** a snapshot approaches the cf-paid ceiling — **8 MiB** of
+snapshot, or 32,768 rows.
 
 **What you'll observe:** on paid Cloudflare, folds start running into
 the ~128 MB Worker memory limit. The fold cannot hold the old snapshot,
 new snapshot, and log tail resident at once. CPU is still fine.
 
-**What to do:** move the collection to a long-lived Node host, then
-raise the env cap as above, or wait for chunked snapshots. The current
-snapshot format is single-level (one L9 snapshot replaces the prior;
-`compactor.ts:22`-`32`) and is forward-compatible with a future
-multi-level L0..L9 scheme that folds incrementally without a wire
-change.
+**What to do:** move the collection to a long-lived Node host, which
+selects the node profile automatically (`C = 32 MiB`, `E = 65,536`),
+then raise the env cap as above if the host has the heap for it, or wait
+for chunked snapshots. The current
+snapshot format is single-level (one L9 snapshot replaces the prior) and
+is forward-compatible with a future multi-level L0..L9 scheme that folds
+incrementally without a wire change.
 
 ### Tail churn is not a graduation signal
 
@@ -438,7 +551,7 @@ of deployment tier. For Postgres, use `baerly export --target=postgres`.
 
 | Axis | Threshold | Source and meaning |
 | --- | --- | --- |
-| Write throughput | ~30 logical writes/min/collection | Per-collection contention ceiling, not account-wide. Code constant: `M_SIZE_WRITES_PER_MIN_PER_COLLECTION = 30` in `packages/cli/src/admin/usage.ts:73`; `baerly admin usage` grades each collection against it. It is hard-coded but still a model/estimate from the CAS-livelock regime, pending real-infra measurement on R2. |
+| Write throughput | ~30 logical writes/min/collection | Per-collection contention ceiling, not account-wide. Code constant: `M_SIZE_WRITES_PER_MIN_PER_COLLECTION = 30` in `packages/cli/src/admin/usage.ts`; `baerly admin usage` grades each collection against it. It is hard-coded but still a model/estimate from the CAS-livelock regime, pending real-infra measurement on R2. |
 | Stored bytes | >10 GB/tenant stored | R2 free-tier storage line, not a protocol ceiling. A tenant is a key prefix; baerly-storage does not read, enforce, or compute per-tenant byte totals. Billing begins above 10 GB-mo on R2; see [cost-model.md](cost-model.md). |
 | Collection fan-out | ~100 collections/tenant | Bench-grounded soft linear-cost guideline. `pnpm bench:collection-fanout` writes `docs/spec/attachments/collection-fanout-baseline.json`; `admin usage` costs ≈ N × (1 LIST + up to 120 GETs per collection). Nothing enforces a cap; cost and scan latency grow linearly with N. |
 
@@ -472,13 +585,14 @@ Maintenance has two configuration planes:
 
 | Env var | Effect | When to set it |
 | --- | --- | --- |
-| `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` | Overrides static snapshot ceiling `C` (default `MAINTENANCE_MAX_FOLD_BYTES_DEFAULT = 512 KB`). Raises `S_max = C`, letting larger snapshot rebuilds pass the gate. | On Cloudflare Paid or a large Node host, after confirming the host can rebuild that snapshot. |
-| `BAERLY_MAINTENANCE_PROFILE` | Cloudflare-only. Accepts `cf-free` (default) or `cf-paid`. `cf-paid` raises fold-entry and GC cadence/mark/sweep caps to Node values, using the paid 10,000-subrequest budget. Ceilings `C` and `E` do not change. | On Cloudflare Paid, after upgrading the plan tier, to recover per-pass throughput. Do not set on Node; Node selects its own profile. |
+| `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` | Overrides static snapshot ceiling `C`, whatever the active profile's value is (512 KB cf-free, 8 MiB cf-paid, 32 MiB node). Raises `S_max = C`, letting larger snapshot rebuilds pass the gate. | On a large Node host, after confirming the host can rebuild that snapshot (`C ≈ heap / 10`). On Cloudflare, prefer the profile switch first. |
+| `BAERLY_MAINTENANCE_PROFILE` | Cloudflare-only. Accepts `cf-free` (default) or `cf-paid`. `cf-paid` raises fold-entry and GC cadence/mark/sweep caps to Node values, using the paid 10,000-subrequest budget, **and** selects the paid ceilings `C = 8 MiB` / `E = 32,768`. This is the only way to raise `E` on Cloudflare. | On Cloudflare Paid, after upgrading the plan tier, to recover per-pass throughput and the paid ceilings. Do not set on Node; Node selects its own profile, and its ceilings, automatically. |
 | `BAERLY_MAINTENANCE_DISABLE` | Kill switch; disables in-band fold/GC phases while preserving bounded `tail_hint` refresh. | Diagnostics, or to stop fold attempts on a deferring collection while you plan graduation. |
 
-`E = MAINTENANCE_MAX_FOLD_ROWS = 2048` is not operator-tunable. It is a
-kernel constant, not adapter-threaded. The fold-cost bench has landed;
-recalibrating `E` is deferred pending demonstrated need.
+There is no env var for `E`. It is a kernel constant, not
+adapter-threaded — but there are three of them, one per profile (2,048 /
+32,768 / 65,536), so the profile in effect is what sets it. Selecting a
+larger profile is the supported way to raise `E`.
 
 **Cloudflare caveat: size the cap to the isolate.** Raising
 `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` above what a CF isolate can rebuild
@@ -498,10 +612,12 @@ rebuild that keeps not landing.
 
 Safe remedies, in order:
 
-- **Cloudflare Paid:** raises CPU limits; then size the cap to the
-  ~128 MB memory wall, not the 30 s CPU budget.
+- **Cloudflare Paid:** raises CPU limits; `BAERLY_MAINTENANCE_PROFILE=cf-paid`
+  then applies ceilings already sized to the ~128 MB memory wall rather
+  than the 30 s CPU budget. Any further override is sized to memory too.
 - **Serverful Node:** no per-request CPU/subrequest cap; bounded by host
-  RAM. Raise the env cap.
+  RAM, and the node profile is selected automatically. Raise the env cap
+  above 32 MiB only with heap to spare.
 - **Chunked snapshots:** future multi-level L0..L9 rebuilds would avoid
   holding the whole snapshot resident. Not shipped.
 
@@ -509,13 +625,15 @@ Safe remedies, in order:
 
 | Limit | How to raise it | Notes |
 | --- | --- | --- |
-| Static fold-byte ceiling `C` (`MAINTENANCE_MAX_FOLD_BYTES_DEFAULT = 512 KB`) | `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` env var | Set out-of-band in the deploy environment; takes effect on the next write tick. Size to what the host can rebuild. |
-| Cloudflare free CPU / subrequest wall (~10 ms CPU, 50 subrequests) | Cloudflare plan upgrade (free → paid), then raise `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` | Paid raises CPU to 30 s default (up to 5 min); subrequest limit lifts to 10,000/request by default, raisable to 10M, changed 2026-02-11. A finer-grained per-platform `cpuLimit` declaration was evaluated and measured unnecessary: the in-band write tick keeps up to ~3x the rate envelope under stress on free, so it is not built. |
+| Static fold-byte ceiling `C` (512 KB cf-free / 8 MiB cf-paid / 32 MiB node) | `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` env var | Set out-of-band in the deploy environment; takes effect on the next write tick. Size to what the host can rebuild — `C ≈ heap / 10`. |
+| Static fold-row ceiling `E` (2,048 cf-free / 32,768 cf-paid / 65,536 node) | Move to a larger host profile: `BAERLY_MAINTENANCE_PROFILE=cf-paid` on Cloudflare, or a Node host (automatic) | No env var sets `E` directly. Node's 65,536 is the largest shipped value; past it, split or graduate the collection. |
+| Cloudflare free CPU / subrequest wall (~10 ms CPU, 50 subrequests) | Cloudflare plan upgrade (free → paid), then `BAERLY_MAINTENANCE_PROFILE=cf-paid` | Paid raises CPU to 30 s default (up to 5 min); subrequest limit lifts to 10,000/request by default, raisable to 10M, changed 2026-02-11. The profile switch also moves `C`/`E` to the paid ceilings, so `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` is only needed to go past 8 MiB. A finer-grained per-platform `cpuLimit` declaration was evaluated and measured unnecessary: the in-band write tick keeps up to ~3x the rate envelope under stress on free, so it is not built. |
 | Per-collection commit scope (one ordered log per collection; no cross-collection atomicity) | Cannot be increased; protocol invariant | The write hotspot is the next numbered `log/<seq>` create for one collection. Cross-collection atomicity is not offered. |
 | Snapshot and legacy-content hash addressing | Cannot be increased; protocol invariant | Snapshot filenames embed full SHA-256, and current readers recompute the body hash before accepting a snapshot. Legacy content filenames use 128-bit truncated SHA-256 and collisions were not runtime-verified; their GC safety comes from conservative liveness, grace, and sweep-time revalidation, not the snapshot no-corruption guarantee. |
 
-The row ceiling `E` is not in this map because it is a kernel constant,
-not an operator knob.
+`E` is in this map, but with a different lever: it is a kernel constant
+per profile rather than an env-var knob, so the profile is what raises
+it.
 
 ## See also
 

--- a/docs/about/workload-fit.md
+++ b/docs/about/workload-fit.md
@@ -2,7 +2,7 @@
 title: Workload fit
 audience: product
 summary: A qualitative shape test for deciding whether an app fits baerly-storage before sizing the workload.
-last-reviewed: 2026-06-26
+last-reviewed: 2026-08-07
 tags: [positioning, product, workload]
 related: [thesis.md, cost-model.md, graduation.md]
 ---
@@ -129,23 +129,45 @@ here; those pages decide when a working app should graduate.
 
 ## Scale at a glance
 
-The numbers a builder needs before writing the first line of code. For
-derivations, see [cost-model.md](cost-model.md) and
-[graduation.md](graduation.md).
+The numbers a builder needs before writing the first line of code. Shape
+comes first — if the fit test above failed, no host on this table fixes
+it. Only one dimension moves with the host.
 
-| Dimension | Number | Notes |
-| --- | --- | --- |
-| Shape | 1 important screen = 1 collection | The fit test above; fails before size matters |
-| Throughput | ~30 writes/min/collection sustained | M-size operating point — model/estimate, pending real-infra measurement on Cloudflare R2 |
-| Per-collection size | ~100–500 docs (~512 KB snapshot) before compaction defers on CF free | A fold fits the free-tier CPU budget at ~512 KB; erosion, not a cliff — model/estimate, pending real CF-isolate measurement |
-| Fan-out | ~100 collections/tenant (soft guideline) | Bench-grounded linear cost (`pnpm bench:collection-fanout`); nothing in the protocol enforces a cap — cost grows linearly with N |
-| Storage | >10 GB/tenant stored = R2 free-tier boundary | A cost line, not a protocol ceiling; billing begins above 10 GB-mo on R2 |
-| Cost | ~$12/mo all-in on R2 (~$7 object-storage ops + $5 Workers Paid floor), ~$19/mo on S3 or GCS at M-size | At ~30 writes/min account-wide aggregate; `baerly cost` projects the object-storage-ops portion only (no platform floor); see [cost-model.md](cost-model.md) for the curve |
+| Dimension | Cloudflare free | Cloudflare paid¹ | Serverful Node | Why |
+| --- | --- | --- | --- | --- |
+| Documents in one collection² | ~100–500 | ~1,600–8,200 | ~6,500–32,800 | A fold rebuilds the whole snapshot in one pass; the ceiling is where that stops fitting the host |
+| Writes to one collection | ~30/min sustained | Same | Same | Writers race to create the same next log entry; losers retry. Contention, not capacity |
+| Collections per tenant | ~100 (soft) | Same | Same | Nothing enforces a cap; the cost is operator tooling, and that cost is bucket round-trips rather than host CPU |
 
-**CPU and throughput walls are surfaced above as model/estimate** — the
-~11 ms/MB fold-cost model (used to derive the ~512 KB CF-free ceiling)
-and the ~30 writes/min contention ceiling both need validation against a
-real CF isolate and real R2. Real-infra measurement is the known
-follow-up. The numbers are the best current estimates; use them to
-decide whether to start here, and revisit if you observe persistent fold
-deferrals (`db.compaction.deferred_total`) or CAS-retry storms.
+¹ A paid Worker keeps the **free-tier** budgets until you set
+`BAERLY_MAINTENANCE_PROFILE=cf-paid`; billing alone changes nothing. The
+Node adapter selects its profile automatically.
+
+² At 1–5 KB per document. Each host caps how large a snapshot one fold
+may rebuild — in bytes, and in rows as a backstop for snapshots of many
+tiny documents. Bytes bind at documents this size. On Node the cap
+scales with available heap, and the column gives the measured floor on a
+512 MB container. Per-host caps and their derivation:
+[graduation.md § The auto-maintained snapshot ceiling](graduation.md#the-auto-maintained-snapshot-ceiling).
+
+**Cloudflare free is the floor, and on Workers it is the default whether
+or not you are paying.** Every host runs the same protocol; a bigger host
+buys a bigger snapshot per fold, nothing else.
+
+Past the ceiling the log stops collapsing into the snapshot: reads keep
+working and get slower — erosion, not a cliff. Stored bytes are not a fit
+limit at all; nothing in baerly-storage measures or enforces per-tenant
+storage, since a tenant is only a key prefix.
+
+Cost is not a shape question. For the dollar envelope and the
+per-operation crossover against D1, Supabase, Neon, and Firestore, see
+[cost-model.md](cost-model.md);
+[graduation.md § Per-tier bounds](graduation.md#per-tier-bounds) owns the
+per-host derivations.
+
+**How solid these are.** The document ceilings are measured
+(`pnpm bench:fold-ceiling`). The ~30 writes/min contention ceiling is
+still a model pending real-infra measurement against R2, and ~100
+collections is bench-grounded but unenforced. Revisit either if you
+observe persistent fold deferrals (`db.compaction.deferred_total`) or
+CAS-retry storms.

--- a/packages/adapter-cloudflare/src/worker-maintenance.test.ts
+++ b/packages/adapter-cloudflare/src/worker-maintenance.test.ts
@@ -19,7 +19,8 @@
  *      `waitUntil` continuation — the ALS store survives past the
  *      response.
  *   4. An over-raised `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` (above
- *      `CF_FREE_MAX_SAFE_FOLD_BYTES`) warns LOUDLY once at handler init.
+ *      `CF_FREE_MAX_SAFE_FOLD_BYTES`) warns LOUDLY once at handler init
+ *      — on the FREE profile only; `cf-paid` carries its own ceiling.
  */
 
 import {
@@ -430,6 +431,34 @@ describe("over-raised BAERLY_MAINTENANCE_MAX_FOLD_BYTES warns at init", () => {
       BUCKET: bucket,
       APP: "t",
       BAERLY_MAINTENANCE_MAX_FOLD_BYTES: String(CF_FREE_MAX_SAFE_FOLD_BYTES),
+    } as unknown as BaerlyEnv;
+
+    const noopCtx = mockExecutionContext();
+    await handler.fetch!(
+      new Request("https://x/v1/healthz") as Request<unknown, IncomingRequestCfProperties>,
+      env,
+      noopCtx,
+    );
+    const maintWarns = warnSpy.mock.calls.filter((args) =>
+      String(args[0] ?? "").includes("BAERLY_MAINTENANCE_MAX_FOLD_BYTES"),
+    );
+    expect(maintWarns).toHaveLength(0);
+  });
+
+  // The guardrail is free's CPU wall, and its first stated remedy is "run
+  // on CF PAID". Since the cf-paid profile carries its own 8 MiB ceiling,
+  // warning an operator who already selected it would contradict the
+  // advice the same message gives.
+  test("the same over-raised value does NOT warn under BAERLY_MAINTENANCE_PROFILE=cf-paid", async () => {
+    const bucket = getBinding();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const verifier: Verifier = async () => ({ tenantPrefix: "paid-nowarn-t", identity: {} });
+    const handler = baerlyWorker<BaerlyEnv>(() => ({ config: testConfig, verifier }));
+    const env = {
+      BUCKET: bucket,
+      APP: "t",
+      BAERLY_MAINTENANCE_MAX_FOLD_BYTES: String(CF_FREE_MAX_SAFE_FOLD_BYTES + 1),
+      BAERLY_MAINTENANCE_PROFILE: "cf-paid",
     } as unknown as BaerlyEnv;
 
     const noopCtx = mockExecutionContext();

--- a/packages/adapter-cloudflare/src/worker.ts
+++ b/packages/adapter-cloudflare/src/worker.ts
@@ -66,37 +66,40 @@ const resolveCfSink = (config: ObservabilityConfig | undefined): ObservabilityCo
  *
  * ## In-band maintenance ops-plane vars
  *
- * Two OPTIONAL `vars` tune the write-tick maintenance the adapter
+ * Three OPTIONAL `vars` tune the write-tick maintenance the adapter
  * dispatches via `ctx.waitUntil` (CF `vars` are always strings):
  *
- *   - `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` — raise the snapshot-rebuild
- *     ceiling `C`. The default ({@link MAINTENANCE_MAX_FOLD_BYTES_DEFAULT},
- *     512 KiB) is sized to rebuild in ~5.5 ms under the CF-free ~10 ms
- *     CPU budget. On CF **paid** (raised CPU limits) an operator raises
- *     this to fold larger snapshots in one shot. A value above
- *     {@link CF_FREE_MAX_SAFE_FOLD_BYTES} warns LOUDLY once at init —
- *     on a free isolate that fold risks a mid-rebuild CPU kill.
+ *   - `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` — override the snapshot-rebuild
+ *     ceiling `C` that the resolved profile carries. The `cf-free` value
+ *     (512 KiB) is sized to rebuild in ~5.5 ms under the CF-free ~10 ms
+ *     CPU budget; `cf-paid` carries 8 MiB. This var wins over either. On
+ *     the free profile a value above {@link CF_FREE_MAX_SAFE_FOLD_BYTES}
+ *     warns LOUDLY once at init — on a free isolate that fold risks a
+ *     mid-rebuild CPU kill.
  *   - `BAERLY_MAINTENANCE_DISABLE` — kill switch. Any non-empty value
  *     other than `"0"` / `"false"` disables write-tick maintenance.
  *   - `BAERLY_MAINTENANCE_PROFILE` — opt-in profile selector. Set to
- *     `"cf-paid"` on a paid Worker to raise the per-pass throughput caps
- *     (GC marks/sweeps, fold entries per pass) to the Node-tier values,
- *     exploiting the paid 10,000-subrequest budget. Default / unknown
- *     values resolve to `cf-free` (unchanged zero-config behaviour). Does
- *     NOT change the snapshot ceilings `C` / `E` — raise those separately
- *     via `BAERLY_MAINTENANCE_MAX_FOLD_BYTES`. Must be set consistently on
- *     BOTH the write-tick path and the cron path (use
- *     {@link resolveCfMaintenanceProfile} in your
+ *     `"cf-paid"` on a paid Worker to select
+ *     {@link MAINTENANCE_PROFILE_CF_PAID}, which raises BOTH the per-pass
+ *     throughput caps (GC marks/sweeps, fold entries per pass) to the
+ *     Node-tier values, exploiting the paid 10,000-subrequest budget, AND
+ *     the snapshot ceilings to `C` = 8 MiB / `E` = 32,768. Default /
+ *     unknown values resolve to `cf-free` (unchanged zero-config
+ *     behaviour). `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` still overrides `C`
+ *     on top of whichever profile resolves; `E` has no var, so the
+ *     profile switch is the ONLY way to raise the row arm on Cloudflare.
+ *     Must be set consistently on BOTH the write-tick path and the cron
+ *     path (use {@link resolveCfMaintenanceProfile} in your
  *     {@link WorkerScheduledHandler}).
  */
 export interface BaerlyEnv {
   BUCKET?: R2Bucket;
   APP: string;
   /**
-   * Raise the snapshot-rebuild ceiling `C`. Parsed as a number;
-   * ignored when unset / non-numeric. Default
-   * {@link MAINTENANCE_MAX_FOLD_BYTES_DEFAULT}. A value above
-   * {@link CF_FREE_MAX_SAFE_FOLD_BYTES} warns once at init.
+   * Override the snapshot-rebuild ceiling `C` the resolved profile
+   * carries (512 KiB on `cf-free`, 8 MiB on `cf-paid`). Parsed as a
+   * number; ignored when unset / non-numeric. On the free profile a
+   * value above {@link CF_FREE_MAX_SAFE_FOLD_BYTES} warns once at init.
    */
   BAERLY_MAINTENANCE_MAX_FOLD_BYTES?: string;
   /**
@@ -106,8 +109,9 @@ export interface BaerlyEnv {
   BAERLY_MAINTENANCE_DISABLE?: string;
   /**
    * Opt-in maintenance profile. `"cf-paid"` raises per-pass throughput
-   * caps to Node-tier values on a paid Worker isolate. Default / unknown
-   * values resolve to `cf-free`. Does NOT change snapshot ceilings.
+   * caps to Node-tier values on a paid Worker isolate AND takes the paid
+   * snapshot ceilings (`C` = 8 MiB, `E` = 32,768). Default / unknown
+   * values resolve to `cf-free`.
    */
   BAERLY_MAINTENANCE_PROFILE?: string;
 }
@@ -115,11 +119,13 @@ export interface BaerlyEnv {
 /**
  * Resolve the maintenance profile from the opt-in operator env var.
  * Default (unset / unknown) is the CPU-killable CF-free profile, so
- * zero-config behavior is unchanged. `cf-paid` raises the per-pass
- * caps to exploit the paid 10,000-subrequest budget; it does NOT change
- * the snapshot ceilings. Used by BOTH the write-tick dispatch and the
- * cron path so the two maintenance triggers stay coherent when the
- * operator wires the recipe below into their scheduled handler.
+ * zero-config behavior is unchanged. `cf-paid` raises the per-pass caps
+ * to exploit the paid 10,000-subrequest budget AND the snapshot ceilings
+ * to `C` = 8 MiB / `E` = 32,768, measured against the paid isolate's own
+ * memory wall rather than free's CPU wall. Used by BOTH the write-tick
+ * dispatch and the cron path so the two maintenance triggers stay
+ * coherent when the operator wires the recipe below into their
+ * scheduled handler.
  */
 export const resolveCfMaintenanceProfile = (readEnv: (key: string) => string | undefined) =>
   readEnv("BAERLY_MAINTENANCE_PROFILE") === "cf-paid"
@@ -139,23 +145,26 @@ export const resolveCfMaintenanceProfile = (readEnv: (key: string) => string | u
  * On Cloudflare the fold runs in a `ctx.waitUntil` continuation — FIRE
  * AND FORGET off the response ack, so the commit never blocks on it. The
  * isolate stays alive long enough to drain the continuation; the
- * per-pass caps are the TESTED CF-free `WRITE_TICK_*` defaults
+ * per-pass caps default to the TESTED CF-free `WRITE_TICK_*` values
  * (`phasesPerTick: "single"` — a CPU-killable free isolate does ONE of
  * fold/GC per request, never both), sized so a single pass stays well
- * under the free-tier 50-subrequest budget. An operator on CF **paid**
- * raises the ceiling via `BAERLY_MAINTENANCE_MAX_FOLD_BYTES`; the
- * per-pass entry/sweep caps stay fixed here (raising them toward the
- * 10,000-subrequest paid budget — the default since 2026-02-11, up from
- * 1,000, and configurable to 10M — is a future graduation knob, not a
- * var). Free stays at 50 external / 1,000 internal-service subrequests.
+ * under the free-tier 50-subrequest budget. Free stays at 50 external /
+ * 1,000 internal-service subrequests. An operator on CF **paid** opts
+ * into the whole paid tier — per-pass caps AND snapshot ceilings — with
+ * `BAERLY_MAINTENANCE_PROFILE=cf-paid`, which is what exploits the
+ * 10,000-subrequest paid budget (the default since 2026-02-11, up from
+ * 1,000, and configurable to 10M).
  *
- * The two ops-plane vars are read off the `env` BINDING (a string map),
+ * The three ops-plane vars are read off the `env` BINDING (a string map),
  * NOT `process.env` — Workers have no process env:
  *
- *   - `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` → `maxFoldBytes` (`C`). Parsed
- *     as a number; ignored when unset / NaN.
+ *   - `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` → `maxFoldBytes` (`C`), which
+ *     overrides the resolved profile's ceiling. Parsed as a number;
+ *     ignored when unset / NaN.
  *   - `BAERLY_MAINTENANCE_DISABLE` → `disabled` (kill switch). Truthy
  *     when set to a non-empty value other than `"0"` / `"false"`.
+ *   - `BAERLY_MAINTENANCE_PROFILE` → `options.profile`, via
+ *     {@link resolveCfMaintenanceProfile}.
  *
  * `readEnv` defaults to reading off the bound `env`; the parameter
  * exists for direct unit coverage.

--- a/packages/adapter-cloudflare/src/worker.ts
+++ b/packages/adapter-cloudflare/src/worker.ts
@@ -408,6 +408,15 @@ export function baerlyWorker<E extends BaerlyEnv = BaerlyEnv>(
     // never lands, so the fold silently never advances `log_seq_start`
     // and the tail grows unbounded. `console.warn` (not LogTape) so the
     // signal survives even when observability is unconfigured.
+    //
+    // Scoped to the FREE profile. `CF_FREE_MAX_SAFE_FOLD_BYTES` is free's
+    // CPU wall, and the warning's own first remedy is "run on CF PAID" —
+    // an operator who set `BAERLY_MAINTENANCE_PROFILE=cf-paid` has taken
+    // it, and the paid profile's own ceiling (8 MiB) is already 8x this
+    // bound. Warning them would contradict the advice. There is no paid
+    // equivalent of this guardrail because paid's ceiling is memory-bound,
+    // not CPU-bound, and no safe-override threshold has been measured
+    // above it.
     if (!maintenanceCeilingWarned) {
       maintenanceCeilingWarned = true;
       const rawFoldBytes = (env as unknown as Record<string, unknown>)[
@@ -418,7 +427,16 @@ export function baerlyWorker<E extends BaerlyEnv = BaerlyEnv>(
           ? rawFoldBytes
           : undefined,
       );
-      if (maxFoldBytes !== undefined && maxFoldBytes > CF_FREE_MAX_SAFE_FOLD_BYTES) {
+      const onFreeProfile =
+        resolveCfMaintenanceProfile((k) => {
+          const v = (env as unknown as Record<string, unknown>)[k];
+          return typeof v === "string" ? v : undefined;
+        }) === MAINTENANCE_PROFILE_CF_FREE;
+      if (
+        onFreeProfile &&
+        maxFoldBytes !== undefined &&
+        maxFoldBytes > CF_FREE_MAX_SAFE_FOLD_BYTES
+      ) {
         console.warn(
           `[baerly] BAERLY_MAINTENANCE_MAX_FOLD_BYTES=${rawFoldBytes} exceeds the ` +
             `CF free-tier safe ceiling (${CF_FREE_MAX_SAFE_FOLD_BYTES} bytes). On a free ` +

--- a/packages/protocol/src/constants.ts
+++ b/packages/protocol/src/constants.ts
@@ -528,13 +528,93 @@ export const CF_FREE_MAX_SAFE_FOLD_BYTES: number = 1024 * 1024;
 /**
  * SNAPSHOT-rebuild ceiling `E`, per-entry CPU axis: gates `snapshot_rows` (per-entry
  * parse/merge/serialize is ~half of fold CPU and scales with ROW COUNT not bytes, VLDB 2021
- * Sarkar — a tiny-doc snapshot can blow CPU under C). PROVISIONAL — bench
- * landed; paid recalibration deferred.
+ * Sarkar — a tiny-doc snapshot can blow CPU under C).
+ *
+ * This is the **cf-free** value and the shared default. `pnpm bench:fold-ceiling`
+ * measures 2048 rows at ~1.5 ms against the ~10 ms free-tier budget (a ~6.6×
+ * margin), and the row axis does not reach 10 ms until ~16,384 rows. The value
+ * stays at 2048 because overrun on a free isolate is CPU-killed MID-REBUILD and
+ * strands the `current.json` CAS — see {@link CF_FREE_MAX_SAFE_FOLD_BYTES}. The
+ * larger hosts no longer inherit it; see {@link CF_PAID_MAINTENANCE_MAX_FOLD_ROWS}
+ * and {@link NODE_MAINTENANCE_MAX_FOLD_ROWS}.
  *
  * @see docs/about/graduation.md
  * @see packages/server/src/maintenance.ts
  */
 export const MAINTENANCE_MAX_FOLD_ROWS: number = 2048;
+
+/**
+ * Snapshot-rebuild byte ceiling `C` for the **cf-paid** profile.
+ *
+ * A paid isolate's wall is ~128 MB of Worker memory, not CPU — at a 30 s CPU
+ * budget the rebuild is never CPU-bound, but a fold holds the old snapshot, the
+ * new snapshot, and the tail at once. `pnpm bench:fold-ceiling` measures peak
+ * heap at ~2.4× the snapshot on the byte axis, stable across 704 MB–4.3 GB
+ * heaps: 8 MiB peaks at ~19.5 MB, a 4× margin under 128 MB. The next grid cell
+ * up (16 MiB ⇒ 37.3 MB peak) exceeds that margin, which is what fixes this
+ * value.
+ *
+ * The margin is deliberately tight because overrun is NOT graceful here: an
+ * isolate OOM mid-fold strands the `current.json` CAS exactly like a CF-free
+ * CPU kill, so the fold silently never advances `log_seq_start`.
+ *
+ * @see docs/about/graduation.md
+ * @see bench/measurement/fold-ceiling-probe.ts
+ */
+// Stryker disable next-line ArithmeticOperator: internal tuning value, not an off-process contract — asserting the literal would be a tautological change-detector. See docs/contributing/mutation-testing.md constants policy.
+export const CF_PAID_MAINTENANCE_MAX_FOLD_BYTES: number = 8 * 1024 * 1024;
+
+/**
+ * Snapshot-rebuild row ceiling `E` for the **cf-paid** profile. Same 128 MB
+ * memory wall and same 4× margin as {@link CF_PAID_MAINTENANCE_MAX_FOLD_BYTES};
+ * the row axis costs ~600 B of peak heap per row (measured), so 32,768 rows
+ * peaks at ~19.7 MB. The next grid cell up (65,536 rows ⇒ 39.4 MB) exceeds the
+ * margin.
+ *
+ * @see docs/about/graduation.md
+ */
+export const CF_PAID_MAINTENANCE_MAX_FOLD_ROWS: number = 32_768;
+
+/**
+ * Snapshot-rebuild byte ceiling `C` for the **node** profile.
+ *
+ * Serverful Node has no per-request cap, and its fold is not abortable —
+ * `nodeMaintenanceDispatch` passes no `signal` — so an over-large fold
+ * COMPLETES. The failure mode is one slow write, not a stranded CAS. That
+ * asymmetry is why Node's ceiling is set generously where cf-free's and
+ * cf-paid's are set tightly: UNDER-setting `C` permanently defers the fold,
+ * which is the worse failure on every host. Inline fold latency is budgeted by
+ * {@link NODE_MAINTENANCE_FOLD_ENTRIES_PER_PASS} (the sliceable tail work), not
+ * by this ceiling (the unsliceable snapshot rebuild).
+ *
+ * 32 MiB is the top of the measured grid, NOT the wall: `pnpm bench:fold-ceiling`
+ * reports `grid-exhausted` for this profile at every margin and at every heap
+ * from 704 MB up. At a 704 MB heap — the smallest realistic container — a
+ * 32 MiB fold peaks at ~37 MB, a ~19× margin. The scaling rule past the grid is
+ * `C ≈ heap / 10` (peak ≈ 2.4× snapshot, 4× margin). Finding the real wall
+ * needs the byte axis extended past 32 MiB.
+ *
+ * A separate hard ceiling sits near 512 MB regardless of heap: `encodeJsonBytes`
+ * / `decodeJsonBytes` materialize the whole snapshot as a JS string, so a
+ * snapshot at V8's `MAX_STRING_LENGTH` throws mid-fold.
+ *
+ * @see docs/about/graduation.md
+ * @see bench/measurement/fold-ceiling-probe.ts
+ */
+// Stryker disable next-line ArithmeticOperator: internal tuning value, not an off-process contract — asserting the literal would be a tautological change-detector. See docs/contributing/mutation-testing.md constants policy.
+export const NODE_MAINTENANCE_MAX_FOLD_BYTES: number = 32 * 1024 * 1024;
+
+/**
+ * Snapshot-rebuild row ceiling `E` for the **node** profile. 65,536 rows is the
+ * largest row cell with a stable measured peak (~39.4 MB, reproduced within
+ * 0.05 MB across four runs); the 131,072-row cell's peak is not yet reliably
+ * measurable. Against even a 704 MB heap that is a ~17× margin, consistent with
+ * {@link NODE_MAINTENANCE_MAX_FOLD_BYTES} being a measured floor rather than a
+ * wall.
+ *
+ * @see docs/about/graduation.md
+ */
+export const NODE_MAINTENANCE_MAX_FOLD_ROWS: number = 65_536;
 
 // Declared here (not the nominal server `MaintenanceProfile`) to avoid a server→protocol cycle; keep field-identical to it.
 type MaintenanceProfileShape = Readonly<{
@@ -560,24 +640,29 @@ export const MAINTENANCE_PROFILE_CF_FREE: MaintenanceProfileShape = {
   maxFoldRows: MAINTENANCE_MAX_FOLD_ROWS,
 };
 
-/** Node profile; 10× CF-free caps. */
+/** Node profile; 10× CF-free per-pass caps, and its own measured snapshot ceilings. */
 export const MAINTENANCE_PROFILE_NODE: MaintenanceProfileShape = {
   gcInterval: NODE_MAINTENANCE_GC_INTERVAL,
   gcMaxMarks: NODE_MAINTENANCE_GC_MAX_MARKS,
   gcMaxSweeps: NODE_MAINTENANCE_GC_MAX_SWEEPS,
   maxFoldEntriesPerPass: NODE_MAINTENANCE_FOLD_ENTRIES_PER_PASS,
-  maxFoldBytes: MAINTENANCE_MAX_FOLD_BYTES_DEFAULT,
-  maxFoldRows: MAINTENANCE_MAX_FOLD_ROWS,
+  maxFoldBytes: NODE_MAINTENANCE_MAX_FOLD_BYTES,
+  maxFoldRows: NODE_MAINTENANCE_MAX_FOLD_ROWS,
 };
 
 /**
  * CF-paid profile — opt-in via `BAERLY_MAINTENANCE_PROFILE=cf-paid`. A paid
  * isolate keeps the CPU-killable single-phase shape but has the 10,000-
  * subrequest budget (vs free's 50), so it reuses the `NODE_MAINTENANCE_*`
- * per-pass caps. CRITICAL: snapshot ceilings `maxFoldBytes` (`C`) /
- * `maxFoldRows` (`E`) are UNCHANGED — a profile moves rate, never correctness
- * (the equivalence invariant); the memory wall is raised via
- * `BAERLY_MAINTENANCE_MAX_FOLD_BYTES`.
+ * per-pass caps.
+ *
+ * A profile moves RATE and the DEFER THRESHOLD, never the stored data or the
+ * query semantics — that is the equivalence invariant, and it is what
+ * `tests/integration/maintenance-profile-equivalence.test.ts` proves: a read
+ * folds snapshot + live tail, so HOW MUCH a profile has folded is invisible to
+ * a reader. Snapshot ceilings therefore differ per host, sized to each host's
+ * real wall (see {@link CF_PAID_MAINTENANCE_MAX_FOLD_BYTES}). Operators can
+ * still raise `C` out-of-band with `BAERLY_MAINTENANCE_MAX_FOLD_BYTES`.
  *
  * @see packages/adapter-cloudflare/src/worker.ts
  * @see docs/about/graduation.md
@@ -587,8 +672,8 @@ export const MAINTENANCE_PROFILE_CF_PAID: MaintenanceProfileShape = {
   gcMaxMarks: NODE_MAINTENANCE_GC_MAX_MARKS,
   gcMaxSweeps: NODE_MAINTENANCE_GC_MAX_SWEEPS,
   maxFoldEntriesPerPass: NODE_MAINTENANCE_FOLD_ENTRIES_PER_PASS,
-  maxFoldBytes: MAINTENANCE_MAX_FOLD_BYTES_DEFAULT,
-  maxFoldRows: MAINTENANCE_MAX_FOLD_ROWS,
+  maxFoldBytes: CF_PAID_MAINTENANCE_MAX_FOLD_BYTES,
+  maxFoldRows: CF_PAID_MAINTENANCE_MAX_FOLD_ROWS,
 };
 
 /**


### PR DESCRIPTION
## What & why

Fixes #118.

Maintenance profiles no longer inherit Cloudflare free snapshot-fold ceilings. The opt-in Cloudflare paid profile now uses 8 MiB / 32,768 rows, and Node automatically uses 32 MiB / 65,536 rows, so a larger host no longer stops folding at a lower document count than Cloudflare free. The ceilings are calibrated from the fold-ceiling benchmark; the Cloudflare adapter guidance and public capacity docs now describe the shipped behavior.

## Key points

- A profile changes the bounded fold defer threshold, never stored data or query semantics; readers materialize the snapshot plus live tail either way.
- Cloudflare paid requires `BAERLY_MAINTENANCE_PROFILE=cf-paid`; a paid Worker otherwise retains the free profile.
- Node values are the top of the measured grid, not its hardware limit; `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` remains the escape hatch for a suitably sized host.

## Verification

| Command | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm build && pnpm test:agent` | 3331 passed, 101 skipped |
| `pnpm test:adapter-cloudflare` | 158 passed, 2 skipped |
| `pnpm bundle-sizes` | ok (14 entries) |
| `pnpm bench:fold-ceiling` | 4 runs: unconstrained, plus 512/1024/2048 MB heaps |

Not run: Minio, credentials, and Postgres infra-gated suites.