### PR TITLE
feat(db)!: floor the log-read seams at log_seq_start

### DIFF
--- a/.changeset/log-read-seams-floored.md
+++ b/.changeset/log-read-seams-floored.md
@@ -1,0 +1,27 @@
+---
+"@gusto/baerly-storage": minor
+---
+
+The two `@internal` log-read seams on `Db` now take the `current.json`
+they are floored against and reject a seq below `log_seq_start` with
+`BaerlyError{code:"Internal"}`.
+
+**Migration — agents: if you wrote the LEFT, use the RIGHT:**
+
+```ts
+// before
+const entry = await db.getLogEntry(collection, seq);
+const tail = await db.probeLogTail(collection, hint);
+// after
+const read = await db.getCurrentJson(collection);
+const entry = await db.getLogEntry(collection, seq, read.json);
+const tail = await db.probeLogTail(collection, hint, read.json);
+```
+
+Pass the same manifest the seq was derived from. Entries below
+`log_seq_start` are already folded into the snapshot and may be
+reclaimed at any time, so reading one is a protocol violation rather
+than a tolerable miss — see invariant 5 in `docs/spec/sync-protocol.md`.
+Previously the floor lived entirely in the caller, and nothing in the
+type stopped a new HTTP route, CDC path, or adapter from reading
+beneath it. Application code is unaffected: use the collection API.

--- a/docs/spec/sync-protocol.md
+++ b/docs/spec/sync-protocol.md
@@ -486,6 +486,16 @@ These are the load-bearing rules.
    `[0, log_seq_start)` (carve-out: `baerly admin restore --force`
    leaves `snapshot: null` with a possibly-positive floor, because a
    truncate drops those entries rather than folding them).
+   **No reader depends on a log object below the floor.** Entries in
+   `[0, log_seq_start)` are already represented in the snapshot and may
+   be reclaimed at any time, so a sub-floor read is a protocol
+   violation, not a miss to tolerate. The two `Db` log-read seams —
+   `getLogEntry` and `probeLogTail` — take the `current.json` they are
+   floored against and throw `Internal` below it, so the floor is a
+   property of the seam rather than a discipline each caller has to
+   repeat. The one deliberate sub-floor GET is the writer's pre-image
+   scan, which is 404-tolerant by construction and whose worst case is
+   a redundant index key (invariant 7), never a wrong read.
 6. **`current.json` is compaction state; the commit path does not write
    it.** The compactor's fold CAS is the only steady-state writer of
    the snapshot pointer, `log_seq_start`, and snapshot counters.

--- a/packages/server/src/config.test-d.ts
+++ b/packages/server/src/config.test-d.ts
@@ -135,3 +135,16 @@ export const _idIsNotAPredicateKeyOnTypedTables = () => {
   // @ts-expect-error — `_id` is excluded from `Path<T>` on typed shapes.
   void boundCollection.where({ _id: "x" });
 };
+
+// The `Db` log-read seams take the manifest they are floored against.
+// Required pin 2 of the log-retention safety contract: the runtime
+// guard is in `db.test.ts`, but the reason a future HTTP route, CDC
+// path, or adapter cannot read below `log_seq_start` is that omitting
+// the manifest does not compile. Arity is the pin; delete the third
+// parameter and this file fails `tsgo --noEmit`.
+export const _logReadsRequireTheManifest = () => {
+  // @ts-expect-error — `current` is required; a bare seq has no floor.
+  void dbLegacy.getLogEntry("any", 0);
+  // @ts-expect-error — `current` is required; a bare hint has no floor.
+  void dbLegacy.probeLogTail("any", 0);
+};

--- a/packages/server/src/db.test.ts
+++ b/packages/server/src/db.test.ts
@@ -1,6 +1,7 @@
 import {
   type BaerlyConfig,
   BaerlyError,
+  type CurrentJson,
   CURRENT_JSON_SCHEMA_VERSION,
   createCurrentJson,
   MemoryStorage,
@@ -8,8 +9,19 @@ import {
   type Storage,
 } from "@baerly/protocol";
 import { describe, expect, test } from "vitest";
+import { logStateCurrentJson } from "../../../tests/fixtures/log-state.ts";
 import { Db } from "./db.ts";
 import { createObservabilityContext, runWithContext } from "./observability/index.ts";
+
+/**
+ * Zero-state manifest for the log-read seams. `log_seq_start: 0` floors
+ * nothing, so tests that assert on some *other* guard (path-segment
+ * validation) pass it and stay unaffected by the floor.
+ *
+ * Routed through the shared factory rather than hand-written, so the
+ * next `CurrentJson` field lands in one place instead of two.
+ */
+const FLOOR_ZERO: CurrentJson = logStateCurrentJson();
 
 describe("Db.create", () => {
   test("returns a Db scoped to the given app and tenant", () => {
@@ -87,7 +99,9 @@ describe("Db.create", () => {
     "db.getLogEntry(%j) rejects InvalidConfig (no unvalidated traversal)",
     async (bad) => {
       const db = Db.create({ storage: new MemoryStorage(), app: "a", tenant: "t" });
-      await expect(db.getLogEntry(bad, 0)).rejects.toMatchObject({ code: "InvalidConfig" });
+      await expect(db.getLogEntry(bad, 0, FLOOR_ZERO)).rejects.toMatchObject({
+        code: "InvalidConfig",
+      });
     },
   );
 
@@ -205,5 +219,117 @@ describe("Db → per-request metrics emission", () => {
     await provision(storage);
     const db = Db.create({ storage, app: APP, tenant: TENANT });
     await expect(db.collection(TABLE).insert({ title: "hi" })).resolves.toBeDefined();
+  });
+});
+
+// Required pin 2 of the log-retention safety contract: the two log-read
+// seams on the public `Db` are floored at `log_seq_start`. Before this,
+// `getLogEntry` took an arbitrary `seq` with no floor of any kind and
+// `probeLogTail` an unvalidated `hint`; the only production caller
+// (`http/since.ts`) floored correctly, but the floor lived entirely in
+// that caller. Nothing in the type or a test stopped a future HTTP
+// route, CDC path, or adapter from reading below the floor — which is
+// exactly the range arithmetic log retention will reclaim.
+describe("Db log-read seams are floored at log_seq_start", () => {
+  const APP = "tickets";
+  const TENANT = "acme";
+  const TABLE = "tickets";
+
+  /**
+   * A provisioned collection holding `count` committed entries at
+   * `log/0` … `log/<count-1>`. Commits never advance `log_seq_start`,
+   * so the returned manifest always has floor 0 — raise it with
+   * {@link raiseFloor}.
+   */
+  const seedEntries = async (count = 1): Promise<{ db: Db; current: CurrentJson }> => {
+    const storage = new MemoryStorage();
+    await createCurrentJson(
+      storage,
+      `app/${APP}/tenant/${TENANT}/manifests/${TABLE}/current.json`,
+      FLOOR_ZERO,
+    );
+    const db = Db.create({ storage, app: APP, tenant: TENANT });
+    for (let i = 0; i < count; i++) {
+      await db.collection(TABLE).insert({ title: `row ${i}` });
+    }
+    const read = await db.getCurrentJson(TABLE);
+    if (read === null) {
+      throw new Error("test setup: current.json missing after insert");
+    }
+    return { db, current: read.json };
+  };
+
+  /**
+   * The same manifest with the fold floor raised. `tail_hint` moves with
+   * it because `0 <= log_seq_start <= tail_hint` is a documented
+   * `CurrentJson` invariant and these literals never pass through
+   * `assertCurrentJson`, so nothing else would catch an impossible one.
+   */
+  const raiseFloor = (current: CurrentJson, to: number): CurrentJson => ({
+    ...current,
+    log_seq_start: to,
+    tail_hint: Math.max(current.tail_hint, to),
+  });
+
+  test("getLogEntry reads an entry at the floor", async () => {
+    const { db, current } = await seedEntries();
+    await expect(db.getLogEntry(TABLE, 0, current)).resolves.toMatchObject({ op: "I", seq: 0 });
+  });
+
+  test("getLogEntry throws Internal below the floor", async () => {
+    const { db, current } = await seedEntries();
+    await expect(db.getLogEntry(TABLE, 0, raiseFloor(current, 5))).rejects.toMatchObject({
+      code: "Internal",
+    });
+  });
+
+  // The floor retention actually reclaims against is a NON-ZERO one, and
+  // at floor 0 "at the floor" is indistinguishable from "not negative".
+  // Two entries with the floor raised to 1 separate them: seq 1 is at a
+  // real floor with a folded entry beneath it and must still read.
+  test("getLogEntry reads an entry at a raised floor", async () => {
+    const { db, current } = await seedEntries(2);
+    await expect(db.getLogEntry(TABLE, 1, raiseFloor(current, 1))).resolves.toMatchObject({
+      op: "I",
+      seq: 1,
+    });
+  });
+
+  // The guard is ordering-only, so a negative seq is rejected because it
+  // sorts below a zero floor — NOT because the seam validates its input.
+  // `NaN`, `Infinity`, and fractional seqs still pass (`NaN < 0` is
+  // `false`) and resolve `null` off a `log/NaN.json` GET.
+  test("getLogEntry throws Internal on a seq below a zero floor", async () => {
+    const { db, current } = await seedEntries();
+    await expect(db.getLogEntry(TABLE, -1, current)).rejects.toMatchObject({ code: "Internal" });
+  });
+
+  test("collection validation precedes the floor check", async () => {
+    const db = Db.create({ storage: new MemoryStorage(), app: APP, tenant: TENANT });
+    // Both guards would fire. The path-segment guard is the security
+    // boundary, so it must win — a traversal attempt is never
+    // reclassified as an internal invariant violation.
+    await expect(db.getLogEntry("..", 0, raiseFloor(FLOOR_ZERO, 5))).rejects.toMatchObject({
+      code: "InvalidConfig",
+    });
+  });
+
+  test("probeLogTail probes from the floor", async () => {
+    const { db, current } = await seedEntries();
+    await expect(db.probeLogTail(TABLE, 0, current)).resolves.toBe(1);
+  });
+
+  // Same reason as the raised-floor read above: the probe must still find
+  // the true tail when it starts at a non-zero floor.
+  test("probeLogTail probes from a raised floor", async () => {
+    const { db, current } = await seedEntries(2);
+    await expect(db.probeLogTail(TABLE, 1, raiseFloor(current, 1))).resolves.toBe(2);
+  });
+
+  test("probeLogTail throws Internal on a sub-floor hint", async () => {
+    const { db, current } = await seedEntries();
+    await expect(db.probeLogTail(TABLE, 0, raiseFloor(current, 5))).rejects.toMatchObject({
+      code: "Internal",
+    });
   });
 });

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -3,12 +3,14 @@ import {
   BaerlyError,
   type Collection,
   type CollectionNames,
+  type CurrentJson,
   type CurrentJsonRead,
   decodeJsonBytes,
   type DocumentData,
   type IndexDefinition,
   logObjectKey,
   type LogEntry,
+  logSeqStartOf,
   readCurrentJson,
   type RowOf,
   type SchemaValidator,
@@ -279,17 +281,31 @@ export class Db<TConfig extends BaerlyConfig = UnboundConfig> {
    * entry). Throws `BaerlyError{code:"InvalidResponse"}` on a body
    * that isn't valid JSON.
    *
+   * `current` is the manifest this read is floored against — pass the
+   * same one the `seq` was derived from. It is a parameter rather than
+   * caller-enforced discipline so a new caller cannot introduce a
+   * sub-floor read: entries below `current.log_seq_start` are folded
+   * into the snapshot and may already be reclaimed (invariant 5 in
+   * `docs/spec/sync-protocol.md`).
+   *
+   * @throws BaerlyError code="Internal" — `seq` is below
+   *         `current.log_seq_start`.
+   *
    * @internal — typed seam for the HTTP handler; app code should use
    *             the collection API.
    */
   async getLogEntry(
     collection: string,
     seq: number,
+    current: CurrentJson,
     opts?: { signal?: AbortSignal },
   ): Promise<LogEntry | null> {
     // Defensive at the db layer so ALL callers are covered — same
     // rationale as `getCurrentJson`; the `/v1/since` poll reaches here.
+    // Path validation runs FIRST: a traversal attempt is a security
+    // boundary and must not be reclassified as an invariant violation.
     assertPathSegment(collection, "collection");
+    assertAtOrAboveLogFloor("getLogEntry", seq, current);
     const key = logObjectKey(
       `${physicalPrefixFor(this.app, this.tenant)}manifests/${collection}`,
       seq,
@@ -315,19 +331,62 @@ export class Db<TConfig extends BaerlyConfig = UnboundConfig> {
    * Forward-probe the TRUE committed log tail from `hint` (a lower
    * bound, typically `tail_hint`). Backs the `/v1/since` end-bound.
    *
+   * `hint` stays a caller-chosen lower bound — the probe is defined
+   * from an arbitrary starting point at or above the floor, and every
+   * other consumer starts at `max(log_seq_start, tail_hint)`. What
+   * `current` adds is that the floor cannot be forgotten (invariant 5
+   * in `docs/spec/sync-protocol.md`).
+   *
+   * @throws BaerlyError code="Internal" — `hint` is below
+   *         `current.log_seq_start`.
+   *
    * @internal — typed seam for the HTTP handler.
    */
   async probeLogTail(
     collection: string,
     hint: number,
+    current: CurrentJson,
     opts?: { signal?: AbortSignal },
   ): Promise<number> {
     assertPathSegment(collection, "collection");
+    assertAtOrAboveLogFloor("probeLogTail", hint, current);
     const logPrefix = `${physicalPrefixFor(this.app, this.tenant)}manifests/${collection}`;
     const { tail } = await probeTailFrom(this.#storage, logPrefix, hint, opts);
     return tail;
   }
 }
+
+/**
+ * Guard a log-read seq against the fold floor it was derived from.
+ *
+ * Entries below `log_seq_start` have been folded into the snapshot
+ * (invariant 5 in `docs/spec/sync-protocol.md`) and may be reclaimed at
+ * any time, so a sub-floor read is never a legitimate request — it is
+ * either a stale seq the caller failed to screen, or a caller that
+ * never screened at all. Both are protocol-invariant violations by
+ * internal code, hence `Internal` rather than `InvalidConfig`: no
+ * client input reaches these seams unscreened (`/v1/since` rejects a
+ * sub-floor cursor with `SchemaError` before ever getting here).
+ *
+ * The floor arrives as the whole `CurrentJson` rather than a bare
+ * number so it cannot be invented independently of the manifest, and
+ * so a later floor on the same object — the retention delete floor —
+ * lands here without another signature change.
+ *
+ * Loud on purpose. PostgreSQL removed `old_snapshot_threshold` in PG17
+ * because a fixed reclamation window that let a reader proceed
+ * *silently* produced wrong answers; Oracle's `ORA-01555` is the same
+ * trade and survives because it throws.
+ */
+const assertAtOrAboveLogFloor = (seam: string, seq: number, current: CurrentJson): void => {
+  const floor = logSeqStartOf(current);
+  if (seq < floor) {
+    throw new BaerlyError(
+      "Internal",
+      `${seam}: seq ${seq} is below the fold floor log_seq_start=${floor}; entries beneath the floor are folded into the snapshot and may already be reclaimed`,
+    );
+  }
+};
 
 /**
  * Guard a string used as a path-segment in the bucket-key encoding.

--- a/packages/server/src/http/since.ts
+++ b/packages/server/src/http/since.ts
@@ -308,6 +308,7 @@ async function pollOnce(
   const tail = await db.probeLogTail(
     collection,
     Math.max(logSeqStart, read.json.tail_hint),
+    read.json,
     signalOpt(signal),
   );
 
@@ -362,7 +363,7 @@ async function pollOnce(
   // memory bounded under pathological workloads.
   const entries: LogEntry[] = [];
   for (let s = startSeq; s < endSeq; s++) {
-    const entry = await db.getLogEntry(collection, s, signalOpt(signal));
+    const entry = await db.getLogEntry(collection, s, read.json, signalOpt(signal));
     if (entry === null) {
       // Race: the GC sweeper deleted this entry between
       // `getCurrentJson` and the GET. Skip; don't error.


### PR DESCRIPTION
## What & why

`Db.getLogEntry` took an arbitrary `seq` with no floor of any kind, and `Db.probeLogTail` an unvalidated `hint`. Both are `@internal` and the one production caller (`http/since.ts`) floors correctly — but the floor lived entirely in that caller, so nothing in the type or a test stopped a future HTTP route, CDC path, or adapter from reading below `log_seq_start`. That range is exactly what arithmetic log retention will reclaim. Both seams now take the `current.json` they are floored against and throw `Internal` beneath it.

This is required pin 2 of the log-retention safety contract (PR 4a of the GC simplification program). It enables no deletion on its own and is independently revertible.

## Key points

- Takes the manifest rather than a bare `floor: number` for two reasons: the floor can't be invented independently of the manifest, and the retention delete floor (PR 4b) lands on the same object with no further signature change.
- Arity is the real pin — `config.test-d.ts` fails `tsgo --noEmit` if either seam goes back to accepting `(collection, seq)`. The runtime guard is defense in depth.
- `Internal`, not `InvalidConfig`: no client input reaches these seams unscreened (`/v1/since` rejects a sub-floor cursor with `SchemaError` first), so a sub-floor read is an internal invariant violation. Loud rather than silent, per the `old_snapshot_threshold` / `ORA-01555` rationale in the guard's JSDoc.
- `hint` stays a caller-chosen lower bound; the probe is still defined from any starting point at or above the floor.
- Scope note: this floors the two `Db` seams. The lower-level `walkLogRange` / `probeTailFrom` are public exports taking a bare seq and are deliberately out of scope — tracked as PR 4e, since threading a manifest into storage-level primitives is the wrong layer and `packages/cli` consumes both.
- Path-segment validation still runs first, pinned by a test — a traversal attempt is never reclassified as an invariant violation.
- Zero behavior change: the sole caller already satisfied the floor.
- The writer's pre-image scan remains deliberately sub-floor and 404-tolerant; sync-protocol invariant 5 now records that alongside the read-side rule.

## Verification

| Command | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3294 passed, 101 skipped |
| `pnpm test:adapter-cloudflare` | 158 passed, 2 skipped |
| `pnpm bundle-sizes` | ok (14 entries), no rebaseline needed |

Each new guard was watched failing before implementation. The guard-ordering test was additionally proven to discriminate by swapping the two asserts and confirming it goes red. The floor comparison itself was mutation-checked: relaxing it to `seq <= floor` fails four tests, including both raised-floor reads.

## Notes for reviewers

Start at `assertAtOrAboveLogFloor` in `db.ts` — the error-code choice and the reason the whole manifest is threaded are both argued there. Only PR 4d (the read-to-delete fence) is still an open design question in PR 4; this one is mechanical.
