### PR TITLE
feat(protocol)!: establish log-retention floor invariants

### DIFF
--- a/.changeset/log-delete-floor.md
+++ b/.changeset/log-delete-floor.md
@@ -1,0 +1,37 @@
+---
+"@gusto/baerly-storage": minor
+---
+
+`current.json` gains an optional `log_delete_floor`: the exclusive upper
+bound of the contiguous log prefix certified deleted. Every lower log
+object is gone from the bucket. This is distinct from `log_seq_start`,
+which is the lowest sequence a reader may still need; the gap between
+them is the retained safety window. Absent or `0` means no deleted prefix
+is certified, even if existing GC deleted sparse log objects, so
+`schema_version` stays at `3` and existing buckets are unaffected.
+
+No writer sets the field yet. What ships is the safety envelope around
+it, so that the pass which does set it lands against invariants that
+already exist and are already tested:
+
+- `assertCurrentJsonTransition` rejects a transition that lowers the
+  delete floor, or that raises it above `log_seq_start`, with
+  `BaerlyError{code:"Internal"}`. Both rules are transition-scoped; the
+  single-state guard `assertCurrentJson` checks shape only.
+- The two `@internal` `Db` log-read seams now distinguish *folded and
+  possibly reclaimed* from **gone**. Below `log_seq_start` they keep the
+  existing message; below `log_delete_floor` they say the object has
+  been reclaimed. Same `Internal` code, different wording — an operator
+  reading the throw needs to know whether the bytes are recoverable.
+  Both clamp to `min(log_delete_floor, log_seq_start)` rather than
+  trusting a stored value that the single-state guard does not bound.
+- `baerly admin restore --force` deliberately **drops** the field when it
+  reseeds. If the certified old prefix includes the entire old log, LIST
+  finds no surviving log object and the new generation reseeds at `0`,
+  below the old delete floor. Carrying the old-generation certificate
+  would then publish `log_delete_floor > log_seq_start` through the one
+  `current.json` PUT exempt from transition validation. The test now
+  constructs that valid empty-old-log state and pins the reset.
+
+No behavior change for any shipping caller. See invariants 5 and 12 in
+`docs/spec/sync-protocol.md`.

--- a/.changeset/log-read-seams-floored.md
+++ b/.changeset/log-read-seams-floored.md
@@ -14,6 +14,7 @@ const entry = await db.getLogEntry(collection, seq);
 const tail = await db.probeLogTail(collection, hint);
 // after
 const read = await db.getCurrentJson(collection);
+if (read === null) throw new Error("collection is not provisioned");
 const entry = await db.getLogEntry(collection, seq, read.json);
 const tail = await db.probeLogTail(collection, hint, read.json);
 ```

--- a/bundle-sizes.json
+++ b/bundle-sizes.json
@@ -16,9 +16,9 @@
   "entries": {
     "index.js": {
       "tier": "shipped",
-      "raw": 253413,
-      "gz": 80529,
-      "minGz": 20792,
+      "raw": 257550,
+      "gz": 81657,
+      "minGz": 20965,
       "note": "kernel barrel; every consumer pays. Must not pull the observability subgraph — see the dedicated test."
     },
     "client.js": {
@@ -37,30 +37,30 @@
     },
     "cloudflare.js": {
       "tier": "shipped",
-      "raw": 442974,
-      "gz": 134597,
-      "minGz": 44605,
+      "raw": 447133,
+      "gz": 135728,
+      "minGz": 44761,
       "note": "Worker isolate cold start. Aggregator: closure includes the index.js and http.js subgraphs, so growth that slips past those entries still surfaces here."
     },
     "s3.js": {
       "tier": "shipped",
-      "raw": 86010,
-      "gz": 27726,
-      "minGz": 11501,
+      "raw": 86031,
+      "gz": 27732,
+      "minGz": 11500,
       "note": "Worker-safe S3 entry, so consumer-facing. Demonstrated catch: fast-xml-parser is pinned at 5.8.0 because 5.9.3 inflated this closure ~25%."
     },
     "gcs.js": {
       "tier": "shipped",
-      "raw": 80627,
-      "gz": 26343,
-      "minGz": 9693,
+      "raw": 80648,
+      "gz": 26348,
+      "minGz": 9692,
       "note": "Worker-safe GCS entry, so consumer-facing. Smaller than s3.js because the GOOG4 signer is lighter than aws4fetch."
     },
     "http.js": {
       "tier": "shipped",
-      "raw": 382151,
-      "gz": 115084,
-      "minGz": 37331,
+      "raw": 383841,
+      "gz": 115375,
+      "minGz": 37382,
       "note": "server-side. Also inside the cloudflare.js closure, so growth here shows up on that entry too."
     },
     "auth.js": {
@@ -72,9 +72,9 @@
     },
     "maintenance.js": {
       "tier": "shipped",
-      "raw": 145390,
-      "gz": 45498,
-      "minGz": 11981,
+      "raw": 147058,
+      "gz": 45796,
+      "minGz": 12022,
       "note": "operator-side; reached from the cloudflare.js closure."
     },
     "observability.js": {
@@ -97,17 +97,17 @@
     },
     "dev.js": {
       "tier": "tooling",
-      "raw": 55956,
+      "raw": 56906,
       "note": "dev-only; never enters a consumer bundle. At the 2% shipped rate it produced 12 of 32 historical trips for no safety benefit."
     },
     "node.js": {
       "tier": "tooling",
-      "raw": 607421,
+      "raw": 611580,
       "note": "server-only aggregator. Raw-only dep-creep tripwire; live-external-import creep is caught separately by the bare-specifier allowlist test."
     },
     "dev-vite.js": {
       "tier": "tooling",
-      "raw": 616334,
+      "raw": 620493,
       "note": "dev-only aggregator. Raw-only dep-creep tripwire; see node.js."
     }
   }

--- a/bundle-sizes.json
+++ b/bundle-sizes.json
@@ -16,9 +16,9 @@
   "entries": {
     "index.js": {
       "tier": "shipped",
-      "raw": 257550,
-      "gz": 81657,
-      "minGz": 20965,
+      "raw": 259465,
+      "gz": 82093,
+      "minGz": 21148,
       "note": "kernel barrel; every consumer pays. Must not pull the observability subgraph — see the dedicated test."
     },
     "client.js": {
@@ -37,9 +37,9 @@
     },
     "cloudflare.js": {
       "tier": "shipped",
-      "raw": 447133,
-      "gz": 135728,
-      "minGz": 44761,
+      "raw": 449048,
+      "gz": 136137,
+      "minGz": 44965,
       "note": "Worker isolate cold start. Aggregator: closure includes the index.js and http.js subgraphs, so growth that slips past those entries still surfaces here."
     },
     "s3.js": {
@@ -58,9 +58,9 @@
     },
     "http.js": {
       "tier": "shipped",
-      "raw": 383841,
-      "gz": 115375,
-      "minGz": 37382,
+      "raw": 384718,
+      "gz": 115516,
+      "minGz": 37466,
       "note": "server-side. Also inside the cloudflare.js closure, so growth here shows up on that entry too."
     },
     "auth.js": {
@@ -72,9 +72,9 @@
     },
     "maintenance.js": {
       "tier": "shipped",
-      "raw": 147058,
-      "gz": 45796,
-      "minGz": 12022,
+      "raw": 147935,
+      "gz": 45935,
+      "minGz": 12107,
       "note": "operator-side; reached from the cloudflare.js closure."
     },
     "observability.js": {
@@ -97,17 +97,17 @@
     },
     "dev.js": {
       "tier": "tooling",
-      "raw": 56906,
+      "raw": 57783,
       "note": "dev-only; never enters a consumer bundle. At the 2% shipped rate it produced 12 of 32 historical trips for no safety benefit."
     },
     "node.js": {
       "tier": "tooling",
-      "raw": 611580,
+      "raw": 613495,
       "note": "server-only aggregator. Raw-only dep-creep tripwire; live-external-import creep is caught separately by the bare-specifier allowlist test."
     },
     "dev-vite.js": {
       "tier": "tooling",
-      "raw": 620493,
+      "raw": 622408,
       "note": "dev-only aggregator. Raw-only dep-creep tripwire; see node.js."
     }
   }

--- a/docs/spec/causal-consistency-checking.md
+++ b/docs/spec/causal-consistency-checking.md
@@ -3,7 +3,7 @@ title: Causal-consistency property checking
 audience: spec
 doc_type: verification
 summary: Low-complexity verification of causal consistency via a known global timeline.
-last-reviewed: 2026-07-01
+last-reviewed: 2026-08-13
 tags: [protocol, verification, property-testing]
 related: [sync-protocol.md]
 ---
@@ -299,6 +299,23 @@ observed schedule on any causal-consistency violation, so a failing
 interleaving can be inspected and the injected entropy replayed by
 passing the seed back. (Timer-driven interleaving remains wall-clock
 dependent, so replay is not fully deterministic.)
+
+## Deterministic delete-floor coverage
+
+The optional `current.json.log_delete_floor` safety envelope is covered by
+deterministic protocol, reader-seam, and restore tests:
+
+- optional-field shape and the absent-to-`0` default;
+- transition monotonicity for both `log_seq_start` and
+  `log_delete_floor`;
+- the transition bound `log_delete_floor <= log_seq_start`;
+- distinct fold-floor versus certified-delete-floor diagnostics;
+- clamping malformed stored values above `log_seq_start`; and
+- `baerly admin restore --force` resetting the field when it reseeds a
+  new generation below the old certified floor.
+
+No deletion pass writes `log_delete_floor` yet, so there is currently no
+deletion/publication crash schedule to model.
 
 ## Conclusion
 

--- a/docs/spec/sync-protocol.md
+++ b/docs/spec/sync-protocol.md
@@ -90,6 +90,8 @@ interface CurrentJson {
   snapshot_bytes: number;
   snapshot_rows: number;
   last_warned_seq?: number;
+  log_delete_floor?: number;
+  generation?: string;
 }
 ```
 
@@ -108,6 +110,11 @@ size that drives the derived live-tail estimate after the first fold. It
 is a maintenance sizing estimate, not tail authority. It replaces the
 old exact stored-byte counter, which can no longer be writer-incremented
 once commits skip `current.json`.
+
+`log_delete_floor` is the exclusive upper bound of the contiguous log
+prefix certified deleted: every `log/<seq>.json` below it is gone from
+the bucket. An absent field or `0` means no deleted prefix is certified;
+it does not claim that existing GC has never deleted a sparse log object.
 
 `writer_fence` is **dormant** authority metadata: no production
 commit/read path uses it for authority. Its drop is deferred (see
@@ -496,6 +503,20 @@ These are the load-bearing rules.
    repeat. The one deliberate sub-floor GET is the writer's pre-image
    scan, which is 404-tolerant by construction and whose worst case is
    a redundant index key (invariant 7), never a wrong read.
+
+   A **second, stricter floor** sits beneath it. `log_seq_start` marks
+   what a reader may *need*; the optional `log_delete_floor` is the
+   exclusive upper bound of the contiguous log prefix certified deleted.
+   Every lower log object is gone; absent or `0` means no deleted prefix
+   is certified. The gap between the floors is the deliberately-retained
+   safety window. Both seams check it, and the two throws carry different
+   messages on purpose: below `log_seq_start` an object is folded and
+   *may* already be reclaimed, while below `log_delete_floor` it is
+   **gone**. An operator reading the throw has to be able to tell those
+   apart. The seams clamp the effective delete floor to
+   `min(log_delete_floor, log_seq_start)` rather than trusting the stored
+   value — see invariant 12 for why an out-of-bound value is readable at
+   all.
 6. **`current.json` is compaction state; the commit path does not write
    it.** The compactor's fold CAS is the only steady-state writer of
    the snapshot pointer, `log_seq_start`, and snapshot counters.
@@ -554,10 +575,36 @@ These are the load-bearing rules.
     centralize publication. `baerly admin restore --force` is the
     deliberate operator exemption: it reseeds a truncated collection to
     one past the highest _surviving_ log object, which can sit below the
-    old floor when a bounded GC sweep has left sub-floor log objects in
-    place. That is sound because the reseed value is strictly greater
-    than every log object still present, so the committing `log/<seq>`
-    create cannot collide with the old generation.
+    old fold floor when a bounded GC sweep has left folded log objects in
+    place. Any such survivor must be at or above the certified delete
+    floor. The reseed is sound because it remains strictly greater than
+    every log object still present, so the committing `log/<seq>` create
+    cannot collide with the old generation.
+
+    The optional `log_delete_floor` (invariant 5) obeys two rules in the
+    same validator: it never decreases, and it never exceeds
+    `log_seq_start`. Both are **transition-scoped**. The single-state
+    read guard `assertCurrentJson` checks shape only — optional
+    non-negative integer — and deliberately does not carry the
+    `<= log_seq_start` bound, unlike the `log_seq_start <= tail_hint`
+    bound it does carry. That asymmetry is intentional: an inverted live
+    *read* range must stop a reader, whereas an out-of-bound delete
+    floor affects only *deletion*, and `readCurrentJson` sits on `admin
+    restore`'s own path, so rejecting the state there would leave the
+    bucket with no in-product repair path. Fail-safe direction is stall,
+    not lockout. The consequence is that an out-of-bound floor **can**
+    be read back off disk, so every consumer of the field — the read
+    seams and any retirement pass that deletes against it — must clamp
+    to `min(log_delete_floor, log_seq_start)` rather than trust the
+    stored value. `baerly admin restore --force` **drops** the field
+    entirely because the truncate starts a new generation. A reseed can
+    land below the old delete floor when the certified old prefix — and
+    potentially the entire old log — is gone: LIST then finds no surviving
+    log object and returns `truncatedNext = 0`. Restored rows reuse slots
+    below the old floor, so carrying the old-generation certificate through
+    that unchecked raw PUT could persist
+    `log_delete_floor > log_seq_start`. Dropping it resets the new
+    generation to no deleted prefix certified.
 13. **A `/v1/since` cursor is valid only within the generation that
     minted it.** `current.json` carries an opaque `generation` nonce,
     and the cursor the server hands a long-poll client is

--- a/packages/cli/src/admin/restore.test.ts
+++ b/packages/cli/src/admin/restore.test.ts
@@ -244,7 +244,7 @@ describe("baerly admin restore", () => {
     // is strictly above every log object still present and the committing
     // `log/<seq>` create cannot collide with the old generation. The
     // reseed sets `snapshot: null`, so the old generation becomes
-    // unreachable to every reader — the intent of truncating. Sub-floor
+    // unreachable to every reader — the intent of truncating. Sub-fold-floor
     // `log/` survivors are swept as `stale-log`; legacy `content/` side
     // objects are left in place and are inert. See the FLOOR EXEMPTION
     // comment in `restore.ts`.
@@ -297,8 +297,9 @@ describe("baerly admin restore", () => {
     // The realistic shape, and the one the exemption's soundness argument
     // actually rests on. GC's sweep is budget-bounded and walks `log/` in
     // lex order, so it routinely clears the TOP of the old range while
-    // leaving sub-floor objects behind. The reseed must then land strictly
-    // above the highest survivor — which can be below the old floor.
+    // leaving sub-fold-floor objects behind. The reseed must then land
+    // strictly above the highest survivor — which can be below the old fold
+    // floor.
     //
     // Here: fold the whole range (floor → 2), then sweep only `log/1`.
     // `log/0` survives, so `truncatedNext` is 1 — below the old floor of 2,
@@ -344,6 +345,71 @@ describe("baerly admin restore", () => {
       survivors.push(entry.key);
     }
     expect(survivors).toContain(`${TABLE_PREFIX}/log/0.json`);
+  });
+
+  test("--force drops a certified delete floor before reseeding an empty old log", async () => {
+    // A nonzero delete floor certifies that every lower log object is gone.
+    // When the certified prefix is the entire old log, LIST finds no old
+    // survivor and `--force` safely reseeds at 0, below that old floor.
+    // Carrying the field through the unchecked truncate PUT would publish
+    // `log_delete_floor > log_seq_start`; dropping it correctly resets the
+    // new generation to "no deleted prefix is certified."
+    await writeFile(stdinPath, CANONICAL_NDJSON, "utf8");
+    await expect(
+      runRestore(
+        [`--bucket=file://${root}`, `--app=${APP}`, `--tenant=${TENANT}`, `--collection=${COLL}`],
+        { streams: { stdin: createReadStream(stdinPath) } },
+      ),
+    ).resolves.toBe(0);
+
+    // First advance the fold floor to the old tail. Delete every old log
+    // object below it, and only then publish the certified delete floor.
+    const folded = await casUpdateCurrentJson(storage, CURRENT_JSON_KEY, (c) => ({
+      ...c,
+      log_seq_start: c.tail_hint,
+    }));
+    const oldTail = folded.json.log_seq_start;
+    for (let seq = 0; seq < oldTail; seq += 1) {
+      await storage.delete(`${TABLE_PREFIX}/log/${seq}.json`);
+    }
+    await casUpdateCurrentJson(storage, CURRENT_JSON_KEY, (c) => ({
+      ...c,
+      log_delete_floor: oldTail,
+    }));
+
+    const before = await readCurrentJson(storage, CURRENT_JSON_KEY);
+    const oldDeleteFloor = before?.json.log_delete_floor ?? 0;
+    expect(oldDeleteFloor).toBeGreaterThan(0);
+    const oldLogKeys: string[] = [];
+    for await (const entry of storage.list(`${TABLE_PREFIX}/log/`)) {
+      oldLogKeys.push(entry.key);
+    }
+    expect(oldLogKeys).toEqual([]);
+
+    await writeFile(stdinPath, `{"_id":"v-1","x":1}\n`, "utf8");
+    await expect(
+      runRestore(
+        [
+          `--bucket=file://${root}`,
+          `--app=${APP}`,
+          `--tenant=${TENANT}`,
+          `--collection=${COLL}`,
+          "--force",
+        ],
+        { streams: { stdin: createReadStream(stdinPath) } },
+      ),
+    ).resolves.toBe(0);
+
+    const head = await readCurrentJson(storage, CURRENT_JSON_KEY);
+    expect(head?.json.log_seq_start).toBe(0);
+    expect(head?.json.log_seq_start).toBeLessThan(oldDeleteFloor);
+    expect(head?.json.log_delete_floor).toBeUndefined();
+
+    // The reseed leaves a manifest that still admits validated transitions.
+    // Had the old floor been carried, this no-op CAS would reject it.
+    await expect(
+      casUpdateCurrentJson(storage, CURRENT_JSON_KEY, (c) => ({ ...c })),
+    ).resolves.toBeDefined();
   });
 
   test("both restore branches mint a generation, and --force re-mints a different one", async () => {

--- a/packages/cli/src/admin/restore.ts
+++ b/packages/cli/src/admin/restore.ts
@@ -199,11 +199,11 @@ const bundle = defineBaerlySubcommand({
       // every log object still on the bucket, so the writer's committing
       // `log/<seq>` create cannot collide with an old-generation object —
       // that 412 hazard is the whole point of the reseed (see above). It
-      // can land below the old floor whenever GC has swept the objects at
-      // the top of the old range but not all of them: the sweep is
-      // budget-bounded and walks `log/` in lex order (`0,1,10,11,2,...`),
-      // so sub-floor objects routinely survive a pass. Old floor 12 with
-      // `log/8`, `log/9` left behind yields `truncatedNext` 10 < 12.
+      // can land below the old FOLD floor whenever GC has swept the objects
+      // at the top of the folded range but not all of them: the sweep is
+      // budget-bounded and walks `log/` in lex order (`0,1,10,11,2,...`).
+      // For example, fold floor 12 and certified delete floor 8 may validly
+      // retain `log/8` and `log/9`, yielding `truncatedNext` 10 < 12.
       //
       // Nothing is lost by that. Readers never see the survivors: they
       // walk from the new floor, and `fsck` bounds itself by listed keys,
@@ -223,6 +223,26 @@ const bundle = defineBaerlySubcommand({
       // `tail_hint`, trips `assertCurrentJson`, and breaks truncate.
       // `restore.test.ts` pins both the empty-prefix and partial-sweep
       // cases.
+      // `log_delete_floor` IS DELIBERATELY ABSENT from this literal. Do not
+      // "repair" that with `...head.json`.
+      //
+      // Dropping it is the correct truncate semantics: the field is the
+      // exclusive upper bound of the contiguous log prefix certified
+      // deleted. A truncate starts a new generation, so its certification
+      // resets to "no deleted prefix is certified."
+      //
+      // Carrying it forward is not merely redundant, it is unsound. This PUT
+      // is the one `current.json` writer that does not call
+      // `assertCurrentJsonTransition` (invariant 12 names it as the deliberate
+      // exemption), so a carried floor is published UNCHECKED. A reseed can
+      // land below the old delete floor only when the certified old prefix —
+      // potentially the entire old log — is gone. With no surviving log
+      // objects, LIST yields `truncatedNext = 0`; restored rows then reuse
+      // slots below the old floor. Carrying that old-generation certificate
+      // would store `log_delete_floor > log_seq_start`, which the very next
+      // validated write rejects — in practice this command's own post-reseed
+      // tail stamp. `restore.test.ts` pins the empty-old-log case, the field
+      // omission, and the subsequent validated transition.
       const reseeded: CurrentJson = {
         schema_version: CURRENT_JSON_SCHEMA_VERSION,
         snapshot: null,
@@ -273,7 +293,12 @@ const bundle = defineBaerlySubcommand({
       // safe whether or not a ledger exists.
       await bucket.storage.delete(pendingKey);
     } else {
-      // Fresh target: seed `current.json` with `tail_hint=0`.
+      // Fresh target: seed `current.json` with `tail_hint=0`. This literal
+      // omits `log_delete_floor` too, and correctly: it routes through
+      // `createCurrentJson`, so no transition rule applies, and "no deleted
+      // prefix is certified" is exactly what an absent field decodes to.
+      // Named here so a sweep for missing-field sites stops rather than
+      // adding it.
       const seed: CurrentJson = {
         schema_version: CURRENT_JSON_SCHEMA_VERSION,
         snapshot: null,

--- a/packages/protocol/src/coordination/current-json.test.ts
+++ b/packages/protocol/src/coordination/current-json.test.ts
@@ -10,6 +10,7 @@ import {
   casUpdateCurrentJson,
   createCurrentJson,
   encodeJsonBytes,
+  logDeleteFloorOf,
   logSeqStartOf,
   MemoryStorage,
   mintGeneration,
@@ -50,6 +51,87 @@ describe("assertCurrentJsonTransition", () => {
       expect((error as BaerlyError).code).toBe("Internal");
       expect((error as BaerlyError).message).toContain("log_seq_start must not decrease");
     }
+  });
+
+  describe("log_delete_floor", () => {
+    plainTest("permits an advancing delete floor", () => {
+      const before = { ...base(100), log_delete_floor: 10 };
+      const after = { ...base(100), log_delete_floor: 20 };
+      expect(() => assertCurrentJsonTransition(before, after, "k")).not.toThrow();
+    });
+
+    plainTest("rejects a lowered delete floor with Internal", () => {
+      const before = { ...base(100), log_delete_floor: 20 };
+      const after = { ...base(100), log_delete_floor: 10 };
+      try {
+        assertCurrentJsonTransition(before, after, "k");
+        expect.unreachable("expected a throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(BaerlyError);
+        expect((error as BaerlyError).code).toBe("Internal");
+        expect((error as BaerlyError).message).toContain("log_delete_floor must not decrease");
+      }
+    });
+
+    plainTest("rejects a delete floor above the live floor", () => {
+      const before = { ...base(100), log_delete_floor: 10 };
+      const after = { ...base(100), log_delete_floor: 101 };
+      try {
+        assertCurrentJsonTransition(before, after, "k");
+        expect.unreachable("expected a throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(BaerlyError);
+        expect((error as BaerlyError).code).toBe("Internal");
+        expect((error as BaerlyError).message).toContain("must not exceed log_seq_start");
+      }
+    });
+
+    // The boundary the rule permits: certifying deletion up to but not
+    // including the lowest live seq. `log_delete_floor === log_seq_start`
+    // means every folded entry is gone and nothing a reader needs was touched.
+    plainTest("permits a delete floor exactly at the live floor", () => {
+      const after = { ...base(100), log_delete_floor: 100 };
+      expect(() => assertCurrentJsonTransition(base(100), after, "k")).not.toThrow();
+    });
+
+    plainTest("treats an absent prior floor as 0 (no deleted prefix certified)", () => {
+      const after = { ...base(100), log_delete_floor: 5 };
+      expect(() => assertCurrentJsonTransition(base(100), after, "k")).not.toThrow();
+    });
+
+    // A pre-field manifest on both sides must be admitted. Kills
+    // `<` → `<=` on the monotonicity check, which would read 0 → 0 as a
+    // decrease and stall every write to every bucket that has never set
+    // the field — i.e. all of them today.
+    plainTest("accepts an absent floor on both sides", () => {
+      expect(() => assertCurrentJsonTransition(base(100), base(100), "k")).not.toThrow();
+    });
+
+    // Kills the mutant that drops the `?? 0` when reading the AFTER side:
+    // `undefined < 20` is false, so an unguarded comparison would let a
+    // present floor silently regress to absent.
+    plainTest("rejects dropping a present delete floor back to absent", () => {
+      const before = { ...base(100), log_delete_floor: 20 };
+      try {
+        assertCurrentJsonTransition(before, base(100), "k");
+        expect.unreachable("expected a throw");
+      } catch (error) {
+        expect((error as BaerlyError).code).toBe("Internal");
+        expect((error as BaerlyError).message).toContain("log_delete_floor must not decrease");
+      }
+    });
+  });
+});
+
+describe("logDeleteFloorOf", () => {
+  plainTest("absent decodes to 0 (no deleted prefix certified)", () => {
+    expect(logDeleteFloorOf(seedJson({ tail_hint: 1_000_000, log_seq_start: 10 }))).toBe(0);
+  });
+
+  plainTest("present is returned as-is", () => {
+    expect(
+      logDeleteFloorOf(seedJson({ tail_hint: 1_000_000, log_seq_start: 10, log_delete_floor: 7 })),
+    ).toBe(7);
   });
 });
 
@@ -1601,6 +1683,76 @@ describe("assertCurrentJson — last_warned_seq guard", () => {
     await putRaw(s, "k", { ...rawSeed(), last_warned_seq: 100 });
     const got = await readCurrentJson(s, "k");
     expect(got!.json.last_warned_seq).toBe(100);
+  });
+});
+
+// Shape only, deliberately. The `log_delete_floor <= log_seq_start` bound is
+// transition-scoped (`assertCurrentJsonTransition`) and NOT checked here —
+// `readCurrentJson` sits on `admin restore`'s own repair path, so rejecting a
+// single state on that bound would leave an out-of-bound floor with no
+// in-product way out. The last case below pins that the read succeeds.
+describe("assertCurrentJson — log_delete_floor guard", () => {
+  plainTest("accepts record with log_delete_floor absent (undefined)", async () => {
+    const s = new MemoryStorage();
+    await putRaw(s, "k", rawSeed());
+    const got = await readCurrentJson(s, "k");
+    expect(got!.json.log_delete_floor).toBeUndefined();
+  });
+
+  plainTest("accepts log_delete_floor: 0 (boundary)", async () => {
+    const s = new MemoryStorage();
+    await putRaw(s, "k", { ...rawSeed(), log_delete_floor: 0 });
+    const got = await readCurrentJson(s, "k");
+    expect(got!.json.log_delete_floor).toBe(0);
+  });
+
+  plainTest("rejects log_delete_floor: -1 (negative)", async () => {
+    const s = new MemoryStorage();
+    await putRaw(s, "k", { ...rawSeed(), log_delete_floor: -1 });
+    await expect(readCurrentJson(s, "k")).rejects.toMatchObject({
+      code: "InvalidResponse",
+      message: expect.stringMatching(/log_delete_floor/),
+    });
+  });
+
+  plainTest("rejects log_delete_floor: 1.5 (non-integer)", async () => {
+    const s = new MemoryStorage();
+    await putRaw(s, "k", { ...rawSeed(), log_delete_floor: 1.5 });
+    await expect(readCurrentJson(s, "k")).rejects.toMatchObject({
+      code: "InvalidResponse",
+      message: expect.stringMatching(/log_delete_floor/),
+    });
+  });
+
+  plainTest("rejects log_delete_floor: 'x' (string, not a number)", async () => {
+    const s = new MemoryStorage();
+    await putRaw(s, "k", { ...rawSeed(), log_delete_floor: "x" });
+    await expect(readCurrentJson(s, "k")).rejects.toMatchObject({
+      code: "InvalidResponse",
+      message: expect.stringMatching(/log_delete_floor/),
+    });
+  });
+
+  plainTest("accepts log_delete_floor: 100 (positive integer)", async () => {
+    const s = new MemoryStorage();
+    await putRaw(s, "k", {
+      ...rawSeed(),
+      log_delete_floor: 100,
+      log_seq_start: 100,
+      tail_hint: 100,
+    });
+    const got = await readCurrentJson(s, "k");
+    expect(got!.json.log_delete_floor).toBe(100);
+  });
+
+  // The R1 ruling, pinned: a floor ABOVE `log_seq_start` reads back clean.
+  // Fail-safe direction is stall, not lockout — and this is what makes the
+  // clamp in the `Db` read seam reachable and testable.
+  plainTest("accepts log_delete_floor above log_seq_start (transition-scoped bound)", async () => {
+    const s = new MemoryStorage();
+    await putRaw(s, "k", { ...rawSeed(), log_delete_floor: 5, log_seq_start: 0 });
+    const got = await readCurrentJson(s, "k");
+    expect(got!.json.log_delete_floor).toBe(5);
   });
 });
 

--- a/packages/protocol/src/coordination/current-json.ts
+++ b/packages/protocol/src/coordination/current-json.ts
@@ -135,6 +135,39 @@ export interface CurrentJson {
   last_warned_seq?: number;
 
   /**
+   * The exclusive upper bound of the contiguous log prefix certified
+   * deleted. Every `log/<seq>.json` with `seq < log_delete_floor` is
+   * gone from the bucket. Distinct from {@link log_seq_start}, which is the
+   * lowest sequence a READER may need: the gap between them is the
+   * deliberately-retained safety window, which absorbs a paused writer
+   * resuming against its idempotency anchor.
+   *
+   * A FLOOR, not a rotation cursor. The deletable set is a contiguous
+   * range over integer `seq` order that only ever grows at one end, so
+   * this never wraps and never re-scans — which is why retiring stale
+   * logs needs no LIST and no `gc/pending.json` entry. Compare
+   * `GcPending.log_scan_cursor`, which drives a budget-bounded LIST in
+   * LEXICOGRAPHIC key order (`0,1,10,11,2,…`) and therefore must be a
+   * wrapping position rather than a bound.
+   *
+   * Optional because it postdates `schema_version: 3`. Absent is a
+   * well-defined state meaning "no deleted prefix is certified" and
+   * decodes to `0` via {@link logDeleteFloorOf}; a bucket written by an
+   * earlier build simply starts its first retention pass from the bottom
+   * of the keyspace.
+   *
+   * Invariants:
+   *   - advances monotonically (never decreases)
+   *   - `0 <= log_delete_floor <= log_seq_start`
+   *
+   * Both are transition-scoped and enforced in
+   * {@link assertCurrentJsonTransition}. The single-state guard checks
+   * shape only, so a retirement pass must clamp against
+   * {@link log_seq_start} rather than trust this value.
+   */
+  log_delete_floor?: number;
+
+  /**
    * Opaque non-empty generation nonce, re-minted by every writer that
    * *replaces* this collection rather than advancing it — the two
    * `baerly admin restore` seeds and the writer/dev auto-provision
@@ -351,6 +384,26 @@ export const assertCurrentJsonTransition = (
       `current.json at ${key}: log_seq_start must not decrease (${String(before.log_seq_start)} → ${String(after.log_seq_start)})`,
     );
   }
+  // Same argument one floor down, and read through the accessor on BOTH
+  // sides: absent means "no deleted prefix is certified", so a pre-field
+  // manifest compares as 0 rather than as `undefined`.
+  const beforeDeleteFloor = logDeleteFloorOf(before);
+  const afterDeleteFloor = logDeleteFloorOf(after);
+  if (afterDeleteFloor < beforeDeleteFloor) {
+    throw new BaerlyError(
+      "Internal",
+      `current.json at ${key}: log_delete_floor must not decrease (${String(beforeDeleteFloor)} → ${String(afterDeleteFloor)})`,
+    );
+  }
+  // Deleting at or above the live floor would remove an object a reader
+  // walking `[log_seq_start, tail_hint)` still needs. This is the hard
+  // safety line for both maintenance triggers.
+  if (afterDeleteFloor > after.log_seq_start) {
+    throw new BaerlyError(
+      "Internal",
+      `current.json at ${key}: log_delete_floor must not exceed log_seq_start (${String(afterDeleteFloor)} > ${String(after.log_seq_start)})`,
+    );
+  }
 };
 
 /**
@@ -369,16 +422,12 @@ export const assertCurrentJsonTransition = (
  * @throws BaerlyError{code:"InvalidResponse"} — `key` does not exist
  *         (use {@link createCurrentJson} instead) or body doesn't
  *         parse / fails the shape guard.
- * @throws BaerlyError{code:"Internal"} — the mutator lowered
- *         `log_seq_start`. The floor is monotone non-decreasing;
- *         equality is permitted (a `tail_hint` refresh or
- *         `last_warned_seq` stamp holds it fixed). No *production*
- *         mutator writes the floor, so no shipping caller can regress
- *         it; this guards future ones, and the protocol suite
- *         exercises the branch directly. The compactor calls the same
- *         transition validator before its direct `If-Match` PUT.
- *         `baerly admin restore --force` is the deliberate truncate
- *         exemption.
+ * @throws BaerlyError{code:"Internal"} — the mutator decreased
+ *         `log_seq_start`, decreased `log_delete_floor`, or set
+ *         `log_delete_floor > log_seq_start`. Equality is permitted.
+ *         The compactor calls the same transition validator before its
+ *         direct `If-Match` PUT; `baerly admin restore --force` is the
+ *         deliberate truncate exemption.
  */
 export async function casUpdateCurrentJson(
   storage: Storage,
@@ -532,6 +581,13 @@ export async function claimWriter(
  */
 export const logSeqStartOf = (c: CurrentJson): number => c.log_seq_start;
 
+/**
+ * Read `log_delete_floor`, defaulting an absent field to `0`. Absent
+ * means "no deleted prefix is certified", which is exactly what a
+ * pre-field bucket records even if older GC deleted sparse log objects.
+ */
+export const logDeleteFloorOf = (c: CurrentJson): number => c.log_delete_floor ?? 0;
+
 // ---------------------------------------------------------------------
 // Internals
 // ---------------------------------------------------------------------
@@ -660,6 +716,25 @@ const assertCurrentJson = (parsed: unknown, key: string): CurrentJson => {
     throw new BaerlyError(
       "InvalidResponse",
       `current.json at ${key}: last_warned_seq must be a non-negative integer if present`,
+    );
+  }
+  // Shape only. `log_delete_floor <= log_seq_start` is deliberately NOT
+  // checked here: `readCurrentJson` sits on `admin restore`'s own path
+  // (it reads `head` before it can reseed), so rejecting a single state
+  // on that bound would turn an out-of-bound floor into a bucket with no
+  // in-product repair path. The bound is transition-scoped in
+  // {@link assertCurrentJsonTransition}, and consumers of the field
+  // clamp against `log_seq_start` rather than trust it.
+  if (
+    r["log_delete_floor"] !== undefined &&
+    // Stryker disable next-line ConditionalExpression: same rationale as `log_seq_start` above.
+    (typeof r["log_delete_floor"] !== "number" ||
+      !Number.isInteger(r["log_delete_floor"]) ||
+      r["log_delete_floor"] < 0)
+  ) {
+    throw new BaerlyError(
+      "InvalidResponse",
+      `current.json at ${key}: log_delete_floor must be a non-negative integer if present`,
     );
   }
   if (

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -10,6 +10,7 @@ export {
   assertCurrentJsonTransition,
   casUpdateCurrentJson,
   createCurrentJson,
+  logDeleteFloorOf,
   logSeqStartOf,
   mintGeneration,
   readCurrentJson,

--- a/packages/server/src/db.test.ts
+++ b/packages/server/src/db.test.ts
@@ -301,7 +301,15 @@ describe("Db log-read seams are floored at log_seq_start", () => {
   // `false`) and resolve `null` off a `log/NaN.json` GET.
   test("getLogEntry throws Internal on a seq below a zero floor", async () => {
     const { db, current } = await seedEntries();
-    await expect(db.getLogEntry(TABLE, -1, current)).rejects.toMatchObject({ code: "Internal" });
+    await expect(db.getLogEntry(TABLE, -1, current)).rejects.toMatchObject({
+      code: "Internal",
+      // The FOLD-floor wording, not the certified-delete-floor one. An absent
+      // `log_delete_floor` decodes to 0, so a negative seq sorts below it
+      // arithmetically — but no deleted prefix is certified, and reporting
+      // the nonexistent object as reclaimed would be a lie. Pinning the
+      // message stops the certified-delete-floor arm swallowing this case.
+      message: expect.stringContaining("below the fold floor log_seq_start=0"),
+    });
   });
 
   test("collection validation precedes the floor check", async () => {
@@ -330,6 +338,98 @@ describe("Db log-read seams are floored at log_seq_start", () => {
     const { db, current } = await seedEntries();
     await expect(db.probeLogTail(TABLE, 0, raiseFloor(current, 5))).rejects.toMatchObject({
       code: "Internal",
+    });
+  });
+
+  // Required pin 5. The fold floor says "folded, and MAY already be
+  // reclaimed"; the certified delete floor says "DELETED, and is gone."
+  // Both throw `Internal`, so only the message tells an operator reading
+  // the throw which state applies — the reason these floors are separate.
+  // `old_snapshot_threshold` was
+  // removed from PostgreSQL in PG17 as dangerously broken while Oracle's
+  // `ORA-01555` survives the identical trade: the lethal property was
+  // silence, not the window.
+  describe("and at the certified delete floor", () => {
+    /** `current` with a stored `log_delete_floor`, set independently of the fold floor. */
+    const withDeleteFloor = (current: CurrentJson, to: number): CurrentJson => ({
+      ...current,
+      log_delete_floor: to,
+    });
+
+    test("getLogEntry names the certified delete floor below it", async () => {
+      const { db, current } = await seedEntries(4);
+      const manifest = withDeleteFloor(raiseFloor(current, 3), 2);
+      await expect(db.getLogEntry(TABLE, 1, manifest)).rejects.toMatchObject({
+        code: "Internal",
+        message: expect.stringContaining("below the certified delete floor 2"),
+      });
+    });
+
+    test("probeLogTail names the certified delete floor below it", async () => {
+      const { db, current } = await seedEntries(4);
+      const manifest = withDeleteFloor(raiseFloor(current, 3), 2);
+      await expect(db.probeLogTail(TABLE, 1, manifest)).rejects.toMatchObject({
+        code: "Internal",
+        message: expect.stringContaining("below the certified delete floor 2"),
+      });
+    });
+
+    // A seq in the gap between the two floors is folded but not yet
+    // deleted, and must keep the weaker "may already be reclaimed"
+    // wording. This is what a MERGED single arm would break, and what
+    // `Math.min` → `Math.max` would break; the two cases above are what
+    // an arm appended AFTER the fold-floor check would break, since a
+    // sub-delete-floor seq is also sub-fold-floor and would take the
+    // first arm.
+    test("a seq between the two floors keeps the fold-floor wording", async () => {
+      const { db, current } = await seedEntries(4);
+      const manifest = withDeleteFloor(raiseFloor(current, 3), 1);
+      await expect(db.getLogEntry(TABLE, 2, manifest)).rejects.toMatchObject({
+        code: "Internal",
+        message: expect.stringContaining("below the fold floor log_seq_start=3"),
+      });
+    });
+
+    // The effective floor is CLAMPED to `log_seq_start`. An out-of-bound
+    // `log_delete_floor` is readable off disk on purpose — the
+    // `<= log_seq_start` bound is transition-scoped, not enforced by the
+    // single-state guard, so that a manifest in that state stays
+    // repairable by `admin restore`. Unclamped, this seam would report an
+    // entry that is demonstrably PRESENT as gone.
+    test("clamps an out-of-bound delete floor to log_seq_start", async () => {
+      const { db, current } = await seedEntries(2);
+      const manifest = withDeleteFloor(raiseFloor(current, 1), 5);
+      await expect(db.getLogEntry(TABLE, 1, manifest)).resolves.toMatchObject({
+        op: "I",
+        seq: 1,
+      });
+    });
+
+    // When the clamp bites, the message must not attribute the clamped
+    // value to the field. An operator debugging an out-of-bound floor is
+    // the one reader who most needs the stored number, and "the manifest
+    // says 5, I am using 3" is the whole diagnosis.
+    test("reports the stored floor alongside the clamped one", async () => {
+      const { db, current } = await seedEntries(4);
+      const manifest = withDeleteFloor(raiseFloor(current, 3), 5);
+      await expect(db.getLogEntry(TABLE, 1, manifest)).rejects.toMatchObject({
+        code: "Internal",
+        message: expect.stringContaining(
+          "below the certified delete floor 3 (stored log_delete_floor=5, clamped to log_seq_start=3)",
+        ),
+      });
+    });
+
+    // A manifest that certifies no deleted prefix must never take this arm,
+    // even for a seq that sorts below its zero delete floor.
+    test("stays silent when no deleted prefix is certified", async () => {
+      const { db, current } = await seedEntries(2);
+      await expect(
+        db.getLogEntry(TABLE, -1, withDeleteFloor(raiseFloor(current, 1), 0)),
+      ).rejects.toMatchObject({
+        code: "Internal",
+        message: expect.stringContaining("below the fold floor log_seq_start=1"),
+      });
     });
   });
 });

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -8,6 +8,7 @@ import {
   decodeJsonBytes,
   type DocumentData,
   type IndexDefinition,
+  logDeleteFloorOf,
   logObjectKey,
   type LogEntry,
   logSeqStartOf,
@@ -289,7 +290,9 @@ export class Db<TConfig extends BaerlyConfig = UnboundConfig> {
    * `docs/spec/sync-protocol.md`).
    *
    * @throws BaerlyError code="Internal" — `seq` is below
-   *         `current.log_seq_start`.
+   *         `current.log_seq_start`, or below the certified prefix bound
+   *         `current.log_delete_floor` (a distinct message: the object is
+   *         gone, not merely reclaimable).
    *
    * @internal — typed seam for the HTTP handler; app code should use
    *             the collection API.
@@ -338,7 +341,9 @@ export class Db<TConfig extends BaerlyConfig = UnboundConfig> {
    * in `docs/spec/sync-protocol.md`).
    *
    * @throws BaerlyError code="Internal" — `hint` is below
-   *         `current.log_seq_start`.
+   *         `current.log_seq_start`, or below the certified prefix bound
+   *         `current.log_delete_floor` (a distinct message: the object is
+   *         gone, not merely reclaimable).
    *
    * @internal — typed seam for the HTTP handler.
    */
@@ -357,7 +362,8 @@ export class Db<TConfig extends BaerlyConfig = UnboundConfig> {
 }
 
 /**
- * Guard a log-read seq against the fold floor it was derived from.
+ * Guard a log-read seq against both floors on the manifest it was
+ * derived from.
  *
  * Entries below `log_seq_start` have been folded into the snapshot
  * (invariant 5 in `docs/spec/sync-protocol.md`) and may be reclaimed at
@@ -368,10 +374,14 @@ export class Db<TConfig extends BaerlyConfig = UnboundConfig> {
  * client input reaches these seams unscreened (`/v1/since` rejects a
  * sub-floor cursor with `SchemaError` before ever getting here).
  *
- * The floor arrives as the whole `CurrentJson` rather than a bare
- * number so it cannot be invented independently of the manifest, and
- * so a later floor on the same object — the retention delete floor —
- * lands here without another signature change.
+ * Below `log_delete_floor` the contiguous prefix is certified deleted,
+ * so the object is not merely *reclaimable* but already *reclaimed*.
+ * The two floors get distinct messages. Same code, because both are the
+ * same class of caller bug; different wording, because an operator
+ * reading the throw has to know whether the bytes are recoverable.
+ *
+ * The floors arrive as the whole `CurrentJson` rather than as bare
+ * numbers so neither can be invented independently of the manifest.
  *
  * Loud on purpose. PostgreSQL removed `old_snapshot_threshold` in PG17
  * because a fixed reclamation window that let a reader proceed
@@ -380,6 +390,38 @@ export class Db<TConfig extends BaerlyConfig = UnboundConfig> {
  */
 const assertAtOrAboveLogFloor = (seam: string, seq: number, current: CurrentJson): void => {
   const floor = logSeqStartOf(current);
+  // The delete floor is checked FIRST, and clamped.
+  //
+  // First, because `log_delete_floor <= log_seq_start` is a transition
+  // invariant: any seq below the delete floor is also below the fold
+  // floor, so an arm appended after the check below would be unreachable
+  // dead code. Ordering it here changes no accept/reject outcome — only
+  // which diagnostic wins — and lets the more specific one win.
+  //
+  // Clamped, because that `<= log_seq_start` bound is transition-scoped
+  // and NOT enforced by the single-state read guard (deliberately: the
+  // guard sits on `admin restore`'s own path, so failing it would leave
+  // an out-of-bound floor unrepairable). An out-of-bound value therefore
+  // arrives here off disk, and unclamped it would report an entry that is
+  // present as already deleted.
+  const storedDeleteFloor = logDeleteFloorOf(current);
+  const deleteFloor = Math.min(storedDeleteFloor, floor);
+  // `deleteFloor === 0` means no deleted prefix is certified, so this arm
+  // has nothing to say and must stay silent: a negative seq against a
+  // zero floor is a fold-floor rejection, and claiming its nonexistent
+  // object was reclaimed would be the misdiagnosis this floor prevents.
+  if (deleteFloor > 0 && seq < deleteFloor) {
+    // Render the stored value too when the clamp bit, so an operator is
+    // not told the field holds a number it does not hold.
+    const clamped =
+      storedDeleteFloor === deleteFloor
+        ? ""
+        : ` (stored log_delete_floor=${storedDeleteFloor}, clamped to log_seq_start=${floor})`;
+    throw new BaerlyError(
+      "Internal",
+      `${seam}: seq ${seq} is below the certified delete floor ${deleteFloor}${clamped}; the log object is GONE — it has been reclaimed, not merely made reclaimable`,
+    );
+  }
   if (seq < floor) {
     throw new BaerlyError(
       "Internal",


### PR DESCRIPTION
## What & why

Establish the safety envelope required before retained logs can be reclaimed. `current.json` now carries an optional certified delete floor, all non-exempt manifest writers share transition validation, and the internal log-read seams reject reads below the manifest floors instead of relying on caller discipline.

The field is backward-compatible with schema v3 and no retention pass writes it or deletes log objects yet. `baerly admin restore --force` remains the deliberate transition exemption and resets the old-generation certificate while reseeding.

## Key points

- Absent or zero `log_delete_floor` means no contiguous deleted prefix is certified; validated transitions keep it monotone and at or below `log_seq_start`.
- `Db.getLogEntry` and `Db.probeLogTail` now require the manifest used to derive their sequence or hint, with distinct diagnostics for possibly reclaimed and certified-gone entries.
- Rebaselines the affected bundle entries after first separating the pre-existing stale measurements.

## Verification

| Command | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` | passed |
| `pnpm test:adapter-cloudflare` | 158 passed, 2 skipped |
| `pnpm bundle-sizes` | 14/14 within budget |

## Notes for reviewers

Start with `packages/protocol/src/coordination/current-json.ts` for transition admission and `packages/server/src/db.ts` for the read-floor behavior.
