### PR TITLE
docs(restore): harden the recovery cutover procedure

### DIFF
--- a/docs/guide/backups.md
+++ b/docs/guide/backups.md
@@ -207,18 +207,42 @@ The safe cutover shape is:
    restore imports rows; it does not rebuild secondary index markers. If
    the index check reports drift, run it with `--fix` or run
    `baerly admin rebuild-index` for each index before cutover.
-5. Point the app at the recovered bucket/prefix. Prefer this to
-   copying. If you must copy the recovery prefix into place, do it
-   only after writers and maintenance have drained, inside the maintenance
-   window, and copy `current.json` **last** —
-   after the snapshot it names (when non-null), the live log objects,
-   and any rebuilt index objects required by indexed reads exist at the
-   destination. If `current.json` lands before its snapshot or live log,
-   readers can reference missing objects; if required index markers are
-   missing, index-routed reads can miss rows. No current kernel reader
-   depends on content side objects. Copy `content/` only when preserving
-   a legacy or mixed-version bucket for legacy writers or tooling.
-6. Resume writers only after a successful authenticated read against
+5. Point the app at the recovered bucket/prefix. This direct route
+   cutover is preferred, and it is the only route that rewrites no keys.
+6. If infrastructure requires a raw object copy instead, copy into a
+   separate bucket or storage namespace at the **identical
+   bucket-relative collection path**. `current.snapshot` and every
+   `gc/pending.json` candidate store complete bucket-relative keys, so a
+   copy that lands the same objects under a different collection path
+   leaves the snapshot pointer aimed at a key that does not exist and
+   gives the destination's GC candidates that address the *source*
+   prefix. If the destination collection path differs at all, do not
+   relocate objects — run `baerly admin restore` directly into that
+   final, fresh prefix. When the path does match:
+   - Copy into a fresh, empty destination collection prefix only; never
+     overlay recovery objects onto a prefix that contains an older
+     collection generation. Old higher-numbered `log/` objects are not
+     fenced by `current.json`: readers forward-probe past the restored
+     `tail_hint` and can replay a consecutive old suffix.
+   - Copy only after writers and maintenance have drained, inside the
+     maintenance window.
+   - Do not copy `gc/pending.json`. Its candidates name source-prefix
+     keys under the source generation; the destination bootstraps a
+     fresh ledger on its first GC pass.
+   - Copy `current.json` **last** — after the snapshot it names (when
+     non-null), every live log object, and rebuilt index objects
+     required by indexed reads exist at the destination. If
+     `current.json` lands first, readers can reference missing objects;
+     if required index markers are missing, index-routed reads can miss
+     rows.
+   - No current kernel reader depends on content side objects. Copy
+     `content/` only when preserving a legacy or mixed-version bucket
+     for legacy writers or tooling.
+7. Run `baerly admin fsck` (plus `--indexes` for indexed collections)
+   against the final destination — the exact route the app will read —
+   before enabling reads. Step 3 checked the recovery prefix, not the
+   copy.
+8. Resume writers only after a successful authenticated read against
    the recovered route.
 
 ## Restore Drill


### PR DESCRIPTION
## What & why

`docs/guide/backups.md` described a raw-copy restore route that can silently produce an unreadable destination. `current.snapshot` and every `gc/pending.json` candidate store complete bucket-relative keys, so a copy landing under a different collection path aims the snapshot pointer at a key that does not exist and hands the destination's GC candidates addresses in the source prefix. The cutover is now split into a preferred direct route and a constrained raw-copy route.

## Key points

- The copy route is restricted to a separate bucket or namespace at the *identical* bucket-relative path, excludes `gc/pending.json`, and requires a fresh empty destination.
- The empty-destination requirement is not tidiness: old higher-numbered `log/` objects are not fenced by `current.json`, so readers forward-probe past the restored `tail_hint` and can replay a consecutive old suffix as committed history.
- Writers and maintenance must drain before cutover, and `fsck` now runs against the final destination before reads are enabled — step 3 only ever checked the recovery prefix.

## Verification

| Command | Result |
| --- | --- |
| `pnpm verify:docs` | clean (docs + taxonomy + remark + mermaid) |

Documentation only — no code, schema, or wire change, so no changeset.
