### PR TITLE
docs(protocol): remove high-confidence comment noise (pass 1)

### DIFF
--- a/packages/protocol/src/collection-api.ts
+++ b/packages/protocol/src/collection-api.ts
@@ -303,12 +303,13 @@ type _SubPredicate<T> = T extends object
  *    nested object may carry only a subset of keys (open-world
  *    matching against the document).
  *
- * **Operator vocabulary moved to the callback form.** Range / `in`
- * / mixed eq+range queries write
+ * **Operators live on the callback form only.** Range / `in` /
+ * mixed eq+range queries write
  * `.where(q => q.gt("priority", 5).in("status", ["open", "pending"]))`.
- * Operator vocabulary lives on {@link PredicateBuilder} (see there
- * for the locked method list); object-form has no `$`-keyed surface
- * for the same reason. For OR/AND:
+ * That vocabulary lives on {@link PredicateBuilder} (see there for
+ * the locked method list); object-form has no `$`-keyed surface, so
+ * an operator we never implemented cannot be invoked from either
+ * shape. For OR/AND:
  *   - `q.in(field, ["a", "b"])` for OR over one field.
  *   - Chained `.where(p1).where(p2)` for AND across multiple
  *     predicates — the chain AND-merges.

--- a/packages/protocol/src/collection-api.ts
+++ b/packages/protocol/src/collection-api.ts
@@ -77,9 +77,8 @@ export interface Collection<T extends DocumentData = DocumentData> {
    *    callback; chained `.where(...).where(...)` AND-merges
    *    across calls and across shapes.
    *
-   * Methods that do not exist on {@link PredicateBuilder}
-   * (`or`, `not`, `regex`, `ne`, `exists`, ...) are intentionally
-   * absent — invoking them is a TS compile error.
+   * Operator vocabulary is locked to {@link PredicateBuilder}'s
+   * method list; invoking anything else is a TS compile error.
    *
    * @example
    * ```ts
@@ -307,12 +306,9 @@ type _SubPredicate<T> = T extends object
  * **Operator vocabulary moved to the callback form.** Range / `in`
  * / mixed eq+range queries write
  * `.where(q => q.gt("priority", 5).in("status", ["open", "pending"]))`.
- * The methods on {@link PredicateBuilder} ARE the supported vocabulary
- * — there is no `$`-keyed object surface, so a method we did not
- * write cannot be called.
- *
- * **No top-level boolean connectives.** `or` / `not` are
- * intentionally absent. Use:
+ * Operator vocabulary lives on {@link PredicateBuilder} (see there
+ * for the locked method list); object-form has no `$`-keyed surface
+ * for the same reason. For OR/AND:
  *   - `q.in(field, ["a", "b"])` for OR over one field.
  *   - Chained `.where(p1).where(p2)` for AND across multiple
  *     predicates — the chain AND-merges.

--- a/packages/protocol/src/coordination/current-json.ts
+++ b/packages/protocol/src/coordination/current-json.ts
@@ -300,7 +300,6 @@ export async function createCurrentJson(
   initial: CurrentJson,
   opts?: { signal?: AbortSignal },
 ): Promise<CurrentJsonRead> {
-  // Catch shape bugs in callers before they hit storage. Cheap.
   assertCurrentJson(initial, key);
   const body = encodeJson(initial);
   const putOpts: StoragePutOptions = {
@@ -419,10 +418,8 @@ export async function casUpdateCurrentJson(
  *
  * @see {@link ../../../../docs/spec/writer-fence-adversarial-model.md} —
  *   the full failure envelope (absent / lying / non-monotonic Date,
- *   peer-between-PUTs, bounded clock skew).
- * @see {@link ../../../../docs/spec/writer-fence-adversarial-model.md} —
- *   the "Differentiation from mps3" subsection that frames the §103
- *   non-obviousness story.
+ *   peer-between-PUTs, bounded clock skew), and the "Differentiation
+ *   from mps3" subsection framing the §103 non-obviousness story.
  * @see {@link ../../../../docs/spec/prior-art.md} —
  *   IDS-shaped prior-art differentiation against mps3, SlateDB,
  *   Iceberg, Delta, and the broader S3-leader-election literature.

--- a/packages/protocol/src/coordination/current-json.ts
+++ b/packages/protocol/src/coordination/current-json.ts
@@ -580,7 +580,7 @@ const assertCurrentJson = (parsed: unknown, key: string): CurrentJson => {
     throw new BaerlyError("InvalidResponse", `current.json at ${key}: writer_fence missing`);
   }
   const f = fence as Record<string, unknown>;
-  // Stryker disable next-line ConditionalExpression: `typeof f["epoch"] !== "number"` → false is equivalent — !Number.isInteger rejects all non-numbers, making the typeof guard fully subsumed.
+  // Stryker disable next-line ConditionalExpression: same rationale as `log_seq_start` above.
   if (typeof f["epoch"] !== "number" || !Number.isInteger(f["epoch"]) || f["epoch"] < 0) {
     throw new BaerlyError(
       "InvalidResponse",
@@ -606,7 +606,7 @@ const assertCurrentJson = (parsed: unknown, key: string): CurrentJson => {
     );
   }
   if (
-    // Stryker disable next-line ConditionalExpression: `typeof r["snapshot_bytes"] !== "number"` → false is equivalent — !Number.isInteger rejects all non-numbers, making the typeof check fully subsumed.
+    // Stryker disable next-line ConditionalExpression: same rationale as `log_seq_start` above.
     typeof r["snapshot_bytes"] !== "number" ||
     !Number.isInteger(r["snapshot_bytes"]) ||
     r["snapshot_bytes"] < 0
@@ -617,7 +617,7 @@ const assertCurrentJson = (parsed: unknown, key: string): CurrentJson => {
     );
   }
   if (
-    // Stryker disable next-line ConditionalExpression: `typeof r["snapshot_rows"] !== "number"` → false is equivalent — !Number.isInteger rejects all non-numbers, making the typeof check fully subsumed.
+    // Stryker disable next-line ConditionalExpression: same rationale as `log_seq_start` above.
     typeof r["snapshot_rows"] !== "number" ||
     !Number.isInteger(r["snapshot_rows"]) ||
     r["snapshot_rows"] < 0
@@ -629,7 +629,7 @@ const assertCurrentJson = (parsed: unknown, key: string): CurrentJson => {
   }
   if (
     r["last_warned_seq"] !== undefined &&
-    // Stryker disable next-line ConditionalExpression: `typeof r["last_warned_seq"] !== "number"` → false is equivalent — !Number.isInteger rejects all non-numbers, making the typeof check fully subsumed.
+    // Stryker disable next-line ConditionalExpression: same rationale as `log_seq_start` above.
     (typeof r["last_warned_seq"] !== "number" ||
       !Number.isInteger(r["last_warned_seq"]) ||
       r["last_warned_seq"] < 0)
@@ -641,7 +641,7 @@ const assertCurrentJson = (parsed: unknown, key: string): CurrentJson => {
   }
   if (
     r["mean_entry_bytes"] !== undefined &&
-    // Stryker disable next-line ConditionalExpression: typeof → false is subsumed by !Number.isInteger.
+    // Stryker disable next-line ConditionalExpression: same rationale as `log_seq_start` above.
     (typeof r["mean_entry_bytes"] !== "number" ||
       !Number.isInteger(r["mean_entry_bytes"]) ||
       r["mean_entry_bytes"] < 0)

--- a/packages/protocol/src/coordination/gc-pending.ts
+++ b/packages/protocol/src/coordination/gc-pending.ts
@@ -1,15 +1,13 @@
 /**
  * `gc/pending.json` — the per-collection GC candidate ledger. CAS-
  * protected; one per `(tenant, collection)` key — for example
- * `<tenant>/<collection>/gc/pending.json`. `runGc()` in
- * `packages/server/src/gc.ts` is the single writer that adds and
- * removes entries. Stays small in steady state because every
- * candidate is deleted once `due_at` passes.
+ * `<tenant>/<collection>/gc/pending.json`. `runGc()` is the single
+ * writer that adds and removes entries. Stays small in steady state
+ * because every candidate is deleted once `due_at` passes.
  *
  * "Mark" appends candidates with a future `due_at`; "sweep" deletes
- * candidates whose `due_at` is in the past. The two phases run in
- * the same compactor pass — see `runGc()` in
- * `packages/server/src/gc.ts`.
+ * candidates whose `due_at` is in the past. Both run in the same
+ * compactor pass, not separate passes.
  *
  * Lives next to {@link CurrentJson} in `coordination/` — same shape
  * of "CAS-protected small control object." Pure module; no Node

--- a/packages/protocol/src/errors.ts
+++ b/packages/protocol/src/errors.ts
@@ -250,11 +250,11 @@ export class BaerlyError extends Error {
     if (issues !== undefined) {
       this.issues = issues;
     }
-    // Stryker disable next-line ConditionalExpression: field declaration creates property with undefined value; mutation to true is equivalent
+    // Stryker disable next-line ConditionalExpression: same rationale as `issues` above
     if (status !== undefined) {
       this.status = status;
     }
-    // Stryker disable next-line ConditionalExpression: field declaration creates property with undefined value; mutation to true is equivalent
+    // Stryker disable next-line ConditionalExpression: same rationale as `issues` above
     if (resolution !== undefined) {
       this.resolution = resolution;
     }

--- a/packages/protocol/src/query/_internals.ts
+++ b/packages/protocol/src/query/_internals.ts
@@ -1,12 +1,13 @@
 /**
  * Shared comparator helpers for the predicate algebra. `./satisfiable.ts`
- * is the only in-package importer of this module.
+ * is the only module that consumes the comparator primitives.
  *
  * Only {@link deepEqualDocumentValue} is part of the public surface —
- * it's also re-exported from `./index.ts` and imported directly by
- * `packages/server/src/query-planner-implies.ts`. The comparator
- * primitives (`compareScalar`, `sameComparableType`, `formatPath`) are
- * internal to the protocol package.
+ * it's also re-exported from `./index.ts` and reaches
+ * `packages/server/src/query-planner-implies.ts` through the
+ * `@baerly/protocol` barrel. The comparator primitives (`compareScalar`,
+ * `sameComparableType`, `formatPath`) are internal to the protocol
+ * package.
  */
 
 import type { DocumentValue } from "../json.ts";

--- a/packages/protocol/src/query/_internals.ts
+++ b/packages/protocol/src/query/_internals.ts
@@ -1,13 +1,12 @@
 /**
- * Shared helpers for the predicate algebras in `./validate.ts`,
- * `./matches.ts`, and `./merge.ts`. These exist as a single module
- * because more than one of those files uses them and duplicating
- * the implementations would drift over time.
+ * Shared comparator helpers for the predicate algebra. `./satisfiable.ts`
+ * is the only in-package importer of this module.
  *
- * Only {@link deepEqualDocumentValue} is part of the public surface;
- * the comparator primitives (`compareScalar`, `sameComparableType`,
- * `formatPath`) are internal to the protocol package and imported
- * by `./validate.ts` / `./merge.ts` / `./normalize.ts` directly.
+ * Only {@link deepEqualDocumentValue} is part of the public surface —
+ * it's also re-exported from `./index.ts` and imported directly by
+ * `packages/server/src/query-planner-implies.ts`. The comparator
+ * primitives (`compareScalar`, `sameComparableType`, `formatPath`) are
+ * internal to the protocol package.
  */
 
 import type { DocumentValue } from "../json.ts";

--- a/packages/protocol/src/query/builder.ts
+++ b/packages/protocol/src/query/builder.ts
@@ -5,9 +5,8 @@
  * {@link PredicateClause} to a private list and returns the same
  * handle for chaining.
  *
- * Why a builder, not imported helpers? The methods that exist on
- * the type ARE the supported vocabulary — there is no
- * "what we don't support" page to maintain. The agent cannot call
+ * Why a builder, not imported helpers? See {@link PredicateBuilder}
+ * for the locked method vocabulary. The agent cannot call
  * `q.regex(...)` because there is no `regex` method; the compiler
  * surfaces the error before the request is sent.
  *

--- a/packages/protocol/src/query/merge.ts
+++ b/packages/protocol/src/query/merge.ts
@@ -1,10 +1,6 @@
 /**
  * AND-merge two validated wire predicates. Powers chained
- * `Query<T>.where(...).where(...)`: each new clause set AND's with
- * the existing wire by clause-list concatenation; the per-field
- * satisfiability check runs across the combined list.
- *
- * Companion modules: `./validate.ts`, `./matches.ts`, `./wire.ts`.
+ * `Query<T>.where(...).where(...)`.
  */
 
 import { assertWireSatisfiable } from "./satisfiable.ts";

--- a/packages/protocol/src/storage/memory.ts
+++ b/packages/protocol/src/storage/memory.ts
@@ -124,7 +124,7 @@ export class MemoryStorage implements Storage {
       return null;
     }
     if (opts?.ifNoneMatch !== undefined && opts.ifNoneMatch === stored.etag) {
-      // 304 Not Modified — caller's cached copy is current.
+      // 304, not 404 — see Storage.get
       return null;
     }
     return { body: stored.body, etag: stored.etag };

--- a/packages/protocol/src/storage/probe-cas.ts
+++ b/packages/protocol/src/storage/probe-cas.ts
@@ -72,7 +72,7 @@ export const probeCas = async (
   try {
     const first = await storage.put(key, enc.encode("v1"), { signal });
 
-    // ── Check 1: a stale ifMatch must be rejected. ──────────────────
+    // Check 1
     try {
       // Stryker disable next-line StringLiteral: body content is irrelevant to CAS probe; only the conditional header is tested
       await storage.put(key, enc.encode("v2"), { ifMatch: staleEtag, signal });
@@ -98,9 +98,9 @@ export const probeCas = async (
       );
     }
 
-    // ── Check 2: ifNoneMatch:"*" over an existing key must reject. ──
+    // Check 2
     try {
-      // Stryker disable next-line StringLiteral: body content is irrelevant to CAS probe; only the conditional header is tested
+      // Stryker disable next-line StringLiteral: same rationale as ifMatch-stale above
       await storage.put(key, enc.encode("v3"), { ifNoneMatch: "*", signal });
       checks.push({
         name: "ifNoneMatch-exists",
@@ -124,7 +124,7 @@ export const probeCas = async (
       );
     }
 
-    // ── Check 3: at most one of N concurrent ifNoneMatch:"*" creates wins. ──
+    // Check 3
     // The writer already depends on this today: log entries are PUT with
     // ifNoneMatch:"*", and a 412 means a peer won that seq (writer.ts). Two
     // winners ⇒ two writers believe they appended the same log seq.
@@ -138,7 +138,7 @@ export const probeCas = async (
     try {
       const outcomes = await Promise.allSettled(
         Array.from({ length: RACERS }, (_unused, i) =>
-          // Stryker disable next-line StringLiteral: body content irrelevant; only the conditional header + winner count is tested
+          // Stryker disable next-line StringLiteral: same rationale as ifMatch-stale above (plus winner count)
           storage.put(raceKey, enc.encode(`r${i}`), { ifNoneMatch: "*", signal }),
         ),
       );


### PR DESCRIPTION
## What & why

`packages/protocol` had significant comment noise — duplicate module/function contract descriptions, stale factual claims about which files import a module, byte-identical mutation-test (Stryker) rationale repeated across multiple lines, and redundant `@see` reference blocks. This is pass 1 of a planned multi-pass cleanup, scoped to remove or condense only high-confidence noise with no protocol-semantic judgment involved; durable-format, CAS, fencing, and compatibility content is untouched and deferred to a later semantic-review pass.

## Key points

- Comment/JSDoc changes only — no exports, types, error text, or runtime logic changed anywhere on this branch.
- Every edit traces to a decision recorded in a per-candidate audit trail (read-and-review discipline, not density-driven deletion); the two `defer-semantic` items flagged during review (`query/wire.ts:30`, `storage/types.ts:108`) were left completely untouched.
- Mutation-test (Stryker) directives were kept on every targeted line; only the repeated rationale text after the directive was condensed to a single stated reason plus short cross-references.
- A larger deferred-semantic queue (durable-format/CAS/fencing content in `coordination/`, `storage/`, and `query/`) and a handful of out-of-scope items (e.g. a sibling stale-importer claim in `query/validate.ts:15`, a wording divergence introduced against `packages/dev/src/local-fs.ts:140`) are recorded in `docs/superpowers/trackers/deferred-defects.md` for a follow-up pass, rather than inventoried here.

## Verification

| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3312 passed, 101 skipped |
| `pnpm bundle-sizes` | ok (14 entries), no rebaseline needed (comment removal only shrinks size) |

## Notes for reviewers

The diff is comment-only across 9 files in `packages/protocol/src/{query,storage,coordination}`, plus `collection-api.ts` and `errors.ts`. `storage/probe-cas.ts:128-135` (the CAS/linearizability paragraph) and `storage/types.ts` are unchanged and worth spot-checking if you want independent confirmation nothing durable was touched.