### PR TITLE
chore(test): cap agent test workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "typecheck": "tsgo --noEmit",
     "pretest": "node scripts/build-if-needed.mjs",
     "test": "vitest run --project=default",
-    "test:agent": "vitest run --project=default --reporter=minimal --silent=passed-only",
+    "test:agent": "vitest run --project=default --reporter=minimal --silent=passed-only --maxWorkers=4",
     "test:one": "pnpm run build && vitest run --project=default",
     "test:coverage": "vitest run --project=default --coverage",
     "test:minio": "MINIO=1 vitest run --project=default",


### PR DESCRIPTION
## What & why

Cap `test:agent` at four Vitest workers so overlapping agent runs do not oversubscribe developer machines. Human, CI, and specialized test entry points retain their existing concurrency behavior.

## Verification

| Check | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| Live broad-slice process count | 4 `forks.js` workers |
| Two overlapping 92-file slices | both capped at 4; 1,623 tests passed per run |
| `pnpm test:agent` | known local-fs `maintenance-e2e` 30s timeout; 3,297 tests passed |