### PR TITLE
feat(react): add non-live queries and reliable polling

### DIFF
--- a/.changeset/calm-queries-refetch.md
+++ b/.changeset/calm-queries-refetch.md
@@ -12,3 +12,12 @@ Live queries now stop and surface non-retriable `/v1/since` failures,
 including `Unauthorized`, instead of retrying forever behind stale data.
 Retriable transport failures use bounded exponential backoff with jitter,
 and dead `SchemaError` cursors continue to re-bootstrap automatically.
+`refetch()` on any query sharing a stopped subscription clears the error
+on all of them, not just the caller.
+
+An HTTP error response carrying no `baerly` error envelope — what a load
+balancer, CDN, or service mesh returns when it answers for the server —
+is now classified from its status: 5xx becomes a retriable
+`NetworkError` rather than a terminal `Internal`. A transient gateway
+502 during a rolling deploy therefore backs off and recovers instead of
+stopping every live query until remount.

--- a/.changeset/calm-queries-refetch.md
+++ b/.changeset/calm-queries-refetch.md
@@ -1,0 +1,14 @@
+---
+"@gusto/baerly-storage": minor
+---
+
+Add `useQuery(callback, deps, { live: false })` for typed React reads
+that run initially and when dependencies change without opening a
+`/v1/since` subscription. Every `UseQueryResult` state now includes a
+stable `refetch()` function; calling it refreshes the current query and
+preserves the previous successful data while refreshing or on error.
+
+Live queries now stop and surface non-retriable `/v1/since` failures,
+including `Unauthorized`, instead of retrying forever behind stale data.
+Retriable transport failures use bounded exponential backoff with jitter,
+and dead `SchemaError` cursors continue to re-bootstrap automatically.

--- a/bundle-sizes.json
+++ b/bundle-sizes.json
@@ -17,77 +17,77 @@
     "index.js": {
       "tier": "shipped",
       "raw": 259465,
-      "gz": 82055,
-      "minGz": 21169,
+      "gz": 82093,
+      "minGz": 21148,
       "note": "kernel barrel; every consumer pays. Must not pull the observability subgraph — see the dedicated test."
     },
     "client.js": {
       "tier": "shipped",
       "raw": 16275,
-      "gz": 5663,
-      "minGz": 2319,
+      "gz": 5644,
+      "minGz": 2300,
       "note": "browser client; must stay tiny. No kernel modules in the closure."
     },
     "client-react.js": {
       "tier": "shipped",
-      "raw": 33045,
-      "gz": 10621,
-      "minGz": 4247,
+      "raw": 33342,
+      "gz": 10692,
+      "minGz": 4276,
       "note": "browser client + React hooks. React itself is external."
     },
     "cloudflare.js": {
       "tier": "shipped",
-      "raw": 449048,
-      "gz": 136047,
-      "minGz": 44977,
+      "raw": 448846,
+      "gz": 136111,
+      "minGz": 44947,
       "note": "Worker isolate cold start. Aggregator: closure includes the index.js and http.js subgraphs, so growth that slips past those entries still surfaces here."
     },
     "s3.js": {
       "tier": "shipped",
       "raw": 86031,
-      "gz": 27635,
-      "minGz": 11455,
+      "gz": 27732,
+      "minGz": 11500,
       "note": "Worker-safe S3 entry, so consumer-facing. Demonstrated catch: fast-xml-parser is pinned at 5.8.0 because 5.9.3 inflated this closure ~25%."
     },
     "gcs.js": {
       "tier": "shipped",
       "raw": 80648,
-      "gz": 26200,
-      "minGz": 9648,
+      "gz": 26348,
+      "minGz": 9692,
       "note": "Worker-safe GCS entry, so consumer-facing. Smaller than s3.js because the GOOG4 signer is lighter than aws4fetch."
     },
     "http.js": {
       "tier": "shipped",
-      "raw": 384718,
-      "gz": 115278,
-      "minGz": 37488,
+      "raw": 384516,
+      "gz": 115492,
+      "minGz": 37450,
       "note": "server-side. Also inside the cloudflare.js closure, so growth here shows up on that entry too."
     },
     "auth.js": {
       "tier": "shipped",
       "raw": 57470,
-      "gz": 15191,
-      "minGz": 9154,
+      "gz": 15257,
+      "minGz": 9193,
       "note": "server-side. Reached from the index.js closure. Adding a fourth verifier grows this, not the kernel's."
     },
     "maintenance.js": {
       "tier": "shipped",
       "raw": 147935,
-      "gz": 45922,
-      "minGz": 12116,
+      "gz": 45935,
+      "minGz": 12107,
       "note": "operator-side; reached from the cloudflare.js closure."
     },
     "observability.js": {
       "tier": "shipped",
       "raw": 101634,
-      "gz": 27852,
-      "minGz": 12674,
+      "gz": 27972,
+      "minGz": 12686,
       "note": "operator-side. LogTape accounts for the bulk."
     },
     "app-config.js": {
       "tier": "shipped",
       "raw": 167,
-      "gz": 149,
+      "gz": 147,
       "minGz": 70,
       "hardCeiling": {
         "raw": 1024,
@@ -102,12 +102,12 @@
     },
     "node.js": {
       "tier": "tooling",
-      "raw": 613495,
+      "raw": 612915,
       "note": "server-only aggregator. Raw-only dep-creep tripwire; live-external-import creep is caught separately by the bare-specifier allowlist test."
     },
     "dev-vite.js": {
       "tier": "tooling",
-      "raw": 622408,
+      "raw": 621828,
       "note": "dev-only aggregator. Raw-only dep-creep tripwire; see node.js."
     }
   }

--- a/bundle-sizes.json
+++ b/bundle-sizes.json
@@ -17,77 +17,77 @@
     "index.js": {
       "tier": "shipped",
       "raw": 259465,
-      "gz": 82093,
-      "minGz": 21148,
+      "gz": 82055,
+      "minGz": 21169,
       "note": "kernel barrel; every consumer pays. Must not pull the observability subgraph — see the dedicated test."
     },
     "client.js": {
       "tier": "shipped",
-      "raw": 15822,
-      "gz": 5514,
-      "minGz": 2254,
+      "raw": 16105,
+      "gz": 5595,
+      "minGz": 2302,
       "note": "browser client; must stay tiny. No kernel modules in the closure."
     },
     "client-react.js": {
       "tier": "shipped",
-      "raw": 27172,
-      "gz": 9086,
-      "minGz": 3513,
+      "raw": 32482,
+      "gz": 10447,
+      "minGz": 4185,
       "note": "browser client + React hooks. React itself is external."
     },
     "cloudflare.js": {
       "tier": "shipped",
       "raw": 449048,
-      "gz": 136137,
-      "minGz": 44965,
+      "gz": 136047,
+      "minGz": 44977,
       "note": "Worker isolate cold start. Aggregator: closure includes the index.js and http.js subgraphs, so growth that slips past those entries still surfaces here."
     },
     "s3.js": {
       "tier": "shipped",
       "raw": 86031,
-      "gz": 27732,
-      "minGz": 11500,
+      "gz": 27635,
+      "minGz": 11455,
       "note": "Worker-safe S3 entry, so consumer-facing. Demonstrated catch: fast-xml-parser is pinned at 5.8.0 because 5.9.3 inflated this closure ~25%."
     },
     "gcs.js": {
       "tier": "shipped",
       "raw": 80648,
-      "gz": 26348,
-      "minGz": 9692,
+      "gz": 26200,
+      "minGz": 9648,
       "note": "Worker-safe GCS entry, so consumer-facing. Smaller than s3.js because the GOOG4 signer is lighter than aws4fetch."
     },
     "http.js": {
       "tier": "shipped",
       "raw": 384718,
-      "gz": 115516,
-      "minGz": 37466,
+      "gz": 115278,
+      "minGz": 37488,
       "note": "server-side. Also inside the cloudflare.js closure, so growth here shows up on that entry too."
     },
     "auth.js": {
       "tier": "shipped",
       "raw": 57470,
-      "gz": 15257,
-      "minGz": 9193,
+      "gz": 15191,
+      "minGz": 9154,
       "note": "server-side. Reached from the index.js closure. Adding a fourth verifier grows this, not the kernel's."
     },
     "maintenance.js": {
       "tier": "shipped",
       "raw": 147935,
-      "gz": 45935,
-      "minGz": 12107,
+      "gz": 45922,
+      "minGz": 12116,
       "note": "operator-side; reached from the cloudflare.js closure."
     },
     "observability.js": {
       "tier": "shipped",
       "raw": 101634,
-      "gz": 27972,
-      "minGz": 12686,
+      "gz": 27852,
+      "minGz": 12674,
       "note": "operator-side. LogTape accounts for the bulk."
     },
     "app-config.js": {
       "tier": "shipped",
       "raw": 167,
-      "gz": 147,
+      "gz": 149,
       "minGz": 70,
       "hardCeiling": {
         "raw": 1024,

--- a/bundle-sizes.json
+++ b/bundle-sizes.json
@@ -23,16 +23,16 @@
     },
     "client.js": {
       "tier": "shipped",
-      "raw": 16105,
-      "gz": 5595,
-      "minGz": 2302,
+      "raw": 16275,
+      "gz": 5663,
+      "minGz": 2319,
       "note": "browser client; must stay tiny. No kernel modules in the closure."
     },
     "client-react.js": {
       "tier": "shipped",
-      "raw": 32482,
-      "gz": 10447,
-      "minGz": 4185,
+      "raw": 33045,
+      "gz": 10621,
+      "minGz": 4247,
       "note": "browser client + React hooks. React itself is external."
     },
     "cloudflare.js": {

--- a/docs/superpowers/plans/2026-08-13-dead-cursor-retry.md
+++ b/docs/superpowers/plans/2026-08-13-dead-cursor-retry.md
@@ -1,0 +1,141 @@
+# Dead-Cursor Retry Damping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent repeated replacement-cursor rejection from resetting the
+React subscription pool to its initial retry delay after every successful
+empty-cursor bootstrap.
+
+**Architecture:** Keep one retry counter for the table-poll loop and add one
+local boolean recording that dead-cursor recovery is not yet proven. Capture
+the cursor used for each request so only a successful request made with a
+non-empty replacement cursor clears that state and resets backoff.
+
+**Tech Stack:** TypeScript, Vitest fake timers, pnpm, oxfmt, oxlint.
+
+## Global Constraints
+
+- Keep the equal-jitter retry bounds at 250 ms initial and 10 seconds maximum.
+- Preserve the existing reset after an ordinary successful poll.
+- Preserve automatic empty-cursor bootstrap and query invalidation after a
+  dead-cursor `SchemaError`.
+- Add no public API, wire-protocol change, or dependency.
+- Do not push the resulting commit without explicit authorization.
+
+---
+
+### Task 1: Carry backoff across unproven dead-cursor bootstrap
+
+**Files:**
+
+- Modify: `packages/client/src/react/subscription-pool.test.ts`
+- Modify: `packages/client/src/react/subscription-pool.ts`
+- External update: PR #126 description
+
+**Interfaces:**
+
+- Consumes: `pollSinceOnce(ctx, table, cursor, signal)` and the existing
+  `retryDelay(attempt)` / `waitForRetry(delay, signal)` helpers.
+- Produces: no new exported interface; only table-poll-local recovery state.
+
+- [ ] **Step 1: Replace the loose oscillation assertion with a failing timing
+      contract.**
+
+  Rename the test to
+  `a repeatedly rejected replacement cursor retains backoff across bootstrap success`.
+  Record `Date.now()` for every `/v1/since` call, set system time to `0`, and
+  make `Math.random()` return `0`. Keep the alternating empty-cursor success
+  and non-empty-cursor `SchemaError` responses. Assert the literal schedule:
+
+  ```ts
+  expect(callTimes).toEqual([0, 0]);
+  await vi.advanceTimersByTimeAsync(125);
+  expect(callTimes).toEqual([0, 0, 125, 125]);
+  await vi.advanceTimersByTimeAsync(125);
+  expect(callTimes).toEqual([0, 0, 125, 125]);
+  await vi.advanceTimersByTimeAsync(125);
+  expect(callTimes).toEqual([0, 0, 125, 125, 375, 375]);
+  await vi.advanceTimersByTimeAsync(500);
+  expect(callTimes).toEqual([0, 0, 125, 125, 375, 375, 875, 875]);
+  ```
+
+  The production mutation this catches is resetting `retryAttempt` after the
+  empty-cursor bootstrap even though the replacement cursor has not succeeded.
+
+- [ ] **Step 2: Run the focused test and verify RED.**
+
+  Run:
+
+  ```sh
+  pnpm test:agent packages/client/src/react/subscription-pool.test.ts
+  ```
+
+  Expected: the renamed oscillation test fails at simulated time 250 ms
+  because the current implementation has already issued another bootstrap and
+  rejected-cursor pair.
+
+- [ ] **Step 3: Implement the minimal recovery-state distinction.**
+
+  In `startTablePoll`, add `let deadCursorRecoveryPending = false` next to
+  `retryAttempt`. At the top of each loop iteration capture
+  `const requestCursor = poll.cursor` and pass it to `pollSinceOnce`.
+
+  When the dead-cursor `SchemaError` branch clears `poll.cursor`, also set
+  `deadCursorRecoveryPending = true`. Replace the unconditional success reset
+  with:
+
+  ```ts
+  if (!deadCursorRecoveryPending || requestCursor !== "") {
+    retryAttempt = 0;
+    deadCursorRecoveryPending = false;
+  }
+  ```
+
+  This leaves normal successful polls unchanged and treats an empty-cursor
+  success during recovery only as receipt of a candidate replacement cursor.
+
+- [ ] **Step 4: Run the focused test and verify GREEN.**
+
+  Run:
+
+  ```sh
+  pnpm test:agent packages/client/src/react/subscription-pool.test.ts
+  ```
+
+  Expected: all subscription-pool tests pass, including the existing transport
+  test that proves a normal success resets backoff.
+
+- [ ] **Step 5: Update the PR description.**
+
+  Replace “Preserves bounded retry for transport failures and dead-cursor
+  SchemaError recovery” with prose that explicitly states retriable transport
+  failures use equal-jitter exponential backoff with a 250 ms initial bound
+  and 10 second cap, and that repeated replacement-cursor rejection retains
+  backoff across empty-cursor bootstrap.
+
+- [ ] **Step 6: Run repository verification.**
+
+  Run, without piping output:
+
+  ```sh
+  pnpm verify:agent
+  pnpm bundle-sizes
+  pnpm test:agent
+  ```
+
+  Expected: all commands exit zero. Report any known load-sensitive timeout
+  separately rather than claiming it passed.
+
+- [ ] **Step 7: Commit the local changes.**
+
+  Stage only the design, plan, test, and implementation files. Inspect
+  `git status --short`, `git diff --cached --stat`, and `git diff --cached`
+  before committing with:
+
+  ```sh
+  git commit -m "fix(react): damp dead-cursor retry oscillation"
+  ```
+
+  Do not push. Report the commit hash and ask for explicit push permission.

--- a/docs/superpowers/specs/2026-08-13-dead-cursor-retry-design.md
+++ b/docs/superpowers/specs/2026-08-13-dead-cursor-retry-design.md
@@ -1,0 +1,63 @@
+# Dead-cursor retry damping — design
+
+**Base:** `fix/react-query-subscriptions` @ `0132d46c`, 2026-08-13.
+**Status:** approved.
+
+## Problem
+
+The React subscription pool uses equal-jitter exponential backoff for
+retriable `/v1/since` failures. A successful poll resets the attempt counter.
+That is correct for an established subscription, but not for the two-request
+dead-cursor recovery sequence:
+
+1. a non-empty cursor receives `SchemaError`;
+2. the pool invalidates affected queries, clears the cursor, and backs off;
+3. an empty-cursor bootstrap succeeds and issues a replacement cursor;
+4. a mixed-version peer rejects that replacement cursor; and
+5. the sequence repeats.
+
+Resetting after step 3 keeps every rejection in the initial 125–250 ms jitter
+window. The previous fixed delay admitted at most one invalidation cycle per
+second, so the new behavior can refetch roughly four times as often during a
+rolling-deploy oscillation.
+
+## Design
+
+Track whether a dead-cursor recovery is still unproven. Capture the cursor
+used for each poll before awaiting the request.
+
+- A normal successful poll resets the retry attempt counter.
+- A successful empty-cursor bootstrap that returns a non-empty replacement
+  while recovery is unproven keeps the existing attempt counter: it only
+  obtained a candidate replacement.
+- A successful empty-cursor bootstrap that remains at an empty cursor has no
+  replacement left to prove, so it clears recovery state and resets the
+  attempt counter.
+- A successful poll made with a non-empty replacement cursor proves recovery,
+  clears the recovery state, and resets the attempt counter.
+- Another `SchemaError` for the replacement cursor keeps recovery unproven and
+  advances the existing exponential backoff.
+- Transport failures continue using the same retry counter and 250 ms initial
+  bound / 10 second cap.
+
+This preserves the fast first dead-cursor recovery while damping repeated
+invalidation storms. It adds no public option, dependency, or wire change.
+
+## Verification
+
+Replace the oscillation test's loose request-count ceiling with exact request
+times under deterministic maximum jitter. The test must fail when every
+empty-cursor success resets the attempt counter and pass when consecutive
+replacement-cursor rejections produce increasing delays. Keep the existing
+test proving that an ordinary successful poll resets transport backoff.
+
+Run the focused subscription-pool suite, then `pnpm verify:agent`,
+`pnpm bundle-sizes`, and `pnpm test:agent`.
+
+## PR description
+
+Replace the ambiguous claim that the branch “preserves bounded retry” with an
+explicit statement that retriable transport failures use equal-jitter
+exponential backoff with a 250 ms initial bound and 10 second cap, while
+dead-cursor recovery retains its bound and damps repeated replacement-cursor
+rejection.

--- a/examples/react-cloudflare/AGENTS.md
+++ b/examples/react-cloudflare/AGENTS.md
@@ -667,12 +667,14 @@ const result = useQuery(
 );
 ```
 
-`useQuery` re-runs the callback when `deps` changes OR when the
-`/v1/since?collection=<name>&cursor=<opaque>` long-poll batches a
-non-empty change for any subscribed
-collection. Idle long-poll cycles (empty batches) drop at the
-`subscription-pool` layer, so a steady-state collection costs zero list
-reads. Add a `<select>` bound to `setFilter` and the list narrows live.
+`useQuery` is live by default: it re-runs on dependency changes and
+non-empty `/v1/since` batches for any collection the callback reads.
+Pass `{ live: false }` for mount/dependency reads without `/v1/since`.
+Every result state has a stable `refetch()`; successful data stays
+available while refreshing and on error. A non-retriable subscription
+error stops automatic polling, while explicit `refetch()` retries the
+read and restarts the terminal live subscription. Idle long-poll cycles
+do not re-run the query.
 
 For conditional / deferred reads, return the `useQuery.skip` sentinel
 from the callback — the hook short-circuits to

--- a/examples/react-node/AGENTS.md
+++ b/examples/react-node/AGENTS.md
@@ -611,12 +611,14 @@ const result = useQuery(
 );
 ```
 
-`useQuery` re-runs the callback when `deps` changes OR when the
-`/v1/since?collection=<name>&cursor=<opaque>` long-poll batches a
-non-empty change for any subscribed
-collection. Idle long-poll cycles (empty batches) drop at the
-`subscription-pool` layer, so a steady-state collection costs zero list
-reads. Add a `<select>` bound to `setFilter` and the list narrows live.
+`useQuery` is live by default: it re-runs on dependency changes and
+non-empty `/v1/since` batches for any collection the callback reads.
+Pass `{ live: false }` for mount/dependency reads without `/v1/since`.
+Every result state has a stable `refetch()`; successful data stays
+available while refreshing and on error. A non-retriable subscription
+error stops automatic polling, while explicit `refetch()` retries the
+read and restarts the terminal live subscription. Idle long-poll cycles
+do not re-run the query.
 
 For conditional / deferred reads, return the `useQuery.skip` sentinel
 from the callback — the hook short-circuits to

--- a/packages/client/src/poll-since-once.test.ts
+++ b/packages/client/src/poll-since-once.test.ts
@@ -118,6 +118,37 @@ describe("pollSinceOnce", () => {
     });
   });
 
+  test("a 5xx with no error envelope is retriable, a 4xx with none is not", async () => {
+    // Proxies, load balancers, and CDNs answer with their own bodies,
+    // so the server's failure class is unavailable and the status is
+    // all there is to go on. Consumers that gate retries on
+    // `retriable` — the React subscription pool treats a
+    // non-retriable poll failure as permanently terminal — depend on
+    // a transient gateway 5xx not being classified as a caller fault.
+    const gatewayBody = () =>
+      new Response("<html>upstream unavailable</html>", {
+        status: 503,
+        headers: { "content-type": "text/html" },
+      });
+    const notFoundBody = () =>
+      new Response("<html>no route</html>", {
+        status: 404,
+        headers: { "content-type": "text/html" },
+      });
+
+    const gatewayMock = new MockFetch();
+    gatewayMock.on("GET", "/v1/since", gatewayBody);
+    await expect(
+      pollSinceOnce(ctxFor(gatewayMock), "tickets", "", undefined),
+    ).rejects.toMatchObject({ code: "NetworkError", status: 503, retriable: true });
+
+    const notFoundMock = new MockFetch();
+    notFoundMock.on("GET", "/v1/since", notFoundBody);
+    await expect(
+      pollSinceOnce(ctxFor(notFoundMock), "tickets", "", undefined),
+    ).rejects.toMatchObject({ code: "Internal", status: 404, retriable: false });
+  });
+
   test("collection names are URL-encoded so '/' and '&' round-trip cleanly", async () => {
     const mock = new MockFetch();
     mock.on("GET", "/v1/since", (req) => {

--- a/packages/client/src/poll-since-once.test.ts
+++ b/packages/client/src/poll-since-once.test.ts
@@ -54,6 +54,28 @@ describe("pollSinceOnce", () => {
     expect(res.next_cursor).toBe("c-3");
   });
 
+  test("rejects malformed JSON from a successful response as InvalidResponse", async () => {
+    const mock = new MockFetch();
+    mock.on(
+      "GET",
+      "/v1/since",
+      () => new Response("{", { status: 200, headers: { "content-type": "application/json" } }),
+    );
+
+    await expect(pollSinceOnce(ctxFor(mock), "tickets", "", undefined)).rejects.toMatchObject({
+      code: "InvalidResponse",
+    });
+  });
+
+  test("rejects a successful response without the SinceResponse fields", async () => {
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", () => jsonResponse({}));
+
+    await expect(pollSinceOnce(ctxFor(mock), "tickets", "", undefined)).rejects.toMatchObject({
+      code: "InvalidResponse",
+    });
+  });
+
   test("propagates the AbortSignal to the underlying fetch (and rejects when fired)", async () => {
     // Drive the underlying fetcher directly so we can observe signal
     // propagation without depending on MockFetch's regex matcher.

--- a/packages/client/src/poll-since-once.ts
+++ b/packages/client/src/poll-since-once.ts
@@ -1,3 +1,4 @@
+import { BaerlyError } from "@baerly/protocol";
 import type { SinceResponse } from "./contract.ts";
 import { type RequestContext, request } from "./request.ts";
 
@@ -27,9 +28,23 @@ export const pollSinceOnce = async (
   const params = new URLSearchParams();
   params.set("collection", name);
   params.set("cursor", cursor);
-  return request<SinceResponse>(ctx, {
+  const response = await request<unknown>(ctx, {
     method: "GET",
     path: `/v1/since?${params.toString()}`,
     signal,
   });
+  if (
+    typeof response !== "object" ||
+    response === null ||
+    !("events" in response) ||
+    !Array.isArray(response.events) ||
+    !("next_cursor" in response) ||
+    typeof response.next_cursor !== "string"
+  ) {
+    throw new BaerlyError(
+      "InvalidResponse",
+      "Response to GET /v1/since must contain an events array and string next_cursor",
+    );
+  }
+  return response as SinceResponse;
 };

--- a/packages/client/src/react/create-react.test-d.ts
+++ b/packages/client/src/react/create-react.test-d.ts
@@ -10,8 +10,7 @@
 
 import { defineConfig, type DocumentData, type SchemaValidator } from "@baerly/protocol";
 import type { BaerlyClient } from "../client.ts";
-import { createBaerlyReact } from "./create-react.ts";
-import type { UseQueryResult } from "./use-query.ts";
+import { createBaerlyReact, type UseQueryOptions, type UseQueryResult } from "./index.ts";
 
 // Minimal validator stand-in — independent of zod / valibot so this
 // file pulls no runtime dep. Mirrors `client.test-d.ts`.
@@ -38,6 +37,10 @@ type Equal<X, Y> =
   (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
 type Expect<T extends true> = T;
 
+export type _LiveOptionIsOptionalBoolean = Expect<
+  Equal<UseQueryOptions["live"], boolean | undefined>
+>;
+
 const { useQuery, useMutation, useBaerlyClient } = createBaerlyReact<typeof config>();
 
 // (A) The headline fix: a bound `useQuery` infers the row type from
@@ -54,19 +57,29 @@ export type _BoundGetInfersTicket = Expect<
   Equal<ReturnType<typeof boundGet>, UseQueryResult<(TicketShape & DocumentData) | undefined>>
 >;
 
-// (C) `useBaerlyClient` returns the bound client, not the unbound one.
+// (C) Non-live mode preserves the same config-bound inference and
+// exposes the supported refetch function on every result state.
+const boundNonLive = () => useQuery((c) => c.collection("tickets").all(), [], { live: false });
+export type _BoundNonLiveInfersTickets = Expect<
+  Equal<ReturnType<typeof boundNonLive>, UseQueryResult<(TicketShape & DocumentData)[]>>
+>;
+export type _BoundQueryRefetch = Expect<
+  Equal<ReturnType<typeof boundNonLive>["refetch"], () => void>
+>;
+
+// (D) `useBaerlyClient` returns the bound client, not the unbound one.
 export type _BoundUseClient = Expect<
   Equal<ReturnType<typeof useBaerlyClient>, BaerlyClient<typeof config>>
 >;
 
-// (D) `useMutation` callbacks receive the bound client — `insert`
+// (E) `useMutation` callbacks receive the bound client — `insert`
 // accepts the schema's partial shape.
 export const _boundMutate = () => {
   const [mutate] = useMutation();
   return mutate((c) => c.collection("tickets").insert({ title: "hi", status: "open" }));
 };
 
-// (E) No type parameter → unbound surface: names widen to `string`,
+// (F) No type parameter → unbound surface: names widen to `string`,
 // rows to `DocumentData`. Matches the in-process `Db.collection` fallback.
 const unbound = createBaerlyReact();
 const unboundList = () => unbound.useQuery((c) => c.collection("anything").all(), []);

--- a/packages/client/src/react/create-react.ts
+++ b/packages/client/src/react/create-react.ts
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import type { BaerlyClient } from "../client.ts";
 import { BaerlyProvider, useBaerlyClient } from "./provider.ts";
 import { useMutation, type UseMutationTuple } from "./use-mutation.ts";
-import { useQuery, type UseQueryResult } from "./use-query.ts";
+import { useQuery, type UseQueryOptions, type UseQueryResult } from "./use-query.ts";
 
 /**
  * Props for the config-bound `BaerlyProvider` returned by
@@ -27,14 +27,18 @@ export interface BaerlyReact<TConfig extends BaerlyConfig> {
   /** Wrap your app once; provides the bound client to every hook below it. */
   readonly BaerlyProvider: (props: BaerlyProviderProps<TConfig>) => React.JSX.Element;
   /**
-   * Reactive read. The callback receives `BaerlyClient<TConfig>`, so
-   * the chain is fully typed. `useQuery.skip` short-circuits to
-   * `{ status: "skipped" }`.
+   * Read, live by default. The callback receives
+   * `BaerlyClient<TConfig>`, so the chain is fully typed.
+   * `useQuery.skip` short-circuits to `{ status: "skipped" }`.
+   * Pass `{ live: false }` as the third argument for an initial and
+   * dependency-driven read with no `/v1/since` subscription. Every
+   * result state includes a stable `refetch()` function.
    */
   readonly useQuery: {
     <T>(
       callback: (client: BaerlyClient<TConfig>) => Promise<T> | symbol,
       deps?: ReadonlyArray<unknown>,
+      options?: UseQueryOptions,
     ): UseQueryResult<T>;
     /**
      * Sentinel — return it from the callback to defer the read
@@ -74,6 +78,13 @@ export interface BaerlyReact<TConfig extends BaerlyConfig> {
  * import { useQuery } from "./client.ts";
  * const notes = useQuery((c) => c.collection("notes").all(), []);
  * //    ^? UseQueryResult<Note[]>   — no cast
+ *
+ * const report = useQuery(
+ *   (c) => c.collection("notes").all(),
+ *   [],
+ *   { live: false },
+ * );
+ * // report.refetch() re-runs the read without enabling live updates.
  * ```
  *
  * Omit the type parameter (`createBaerlyReact()`) for an unbound app;

--- a/packages/client/src/react/index.ts
+++ b/packages/client/src/react/index.ts
@@ -15,9 +15,12 @@
  * would silently degrade to `DocumentData` rows and force casts.
  * Binding once at the factory keeps every callback inferred.
  *
- * **Reads:** `useQuery(callback, deps?)` — reactive. Subscribes to every
- * collection the callback touches and re-runs on log events or `deps`
- * change. Return `useQuery.skip` to defer / conditional-render.
+ * **Reads:** `useQuery(callback, deps?, options?)` — live by default.
+ * Subscribes to every collection the callback touches and re-runs on
+ * log events or `deps` change. Pass `{ live: false }` for initial and
+ * dependency-driven reads without `/v1/since`; call the stable
+ * `result.refetch()` for an explicit refresh. Return `useQuery.skip`
+ * to defer / conditional-render.
  *
  * **Mutations:** `useMutation()` → `[mutate, { isPending, error }]`.
  * `mutate(callback)` runs the callback against the real client.
@@ -27,5 +30,5 @@
  */
 
 export { type BaerlyProviderProps, type BaerlyReact, createBaerlyReact } from "./create-react.ts";
-export type { UseQueryResult } from "./use-query.ts";
+export type { UseQueryOptions, UseQueryResult } from "./use-query.ts";
 export type { UseMutationTuple } from "./use-mutation.ts";

--- a/packages/client/src/react/subscription-pool.test.ts
+++ b/packages/client/src/react/subscription-pool.test.ts
@@ -760,26 +760,19 @@ describe("subscription-pool", () => {
     }
   });
 
-  test("a cursor rejected on every lap backs off instead of hot-looping", async () => {
+  test("a repeatedly rejected replacement cursor retains backoff across bootstrap success", async () => {
     // The shape a mixed-version fleet produces mid-rolling-deploy: one
     // replica hands back a cursor the other refuses. The
     // `poll.cursor !== ""` guard bounds a same-iteration respin but NOT
     // this two-iteration oscillation — "" succeeds, adopts a cursor,
     // that cursor 400s, repeat. So the SchemaError path must fall
-    // through to the retry backoff rather than `continue` past it;
-    // otherwise this runs at network speed with an invalidate storm
-    // every lap.
-    let requests = 0;
+    // through to the retry backoff rather than `continue` past it. The
+    // successful bootstrap only supplies a candidate replacement; it
+    // must not reset backoff until that replacement cursor succeeds.
+    const callTimes: number[] = [];
     const mock = new MockFetch();
     mock.on("GET", "/v1/since", (req: Request) => {
-      requests += 1;
-      if (requests > 200) {
-        // Circuit breaker. On regression the loop spins at microtask
-        // speed and never yields to a timer, so `advanceTimersByTime`
-        // would pump forever and hang the runner. Parking the poll here
-        // lets the advance return and the bound below fail loudly.
-        return sinceForever();
-      }
+      callTimes.push(Date.now());
       const cursor = new URL(req.url).searchParams.get("cursor");
       if (cursor !== null && cursor.length > 0) {
         return Promise.resolve(
@@ -799,7 +792,8 @@ describe("subscription-pool", () => {
     });
 
     vi.useFakeTimers();
-    vi.spyOn(Math, "random").mockReturnValue(0.999);
+    vi.setSystemTime(0);
+    vi.spyOn(Math, "random").mockReturnValue(0);
     try {
       const client = makeClient(mock);
       const pool = poolFor(client);
@@ -812,18 +806,75 @@ describe("subscription-pool", () => {
       );
 
       await waitMicrotasks(40);
-      for (let i = 0; i < 5; i += 1) {
-        await vi.advanceTimersByTimeAsync(250);
-      }
+      expect(callTimes).toEqual([0, 0]);
+      await vi.advanceTimersByTimeAsync(125);
+      expect(callTimes).toEqual([0, 0, 125, 125]);
+      await vi.advanceTimersByTimeAsync(125);
+      expect(callTimes).toEqual([0, 0, 125, 125]);
+      await vi.advanceTimersByTimeAsync(125);
+      expect(callTimes).toEqual([0, 0, 125, 125, 375, 375]);
+      await vi.advanceTimersByTimeAsync(500);
+      expect(callTimes).toEqual([0, 0, 125, 125, 375, 375, 875, 875]);
       unsubscribe();
-
-      // Two requests per backoff cycle (bootstrap + doomed resume), so
-      // ~1.25 simulated seconds stays below 20. A successful bootstrap
-      // resets the attempt counter, so every doomed resume uses the
-      // initial jitter window. Without any backoff the loop is bounded
-      // only by microtask scheduling and blows past this.
-      expect(requests).toBeLessThan(20);
     } finally {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    }
+  });
+
+  test("an empty recovery bootstrap resets backoff when it yields no replacement cursor", async () => {
+    const callTimes: number[] = [];
+    const cursors: Array<string | null> = [];
+    let call = 0;
+    let unsubscribe: (() => void) | undefined;
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", (req: Request) => {
+      call += 1;
+      callTimes.push(Date.now());
+      cursors.push(new URL(req.url).searchParams.get("cursor"));
+      if (call === 1) {
+        return sinceOk("deadbeef.aaa_bbb_ccc");
+      }
+      if (call === 2) {
+        return sinceError("SchemaError", 400, false);
+      }
+      if (call === 3) {
+        return sinceOk("");
+      }
+      if (call === 4) {
+        throw new TypeError("transport unavailable");
+      }
+      return sinceForever();
+    });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      const client = makeClient(mock);
+      const pool = poolFor(client);
+      unsubscribe = pool.attach(
+        "empty-recovery-tail",
+        ["notes"],
+        new Set(["notes"]),
+        vi.fn<() => Promise<unknown>>().mockResolvedValue([]),
+        vi.fn<() => void>(),
+      );
+
+      await waitMicrotasks(40);
+      expect(callTimes).toEqual([0, 0]);
+      expect(cursors).toEqual(["", "deadbeef.aaa_bbb_ccc"]);
+
+      await vi.advanceTimersByTimeAsync(125);
+      expect(callTimes).toEqual([0, 0, 125, 125]);
+      expect(cursors).toEqual(["", "deadbeef.aaa_bbb_ccc", "", ""]);
+
+      await vi.advanceTimersByTimeAsync(124);
+      expect(callTimes).toHaveLength(4);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(callTimes).toEqual([0, 0, 125, 125, 250]);
+    } finally {
+      unsubscribe?.();
       vi.restoreAllMocks();
       vi.useRealTimers();
     }

--- a/packages/client/src/react/subscription-pool.test.ts
+++ b/packages/client/src/react/subscription-pool.test.ts
@@ -15,6 +15,24 @@ const waitMicrotasks = async (n = 4): Promise<void> => {
   }
 };
 
+const sinceOk = (nextCursor = ""): Response =>
+  new Response(JSON.stringify({ events: [], next_cursor: nextCursor }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
+const sinceError = (
+  code: "SchemaError" | "Unauthorized",
+  status: number,
+  retriable: boolean,
+): Response =>
+  new Response(
+    JSON.stringify({
+      error: { code, message: `${code} from test`, retriable },
+    }),
+    { status, headers: { "content-type": "application/json" } },
+  );
+
 describe("subscription-pool", () => {
   test("returns LOADING_SNAPSHOT before any subscription", () => {
     const mock = new MockFetch();
@@ -107,6 +125,414 @@ describe("subscription-pool", () => {
     expect(poolFor(client)).toBe(poolFor(client));
   });
 
+  test("a terminal poll error stops retrying and preserves successful query data", async () => {
+    let rejectPoll: ((response: Response) => void) | undefined;
+    let sinceCalls = 0;
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", () => {
+      sinceCalls += 1;
+      return new Promise<Response>((resolve) => {
+        rejectPoll = resolve;
+      });
+    });
+    vi.useFakeTimers();
+    try {
+      const client = makeClient(mock);
+      const pool = poolFor(client);
+      const notify = vi.fn<() => void>();
+      const unsubscribe = pool.attach(
+        "terminal",
+        ["notes"],
+        new Set(["notes"]),
+        vi.fn<() => Promise<unknown>>().mockResolvedValue([{ _id: "before-expiry" }]),
+        notify,
+      );
+      await waitMicrotasks();
+      expect(pool.getSnapshot("terminal")).toMatchObject({
+        status: "ok",
+        data: [{ _id: "before-expiry" }],
+      });
+
+      rejectPoll?.(sinceError("Unauthorized", 401, false));
+      await waitMicrotasks(12);
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(sinceCalls).toBe(1);
+      expect(pool.getSnapshot("terminal")).toMatchObject({
+        status: "error",
+        data: [{ _id: "before-expiry" }],
+        error: { code: "Unauthorized", retriable: false },
+      });
+      expect(notify).toHaveBeenCalled();
+      unsubscribe();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // One `InvalidResponse` case is enough here: malformed JSON and a
+  // wrong `SinceResponse` shape both reach the pool as the same
+  // non-retriable `InvalidResponse` `BaerlyError`, so they take one code
+  // path. Which successful-200 bodies produce that error is
+  // `pollSinceOnce`'s contract, pinned in `poll-since-once.test.ts`.
+  test("a malformed successful poll response is terminal and preserves successful query data", async () => {
+    let releasePoll: ((response: Response) => void) | undefined;
+    let sinceCalls = 0;
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", () => {
+      sinceCalls += 1;
+      return new Promise<Response>((resolve) => {
+        releasePoll = resolve;
+      });
+    });
+    vi.useFakeTimers();
+    try {
+      const client = makeClient(mock);
+      const pool = poolFor(client);
+      const signature = "invalid-response";
+      const unsubscribe = pool.attach(
+        signature,
+        ["notes"],
+        new Set(["notes"]),
+        vi.fn<() => Promise<unknown>>().mockResolvedValue([{ _id: "last-good" }]),
+        vi.fn<() => void>(),
+      );
+      await waitMicrotasks();
+      expect(pool.getSnapshot(signature)).toMatchObject({
+        status: "ok",
+        data: [{ _id: "last-good" }],
+      });
+
+      releasePoll?.(
+        new Response("{", { status: 200, headers: { "content-type": "application/json" } }),
+      );
+      await waitMicrotasks(16);
+      expect(pool.getSnapshot(signature)).toMatchObject({
+        status: "error",
+        data: [{ _id: "last-good" }],
+        error: { code: "InvalidResponse" },
+      });
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(sinceCalls).toBe(1);
+      unsubscribe();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("a complete unsubscribe after a terminal poll error permits a fresh poll", async () => {
+    let sinceCalls = 0;
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", () => {
+      sinceCalls += 1;
+      return Promise.resolve(sinceError("Unauthorized", 401, false));
+    });
+    const client = makeClient(mock);
+    const pool = poolFor(client);
+    const attach = () =>
+      pool.attach(
+        "terminal-remount",
+        ["notes"],
+        new Set(["notes"]),
+        vi.fn<() => Promise<unknown>>().mockResolvedValue([]),
+        vi.fn<() => void>(),
+      );
+
+    const firstUnsubscribe = attach();
+    await waitMicrotasks(12);
+    expect(sinceCalls).toBe(1);
+    firstUnsubscribe();
+
+    const secondUnsubscribe = attach();
+    await waitMicrotasks(12);
+    expect(sinceCalls).toBe(2);
+    secondUnsubscribe();
+  });
+
+  test("a subscriber joining a terminal table receives its error without reviving the dead poll", async () => {
+    let sinceCalls = 0;
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", () => {
+      sinceCalls += 1;
+      return Promise.resolve(sinceError("Unauthorized", 401, false));
+    });
+    const client = makeClient(mock);
+    const pool = poolFor(client);
+    const firstUnsubscribe = pool.attach(
+      "terminal-first",
+      ["notes"],
+      new Set(["notes"]),
+      vi.fn<() => Promise<unknown>>().mockResolvedValue([{ _id: "first" }]),
+      vi.fn<() => void>(),
+    );
+    await waitMicrotasks(12);
+    expect(pool.getSnapshot("terminal-first").status).toBe("error");
+
+    const secondUnsubscribe = pool.attach(
+      "terminal-second",
+      ["notes"],
+      new Set(["notes"]),
+      vi.fn<() => Promise<unknown>>().mockResolvedValue([{ _id: "second" }]),
+      vi.fn<() => void>(),
+    );
+    await waitMicrotasks(12);
+
+    expect(sinceCalls).toBe(1);
+    expect(pool.getSnapshot("terminal-second")).toMatchObject({
+      status: "error",
+      data: undefined,
+      error: { code: "Unauthorized" },
+    });
+    firstUnsubscribe();
+    secondUnsubscribe();
+  });
+
+  test("another table's event cannot mask a terminal error, but refetch restarts only the failed poll", async () => {
+    let releaseComments: ((response: Response) => void) | undefined;
+    let notesSinceCalls = 0;
+    const signals = {
+      comments: new Set<AbortSignal>(),
+      notes: new Set<AbortSignal>(),
+    };
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", (req) => {
+      const collection = new URL(req.url).searchParams.get("collection");
+      if (collection === "notes") {
+        notesSinceCalls += 1;
+        signals.notes.add(req.signal);
+        return notesSinceCalls === 1
+          ? Promise.resolve(sinceError("Unauthorized", 401, false))
+          : sinceForever();
+      }
+      signals.comments.add(req.signal);
+      return new Promise<Response>((resolve) => {
+        releaseComments = resolve;
+      });
+    });
+    const client = makeClient(mock);
+    const pool = poolFor(client);
+    const fetcher = vi.fn<() => Promise<unknown>>().mockResolvedValue([{ _id: "last-good" }]);
+    const unsubscribe = pool.attach(
+      "terminal-multi-table",
+      ["comments", "notes"],
+      new Set(["comments", "notes"]),
+      fetcher,
+      vi.fn<() => void>(),
+    );
+    await waitMicrotasks(16);
+    expect(pool.getSnapshot("terminal-multi-table").status).toBe("error");
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    releaseComments?.(
+      new Response(
+        JSON.stringify({ events: [{ lsn: "aaa_bbb_ccc" }], next_cursor: "comments-cursor" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    await waitMicrotasks(16);
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(pool.getSnapshot("terminal-multi-table")).toMatchObject({
+      status: "error",
+      data: [{ _id: "last-good" }],
+      error: { code: "Unauthorized" },
+    });
+    expect(notesSinceCalls).toBe(1);
+    const commentsSignalsBeforeRecovery = [...signals.comments];
+
+    pool.refetch("terminal-multi-table");
+    await waitMicrotasks(16);
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(pool.getSnapshot("terminal-multi-table")).toMatchObject({
+      status: "ok",
+      data: [{ _id: "last-good" }],
+      error: undefined,
+    });
+    expect(notesSinceCalls).toBe(2);
+    expect(signals.notes.size).toBe(2);
+    expect([...signals.comments]).toEqual(commentsSignalsBeforeRecovery);
+    const [oldNotesSignal, liveNotesSignal] = [...signals.notes];
+    expect(oldNotesSignal?.aborted).toBe(true);
+    expect(liveNotesSignal?.aborted).toBe(false);
+    expect(commentsSignalsBeforeRecovery.every((signal) => !signal.aborted)).toBe(true);
+    unsubscribe();
+  });
+
+  test("refetch restarts one shared terminal poll and preserves its refcount", async () => {
+    const pollSignals = new Set<AbortSignal>();
+    let sinceCalls = 0;
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", (req) => {
+      sinceCalls += 1;
+      pollSignals.add(req.signal);
+      return sinceCalls === 1
+        ? Promise.resolve(sinceError("Unauthorized", 401, false))
+        : sinceForever();
+    });
+    const client = makeClient(mock);
+    const pool = poolFor(client);
+    const firstFetcher = vi.fn<() => Promise<unknown>>().mockResolvedValue([{ _id: "first" }]);
+    const secondFetcher = vi.fn<() => Promise<unknown>>().mockResolvedValue([{ _id: "second" }]);
+    const firstUnsubscribe = pool.attach(
+      "shared-terminal-first",
+      ["notes"],
+      new Set(["notes"]),
+      firstFetcher,
+      vi.fn<() => void>(),
+    );
+    const secondUnsubscribe = pool.attach(
+      "shared-terminal-second",
+      ["notes"],
+      new Set(["notes"]),
+      secondFetcher,
+      vi.fn<() => void>(),
+    );
+    await waitMicrotasks(16);
+    expect(pool.getSnapshot("shared-terminal-first").status).toBe("error");
+    expect(pool.getSnapshot("shared-terminal-second").status).toBe("error");
+
+    pool.refetch("shared-terminal-first");
+    pool.refetch("shared-terminal-second");
+    await waitMicrotasks(16);
+
+    expect(firstFetcher).toHaveBeenCalledTimes(2);
+    expect(secondFetcher).toHaveBeenCalledTimes(2);
+    expect(sinceCalls).toBe(2);
+    expect(pollSignals.size).toBe(2);
+    const [oldSignal, recoveredSignal] = [...pollSignals];
+    expect(oldSignal?.aborted).toBe(true);
+    expect(recoveredSignal?.aborted).toBe(false);
+
+    firstUnsubscribe();
+    expect(recoveredSignal?.aborted).toBe(false);
+    secondUnsubscribe();
+    expect(recoveredSignal?.aborted).toBe(true);
+  });
+
+  test("retriable transport failures use jittered exponential backoff and reset after success", async () => {
+    const callTimes: number[] = [];
+    let calls = 0;
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", () => {
+      calls += 1;
+      callTimes.push(Date.now());
+      if (calls === 1 || calls === 2 || calls === 4) {
+        throw new TypeError("transport unavailable");
+      }
+      if (calls === 3) {
+        return Promise.resolve(sinceOk());
+      }
+      return sinceForever();
+    });
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      const client = makeClient(mock);
+      const pool = poolFor(client);
+      const unsubscribe = pool.attach(
+        "backoff",
+        ["notes"],
+        new Set(["notes"]),
+        vi.fn<() => Promise<unknown>>().mockResolvedValue([]),
+        vi.fn<() => void>(),
+      );
+      await waitMicrotasks(12);
+      expect(callTimes).toEqual([0]);
+
+      await vi.advanceTimersByTimeAsync(124);
+      expect(callTimes).toEqual([0]);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(callTimes).toEqual([0, 125]);
+
+      await vi.advanceTimersByTimeAsync(249);
+      expect(callTimes).toEqual([0, 125]);
+      await vi.advanceTimersByTimeAsync(1);
+      await waitMicrotasks(12);
+      expect(callTimes).toEqual([0, 125, 375, 375]);
+
+      await vi.advanceTimersByTimeAsync(124);
+      expect(callTimes).toEqual([0, 125, 375, 375]);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(callTimes).toEqual([0, 125, 375, 375, 500]);
+      unsubscribe();
+    } finally {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    }
+  });
+
+  test("retriable poll backoff stops growing at its configured cap", async () => {
+    const callTimes: number[] = [];
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", () => {
+      callTimes.push(Date.now());
+      if (callTimes.length < 9) {
+        throw new TypeError("transport unavailable");
+      }
+      return sinceForever();
+    });
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      const client = makeClient(mock);
+      const pool = poolFor(client);
+      const unsubscribe = pool.attach(
+        "backoff-cap",
+        ["notes"],
+        new Set(["notes"]),
+        vi.fn<() => Promise<unknown>>().mockResolvedValue([]),
+        vi.fn<() => void>(),
+      );
+      await waitMicrotasks(12);
+      await vi.advanceTimersByTimeAsync(17_875);
+
+      expect(callTimes).toHaveLength(9);
+      expect(callTimes.slice(1).map((time, index) => time - callTimes[index]!)).toEqual([
+        125, 250, 500, 1_000, 2_000, 4_000, 5_000, 5_000,
+      ]);
+      unsubscribe();
+    } finally {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    }
+  });
+
+  test("unsubscribe cancels a pending retry after a retriable poll failure", async () => {
+    let sinceCalls = 0;
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", () => {
+      sinceCalls += 1;
+      throw new TypeError("transport unavailable");
+    });
+    vi.useFakeTimers();
+    try {
+      const client = makeClient(mock);
+      const pool = poolFor(client);
+      const unsubscribe = pool.attach(
+        "abort-retry",
+        ["notes"],
+        new Set(["notes"]),
+        vi.fn<() => Promise<unknown>>().mockResolvedValue([]),
+        vi.fn<() => void>(),
+      );
+      await waitMicrotasks(12);
+      expect(sinceCalls).toBe(1);
+      expect(vi.getTimerCount()).toBe(1);
+
+      unsubscribe();
+      await waitMicrotasks();
+      expect(vi.getTimerCount()).toBe(0);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(sinceCalls).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("SchemaError re-bootstraps the cursor instead of retrying it", async () => {
     // `/v1/since` returns SchemaError (400) for two permanent cursor
     // states: the entry was folded into a snapshot and GC'd, or the
@@ -167,8 +593,8 @@ describe("subscription-pool", () => {
       // goes back to "" rather than sending `deadbeef.…` a second time.
       expect(cursors.filter((c) => c === "deadbeef.aaa_bbb_ccc")).toHaveLength(1);
 
-      // The re-bootstrap is deliberately behind the 1s error backoff,
-      // not immediate — see the oscillation test below for why.
+      // The re-bootstrap is deliberately behind the retry backoff, not
+      // immediate — see the oscillation test below for why.
       await vi.advanceTimersByTimeAsync(1_000);
       unsubscribe();
       expect(cursors.filter((c) => c === "" || c === null).length).toBeGreaterThan(1);
@@ -183,7 +609,7 @@ describe("subscription-pool", () => {
     // `poll.cursor !== ""` guard bounds a same-iteration respin but NOT
     // this two-iteration oscillation — "" succeeds, adopts a cursor,
     // that cursor 400s, repeat. So the SchemaError path must fall
-    // through to the 1s backoff rather than `continue` past it;
+    // through to the retry backoff rather than `continue` past it;
     // otherwise this runs at network speed with an invalidate storm
     // every lap.
     let requests = 0;
@@ -216,6 +642,7 @@ describe("subscription-pool", () => {
     });
 
     vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.999);
     try {
       const client = makeClient(mock);
       const pool = poolFor(client);
@@ -229,15 +656,18 @@ describe("subscription-pool", () => {
 
       await waitMicrotasks(40);
       for (let i = 0; i < 5; i += 1) {
-        await vi.advanceTimersByTimeAsync(1_000);
+        await vi.advanceTimersByTimeAsync(250);
       }
       unsubscribe();
 
       // Two requests per backoff cycle (bootstrap + doomed resume), so
-      // ~5 simulated seconds is ~12. Without the backoff the loop is
-      // bounded only by microtask scheduling and blows past this.
+      // ~1.25 simulated seconds stays below 20. A successful bootstrap
+      // resets the attempt counter, so every doomed resume uses the
+      // initial jitter window. Without any backoff the loop is bounded
+      // only by microtask scheduling and blows past this.
       expect(requests).toBeLessThan(20);
     } finally {
+      vi.restoreAllMocks();
       vi.useRealTimers();
     }
   });

--- a/packages/client/src/react/subscription-pool.test.ts
+++ b/packages/client/src/react/subscription-pool.test.ts
@@ -398,7 +398,11 @@ describe("subscription-pool", () => {
     await waitMicrotasks(16);
 
     expect(firstFetcher).toHaveBeenCalledTimes(2);
-    expect(secondFetcher).toHaveBeenCalledTimes(2);
+    // Three, not two: the first refetch revived the shared poll and
+    // swept the second signature out of its stale error, then the
+    // second refetch dispatched it again on its own account. The
+    // second refetch finds a healthy poll, so `sinceCalls` stays at 2.
+    expect(secondFetcher).toHaveBeenCalledTimes(3);
     expect(sinceCalls).toBe(2);
     expect(pollSignals.size).toBe(2);
     const [oldSignal, recoveredSignal] = [...pollSignals];
@@ -409,6 +413,159 @@ describe("subscription-pool", () => {
     expect(recoveredSignal?.aborted).toBe(false);
     secondUnsubscribe();
     expect(recoveredSignal?.aborted).toBe(true);
+  });
+
+  test("refetch on one signature also clears the stale error on its siblings", async () => {
+    let sinceCalls = 0;
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", () => {
+      sinceCalls += 1;
+      return sinceCalls === 1
+        ? Promise.resolve(sinceError("Unauthorized", 401, false))
+        : sinceForever();
+    });
+    const client = makeClient(mock);
+    const pool = poolFor(client);
+    const callerFetcher = vi.fn<() => Promise<unknown>>().mockResolvedValue([{ _id: "caller" }]);
+    const bystanderFetcher = vi
+      .fn<() => Promise<unknown>>()
+      .mockResolvedValue([{ _id: "bystander" }]);
+    const callerUnsubscribe = pool.attach(
+      "sibling-caller",
+      ["notes"],
+      new Set(["notes"]),
+      callerFetcher,
+      vi.fn<() => void>(),
+    );
+    const bystanderUnsubscribe = pool.attach(
+      "sibling-bystander",
+      ["notes"],
+      new Set(["notes"]),
+      bystanderFetcher,
+      vi.fn<() => void>(),
+    );
+    await waitMicrotasks(16);
+    expect(pool.getSnapshot("sibling-caller").status).toBe("error");
+    expect(pool.getSnapshot("sibling-bystander").status).toBe("error");
+
+    // Only the caller refetches. The revived poll is healthy but the
+    // collection is quiet, so no `/v1/since` event will ever arrive to
+    // invalidate the bystander — reviving the poll has to clear it.
+    pool.refetch("sibling-caller");
+    await waitMicrotasks(16);
+
+    expect(pool.getSnapshot("sibling-caller")).toMatchObject({
+      status: "ok",
+      data: [{ _id: "caller" }],
+      error: undefined,
+    });
+    expect(pool.getSnapshot("sibling-bystander")).toMatchObject({
+      status: "ok",
+      data: [{ _id: "bystander" }],
+      error: undefined,
+    });
+    // Each signature is dispatched exactly once by the refetch — the
+    // caller directly, the bystander through the revival sweep that
+    // skips it.
+    expect(callerFetcher).toHaveBeenCalledTimes(2);
+    expect(bystanderFetcher).toHaveBeenCalledTimes(2);
+
+    callerUnsubscribe();
+    bystanderUnsubscribe();
+  });
+
+  test("refetch dispatches a multi-table sibling once when both terminal polls revive", async () => {
+    const sinceCalls = new Map<string, number>();
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", (req) => {
+      const collection = new URL(req.url).searchParams.get("collection") ?? "";
+      const calls = (sinceCalls.get(collection) ?? 0) + 1;
+      sinceCalls.set(collection, calls);
+      return calls === 1 ? Promise.resolve(sinceError("Unauthorized", 401, false)) : sinceForever();
+    });
+    const client = makeClient(mock);
+    const pool = poolFor(client);
+    const callerFetcher = vi.fn<() => Promise<unknown>>().mockResolvedValue([{ _id: "caller" }]);
+    const siblingFetcher = vi.fn<() => Promise<unknown>>().mockResolvedValue([{ _id: "sibling" }]);
+    const tables = ["comments", "notes"];
+    const chainTables = new Set(tables);
+    const callerUnsubscribe = pool.attach(
+      "multi-table-caller",
+      tables,
+      chainTables,
+      callerFetcher,
+      vi.fn<() => void>(),
+    );
+    const siblingUnsubscribe = pool.attach(
+      "multi-table-sibling",
+      tables,
+      chainTables,
+      siblingFetcher,
+      vi.fn<() => void>(),
+    );
+    await waitMicrotasks(16);
+    expect(pool.getSnapshot("multi-table-caller").status).toBe("error");
+    expect(pool.getSnapshot("multi-table-sibling").status).toBe("error");
+
+    pool.refetch("multi-table-caller");
+    await waitMicrotasks(16);
+
+    expect(callerFetcher).toHaveBeenCalledTimes(2);
+    expect(siblingFetcher).toHaveBeenCalledTimes(2);
+    expect(sinceCalls).toEqual(
+      new Map([
+        ["comments", 2],
+        ["notes", 2],
+      ]),
+    );
+
+    callerUnsubscribe();
+    siblingUnsubscribe();
+  });
+
+  test("a non-envelope gateway 5xx retries instead of killing the poll", async () => {
+    let sinceCalls = 0;
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", () => {
+      sinceCalls += 1;
+      // What a load balancer returns mid-rolling-deploy: a 5xx whose
+      // body is not an `HttpErrorEnvelope`, so the client has to infer
+      // the failure class from the status alone.
+      return Promise.resolve(
+        new Response("<html><body>502 Bad Gateway</body></html>", {
+          status: 502,
+          headers: { "content-type": "text/html" },
+        }),
+      );
+    });
+    vi.useFakeTimers();
+    try {
+      const client = makeClient(mock);
+      const pool = poolFor(client);
+      const unsubscribe = pool.attach(
+        "gateway-5xx",
+        ["notes"],
+        new Set(["notes"]),
+        vi.fn<() => Promise<unknown>>().mockResolvedValue([{ _id: "last-good" }]),
+        vi.fn<() => void>(),
+      );
+      await waitMicrotasks(16);
+      expect(sinceCalls).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(sinceCalls).toBeGreaterThan(1);
+      // A retriable poll failure never fails the query, so subscribers
+      // keep their data instead of being parked on a terminal error.
+      expect(pool.getSnapshot("gateway-5xx")).toMatchObject({
+        status: "ok",
+        data: [{ _id: "last-good" }],
+        error: undefined,
+      });
+      unsubscribe();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("retriable transport failures use jittered exponential backoff and reset after success", async () => {

--- a/packages/client/src/react/subscription-pool.test.ts
+++ b/packages/client/src/react/subscription-pool.test.ts
@@ -621,15 +621,17 @@ describe("subscription-pool", () => {
     }
   });
 
-  test("retriable poll backoff stops growing at its configured cap", async () => {
+  test("a poll that keeps failing keeps retrying at a bounded interval", async () => {
+    // The delay arithmetic — doubling, the cap, the jitter band — is
+    // pinned in `subscription-retry.test.ts` against `retryDelay`
+    // directly. What only the pool can show is that it feeds that
+    // function a monotonically rising attempt and never gives up: no
+    // max-attempts bail-out parks a table on a transport blip.
     const callTimes: number[] = [];
     const mock = new MockFetch();
     mock.on("GET", "/v1/since", () => {
       callTimes.push(Date.now());
-      if (callTimes.length < 9) {
-        throw new TypeError("transport unavailable");
-      }
-      return sinceForever();
+      throw new TypeError("transport unavailable");
     });
     vi.useFakeTimers();
     vi.setSystemTime(0);
@@ -645,12 +647,16 @@ describe("subscription-pool", () => {
         vi.fn<() => void>(),
       );
       await waitMicrotasks(12);
-      await vi.advanceTimersByTimeAsync(17_875);
+      await vi.advanceTimersByTimeAsync(60_000);
 
-      expect(callTimes).toHaveLength(9);
-      expect(callTimes.slice(1).map((time, index) => time - callTimes[index]!)).toEqual([
-        125, 250, 500, 1_000, 2_000, 4_000, 5_000, 5_000,
-      ]);
+      const gaps = callTimes.slice(1).map((time, index) => time - callTimes[index]!);
+      // Rising while the bound doubles, then flat once it saturates,
+      // with polls still arriving at the far end of the window.
+      expect(gaps.length).toBeGreaterThan(8);
+      for (let index = 1; index < 6; index += 1) {
+        expect(gaps[index]!, `gap ${index}`).toBeGreaterThan(gaps[index - 1]!);
+      }
+      expect(new Set(gaps.slice(7)).size).toBe(1);
       unsubscribe();
     } finally {
       vi.restoreAllMocks();

--- a/packages/client/src/react/subscription-pool.ts
+++ b/packages/client/src/react/subscription-pool.ts
@@ -261,9 +261,11 @@ const createPool = (client: BaerlyClient): SubscriptionPool => {
     const ctx = getClientContext(client);
     void (async () => {
       let retryAttempt = 0;
+      let deadCursorRecoveryPending = false;
       while (!controller.signal.aborted) {
+        const requestCursor = poll.cursor;
         try {
-          const res = await pollSinceOnce(ctx, table, poll.cursor, controller.signal);
+          const res = await pollSinceOnce(ctx, table, requestCursor, controller.signal);
           if (controller.signal.aborted) {
             return;
           }
@@ -273,7 +275,15 @@ const createPool = (client: BaerlyClient): SubscriptionPool => {
               invalidateForTable(table);
             }
           }
-          retryAttempt = 0;
+          // An empty bootstrap is only unproven when it minted a non-empty
+          // replacement cursor. A stable empty tail has no replacement left to
+          // prove, while a non-empty request proves the candidate by succeeding.
+          const recoveryProven =
+            !deadCursorRecoveryPending || requestCursor !== "" || res.next_cursor === "";
+          if (recoveryProven) {
+            retryAttempt = 0;
+            deadCursorRecoveryPending = false;
+          }
         } catch (error) {
           if (controller.signal.aborted) {
             return;
@@ -289,7 +299,7 @@ const createPool = (client: BaerlyClient): SubscriptionPool => {
             // was minted in a generation `restore --force` has since
             // truncated. Retrying the same cursor can never clear
             // either one, so without this the loop would retry it at
-            // 1 req/s forever with the table frozen.
+            // exponential backoff forever with the table frozen.
             //
             // Re-bootstrap: `""` restarts from `log_seq_start`, which
             // is what the server's error text asks for. The invalidate
@@ -310,6 +320,7 @@ const createPool = (client: BaerlyClient): SubscriptionPool => {
             // backoff interval of recovery latency and bounds the
             // pathological cycle.
             poll.cursor = "";
+            deadCursorRecoveryPending = true;
             invalidateForTable(table);
             recoveredDeadCursor = true;
           }

--- a/packages/client/src/react/subscription-pool.ts
+++ b/packages/client/src/react/subscription-pool.ts
@@ -2,10 +2,7 @@ import { BaerlyError } from "@baerly/protocol";
 import type { BaerlyClient } from "../client.ts";
 import { getClientContext } from "../internal/context.ts";
 import { pollSinceOnce } from "../poll-since-once.ts";
-import {
-  SUBSCRIPTION_RETRY_INITIAL_MILLIS,
-  SUBSCRIPTION_RETRY_MAX_MILLIS,
-} from "./subscription-retry.ts";
+import { retryDelay } from "./subscription-retry.ts";
 
 /**
  * Discriminated snapshot a hook hands back from `getSnapshot`. The
@@ -34,14 +31,6 @@ const toError = (raw: unknown): Error => {
 
 const isAbortError = (raw: unknown): boolean =>
   typeof raw === "object" && raw !== null && "name" in raw && raw.name === "AbortError";
-
-const retryDelay = (attempt: number): number => {
-  const upperBound = Math.min(
-    SUBSCRIPTION_RETRY_MAX_MILLIS,
-    SUBSCRIPTION_RETRY_INITIAL_MILLIS * 2 ** attempt,
-  );
-  return Math.floor(upperBound / 2 + Math.random() * (upperBound / 2));
-};
 
 const waitForRetry = async (delay: number, signal: AbortSignal): Promise<void> => {
   if (signal.aborted) {

--- a/packages/client/src/react/subscription-pool.ts
+++ b/packages/client/src/react/subscription-pool.ts
@@ -43,26 +43,25 @@ const retryDelay = (attempt: number): number => {
   return Math.floor(upperBound / 2 + Math.random() * (upperBound / 2));
 };
 
-const waitForRetry = (delay: number, signal: AbortSignal): Promise<void> =>
-  (async () => {
-    if (signal.aborted) {
-      return;
-    }
-    const cleanup: Array<() => void> = [];
-    const timeout = new Promise<void>((resolve) => {
-      const timer = setTimeout(resolve, delay);
-      cleanup.push(() => clearTimeout(timer));
-    });
-    const aborted = new Promise<void>((resolve) => {
-      const onAbort = (): void => resolve();
-      signal.addEventListener("abort", onAbort, { once: true });
-      cleanup.push(() => signal.removeEventListener("abort", onAbort));
-    });
-    await Promise.race([timeout, aborted]);
-    for (const dispose of cleanup) {
-      dispose();
-    }
-  })();
+const waitForRetry = async (delay: number, signal: AbortSignal): Promise<void> => {
+  if (signal.aborted) {
+    return;
+  }
+  const cleanup: Array<() => void> = [];
+  const timeout = new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, delay);
+    cleanup.push(() => clearTimeout(timer));
+  });
+  const aborted = new Promise<void>((resolve) => {
+    const onAbort = (): void => resolve();
+    signal.addEventListener("abort", onAbort, { once: true });
+    cleanup.push(() => signal.removeEventListener("abort", onAbort));
+  });
+  await Promise.race([timeout, aborted]);
+  for (const dispose of cleanup) {
+    dispose();
+  }
+};
 
 interface CacheEntry {
   snapshot: CachedSnapshot;
@@ -196,9 +195,17 @@ const createPool = (client: BaerlyClient): SubscriptionPool => {
     })();
   };
 
-  const invalidateForTable = (table: string): void => {
+  const invalidateForTable = (
+    table: string,
+    skipSignature?: string,
+    dispatchedSignatures?: Set<string>,
+  ): void => {
     for (const [signature, entry] of cache) {
-      if (!entry.chainTables.has(table)) {
+      if (
+        !entry.chainTables.has(table) ||
+        signature === skipSignature ||
+        dispatchedSignatures?.has(signature)
+      ) {
         continue;
       }
       const subs = subscribersBySignature.get(signature);
@@ -210,6 +217,7 @@ const createPool = (client: BaerlyClient): SubscriptionPool => {
       // (signature is hashed on chain shape + deps).
       const fetcher = signatureFetchers.get(signature);
       if (fetcher !== undefined) {
+        dispatchedSignatures?.add(signature);
         dispatchFetch(signature, fetcher);
       }
     }
@@ -318,15 +326,16 @@ const createPool = (client: BaerlyClient): SubscriptionPool => {
     })();
   };
 
-  const restartTerminalPoll = (table: string): void => {
+  const restartTerminalPoll = (table: string): boolean => {
     const poll = tablePolls.get(table);
     if (poll?.terminalError === undefined) {
-      return;
+      return false;
     }
     const refcount = poll.refcount;
     poll.controller.abort();
     tablePolls.delete(table);
     startTablePoll(table, refcount);
+    return true;
   };
 
   const stopTablePoll = (table: string): void => {
@@ -360,10 +369,24 @@ const createPool = (client: BaerlyClient): SubscriptionPool => {
       if (entry === undefined || fetcher === undefined) {
         return;
       }
+      const revived: Array<string> = [];
       for (const table of entry.chainTables) {
-        restartTerminalPoll(table);
+        if (restartTerminalPoll(table)) {
+          revived.push(table);
+        }
       }
       dispatchFetch(signature, fetcher);
+      // `failForTable` parked *every* signature on the dead table, not
+      // just this one. The revived poll only re-invalidates once the
+      // server has an event to report, so on a quiet collection the
+      // siblings would sit on a stale error forever even though the
+      // poll behind them is healthy again. Refresh them here; the
+      // caller is already dispatched above and is skipped so it isn't
+      // aborted and re-issued.
+      const dispatchedSignatures = new Set<string>();
+      for (const table of revived) {
+        invalidateForTable(table, signature, dispatchedSignatures);
+      }
     },
     attach(signature, tables, chainTables, fetcher, notify) {
       let entry = cache.get(signature);

--- a/packages/client/src/react/subscription-pool.ts
+++ b/packages/client/src/react/subscription-pool.ts
@@ -2,6 +2,10 @@ import { BaerlyError } from "@baerly/protocol";
 import type { BaerlyClient } from "../client.ts";
 import { getClientContext } from "../internal/context.ts";
 import { pollSinceOnce } from "../poll-since-once.ts";
+import {
+  SUBSCRIPTION_RETRY_INITIAL_MILLIS,
+  SUBSCRIPTION_RETRY_MAX_MILLIS,
+} from "./subscription-retry.ts";
 
 /**
  * Discriminated snapshot a hook hands back from `getSnapshot`. The
@@ -28,8 +32,42 @@ const toError = (raw: unknown): Error => {
   return new BaerlyError("Internal", String(raw));
 };
 
+const isAbortError = (raw: unknown): boolean =>
+  typeof raw === "object" && raw !== null && "name" in raw && raw.name === "AbortError";
+
+const retryDelay = (attempt: number): number => {
+  const upperBound = Math.min(
+    SUBSCRIPTION_RETRY_MAX_MILLIS,
+    SUBSCRIPTION_RETRY_INITIAL_MILLIS * 2 ** attempt,
+  );
+  return Math.floor(upperBound / 2 + Math.random() * (upperBound / 2));
+};
+
+const waitForRetry = (delay: number, signal: AbortSignal): Promise<void> =>
+  (async () => {
+    if (signal.aborted) {
+      return;
+    }
+    const cleanup: Array<() => void> = [];
+    const timeout = new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, delay);
+      cleanup.push(() => clearTimeout(timer));
+    });
+    const aborted = new Promise<void>((resolve) => {
+      const onAbort = (): void => resolve();
+      signal.addEventListener("abort", onAbort, { once: true });
+      cleanup.push(() => signal.removeEventListener("abort", onAbort));
+    });
+    await Promise.race([timeout, aborted]);
+    for (const dispose of cleanup) {
+      dispose();
+    }
+  })();
+
 interface CacheEntry {
   snapshot: CachedSnapshot;
+  /** Whether this entry has completed at least one successful read. */
+  hasSuccessfulData: boolean;
   /** Tables this signature's chain references — used for invalidation. */
   readonly chainTables: ReadonlySet<string>;
   /** Aborts the in-flight read for this signature, if any. */
@@ -40,6 +78,7 @@ interface TablePoll {
   refcount: number;
   controller: AbortController;
   cursor: string;
+  terminalError: Error | undefined;
 }
 
 interface SubscriptionPool {
@@ -53,6 +92,8 @@ interface SubscriptionPool {
   ): () => void;
   /** Read the cached snapshot for `signature` (or the canonical loading sentinel). */
   getSnapshot(signature: string): CachedSnapshot;
+  /** Re-run an attached signature's current fetcher. */
+  refetch(signature: string): void;
 }
 
 const poolByClient = new WeakMap<BaerlyClient, SubscriptionPool>();
@@ -82,9 +123,31 @@ const createPool = (client: BaerlyClient): SubscriptionPool => {
     }
   };
 
+  const terminalErrorFor = (entry: CacheEntry): Error | undefined => {
+    for (const table of entry.chainTables) {
+      const error = tablePolls.get(table)?.terminalError;
+      if (error !== undefined) {
+        return error;
+      }
+    }
+    return undefined;
+  };
+
   const dispatchFetch = (signature: string, fetcher: () => Promise<unknown>): void => {
     const entry = cache.get(signature);
     if (entry === undefined) {
+      return;
+    }
+    const terminalError = terminalErrorFor(entry);
+    if (terminalError !== undefined) {
+      if (entry.snapshot.status !== "error" || entry.snapshot.error !== terminalError) {
+        entry.snapshot = {
+          status: "error",
+          data: entry.snapshot.data,
+          error: terminalError,
+        };
+        notifyAll(signature);
+      }
       return;
     }
     if (entry.inFlight !== undefined) {
@@ -93,8 +156,7 @@ const createPool = (client: BaerlyClient): SubscriptionPool => {
     const controller = new AbortController();
     entry.inFlight = controller;
     const prevSnapshot = entry.snapshot;
-    const hadData = entry.snapshot.status === "ok" || entry.snapshot.status === "refreshing";
-    entry.snapshot = hadData
+    entry.snapshot = entry.hasSuccessfulData
       ? { status: "refreshing", data: entry.snapshot.data, error: undefined }
       : LOADING_SNAPSHOT;
     if (entry.snapshot !== prevSnapshot) {
@@ -111,6 +173,7 @@ const createPool = (client: BaerlyClient): SubscriptionPool => {
           return;
         }
         live.snapshot = { status: "ok", data, error: undefined };
+        live.hasSuccessfulData = true;
         live.inFlight = undefined;
         notifyAll(signature);
       } catch (error) {
@@ -152,18 +215,44 @@ const createPool = (client: BaerlyClient): SubscriptionPool => {
     }
   };
 
+  const failForTable = (table: string, error: Error): void => {
+    for (const [signature, entry] of cache) {
+      if (!entry.chainTables.has(table)) {
+        continue;
+      }
+      const subs = subscribersBySignature.get(signature);
+      if (subs === undefined || subs.size === 0) {
+        continue;
+      }
+      entry.inFlight?.abort();
+      entry.inFlight = undefined;
+      entry.snapshot = {
+        status: "error",
+        data: entry.snapshot.data,
+        error,
+      };
+      notifyAll(signature);
+    }
+  };
+
   /** Per-signature fetcher; last writer wins (all fetchers for a signature are equivalent). */
   const signatureFetchers = new Map<string, () => Promise<unknown>>();
 
-  const startTablePoll = (table: string): void => {
+  const startTablePoll = (table: string, initialRefcount = 1): void => {
     if (tablePolls.has(table)) {
       return;
     }
     const controller = new AbortController();
-    const poll: TablePoll = { refcount: 1, controller, cursor: "" };
+    const poll: TablePoll = {
+      refcount: initialRefcount,
+      controller,
+      cursor: "",
+      terminalError: undefined,
+    };
     tablePolls.set(table, poll);
     const ctx = getClientContext(client);
     void (async () => {
+      let retryAttempt = 0;
       while (!controller.signal.aborted) {
         try {
           const res = await pollSinceOnce(ctx, table, poll.cursor, controller.signal);
@@ -176,13 +265,15 @@ const createPool = (client: BaerlyClient): SubscriptionPool => {
               invalidateForTable(table);
             }
           }
+          retryAttempt = 0;
         } catch (error) {
           if (controller.signal.aborted) {
             return;
           }
-          if (error instanceof DOMException && error.name === "AbortError") {
+          if (isAbortError(error)) {
             return;
           }
+          let recoveredDeadCursor = false;
           if (error instanceof BaerlyError && error.code === "SchemaError" && poll.cursor !== "") {
             // The cursor is unrecoverable, not the request. `/v1/since`
             // returns this for exactly two states, both permanent: the
@@ -208,18 +299,34 @@ const createPool = (client: BaerlyClient): SubscriptionPool => {
             // rejected again. Skipping the backoff would make that
             // cycle run at network speed, with an `invalidateForTable`
             // refetch storm on every lap. Falling through costs one
-            // second of recovery latency and bounds the pathological
-            // case at 1 cycle/s.
+            // backoff interval of recovery latency and bounds the
+            // pathological cycle.
             poll.cursor = "";
             invalidateForTable(table);
+            recoveredDeadCursor = true;
           }
-          // 1-second backoff on error to avoid hot-spinning on a
-          // persistent failure; downstream subscribers' next fetch
-          // sees the same error if it doesn't clear.
-          await new Promise((r) => setTimeout(r, 1000));
+          if (!recoveredDeadCursor && error instanceof BaerlyError && !error.retriable) {
+            poll.terminalError = error;
+            failForTable(table, error);
+            return;
+          }
+          const delay = retryDelay(retryAttempt);
+          retryAttempt += 1;
+          await waitForRetry(delay, controller.signal);
         }
       }
     })();
+  };
+
+  const restartTerminalPoll = (table: string): void => {
+    const poll = tablePolls.get(table);
+    if (poll?.terminalError === undefined) {
+      return;
+    }
+    const refcount = poll.refcount;
+    poll.controller.abort();
+    tablePolls.delete(table);
+    startTablePoll(table, refcount);
   };
 
   const stopTablePoll = (table: string): void => {
@@ -247,12 +354,24 @@ const createPool = (client: BaerlyClient): SubscriptionPool => {
     getSnapshot(signature: string): CachedSnapshot {
       return cache.get(signature)?.snapshot ?? LOADING_SNAPSHOT;
     },
+    refetch(signature: string): void {
+      const entry = cache.get(signature);
+      const fetcher = signatureFetchers.get(signature);
+      if (entry === undefined || fetcher === undefined) {
+        return;
+      }
+      for (const table of entry.chainTables) {
+        restartTerminalPoll(table);
+      }
+      dispatchFetch(signature, fetcher);
+    },
     attach(signature, tables, chainTables, fetcher, notify) {
       let entry = cache.get(signature);
       const isFirstSubscriber = entry === undefined;
       if (entry === undefined) {
         entry = {
           snapshot: LOADING_SNAPSHOT,
+          hasSuccessfulData: false,
           chainTables,
           inFlight: undefined,
         };

--- a/packages/client/src/react/subscription-retry.test.ts
+++ b/packages/client/src/react/subscription-retry.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  retryDelay,
+  SUBSCRIPTION_RETRY_INITIAL_MILLIS,
+  SUBSCRIPTION_RETRY_MAX_MILLIS,
+} from "./subscription-retry.ts";
+
+const boundFor = (attempt: number): number =>
+  Math.min(SUBSCRIPTION_RETRY_MAX_MILLIS, SUBSCRIPTION_RETRY_INITIAL_MILLIS * 2 ** attempt);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("the delay floor doubles per attempt and then saturates", () => {
+  // `Math.random() === 0` returns the bottom of each jitter band, which
+  // is the bound's own doubling made visible.
+  vi.spyOn(Math, "random").mockReturnValue(0);
+  const floors: number[] = [];
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    floors.push(retryDelay(attempt));
+  }
+
+  expect(floors).toEqual([125, 250, 500, 1_000, 2_000, 4_000, 5_000, 5_000]);
+});
+
+test("no attempt exceeds the cap, however long the table stays wedged", () => {
+  // `2 ** 1024` overflows to Infinity. A wedged table reaches high
+  // attempt counts by design, so the saturating arm has to hold there
+  // rather than only across the handful of attempts a pool test walks.
+  for (const attempt of [8, 16, 64, 1_024]) {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    expect(retryDelay(attempt), `attempt ${attempt} floor`).toBe(SUBSCRIPTION_RETRY_MAX_MILLIS / 2);
+
+    // `(1 - ε/2) * 5000` rounds back to `5000` in float64, so the top
+    // of the band is the cap itself rather than one below it.
+    vi.spyOn(Math, "random").mockReturnValue(1 - Number.EPSILON / 2);
+    expect(retryDelay(attempt), `attempt ${attempt} ceiling`).toBe(SUBSCRIPTION_RETRY_MAX_MILLIS);
+  }
+});
+
+test("every unstubbed draw lands in the top half of its bound", () => {
+  // Half the bound is fixed so a wedged table backs off monotonically;
+  // half is random so a fleet that lost the same server does not
+  // re-converge into one synchronised retry wave. Drawn for real
+  // because every other test here pins `Math.random`.
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const bound = boundFor(attempt);
+    for (let draw = 0; draw < 50; draw += 1) {
+      const delay = retryDelay(attempt);
+      expect(delay, `attempt ${attempt}`).toBeGreaterThanOrEqual(bound / 2);
+      expect(delay, `attempt ${attempt}`).toBeLessThanOrEqual(bound);
+    }
+  }
+});

--- a/packages/client/src/react/subscription-retry.ts
+++ b/packages/client/src/react/subscription-retry.ts
@@ -1,0 +1,24 @@
+/**
+ * Initial upper bound, in milliseconds, for the React client's
+ * `/v1/since` retry delay. Equal jitter selects a delay from half this
+ * value through this value, then the bound doubles after each
+ * consecutive retriable failure.
+ *
+ * Client-side retry tuning, not a wire-protocol value, so it lives
+ * here rather than in `@baerly/protocol`'s `constants.ts` — putting it
+ * there would both widen the shared barrel that server, adapters, cli,
+ * and dev all import for a single React-only consumer, and hand the
+ * client that module's unrelated runtime closure.
+ *
+ * @see ./subscription-pool.ts
+ */
+export const SUBSCRIPTION_RETRY_INITIAL_MILLIS: number = 250;
+
+/**
+ * Maximum upper bound, in milliseconds, for the React client's
+ * `/v1/since` retry delay. The equal-jitter calculation never returns
+ * a delay above this cap.
+ *
+ * @see ./subscription-pool.ts
+ */
+export const SUBSCRIPTION_RETRY_MAX_MILLIS: number = 10_000;

--- a/packages/client/src/react/subscription-retry.ts
+++ b/packages/client/src/react/subscription-retry.ts
@@ -22,3 +22,23 @@ export const SUBSCRIPTION_RETRY_INITIAL_MILLIS: number = 250;
  * @see ./subscription-pool.ts
  */
 export const SUBSCRIPTION_RETRY_MAX_MILLIS: number = 10_000;
+
+/**
+ * Equal-jitter backoff delay for the `attempt`-th consecutive
+ * retriable `/v1/since` failure, counting from zero.
+ *
+ * The upper bound doubles per attempt from
+ * {@link SUBSCRIPTION_RETRY_INITIAL_MILLIS} and saturates at
+ * {@link SUBSCRIPTION_RETRY_MAX_MILLIS}; the returned delay is drawn
+ * uniformly from the top half of that bound. Half the bound is fixed
+ * so a wedged table still backs off monotonically, and half is random
+ * so a fleet of clients that lost the same server does not re-converge
+ * into a synchronised retry wave.
+ */
+export const retryDelay = (attempt: number): number => {
+  const upperBound = Math.min(
+    SUBSCRIPTION_RETRY_MAX_MILLIS,
+    SUBSCRIPTION_RETRY_INITIAL_MILLIS * 2 ** attempt,
+  );
+  return Math.floor(upperBound / 2 + Math.random() * (upperBound / 2));
+};

--- a/packages/client/src/react/use-query.test.ts
+++ b/packages/client/src/react/use-query.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 import { BaerlyError } from "@baerly/protocol";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { createBaerlyClient } from "../client.ts";
 import { MockFetch } from "../testing/index.ts";
 import { BaerlyProvider } from "./provider.ts";
@@ -63,6 +63,82 @@ describe("useQuery — basic reads", () => {
     await waitFor(() => expect(result.current.status).toBe("ok"));
     expect(result.current.data).toEqual([{ _id: "a", body: "hi" }]);
   });
+
+  test("refetch recovers a terminal live subscription without unmounting", async () => {
+    let releasePoll: ((response: Response) => void) | undefined;
+    let sinceCalls = 0;
+    let listCalls = 0;
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", () => {
+      sinceCalls += 1;
+      if (sinceCalls > 2) {
+        return new Promise<Response>(() => {});
+      }
+      return new Promise<Response>((resolve) => {
+        releasePoll = resolve;
+      });
+    });
+    mock.on("GET", "/v1/c/notes", () => {
+      listCalls += 1;
+      return jsonResponse(
+        okEnvelope([
+          {
+            _id: listCalls === 1 ? "before-expiry" : `after-recovery-${listCalls}`,
+            body: "still visible",
+          },
+        ]),
+      );
+    });
+    vi.useFakeTimers();
+    try {
+      const client = makeClient(mock);
+      const { result } = renderHook(() => useQuery((c) => c.collection("notes").all(), []), {
+        wrapper: wrap(client),
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(result.current.status).toBe("ok");
+
+      await act(async () => {
+        releasePoll?.(
+          jsonResponse(
+            { error: { code: "Unauthorized", message: "expired", retriable: false } },
+            401,
+          ),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(result.current.status).toBe("error");
+      expect(result.current.data).toEqual([{ _id: "before-expiry", body: "still visible" }]);
+      expect(result.current.error).toMatchObject({ code: "Unauthorized", retriable: false });
+
+      await act(async () => vi.advanceTimersByTimeAsync(10_000));
+      expect(sinceCalls).toBe(1);
+
+      await act(async () => {
+        result.current.refetch();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(result.current.status).toBe("ok");
+      expect(result.current.data).toEqual([{ _id: "after-recovery-2", body: "still visible" }]);
+      expect(sinceCalls).toBe(2);
+      expect(listCalls).toBe(2);
+
+      await act(async () => {
+        releasePoll?.(jsonResponse({ events: [{ lsn: "aaa_bbb_ccc" }], next_cursor: "cursor-1" }));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(result.current.data).toEqual([{ _id: "after-recovery-3", body: "still visible" }]);
+      expect(listCalls).toBe(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("useQuery.skip — deferred / conditional reads", () => {
@@ -119,6 +195,33 @@ describe("useQuery.skip — deferred / conditional reads", () => {
     expect(result.current.status).toBe("skipped");
     id = "n-1";
     rerender();
+    await waitFor(() => expect(result.current.status).toBe("ok"));
+    expect(result.current.data).toMatchObject({ _id: "n-1" });
+  });
+
+  test("refetch re-runs discovery for a skipped query with no dependency change", async () => {
+    const mock = new MockFetch();
+    installSinceLongPoll(mock);
+    mock.on("GET", "/v1/c/notes/:id", () =>
+      jsonResponse(okEnvelope({ _id: "n-1", body: "hello" })),
+    );
+    const client = makeClient(mock);
+    // Deliberately absent from `deps`, so nothing else can re-render
+    // the hook. Only refetch()'s non-"ok" branch — which force-updates
+    // to re-run discovery rather than dispatching into the pool — can
+    // move this off "skipped".
+    let ready = false;
+    const { result } = renderHook(
+      () => useQuery((c) => (ready ? c.collection("notes").get("n-1") : useQuery.skip), []),
+      { wrapper: wrap(client) },
+    );
+    expect(result.current.status).toBe("skipped");
+
+    ready = true;
+    act(() => {
+      result.current.refetch();
+    });
+
     await waitFor(() => expect(result.current.status).toBe("ok"));
     expect(result.current.data).toMatchObject({ _id: "n-1" });
   });
@@ -203,5 +306,225 @@ describe("useQuery — deps-driven re-reads", () => {
       expect((result.current.data as { _id: string } | undefined)?._id).toBe("b"),
     );
     expect(listCount).toBe(2);
+  });
+});
+
+describe("useQuery — non-live reads", () => {
+  test("live: false performs the initial read without opening /v1/since", async () => {
+    const mock = new MockFetch();
+    let listCalls = 0;
+    let sinceCalls = 0;
+    mock.on("GET", "/v1/since", () => {
+      sinceCalls += 1;
+      return new Promise<Response>(() => {});
+    });
+    mock.on("GET", "/v1/c/notes", () => {
+      listCalls += 1;
+      return jsonResponse(okEnvelope([{ _id: "static" }]));
+    });
+    const client = makeClient(mock);
+    const { result } = renderHook(
+      () => useQuery((c) => c.collection("notes").all(), [], { live: false }),
+      { wrapper: wrap(client) },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("ok"));
+    expect(result.current.data).toEqual([{ _id: "static" }]);
+    expect(listCalls).toBe(1);
+    expect(sinceCalls).toBe(0);
+  });
+
+  test("dependency changes re-run a non-live read", async () => {
+    const mock = new MockFetch();
+    let getCalls = 0;
+    let sinceCalls = 0;
+    mock.on("GET", "/v1/since", () => {
+      sinceCalls += 1;
+      return new Promise<Response>(() => {});
+    });
+    mock.on("GET", "/v1/c/notes/:id", (req) => {
+      getCalls += 1;
+      const id = req.url.split("/").pop() ?? "";
+      return jsonResponse(okEnvelope({ _id: id }));
+    });
+    const client = makeClient(mock);
+    let id = "a";
+    const { result, rerender } = renderHook(
+      () => useQuery((c) => c.collection("notes").get(id), [id], { live: false }),
+      { wrapper: wrap(client) },
+    );
+    await waitFor(() => expect(result.current.data).toMatchObject({ _id: "a" }));
+
+    id = "b";
+    rerender();
+    await waitFor(() => expect(result.current.data).toMatchObject({ _id: "b" }));
+    expect(getCalls).toBe(2);
+    expect(sinceCalls).toBe(0);
+  });
+
+  test("refetch is stable and explicitly refreshes a non-live query", async () => {
+    const mock = new MockFetch();
+    let listCalls = 0;
+    mock.on("GET", "/v1/c/notes", () => {
+      listCalls += 1;
+      return jsonResponse(okEnvelope([{ _id: `read-${listCalls}` }]));
+    });
+    const client = makeClient(mock);
+    const { result, rerender } = renderHook(
+      () => useQuery((c) => c.collection("notes").all(), [], { live: false }),
+      { wrapper: wrap(client) },
+    );
+    await waitFor(() => expect(result.current.data).toEqual([{ _id: "read-1" }]));
+    const snapshot = result.current;
+    const refetch = result.current.refetch;
+
+    rerender();
+    expect(result.current).toBe(snapshot);
+    expect(result.current.refetch).toBe(refetch);
+    act(() => refetch());
+    expect(result.current.status).toBe("refreshing");
+    expect(result.current.data).toEqual([{ _id: "read-1" }]);
+    await waitFor(() => expect(result.current.data).toEqual([{ _id: "read-2" }]));
+    expect(result.current.refetch).toBe(refetch);
+  });
+
+  test("a rejected refetch preserves the previous non-live data", async () => {
+    const mock = new MockFetch();
+    let listCalls = 0;
+    let releaseRecovery: ((response: Response) => void) | undefined;
+    mock.on("GET", "/v1/c/notes", () => {
+      listCalls += 1;
+      if (listCalls === 1) {
+        return jsonResponse(okEnvelope([{ _id: "last-good" }]));
+      }
+      if (listCalls === 3) {
+        return new Promise<Response>((resolve) => {
+          releaseRecovery = resolve;
+        });
+      }
+      return jsonResponse(
+        { error: { code: "Unauthorized", message: "expired", retriable: false } },
+        401,
+      );
+    });
+    const client = makeClient(mock);
+    const { result } = renderHook(
+      () => useQuery((c) => c.collection("notes").all(), [], { live: false }),
+      { wrapper: wrap(client) },
+    );
+    await waitFor(() => expect(result.current.status).toBe("ok"));
+
+    act(() => result.current.refetch());
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.data).toEqual([{ _id: "last-good" }]);
+    expect(result.current.error).toMatchObject({ code: "Unauthorized" });
+
+    act(() => result.current.refetch());
+    expect(result.current.status).toBe("refreshing");
+    expect(result.current.data).toEqual([{ _id: "last-good" }]);
+    releaseRecovery?.(jsonResponse(okEnvelope([{ _id: "recovered" }])));
+    await waitFor(() => expect(result.current.data).toEqual([{ _id: "recovered" }]));
+  });
+
+  test("live and non-live identities are isolated and live events do not invalidate non-live data", async () => {
+    let releaseEvent: ((response: Response) => void) | undefined;
+    let listCalls = 0;
+    let sinceCalls = 0;
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", () => {
+      sinceCalls += 1;
+      if (sinceCalls === 1) {
+        return new Promise<Response>((resolve) => {
+          releaseEvent = resolve;
+        });
+      }
+      return new Promise<Response>(() => {});
+    });
+    mock.on("GET", "/v1/c/notes", () => {
+      listCalls += 1;
+      return jsonResponse(okEnvelope([{ _id: `read-${listCalls}` }]));
+    });
+    const client = makeClient(mock);
+    const { result } = renderHook(
+      () => ({
+        live: useQuery((c) => c.collection("notes").all(), []),
+        nonLive: useQuery((c) => c.collection("notes").all(), [], { live: false }),
+      }),
+      { wrapper: wrap(client) },
+    );
+    await waitFor(() => {
+      expect(result.current.live.status).toBe("ok");
+      expect(result.current.nonLive.status).toBe("ok");
+    });
+    expect(listCalls).toBe(2);
+    const nonLiveData = result.current.nonLive.data;
+
+    releaseEvent?.(jsonResponse({ events: [{ lsn: "aaa_bbb_ccc" }], next_cursor: "cursor-1" }));
+    await waitFor(() => expect(listCalls).toBe(3));
+    expect(result.current.nonLive.data).toBe(nonLiveData);
+    expect(result.current.nonLive.data).toEqual([{ _id: "read-2" }]);
+  });
+
+  test("switching live true to false and back stops and restarts polling", async () => {
+    const pollSignals: AbortSignal[] = [];
+    let listCalls = 0;
+    const mock = new MockFetch();
+    mock.on("GET", "/v1/since", (req) => {
+      pollSignals.push(req.signal);
+      return new Promise<Response>((_, reject) => {
+        req.signal.addEventListener(
+          "abort",
+          () => reject(new DOMException("aborted", "AbortError")),
+          { once: true },
+        );
+      });
+    });
+    mock.on("GET", "/v1/c/notes", () => {
+      listCalls += 1;
+      return jsonResponse(okEnvelope([{ _id: `read-${listCalls}` }]));
+    });
+    const client = makeClient(mock);
+    let live = true;
+    const { result, rerender, unmount } = renderHook(
+      () => useQuery((c) => c.collection("notes").all(), [], { live }),
+      { wrapper: wrap(client) },
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual([{ _id: "read-1" }]));
+    expect(pollSignals).toHaveLength(1);
+    expect(pollSignals[0]?.aborted).toBe(false);
+
+    live = false;
+    rerender();
+    await waitFor(() => expect(result.current.data).toEqual([{ _id: "read-2" }]));
+    const nonLiveSnapshot = result.current;
+    expect(pollSignals).toHaveLength(1);
+    expect(pollSignals[0]?.aborted).toBe(true);
+
+    live = true;
+    rerender();
+    await waitFor(() => expect(result.current.data).toEqual([{ _id: "read-3" }]));
+    expect(result.current).not.toBe(nonLiveSnapshot);
+    expect(pollSignals).toHaveLength(2);
+    expect(pollSignals[1]?.aborted).toBe(false);
+    expect(listCalls).toBe(3);
+    unmount();
+  });
+
+  test("the default mode remains live", async () => {
+    const mock = new MockFetch();
+    let sinceCalls = 0;
+    mock.on("GET", "/v1/since", () => {
+      sinceCalls += 1;
+      return new Promise<Response>(() => {});
+    });
+    mock.on("GET", "/v1/c/notes", () => jsonResponse(okEnvelope([])));
+    const client = makeClient(mock);
+    const { result } = renderHook(() => useQuery((c) => c.collection("notes").all(), []), {
+      wrapper: wrap(client),
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("ok"));
+    expect(sinceCalls).toBe(1);
   });
 });

--- a/packages/client/src/react/use-query.ts
+++ b/packages/client/src/react/use-query.ts
@@ -13,19 +13,43 @@ const SKIP: unique symbol = Symbol("baerly.useQuery.skip");
  * into `"loading"` / `"skipped"` gives `data: undefined`; narrowing
  * into `"error"` gives `data: T | undefined` (the prior successful
  * read survives across errors so the UI can keep rendering).
+ * Every state also carries the same stable `refetch()` function, which
+ * starts an explicit refresh without changing the declared dependencies.
  */
-export type UseQueryResult<T> =
+export type UseQueryResult<T> = (
   | { readonly status: "loading"; readonly data: undefined; readonly error: undefined }
   | { readonly status: "refreshing"; readonly data: T; readonly error: undefined }
   | { readonly status: "ok"; readonly data: T; readonly error: undefined }
   | { readonly status: "skipped"; readonly data: undefined; readonly error: undefined }
-  | { readonly status: "error"; readonly data: T | undefined; readonly error: Error };
+  | { readonly status: "error"; readonly data: T | undefined; readonly error: Error }
+) & {
+  /** Re-run this query without changing its declared dependencies. */
+  readonly refetch: () => void;
+};
 
-const SKIPPED_SNAPSHOT: UseQueryResult<never> = Object.freeze({
+/**
+ * A {@link UseQueryResult} before `refetch` is attached. `withRefetch`
+ * decorates one of these into the value the hook returns; keeping the
+ * un-decorated shape named lets the snapshot literals below be checked
+ * against the result type instead of asserted into it.
+ */
+type UseQuerySnapshot<T> = Omit<UseQueryResult<T>, "refetch">;
+
+const SKIPPED_SNAPSHOT = Object.freeze({
   status: "skipped",
   data: undefined,
   error: undefined,
-});
+} satisfies UseQuerySnapshot<never>);
+
+/** Options for a {@link useQuery} read. */
+export interface UseQueryOptions {
+  /**
+   * Subscribe to collection changes through `/v1/since`. Defaults to
+   * `true`. Set `false` for an initial/dependency-driven read that only
+   * refreshes when {@link UseQueryResult.refetch} is called.
+   */
+  readonly live?: boolean;
+}
 
 interface RecorderState {
   readonly collectionsRead: Set<string>;
@@ -197,6 +221,12 @@ const discover = (
  * `{ status: "skipped" }` and registers no subscription — use it
  * for deferred / conditional reads.
  *
+ * Pass `{ live: false }` as the third argument to perform the initial
+ * read and dependency-driven re-reads without opening `/v1/since`.
+ * Every result state includes a stable `refetch()` function for an
+ * explicit refresh; successful data remains available while that
+ * refresh is running and if it fails.
+ *
  * @example
  * ```tsx
  * // Single read
@@ -212,6 +242,14 @@ const discover = (
  * );
  * if (list.status === "skipped") return null;
  *
+ * // Non-live read with an explicit refresh
+ * const report = useQuery(
+ *   (c) => c.collection("notes").all(),
+ *   [],
+ *   { live: false },
+ * );
+ * <button onClick={report.refetch}>Refresh</button>;
+ *
  * // Dependent read (parent → child)
  * const parent  = useQuery((c) => c.collection("notes").get(id), [id]);
  * const replies = useQuery(
@@ -225,9 +263,11 @@ const discover = (
 const useQueryImpl = <T, TConfig extends BaerlyConfig = UnboundConfig>(
   callback: (client: BaerlyClient<TConfig>) => Promise<T> | typeof SKIP,
   deps?: ReadonlyArray<unknown>,
+  options?: UseQueryOptions,
 ): UseQueryResult<T> => {
   const client = useBaerlyClient<TConfig>();
   const pool = poolFor(client as unknown as BaerlyClient);
+  const live = options?.live !== false;
 
   const callbackRef = useRef(callback);
   callbackRef.current = callback;
@@ -248,8 +288,8 @@ const useQueryImpl = <T, TConfig extends BaerlyConfig = UnboundConfig>(
   const depsKey = stableKey([deps ?? []]);
   const signatureBase =
     discovery.kind === "ok"
-      ? stableKey([discovery.chainShape, deps ?? []])
-      : `__non_ok__${discovery.kind}__${depsKey}`;
+      ? stableKey([discovery.chainShape, deps ?? [], live])
+      : `__non_ok__${discovery.kind}__${depsKey}__${String(live)}`;
 
   // Reset the captured async error if the signature changed (the
   // user is on a different query now — give them a fresh chance).
@@ -316,7 +356,7 @@ const useQueryImpl = <T, TConfig extends BaerlyConfig = UnboundConfig>(
   const discoveryErrorRef = useRef<Error | undefined>(undefined);
   discoveryKindRef.current = discovery.kind;
   if (discovery.kind === "ok") {
-    chainCollectionsRef.current = new Set(discovery.collections);
+    chainCollectionsRef.current = live ? new Set(discovery.collections) : new Set();
     discoveryErrorRef.current = undefined;
   } else if (discovery.kind === "error") {
     discoveryErrorRef.current = discovery.error;
@@ -331,7 +371,7 @@ const useQueryImpl = <T, TConfig extends BaerlyConfig = UnboundConfig>(
       }
       return pool.attach(
         signatureBase,
-        discovery.collections,
+        live ? discovery.collections : [],
         chainCollectionsRef.current,
         () => fetcherRef.current(),
         notify,
@@ -343,6 +383,21 @@ const useQueryImpl = <T, TConfig extends BaerlyConfig = UnboundConfig>(
     [pool, signatureBase, collectionsJoin],
   );
 
+  const refetchTargetRef = useRef({
+    kind: discovery.kind,
+    pool,
+    signature: signatureBase,
+  });
+  refetchTargetRef.current = { kind: discovery.kind, pool, signature: signatureBase };
+  const refetch = useCallback((): void => {
+    const target = refetchTargetRef.current;
+    if (target.kind === "ok") {
+      target.pool.refetch(target.signature);
+    } else {
+      forceUpdate();
+    }
+  }, []);
+
   // Stable per-error snapshot cache so repeated getSnapshot polls
   // within a single render return the same reference. React's
   // useSyncExternalStore detects identity changes; constructing a
@@ -350,36 +405,54 @@ const useQueryImpl = <T, TConfig extends BaerlyConfig = UnboundConfig>(
   const errorSnapshotRef = useRef<
     | {
         error: Error;
-        snapshot: UseQueryResult<unknown>;
+        snapshot: { status: "error"; data: undefined; error: Error };
       }
     | undefined
   >(undefined);
-  const snapshotForError = (err: Error): UseQueryResult<T> => {
+  const snapshotForError = (err: Error): UseQuerySnapshot<T> => {
     if (errorSnapshotRef.current?.error === err) {
-      return errorSnapshotRef.current.snapshot as UseQueryResult<T>;
+      return errorSnapshotRef.current.snapshot;
     }
     const snapshot = {
       status: "error" as const,
       data: undefined,
       error: err,
-    } satisfies UseQueryResult<unknown>;
+    } satisfies UseQuerySnapshot<T>;
     errorSnapshotRef.current = { error: err, snapshot };
+    return snapshot;
+  };
+
+  const decoratedSnapshotRef = useRef<
+    | {
+        base: object;
+        snapshot: UseQueryResult<unknown>;
+      }
+    | undefined
+  >(undefined);
+  const withRefetch = (base: object): UseQueryResult<T> => {
+    if (decoratedSnapshotRef.current?.base === base) {
+      return decoratedSnapshotRef.current.snapshot as UseQueryResult<T>;
+    }
+    const snapshot = { ...base, refetch } as UseQueryResult<unknown>;
+    decoratedSnapshotRef.current = { base, snapshot };
     return snapshot as UseQueryResult<T>;
   };
 
   const getSnapshot = useCallback((): UseQueryResult<T> => {
     if (asyncErrorRef.current) {
-      return snapshotForError(asyncErrorRef.current);
+      return withRefetch(snapshotForError(asyncErrorRef.current));
     }
     if (discoveryKindRef.current === "skip") {
-      return SKIPPED_SNAPSHOT as UseQueryResult<T>;
+      return withRefetch(SKIPPED_SNAPSHOT);
     }
     if (discoveryKindRef.current === "error") {
-      return snapshotForError(
-        discoveryErrorRef.current ?? new BaerlyError("Internal", "unknown discovery error"),
+      return withRefetch(
+        snapshotForError(
+          discoveryErrorRef.current ?? new BaerlyError("Internal", "unknown discovery error"),
+        ),
       );
     }
-    return pool.getSnapshot(signatureBase) as UseQueryResult<T>;
+    return withRefetch(pool.getSnapshot(signatureBase));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pool, signatureBase]);
 
@@ -390,20 +463,23 @@ const useQueryImpl = <T, TConfig extends BaerlyConfig = UnboundConfig>(
 };
 
 /**
- * Reactive read hook. See {@link useQueryImpl} JSDoc for usage.
+ * Read hook, live by default. See {@link useQueryImpl} JSDoc for usage.
  * The `.skip` property is the sentinel that short-circuits the hook
- * into `status: "skipped"`.
+ * into `status: "skipped"`; `{ live: false }` disables `/v1/since`
+ * while retaining initial reads, dependency re-runs, and `refetch()`.
  */
 export const useQuery: {
   <T, TConfig extends BaerlyConfig = UnboundConfig>(
     callback: (client: BaerlyClient<TConfig>) => Promise<T> | typeof SKIP,
     deps?: ReadonlyArray<unknown>,
+    options?: UseQueryOptions,
   ): UseQueryResult<T>;
   readonly skip: typeof SKIP;
 } = Object.assign(useQueryImpl, { skip: SKIP }) as {
   <T, TConfig extends BaerlyConfig = UnboundConfig>(
     callback: (client: BaerlyClient<TConfig>) => Promise<T> | typeof SKIP,
     deps?: ReadonlyArray<unknown>,
+    options?: UseQueryOptions,
   ): UseQueryResult<T>;
   readonly skip: typeof SKIP;
 };

--- a/packages/client/src/react/use-query.ts
+++ b/packages/client/src/react/use-query.ts
@@ -3,7 +3,7 @@ import { useCallback, useReducer, useRef, useSyncExternalStore } from "react";
 import type { BaerlyClient } from "../client.ts";
 import { useBaerlyClient } from "./provider.ts";
 import { stableKey } from "./stable-key.ts";
-import { LOADING_SNAPSHOT, poolFor } from "./subscription-pool.ts";
+import { type CachedSnapshot, LOADING_SNAPSHOT, poolFor } from "./subscription-pool.ts";
 
 const SKIP: unique symbol = Symbol("baerly.useQuery.skip");
 
@@ -206,10 +206,10 @@ const discover = (
 };
 
 /**
- * Reactive read against a `baerly` server. The callback receives a
+ * Read against a `baerly` server, live by default. The callback receives a
  * type-compatible `BaerlyClient` proxy that records which collections it
- * touches; the hook subscribes to those collections and re-runs the
- * callback against the real client when any of them mutate.
+ * touches; in live mode, the hook subscribes to those collections and
+ * re-runs the callback against the real client when any of them mutate.
  *
  * Re-runs also fire whenever the `deps` array changes between
  * renders (shallow `stableKey` compare). Closure variables read
@@ -429,7 +429,7 @@ const useQueryImpl = <T, TConfig extends BaerlyConfig = UnboundConfig>(
       }
     | undefined
   >(undefined);
-  const withRefetch = (base: object): UseQueryResult<T> => {
+  const withRefetch = (base: UseQuerySnapshot<T> | CachedSnapshot): UseQueryResult<T> => {
     if (decoratedSnapshotRef.current?.base === base) {
       return decoratedSnapshotRef.current.snapshot as UseQueryResult<T>;
     }

--- a/packages/client/src/request.ts
+++ b/packages/client/src/request.ts
@@ -52,8 +52,9 @@ const parseSuccessfulJson = async (
  * - 201 → raw parsed body as T (POST insert success — body `{ _id }`).
  * - 4xx / 5xx → parse `HttpErrorEnvelope` and throw
  *   {@link BaerlyError} with `status` set to the wire HTTP code.
- *   Non-JSON error bodies synthesize an `Internal` code so consumers
- *   still get a structured throw.
+ *   Bodies that carry no envelope (a proxy or CDN answering for the
+ *   server) still get a structured throw, with the code synthesized
+ *   from the status: `NetworkError` for 5xx, `Internal` for 4xx.
  * - 200 on non-`GET` (PATCH, future mutations) → raw parsed body
  *   as T (e.g. `{ modified }`).
  * - 200 on `GET /v1/since` → raw `SinceResponse` as T (no `data` unwrap).
@@ -92,10 +93,24 @@ export const request = async <T>(ctx: RequestContext, opts: RequestOptions): Pro
     try {
       envelope = (await res.json()) as HttpErrorEnvelope;
     } catch {
-      // Non-JSON body (e.g. an upstream proxy 502). Synthesize an
-      // Internal error so consumers still get a structured throw.
+      // Non-JSON body (e.g. an upstream proxy 502). Fall through to
+      // the synthesized code below so consumers still get a
+      // structured throw.
     }
-    const code: BaerlyErrorCode = envelope?.error?.code ?? "Internal";
+    // No envelope means the response came from something between the
+    // caller and the server — a load balancer, CDN, or service mesh —
+    // so the server's own failure class is unavailable and we infer
+    // one from the status. A 5xx from that layer is a transport
+    // condition that clears when the backend comes back, and
+    // `NetworkError` is the only synthesized code whose default
+    // `retriable` says so. `Internal` does not: the React
+    // subscription pool treats a non-retriable error as permanently
+    // terminal, so labelling a rolling-deploy 502 `Internal` would
+    // park every live query on a dead poll until the user remounted.
+    // A 4xx without an envelope is a caller or routing fault, which
+    // retrying cannot clear — it stays `Internal`.
+    const synthesized: BaerlyErrorCode = res.status >= 500 ? "NetworkError" : "Internal";
+    const code: BaerlyErrorCode = envelope?.error?.code ?? synthesized;
     const message = envelope?.error?.message ?? `HTTP ${res.status}`;
     throw new BaerlyError(
       code,

--- a/packages/client/src/request.ts
+++ b/packages/client/src/request.ts
@@ -27,6 +27,23 @@ export interface RequestContext {
   readonly headers: Headers;
 }
 
+const parseSuccessfulJson = async (
+  res: Response,
+  opts: Pick<RequestOptions, "method" | "path">,
+): Promise<unknown> => {
+  try {
+    return await res.json();
+  } catch (error) {
+    throw new BaerlyError(
+      "InvalidResponse",
+      `Response to ${opts.method} ${opts.path} was not valid JSON`,
+      error,
+      undefined,
+      res.status,
+    );
+  }
+};
+
 /**
  * Issue one HTTP request and unwrap the response per the locked
  * status-code policy in `packages/server/src/contract.ts:73-89`:
@@ -66,7 +83,7 @@ export const request = async <T>(ctx: RequestContext, opts: RequestOptions): Pro
   // caller (`insert`) types T = `{ _id }` so we return the parsed
   // body raw.
   if (res.status === 201) {
-    return (await res.json()) as T;
+    return (await parseSuccessfulJson(res, opts)) as T;
   }
 
   // 4xx / 5xx — `HttpErrorEnvelope`. Parse + throw.
@@ -94,7 +111,7 @@ export const request = async <T>(ctx: RequestContext, opts: RequestOptions): Pro
   // 200 — only GET reads ship `HttpOkEnvelope<T>`. PATCH (and any
   // future non-GET mutation that hits 200) ships its body raw. GET
   // /v1/since also ships raw (`SinceResponse`).
-  const body = (await res.json()) as unknown;
+  const body = await parseSuccessfulJson(res, opts);
   if (opts.method !== "GET") {
     return body as T;
   }

--- a/packages/create-baerly-storage/src/scaffold.test.ts
+++ b/packages/create-baerly-storage/src/scaffold.test.ts
@@ -589,6 +589,8 @@ describe("scaffold", () => {
       if (shape === "react") {
         expect(result.filesWritten).toContain("index.html");
         expect(result.filesWritten).toContain(join("src", "web", "NoteList.tsx"));
+        expect(agents).toContain("{ live: false }");
+        expect(agents).toContain("refetch()");
         const html = await readFile(join(result.outDir, "index.html"), "utf8");
         // "Notes" is deliberate prose, not a slug. The renames manifest
         // only sentinelizes `react-cloudflare` and `react-demo`; bare

--- a/packages/server/API.md
+++ b/packages/server/API.md
@@ -590,23 +590,21 @@ import { BaerlyProvider, client, useMutation, useQuery } from "./client.ts";
   <App />
 </BaerlyProvider>;
 
-// 2. useQuery(cb, deps) — the callback receives the bound client and
-//    returns a ClientCollection / ClientQuery chain. Re-runs on deps
-//    change OR on long-poll invalidation. Result is a discriminated
-//    union; the row type is inferred from the collection name:
+// 2. useQuery(cb, deps, options?) — inferred rows, live by default.
 const result = useQuery((c) => c.collection("notes").all(), []);
-// result.status: "loading" | "ok" | "error" | "skipped"
-// result.data:   Note[] | undefined      (present iff status === "ok")
-// result.error:  BaerlyError | undefined (present iff status === "error")
+// result has status, data/error, and a stable refetch().
 
-// 3. useQuery.skip — short-circuit to status: "skipped", no
+// 3. live:false reads on mount, deps changes, and refetch—no /v1/since.
+const report = useQuery((c) => c.collection("notes").all(), [reportDate], { live: false });
+
+// 4. useQuery.skip — short-circuit to status: "skipped", no
 //    subscription. Use for conditional or dependent reads.
 const filtered = useQuery(
   (c) => (filter === "all" ? useQuery.skip : c.collection("notes").where({ status: filter }).all()),
   [filter],
 );
 
-// 4. useMutation() — returns [mutate, { isPending, error }].
+// 5. useMutation() — returns [mutate, { isPending, error }].
 //    Run any client call inside mutate; subscribed useQuery reads
 //    re-run automatically once the long-poll sees the write.
 const [mutate, { isPending, error }] = useMutation();


### PR DESCRIPTION
## What & why

Adds opt-in non-live React queries and makes terminal live subscriptions recoverable without remounting. Explicit refetch rebuilds failed shared table polls while preserving stale data, and malformed successful `/v1/since` responses now surface as terminal `InvalidResponse` errors instead of retrying indefinitely.

## Key points

- Keeps live and non-live cache identities distinct and stops or starts polling as the option changes.
- Reclassifies HTTP error responses without a `baerly` envelope by status: proxy or gateway 5xx responses become retriable `NetworkError` failures rather than parking live queries until remount.
- Uses equal-jitter exponential backoff with a 250 ms initial bound and 10 second cap; repeated replacement-cursor rejection retains backoff across empty-cursor bootstrap.
- Synchronizes React scaffold guidance and public barrel type coverage.
- Rebaselines client bundles for the added response validation and recovery lifecycle.

## Verification

| Command | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm bundle-sizes` | ok (14 entries) |
| `pnpm test:agent` | 3,353 passed; 105 skipped |
