### PR TITLE
refactor(protocol): centralize current.json transition validation

### DIFF
--- a/docs/spec/sync-protocol.md
+++ b/docs/spec/sync-protocol.md
@@ -527,21 +527,24 @@ These are the load-bearing rules.
     visibility from `seq`, the snapshot, the trusted log range, and the
     forward-probe.
 12. **The fold floor is monotone.** `current.json`'s `log_seq_start`
-    never decreases in steady state. `casUpdateCurrentJson`
-    (`packages/protocol/src/coordination/current-json.ts`) rejects a
-    mutator that lowers it with `BaerlyError{code:"Internal"}`; equality
-    is permitted, so a `tail_hint` refresh or a `last_warned_seq` stamp
-    holds the floor fixed. Two floor writers bypass that helper
-    (invariant 6 names the `current.json` writers). The compactor's fold
-    CAS (`packages/server/src/compactor.ts`) must CAS on the etag of the
-    read it folded from, so it issues its own `If-Match` PUT; it stays
-    monotone by construction instead, because its fold end is
-    `min(probedTail, log_seq_start + maxEntriesPerRun)` and both the
-    probed tail and the validated budget are `>= 0` relative to the
-    pre-fold floor. `baerly admin restore --force` is the deliberate
-    operator exemption: it reseeds a truncated collection to one past
-    the highest _surviving_ log object, which can sit below the old
-    floor when a bounded GC sweep has left sub-floor log objects in
+    never decreases in steady state. `assertCurrentJsonTransition`
+    (`packages/protocol/src/coordination/current-json.ts`) is the single
+    enforcement point: it rejects a transition that lowers the floor
+    with `BaerlyError{code:"Internal"}`. Equality is permitted, so a
+    `tail_hint` refresh, a bounded probe checkpoint, or a
+    `last_warned_seq` stamp holds the floor fixed.
+    `casUpdateCurrentJson` routes its mutator through the validator, and
+    every writer that bypasses that helper calls the validator directly
+    before publishing: the compactor's fold CAS and probe checkpoint
+    (`packages/server/src/compactor.ts`), the `claimWriter` fence bump,
+    and the `admin restore` tail stamp (invariant 6 names the
+    `current.json` writers). The compactor still issues its own
+    `If-Match` PUT because its CAS must be tied to the etag of the read
+    it folded from — centralizing transition admission does not
+    centralize publication. `baerly admin restore --force` is the
+    deliberate operator exemption: it reseeds a truncated collection to
+    one past the highest _surviving_ log object, which can sit below the
+    old floor when a bounded GC sweep has left sub-floor log objects in
     place. That is sound because the reseed value is strictly greater
     than every log object still present, so the committing `log/<seq>`
     create cannot collide with the old generation.

--- a/packages/cli/src/admin/restore.ts
+++ b/packages/cli/src/admin/restore.ts
@@ -56,6 +56,7 @@
 import { createInterface } from "node:readline";
 import { type ArgsDef } from "citty";
 import {
+  assertCurrentJsonTransition,
   BaerlyError,
   CURRENT_JSON_SCHEMA_VERSION,
   createCurrentJson,
@@ -189,11 +190,10 @@ const bundle = defineBaerlySubcommand({
       baseSeq = truncatedNext;
       // FLOOR EXEMPTION — deliberate. `casUpdateCurrentJson` rejects any
       // write that lowers `log_seq_start`; this PUT is not routed through
-      // it, so `--force` can reseed BELOW the old floor. (The compactor's
-      // fold CAS also bypasses that helper, but it is monotone by
-      // construction — it validates its seq-arithmetic options at the
-      // seam rather than asserting the floor at the fold. `--force` is
-      // the only path that intentionally lowers the floor.)
+      // it, so `--force` can reseed BELOW the old floor. The compactor's
+      // fold CAS also bypasses that helper, but calls the shared transition
+      // validator directly before publication. `--force` is the only path
+      // that intentionally lowers the floor.
       //
       // Why lowering is sound. `truncatedNext` is strictly greater than
       // every log object still on the bucket, so the writer's committing
@@ -366,6 +366,7 @@ const bundle = defineBaerlySubcommand({
           afterLoad.json.log_seq_start,
         );
         const stamped: CurrentJson = { ...afterLoad.json, tail_hint: clampedTail };
+        assertCurrentJsonTransition(afterLoad.json, stamped, currentJsonKey);
         await bucket.storage.put(currentJsonKey, encodeJsonBytes(stamped), {
           ifMatch: afterLoad.etag,
           contentType: "application/json",

--- a/packages/protocol/src/coordination/current-json.test.ts
+++ b/packages/protocol/src/coordination/current-json.test.ts
@@ -6,6 +6,7 @@ import {
   CURRENT_JSON_SCHEMA_VERSION,
   type CurrentJson,
   type CurrentJsonRead,
+  assertCurrentJsonTransition,
   casUpdateCurrentJson,
   createCurrentJson,
   encodeJsonBytes,
@@ -26,6 +27,30 @@ const seedJson = (overrides: Partial<CurrentJson> = {}): CurrentJson => ({
   snapshot_bytes: 0,
   snapshot_rows: 0,
   ...overrides,
+});
+
+describe("assertCurrentJsonTransition", () => {
+  const base = (logSeqStart: number): CurrentJson =>
+    seedJson({ tail_hint: 1_000_000, log_seq_start: logSeqStart });
+
+  plainTest("permits an advancing floor", () => {
+    expect(() => assertCurrentJsonTransition(base(10), base(20), "k")).not.toThrow();
+  });
+
+  plainTest("permits an unchanged floor", () => {
+    expect(() => assertCurrentJsonTransition(base(10), base(10), "k")).not.toThrow();
+  });
+
+  plainTest("rejects a lowered floor with Internal", () => {
+    try {
+      assertCurrentJsonTransition(base(20), base(10), "k");
+      expect.unreachable("expected a throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(BaerlyError);
+      expect((error as BaerlyError).code).toBe("Internal");
+      expect((error as BaerlyError).message).toContain("log_seq_start must not decrease");
+    }
+  });
 });
 
 describe("wire-contract constants", () => {

--- a/packages/protocol/src/coordination/current-json.ts
+++ b/packages/protocol/src/coordination/current-json.ts
@@ -15,6 +15,7 @@
  *   - {@link readCurrentJson}   — fetch + parse + validate
  *   - {@link createCurrentJson} — create-only (CAS via `If-None-Match:"*"`)
  *   - {@link casUpdateCurrentJson} — read-modify-write (CAS via `If-Match`)
+ *   - {@link assertCurrentJsonTransition} — shared before/after admission
  *   - {@link claimWriter}       — bump epoch + stamp server-clock claim time
  *
  * Why the two-round-trip claim protocol: `claimed_at` MUST come from
@@ -90,9 +91,8 @@ export interface CurrentJson {
    * Invariants:
    *   - `0 <= log_seq_start <= tail_hint`
    *   - `log_seq_start` advances monotonically (never decreases).
-   *     {@link casUpdateCurrentJson} rejects a mutator that lowers it;
-   *     `compact()` is monotone by construction once its seq-arithmetic
-   *     options are validated at the seam; `baerly admin restore
+   *     {@link assertCurrentJsonTransition} rejects a writer that lowers
+   *     it; `baerly admin restore
    *     --force` is the deliberate truncate exemption.
    *   - `log_seq_start > 0` implies `snapshot !== null` (the snapshot
    *     covers `[0, log_seq_start)`) — except after a `--force`
@@ -317,6 +317,43 @@ export async function createCurrentJson(
 }
 
 /**
+ * Admission control for a `current.json` state transition.
+ *
+ * Distinct from {@link assertCurrentJson}, which validates one state in
+ * isolation and therefore structurally cannot express a rule about a
+ * pair of states. Every invariant that compares before/after belongs
+ * here, and every writer that bypasses {@link casUpdateCurrentJson}
+ * MUST call it directly — "monotone by construction" is an argument
+ * that has to be re-made every time the writer is reimplemented, and
+ * it does not survive a chunk-aware compactor or a read-banking path.
+ *
+ * `Internal`, not `InvalidResponse`: the fault is a local caller's
+ * mutator, not a malformed storage response, and `InvalidResponse` maps
+ * to HTTP 502 ("storage upstream failed"), which would misattribute a
+ * programmer error to the bucket.
+ *
+ * @throws BaerlyError{code:"Internal"} on any violated transition rule.
+ * @see docs/spec/sync-protocol.md invariant 12
+ */
+export const assertCurrentJsonTransition = (
+  before: CurrentJson,
+  after: CurrentJson,
+  key: string,
+): void => {
+  // A regressed floor makes a stale pre-fold reader cursor pass the
+  // `cursorSeq < log_seq_start` re-bootstrap check (http/since.ts)
+  // instead of failing it. Equality is permitted: the `tail_hint`
+  // refresh and the `last_warned_seq` stamp in maintenance.ts both hold
+  // the floor fixed.
+  if (after.log_seq_start < before.log_seq_start) {
+    throw new BaerlyError(
+      "Internal",
+      `current.json at ${key}: log_seq_start must not decrease (${String(before.log_seq_start)} → ${String(after.log_seq_start)})`,
+    );
+  }
+};
+
+/**
  * Read-modify-write `current.json` under CAS. The `mutator` receives
  * a deep clone of the current parsed JSON (mutate freely) and returns
  * the new state. The new state is written with `If-Match:
@@ -338,12 +375,9 @@ export async function createCurrentJson(
  *         `last_warned_seq` stamp holds it fixed). No *production*
  *         mutator writes the floor, so no shipping caller can regress
  *         it; this guards future ones, and the protocol suite
- *         exercises the branch directly. Two floor writers bypass this
- *         function and are NOT covered by it: `compact()`, which must
- *         CAS on the etag of the read it folded from and so issues its
- *         own If-Match PUT (its fold end cannot dip below the pre-fold
- *         floor once its options are validated at the seam), and
- *         `baerly admin restore --force`, the deliberate truncate
+ *         exercises the branch directly. The compactor calls the same
+ *         transition validator before its direct `If-Match` PUT.
+ *         `baerly admin restore --force` is the deliberate truncate
  *         exemption.
  */
 export async function casUpdateCurrentJson(
@@ -365,20 +399,7 @@ export async function casUpdateCurrentJson(
   // targets Node ≥24 so it is safe.
   const next = mutator(structuredClone(existing.json));
   assertCurrentJson(next, key);
-  // Floor monotonicity is an admission-control invariant, not a shape
-  // one: it needs both sides of the transition, so `assertCurrentJson`
-  // cannot see it. A regressed floor makes a stale pre-fold reader
-  // cursor pass the `cursorSeq < log_seq_start` re-bootstrap check
-  // (http/since.ts) instead of failing it. `Internal`, not
-  // `InvalidResponse`: the fault is a local caller's mutator, not a
-  // malformed storage response. See `CurrentJson.log_seq_start` and
-  // docs/spec/sync-protocol.md invariant 12.
-  if (next.log_seq_start < existing.json.log_seq_start) {
-    throw new BaerlyError(
-      "Internal",
-      `current.json at ${key}: log_seq_start must not decrease (${String(existing.json.log_seq_start)} → ${String(next.log_seq_start)})`,
-    );
-  }
+  assertCurrentJsonTransition(existing.json, next, key);
   const body = encodeJson(next);
   const putOpts: StoragePutOptions = {
     ifMatch: existing.etag,
@@ -457,6 +478,7 @@ export async function claimWriter(
       }),
     },
   };
+  assertCurrentJsonTransition(existing.json, provisional, key);
   const body = encodeJson(provisional);
   const putOpts: StoragePutOptions = {
     ifMatch: existing.etag,
@@ -484,6 +506,7 @@ export async function claimWriter(
       claimed_at: result.serverDate.toISOString(),
     },
   };
+  assertCurrentJsonTransition(provisional, stamped, key);
   const stampedBody = encodeJson(stamped);
   const stampPutOpts: StoragePutOptions = {
     ifMatch: result.etag,

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -7,6 +7,7 @@ export {
   type CurrentJson,
   type CurrentJsonRead,
   type WriterFence,
+  assertCurrentJsonTransition,
   casUpdateCurrentJson,
   createCurrentJson,
   logSeqStartOf,

--- a/packages/server/src/compactor.test.ts
+++ b/packages/server/src/compactor.test.ts
@@ -89,6 +89,31 @@ describe("compact", () => {
     expect(after!.json.generation).toBe("0123456789ab");
   });
 
+  test("an incomplete-probe checkpoint holds the floor fixed", async () => {
+    // The equality arm of `assertCurrentJsonTransition`, which the
+    // checkpoint publication routes through. This PUT bumps only
+    // `tail_hint`, so tightening the shared validator to a STRICT
+    // increase would break the probe-budget checkpoint rather than any
+    // fold — this is the only compactor path that publishes without
+    // moving the floor. The advancing arm is pinned by "subsequent run
+    // extends the snapshot when new writes have landed".
+    const s = new MemoryStorage();
+    const collectionPrefix = KEY.slice(0, KEY.lastIndexOf("/"));
+    await bootstrap(s, KEY);
+    await seedLogEntries(s, collectionPrefix, 0, 100);
+
+    const res = await compact({ storage: s, currentJsonKey: KEY }, {
+      minEntriesToCompact: 50,
+      maxEntriesPerRun: 20,
+      maxTailProbeGets: 25,
+    } as InternalCompactOptions);
+
+    expect(res.skippedReason).toBe("probe-budget-checkpointed");
+    const after = await readCurrentJson(s, KEY);
+    expect(after!.json.log_seq_start).toBe(0);
+    expect(after!.json.tail_hint).toBeGreaterThan(0);
+  });
+
   test("returns current-json-missing when current.json doesn't exist", async () => {
     const s = new MemoryStorage();
     const res = await compact({ storage: s, currentJsonKey: KEY });

--- a/packages/server/src/compactor.ts
+++ b/packages/server/src/compactor.ts
@@ -38,6 +38,7 @@ import {
   type CurrentJson,
   type DocumentData,
   type MetricsRecorder,
+  assertCurrentJsonTransition,
   encodeJsonBytes,
   logSeqStartOf,
   BaerlyError,
@@ -249,12 +250,12 @@ export const compact = async (
   // `admin restore --force`, which reads `current.json` before reaching
   // its own floor exemption. Nothing shipped can repair that.
   //
-  // Validating here rather than asserting the floor at the fold also
+  // Validating here rather than leaning on the Step 7 floor guard also
   // buys the monotonicity invariant outright: with `maxPerRun >= 0` and
   // `nextSeq >= logSeqStartBefore` (guaranteed by `probeFloor`),
-  // `foldEnd >= logSeqStartBefore` holds by construction, so the floor
-  // cannot regress here — and a rejected run costs no orphan snapshot,
-  // because nothing has been written yet. The ceilings are deliberately
+  // `foldEnd >= logSeqStartBefore` holds by construction, so that guard
+  // never fires — and a rejected run costs no orphan snapshot, because
+  // nothing has been written yet. The ceilings are deliberately
   // not checked: a NaN there fails the viability comparisons closed
   // (defer), which is the safe direction.
   const requireSeqOption = (name: string, value: number): void =>
@@ -317,6 +318,7 @@ export const compact = async (
         ...current,
         tail_hint: Math.max(current.tail_hint, discoveredTail),
       };
+      assertCurrentJsonTransition(current, checkpoint, currentJsonKey);
       const checkpointBody = encodeJsonBytes(checkpoint);
       const checkpointCasOpts: StoragePutOptions = {
         ifMatch: baseEtag,
@@ -360,9 +362,11 @@ export const compact = async (
 
   // `foldEnd >= logSeqStartBefore` by construction: `maxPerRun` is a
   // validated non-negative integer and `nextSeq >= logSeqStartBefore`
-  // via `probeFloor`. Step 7's CAS bypasses `casUpdateCurrentJson`'s
-  // floor guard (it must If-Match the etag we folded from), so that
-  // construction is what keeps this writer monotone.
+  // via `probeFloor`. Step 7's CAS can't route through
+  // `casUpdateCurrentJson` (it must If-Match the etag we folded from),
+  // so it calls `assertCurrentJsonTransition` directly before its PUT —
+  // that check is what enforces monotonicity here; the construction
+  // above is why it never fires.
   const foldEnd = Math.min(nextSeq, logSeqStartBefore + maxPerRun);
 
   // ── Step 2. Load the previous snapshot (if any) as the fold base.
@@ -499,6 +503,7 @@ export const compact = async (
         ? Math.round(foldedSliceBytes / entriesFolded)
         : (current.mean_entry_bytes ?? 0),
   };
+  assertCurrentJsonTransition(current, next, currentJsonKey);
   const nextBody = encodeJsonBytes(next);
   const casOpts: StoragePutOptions = {
     ifMatch: baseEtag,


### PR DESCRIPTION
## What & why

`current.json`'s floor-monotonicity rule lived inline in `casUpdateCurrentJson`, so the two writers that issue their own conditional PUT were covered by an informal "monotone by construction" argument instead. This extracts `assertCurrentJsonTransition` as the single enforcement point for before/after invariants and routes every non-exempt writer through it. No behavior change.

The motivation is forward-looking: this is the seam arithmetic log retention extends with `log_delete_floor`, whose "never delete past a durable snapshot" rule is a before/after comparison with nowhere to live today. Centralizing it first keeps that change from having to re-derive enforcement at four call sites.

## Key points

- No shipping caller can currently violate the rule — a validated `maxEntriesPerRun` keeps the compactor's fold end at or above the pre-fold floor, and every other writer holds the floor fixed. The validator is what makes that survive a writer being reimplemented; "by construction" is an argument that has to be re-made each time.
- Routes four bypassing writers, not just the two the floor rule strictly needs: the compactor's fold CAS and probe checkpoint, `claimWriter`'s two PUTs, and `admin restore`'s tail stamp. Uniform routing is the point — admitting a call site only when it can currently fire reintroduces the per-site reasoning this removes.
- `restore --force` remains the deliberate floor-reset exemption and is not routed.
- The compactor keeps its own `If-Match` PUT: its CAS must be tied to the etag of the read it folded from. This centralizes transition admission, not publication.
- `sync-protocol.md` invariant 12 previously documented the compactor as monotone-by-construction and named two writers as bypassing enforcement; both statements stopped being true here, so it is rewritten. Invariant 6 needed no change — it enumerates who writes `current.json`, not where enforcement lives.
- The probe checkpoint is the only compactor publication that advances `tail_hint` while holding the floor fixed, making it the path a validator tightened to a strict increase would break; that equality arm is now pinned. The advancing arm was already covered.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3290 passed, 101 skipped |
| `pnpm test:adapter-cloudflare` | 158 passed, 2 skipped |
| `pnpm bundle-sizes` | ok, 14 entries, no rebaseline |

## Notes for reviewers

Start at the `assertCurrentJsonTransition` JSDoc in `packages/protocol/src/coordination/current-json.ts` — it states the rule for what belongs in the seam. The spec rewrite is the substantive part of the diff; the four call sites are mechanical.

The new test was checked against a mutated validator (`<` widened to `<=`) to confirm it fails rather than merely passing.
