### PR TITLE
feat(server): compute retirable log ranges

### DIFF
--- a/packages/protocol/src/constants.ts
+++ b/packages/protocol/src/constants.ts
@@ -223,6 +223,37 @@ export const LOG_FORWARD_PROBE_CAP: number = 100_000;
 export const PREIMAGE_SCAN_MAX_GETS: number = 8;
 
 /**
+ * Sequence-distance safety window retained below `log_seq_start` before
+ * `log/<seq>.json` objects become retirable.
+ *
+ * `Writer#readPreImage` is the only production reader deliberately allowed
+ * below the manifest floor it observed. Its reach is capped by
+ * {@link PREIMAGE_SCAN_MAX_GETS}; the 128x multiplier gives the current 8-GET
+ * reach a 1024-sequence window while keeping that relationship explicit if the
+ * pre-image budget changes. This window does not fence a writer paused across
+ * manifest advancement; that coordination must land before deletion is enabled.
+ *
+ * @see packages/server/src/log-retention.ts
+ * @see docs/spec/sync-protocol.md invariant 12
+ */
+export const LOG_RETENTION_SEQ_WINDOW: number = PREIMAGE_SCAN_MAX_GETS * 128;
+
+/**
+ * Maximum log-object DELETEs a retention pass may attempt on one write tick.
+ * Twenty fits within the most constrained request budget and drains faster than
+ * the fold floor advances in steady state.
+ *
+ * Not yet wired into a write-tick call site — {@link computeRetirableRange}
+ * only computes the range today. Whichever PR adds the DELETE sweep must
+ * validate the combined per-tick subrequest total (GC sweep + fold + this)
+ * against the 50-subrequest free-tier cap, the way
+ * `maintenance-budget.test.ts` already pins for GC and fold alone.
+ *
+ * @see packages/server/src/log-retention.ts
+ */
+export const LOG_RETENTION_MAX_DELETES_PER_TICK: number = 20;
+
+/**
  * Current major version of the `current.json` control-object schema.
  * Readers MUST reject unknown versions with
  * `BaerlyError{code:"InvalidResponse"}` rather than try to coerce.

--- a/packages/server/src/log-retention.test.ts
+++ b/packages/server/src/log-retention.test.ts
@@ -1,0 +1,74 @@
+import { type CurrentJson, LOG_RETENTION_SEQ_WINDOW } from "@baerly/protocol";
+import { describe, expect, test } from "vitest";
+import { logStateCurrentJson } from "../../../tests/fixtures/log-state.ts";
+import { computeRetirableRange } from "./log-retention.ts";
+
+const cur = (logSeqStart: number, logDeleteFloor?: number): CurrentJson =>
+  logStateCurrentJson({
+    tail_hint: logSeqStart + 1000,
+    log_seq_start: logSeqStart,
+    ...(logDeleteFloor !== undefined && { log_delete_floor: logDeleteFloor }),
+  });
+
+describe("computeRetirableRange", () => {
+  test("is empty when the floor has not cleared the window", () => {
+    expect(computeRetirableRange(cur(100), { window: 500, maxDeletes: 20 })).toEqual({
+      start: 0,
+      end: 0,
+    });
+  });
+
+  test("retires from the delete floor up to the per-pass budget", () => {
+    expect(computeRetirableRange(cur(1000, 400), { window: 500, maxDeletes: 20 })).toEqual({
+      start: 400,
+      end: 420,
+    });
+  });
+
+  test("clamps the end to the window boundary", () => {
+    expect(computeRetirableRange(cur(1000, 495), { window: 500, maxDeletes: 20 })).toEqual({
+      start: 495,
+      end: 500,
+    });
+  });
+
+  test("is empty when a raised window falls behind the delete floor", () => {
+    expect(computeRetirableRange(cur(1000, 900), { window: 500, maxDeletes: 20 })).toEqual({
+      start: 900,
+      end: 900,
+    });
+  });
+
+  test("clamps a malformed delete floor to the live floor", () => {
+    expect(computeRetirableRange(cur(10, 900), { window: 0, maxDeletes: 20 })).toEqual({
+      start: 10,
+      end: 10,
+    });
+  });
+
+  test("treats an absent delete floor as zero", () => {
+    expect(computeRetirableRange(cur(1000), { window: 500, maxDeletes: 20 })).toEqual({
+      start: 0,
+      end: 20,
+    });
+  });
+
+  test("never returns an end above log_seq_start", () => {
+    const range = computeRetirableRange(cur(10), { window: 0, maxDeletes: 1000 });
+    expect(range.end).toBeLessThanOrEqual(10);
+  });
+
+  test("uses the default window before the retention boundary", () => {
+    expect(computeRetirableRange(cur(LOG_RETENTION_SEQ_WINDOW - 1))).toEqual({
+      start: 0,
+      end: 0,
+    });
+  });
+
+  test("uses the default delete budget after the retention boundary", () => {
+    expect(computeRetirableRange(cur(LOG_RETENTION_SEQ_WINDOW + 100))).toEqual({
+      start: 0,
+      end: 20,
+    });
+  });
+});

--- a/packages/server/src/log-retention.ts
+++ b/packages/server/src/log-retention.ts
@@ -1,0 +1,35 @@
+/**
+ * Sequence-based log retention.
+ *
+ * Log keys are derivable, so retirement uses a half-open sequence range rather
+ * than LIST-based discovery. This module computes the range only; PR 5 owns the
+ * deletion and delete-floor advance.
+ */
+
+import {
+  type CurrentJson,
+  LOG_RETENTION_MAX_DELETES_PER_TICK,
+  LOG_RETENTION_SEQ_WINDOW,
+  logDeleteFloorOf,
+  logSeqStartOf,
+} from "@baerly/protocol";
+
+/** A half-open `[start, end)` sequence range. Empty when equal. */
+export interface RetirableRange {
+  readonly start: number;
+  readonly end: number;
+}
+
+/** Compute the budgeted prefix of the currently retirable log range. */
+export const computeRetirableRange = (
+  current: CurrentJson,
+  opts?: { window?: number; maxDeletes?: number },
+): RetirableRange => {
+  const window = opts?.window ?? LOG_RETENTION_SEQ_WINDOW;
+  const maxDeletes = opts?.maxDeletes ?? LOG_RETENTION_MAX_DELETES_PER_TICK;
+  const liveFloor = logSeqStartOf(current);
+  const start = Math.min(logDeleteFloorOf(current), liveFloor);
+  const boundary = Math.min(liveFloor - window, liveFloor);
+  const end = Math.max(start, Math.min(boundary, start + maxDeletes));
+  return { start, end };
+};


### PR DESCRIPTION
## What & why

Log keys are derivable, so retiring old `log/<seq>.json` objects can use a half-open sequence range rather than LIST-based discovery. This adds `computeRetirableRange`, a pure function that computes that range from `current.json`'s live floor and delete floor, bounded by a retention window and a per-tick delete budget.

## Key points

- Computes the range only; wiring an actual DELETE sweep is a later PR.
- Clamps the delete floor to the live floor so a malformed/stale delete floor can't produce a range that reaches above the live floor.

## Verification

| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3334 passed, 105 skipped |

## Notes for reviewers

Whichever PR adds the DELETE sweep needs to validate the combined per-tick subrequest total (GC sweep + fold + this) against the 50-subrequest free-tier cap — noted in the JSDoc on `LOG_RETENTION_MAX_DELETES_PER_TICK`.