### PR TITLE
feat(server): retire log ranges under a CAS-gated floor

### DIFF
--- a/docs/spec/causal-consistency-checking.md
+++ b/docs/spec/causal-consistency-checking.md
@@ -310,12 +310,27 @@ deterministic protocol, reader-seam, and restore tests:
   `log_delete_floor`;
 - the transition bound `log_delete_floor <= log_seq_start`;
 - distinct fold-floor versus certified-delete-floor diagnostics;
-- clamping malformed stored values above `log_seq_start`; and
+- clamping malformed stored values above `log_seq_start`;
 - `baerly admin restore --force` resetting the field when it reseeds a
-  new generation below the old certified floor.
+  new generation below the old certified floor;
+- the floor CAS that `retireLogRange`
+  (`packages/server/src/log-retention.ts`) publishes *before* it deletes
+  anything, under two concurrent-`current.json`-writer schedules — a
+  `restore --force`-shaped reseed that lowers `log_seq_start` in the gap
+  between the pass's advisory gate read and the CAS's own read, which
+  aborts the pass with `Conflict` and zero DELETEs; and a rival that
+  legally advances `log_delete_floor` in that same gap, after which the
+  pass deletes the range its own CAS validated rather than the wider
+  advisory gate; and
+- the deletion/publication crash schedule: a crash mid-DELETE-loop
+  leaves the undeleted remainder physically present but already
+  certified deleted by the advanced floor — the deliberate fail-safe
+  direction, a leak rather than corruption.
 
-No deletion pass writes `log_delete_floor` yet, so there is currently no
-deletion/publication crash schedule to model.
+`retireLogRange` is the first pass to write `log_delete_floor`. It is not
+yet wired into a write-tick call site, so no deletion pass runs in
+production and the randomized cascade does not schedule one; the crash
+and concurrency schedules above are covered deterministically instead.
 
 ## Conclusion
 

--- a/packages/protocol/src/constants.ts
+++ b/packages/protocol/src/constants.ts
@@ -230,11 +230,23 @@ export const PREIMAGE_SCAN_MAX_GETS: number = 8;
  * below the manifest floor it observed. Its reach is capped by
  * {@link PREIMAGE_SCAN_MAX_GETS}; the 128x multiplier gives the current 8-GET
  * reach a 1024-sequence window while keeping that relationship explicit if the
- * pre-image budget changes. This window does not fence a writer paused across
- * manifest advancement; that coordination must land before deletion is enabled.
+ * pre-image budget changes.
+ *
+ * The window also fences a stale writer, which is why it is a safety parameter
+ * and not only a pre-image cost margin. A committing writer picks its slot at
+ * or above the `max(log_seq_start, tail_hint)` of the manifest it read
+ * (`writer.ts:446`), and a pass only certifies
+ * `seq < log_seq_start - LOG_RETENTION_SEQ_WINDOW` deleted, so a commit can
+ * land in a certified-deleted slot only if `log_seq_start` advanced by more
+ * than this window while that single commit was in flight — i.e. only if more
+ * than 1024 entries were committed and folded inside one request's commit
+ * path. Do not lower this value on cost grounds without re-deriving that
+ * bound: it is what closes the paused-writer schedule in place of a
+ * commit-path fence.
  *
  * @see packages/server/src/log-retention.ts
  * @see docs/spec/sync-protocol.md invariant 12
+ * @see docs/adr/002-ephemeral-coordination.md § Closed paths
  */
 export const LOG_RETENTION_SEQ_WINDOW: number = PREIMAGE_SCAN_MAX_GETS * 128;
 
@@ -243,11 +255,24 @@ export const LOG_RETENTION_SEQ_WINDOW: number = PREIMAGE_SCAN_MAX_GETS * 128;
  * Twenty fits within the most constrained request budget and drains faster than
  * the fold floor advances in steady state.
  *
- * Not yet wired into a write-tick call site — {@link computeRetirableRange}
- * only computes the range today. Whichever PR adds the DELETE sweep must
- * validate the combined per-tick subrequest total (GC sweep + fold + this)
- * against the 50-subrequest free-tier cap, the way
- * `maintenance-budget.test.ts` already pins for GC and fold alone.
+ * `retireLogRange` is the pass that spends this budget; it exists but is not
+ * yet wired into a write-tick call site. Whichever PR adds the call site owns
+ * validating the combined per-tick subrequest total (GC sweep + fold + this)
+ * against the 50-subrequest free-tier cap that `maintenance-budget.test.ts`
+ * pins for GC and fold alone. That arithmetic, against the worst cases
+ * `maintenance.ts`'s `CLOUDFLARE_FREE_TIER` JSDoc documents:
+ *
+ * - One retirement pass, worst case, is 23 subrequests: 1 advisory-gate GET
+ *   + `casUpdateCurrentJson`'s own GET + 1 CAS PUT + up to 20 DELETEs.
+ * - A GC tick is ≤26, so GC + retirement is 49 of 50 — one op of headroom.
+ * - A compaction pass is ≤49, so compact + retirement is 72. **Retirement
+ *   cannot share a tick with a fold**; the call site has to phase them apart
+ *   the way the Cloudflare scheduled handler already alternates compact and
+ *   GC.
+ *
+ * A pass whose range is empty returns `{deleted: 0}` and spends 1 GET, so a
+ * permanently-stalled retirement is silent — the call site also owes an
+ * observability decision.
  *
  * @see packages/server/src/log-retention.ts
  */

--- a/packages/server/src/log-retention.test.ts
+++ b/packages/server/src/log-retention.test.ts
@@ -298,3 +298,110 @@ describe("retireLogRange vs. a concurrent current.json writer", () => {
     }
   });
 });
+
+describe("retireLogRange edge paths", () => {
+  test("is a no-op when current.json does not exist yet (a not-yet-provisioned collection)", async () => {
+    const storage = new MemoryStorage();
+
+    await expect(retireLogRange(storage, CURRENT_KEY)).resolves.toEqual({ deleted: 0 });
+  });
+
+  test("rejects immediately on a pre-aborted signal, before any CAS", async () => {
+    const storage = new MemoryStorage();
+    await seedIdle(storage, 50);
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      retireLogRange(storage, CURRENT_KEY, {
+        window: 5,
+        maxDeletes: 20,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    const after = await readCurrentJson(storage, CURRENT_KEY);
+    expect(after!.json.log_delete_floor).toBeUndefined();
+  });
+
+  test("plumbs the abort signal into the DELETE loop specifically", async () => {
+    const storage = new MemoryStorage();
+    await seedIdle(storage, 50);
+    const controller = new AbortController();
+    const origDelete = storage.delete.bind(storage);
+    let deleteCalls = 0;
+    storage.delete = (async (key: string, opts?: { signal?: AbortSignal }) => {
+      deleteCalls++;
+      if (deleteCalls === 1) {
+        controller.abort();
+      }
+      return origDelete(key, opts);
+    }) as typeof storage.delete;
+
+    try {
+      await expect(
+        retireLogRange(storage, CURRENT_KEY, {
+          window: 5,
+          maxDeletes: 20,
+          signal: controller.signal,
+        }),
+      ).rejects.toMatchObject({ name: "AbortError" });
+    } finally {
+      storage.delete = origDelete;
+    }
+
+    // The loop stopped at the DELETE that saw the abort rather than swallowing
+    // it and continuing. `MemoryStorage.delete` calls `throwIfAborted` before
+    // removing anything, so the first call both aborts and removes nothing.
+    expect(deleteCalls).toBe(1);
+    let remaining = 0;
+    for (let seq = 0; seq < 20; seq++) {
+      if ((await storage.get(logObjectKey(PREFIX, seq))) !== null) {
+        remaining++;
+      }
+    }
+    expect(remaining).toBe(20);
+
+    // The floor CAS precedes the loop, so it published the full 20-wide range
+    // even though no object was removed — the same CAS-before-delete ordering
+    // the crash-leak test pins, here on the abort path.
+    const after = await readCurrentJson(storage, CURRENT_KEY);
+    expect(after!.json.log_delete_floor).toBe(20);
+  });
+});
+
+describe("retireLogRange crash-leak", () => {
+  test("a crash mid-DELETE-loop leaks the undeleted slice below the already-advanced floor", async () => {
+    const storage = new MemoryStorage();
+    await seedIdle(storage, 50);
+    const origDelete = storage.delete.bind(storage);
+    let deleteCalls = 0;
+    storage.delete = (async (key: string, opts?: { signal?: AbortSignal }) => {
+      deleteCalls++;
+      if (deleteCalls === 6) {
+        throw new Error("simulated crash mid-DELETE-loop");
+      }
+      return origDelete(key, opts);
+    }) as typeof storage.delete;
+
+    try {
+      await expect(
+        retireLogRange(storage, CURRENT_KEY, { window: 5, maxDeletes: 20 }),
+      ).rejects.toThrow("simulated crash mid-DELETE-loop");
+    } finally {
+      storage.delete = origDelete;
+    }
+
+    // The floor CASed to 20 before the loop ran, so it survives the crash —
+    // the deliberate fail-safe direction: leak, never corruption.
+    const after = await readCurrentJson(storage, CURRENT_KEY);
+    expect(after!.json.log_delete_floor).toBe(20);
+    for (let seq = 0; seq < 5; seq++) {
+      await expect(storage.get(logObjectKey(PREFIX, seq))).resolves.toBeNull();
+    }
+    // The leak: certified deleted by the floor, but still physically present.
+    for (let seq = 5; seq < 20; seq++) {
+      await expect(storage.get(logObjectKey(PREFIX, seq))).resolves.not.toBeNull();
+    }
+  });
+});

--- a/packages/server/src/log-retention.test.ts
+++ b/packages/server/src/log-retention.test.ts
@@ -1,9 +1,12 @@
 import {
   type CurrentJson,
   createCurrentJson,
+  encodeJsonBytes,
   LOG_RETENTION_SEQ_WINDOW,
+  logDeleteFloorOf,
   logObjectKey,
   MemoryStorage,
+  mintGeneration,
   readCurrentJson,
 } from "@baerly/protocol";
 import { describe, expect, test } from "vitest";
@@ -188,5 +191,110 @@ describe("retireLogRange", () => {
       code: "Internal",
       message: expect.stringContaining("certified delete floor"),
     });
+  });
+});
+
+describe("retireLogRange vs. a concurrent current.json writer", () => {
+  test("recomputes the authorized range against the state the CAS validates", async () => {
+    const storage = new MemoryStorage();
+    await seedIdle(storage, 50);
+    // Captured before the interceptor is installed, so the rival's own write
+    // does not perturb the GET counter below.
+    const seeded = await readCurrentJson(storage, CURRENT_KEY);
+
+    // Land a `restore --force`-shaped reseed — a raw, monotonicity-bypassing
+    // PUT that LOWERS log_seq_start; restore is the one writer allowed to do
+    // that (restore.ts:191-206) — in the gap between retireLogRange's gate
+    // read (GET 1) and casUpdateCurrentJson's own read (GET 2).
+    const origGet = storage.get.bind(storage);
+    let currentGets = 0;
+    storage.get = (async (key: string, getOpts?: { signal?: AbortSignal }) => {
+      if (key === CURRENT_KEY) {
+        currentGets++;
+        if (currentGets === 2) {
+          await storage.put(
+            CURRENT_KEY,
+            encodeJsonBytes({
+              ...seeded!.json,
+              snapshot: null,
+              log_seq_start: 5,
+              tail_hint: 5,
+              log_delete_floor: undefined,
+              generation: mintGeneration(),
+            }),
+            { ifMatch: seeded!.etag, contentType: "application/json" },
+          );
+        }
+      }
+      return origGet(key, getOpts);
+    }) as typeof storage.get;
+
+    try {
+      await expect(
+        retireLogRange(storage, CURRENT_KEY, { window: 5, maxDeletes: 20 }),
+      ).rejects.toMatchObject({ code: "Conflict" });
+    } finally {
+      storage.get = origGet;
+    }
+
+    // Zero DELETEs, and no floor published above the reseeded live floor.
+    for (let seq = 0; seq < 20; seq++) {
+      await expect(storage.get(logObjectKey(PREFIX, seq))).resolves.not.toBeNull();
+    }
+    const after = await readCurrentJson(storage, CURRENT_KEY);
+    expect(logDeleteFloorOf(after!.json)).toBe(0);
+    expect(after!.json.log_seq_start).toBe(5);
+  });
+
+  test("deletes the CAS-validated range, not the advisory gate, when a rival advances the floor first", async () => {
+    const storage = new MemoryStorage();
+    await seedIdle(storage, 50);
+    // Captured before the interceptor is installed, so the rival's own write
+    // does not perturb the GET counter below.
+    const seeded = await readCurrentJson(storage, CURRENT_KEY);
+
+    // Land a legal monotone floor advance — unlike the reseed above, this
+    // does not touch log_seq_start and needs no generation remint — in the
+    // gap between retireLogRange's gate read (GET 1) and
+    // casUpdateCurrentJson's own read (GET 2). Gate from GET 1 is
+    // {start: 0, end: 20}; GET 2 sees floor 20 and the mutator recomputes
+    // {start: 20, end: 40}. A loop that deleted `gate` instead of the
+    // CAS-validated `range` would wipe [0, 20) instead.
+    const origGet = storage.get.bind(storage);
+    let currentGets = 0;
+    storage.get = (async (key: string, getOpts?: { signal?: AbortSignal }) => {
+      if (key === CURRENT_KEY) {
+        currentGets++;
+        if (currentGets === 2) {
+          await storage.put(
+            CURRENT_KEY,
+            encodeJsonBytes({ ...seeded!.json, log_delete_floor: 20 }),
+            { ifMatch: seeded!.etag, contentType: "application/json" },
+          );
+        }
+      }
+      return origGet(key, getOpts);
+    }) as typeof storage.get;
+
+    try {
+      const result = await retireLogRange(storage, CURRENT_KEY, { window: 5, maxDeletes: 20 });
+      expect(result).toEqual({ deleted: 20 });
+    } finally {
+      storage.get = origGet;
+    }
+
+    const after = await readCurrentJson(storage, CURRENT_KEY);
+    expect(after!.json.log_delete_floor).toBe(40);
+    // The discriminator: a gate-based loop would have deleted exactly
+    // [0, 20) instead of the CAS-validated [20, 40).
+    for (let seq = 0; seq < 20; seq++) {
+      await expect(storage.get(logObjectKey(PREFIX, seq))).resolves.not.toBeNull();
+    }
+    for (let seq = 20; seq < 40; seq++) {
+      await expect(storage.get(logObjectKey(PREFIX, seq))).resolves.toBeNull();
+    }
+    for (let seq = 40; seq < 50; seq++) {
+      await expect(storage.get(logObjectKey(PREFIX, seq))).resolves.not.toBeNull();
+    }
   });
 });

--- a/packages/server/src/log-retention.test.ts
+++ b/packages/server/src/log-retention.test.ts
@@ -1,7 +1,15 @@
-import { type CurrentJson, LOG_RETENTION_SEQ_WINDOW } from "@baerly/protocol";
+import {
+  type CurrentJson,
+  createCurrentJson,
+  LOG_RETENTION_SEQ_WINDOW,
+  logObjectKey,
+  MemoryStorage,
+  readCurrentJson,
+} from "@baerly/protocol";
 import { describe, expect, test } from "vitest";
-import { logStateCurrentJson } from "../../../tests/fixtures/log-state.ts";
-import { computeRetirableRange } from "./log-retention.ts";
+import { logStateCurrentJson, seedLogEntry } from "../../../tests/fixtures/log-state.ts";
+import { Db } from "./db.ts";
+import { computeRetirableRange, retireLogRange } from "./log-retention.ts";
 
 const cur = (logSeqStart: number, logDeleteFloor?: number): CurrentJson =>
   logStateCurrentJson({
@@ -69,6 +77,116 @@ describe("computeRetirableRange", () => {
     expect(computeRetirableRange(cur(LOG_RETENTION_SEQ_WINDOW + 100))).toEqual({
       start: 0,
       end: 20,
+    });
+  });
+});
+
+const CURRENT_KEY = "app/a/tenant/t/manifests/c/current.json";
+const PREFIX = "app/a/tenant/t/manifests/c";
+
+/**
+ * A fully-folded collection: `log_seq_start` at the tail, `seqCount` log
+ * objects still on disk beneath it. That is the steady state retirement
+ * exists to drain.
+ */
+const seedIdle = async (storage: MemoryStorage, seqCount: number): Promise<void> => {
+  await createCurrentJson(
+    storage,
+    CURRENT_KEY,
+    logStateCurrentJson({ log_seq_start: seqCount, tail_hint: seqCount }),
+  );
+  for (let seq = 0; seq < seqCount; seq++) {
+    await seedLogEntry(storage, PREFIX, seq, {
+      op: "I",
+      doc_id: `seed-${String(seq)}`,
+      after: { _id: `seed-${String(seq)}` },
+    });
+  }
+};
+
+describe("retireLogRange", () => {
+  test("is a no-op, with no CAS at all, when the computed range is empty", async () => {
+    const storage = new MemoryStorage();
+    await seedIdle(storage, 3);
+    const before = await readCurrentJson(storage, CURRENT_KEY);
+
+    const result = await retireLogRange(storage, CURRENT_KEY, { window: 500, maxDeletes: 20 });
+
+    expect(result).toEqual({ deleted: 0 });
+    const after = await readCurrentJson(storage, CURRENT_KEY);
+    expect(after!.etag).toBe(before!.etag);
+  });
+
+  test("retires the budgeted half-open range and advances log_delete_floor", async () => {
+    const storage = new MemoryStorage();
+    await seedIdle(storage, 50);
+
+    const result = await retireLogRange(storage, CURRENT_KEY, { window: 5, maxDeletes: 20 });
+
+    expect(result).toEqual({ deleted: 20 });
+    const after = await readCurrentJson(storage, CURRENT_KEY);
+    expect(after!.json.log_delete_floor).toBe(20);
+    for (let seq = 0; seq < 20; seq++) {
+      await expect(storage.get(logObjectKey(PREFIX, seq))).resolves.toBeNull();
+    }
+    for (let seq = 20; seq < 50; seq++) {
+      await expect(storage.get(logObjectKey(PREFIX, seq))).resolves.not.toBeNull();
+    }
+  });
+
+  test("a repeat pass resumes at the floor and never decreases it", async () => {
+    const storage = new MemoryStorage();
+    await seedIdle(storage, 50);
+
+    await retireLogRange(storage, CURRENT_KEY, { window: 5, maxDeletes: 20 });
+    const second = await retireLogRange(storage, CURRENT_KEY, { window: 5, maxDeletes: 20 });
+
+    expect(second).toEqual({ deleted: 20 });
+    const after = await readCurrentJson(storage, CURRENT_KEY);
+    expect(after!.json.log_delete_floor).toBe(40);
+    await expect(storage.get(logObjectKey(PREFIX, 39))).resolves.toBeNull();
+    await expect(storage.get(logObjectKey(PREFIX, 40))).resolves.not.toBeNull();
+  });
+
+  test("counts DELETEs issued, not physical hits, when a target is already absent", async () => {
+    const storage = new MemoryStorage();
+    await seedIdle(storage, 50);
+    await storage.delete(logObjectKey(PREFIX, 3)); // e.g. a crash-repeat pass
+
+    const result = await retireLogRange(storage, CURRENT_KEY, { window: 5, maxDeletes: 20 });
+
+    expect(result).toEqual({ deleted: 20 });
+    const after = await readCurrentJson(storage, CURRENT_KEY);
+    expect(after!.json.log_delete_floor).toBe(20);
+  });
+
+  test("never advances the floor above log_seq_start, even with an oversized budget", async () => {
+    const storage = new MemoryStorage();
+    await seedIdle(storage, 10);
+
+    const result = await retireLogRange(storage, CURRENT_KEY, { window: 0, maxDeletes: 1000 });
+
+    expect(result).toEqual({ deleted: 10 });
+    const after = await readCurrentJson(storage, CURRENT_KEY);
+    expect(after!.json.log_delete_floor).toBe(10);
+    expect(after!.json.log_delete_floor).toBe(after!.json.log_seq_start);
+  });
+
+  test("a seq a real pass certified deleted is rejected by getLogEntry with the certified-delete message", async () => {
+    // Pin 5's message distinction is already pinned against a SYNTHETIC floor
+    // in db.test.ts. This adds the one thing that does not: that a REAL
+    // retireLogRange call produces a floor state the reader seam rejects, and
+    // rejects with the "gone", not the "folded", diagnostic (db.ts:391-431
+    // checks the delete floor first).
+    const storage = new MemoryStorage();
+    await seedIdle(storage, 50);
+    await retireLogRange(storage, CURRENT_KEY, { window: 5, maxDeletes: 20 });
+
+    const current = await readCurrentJson(storage, CURRENT_KEY);
+    const db = Db.create({ storage, app: "a", tenant: "t" });
+    await expect(db.getLogEntry("c", 5, current!.json)).rejects.toMatchObject({
+      code: "Internal",
+      message: expect.stringContaining("certified delete floor"),
     });
   });
 });

--- a/packages/server/src/log-retention.ts
+++ b/packages/server/src/log-retention.ts
@@ -2,16 +2,23 @@
  * Sequence-based log retention.
  *
  * Log keys are derivable, so retirement uses a half-open sequence range rather
- * than LIST-based discovery. This module computes the range only; PR 5 owns the
- * deletion and delete-floor advance.
+ * than LIST-based discovery. This module computes the range and owns the
+ * CAS-then-delete retirement pass. Nothing calls `retireLogRange` yet; PR 5
+ * wires it into the two maintenance triggers and removes the `stale-log`
+ * discovery it replaces.
  */
 
 import {
+  BaerlyError,
+  casUpdateCurrentJson,
   type CurrentJson,
   LOG_RETENTION_MAX_DELETES_PER_TICK,
   LOG_RETENTION_SEQ_WINDOW,
   logDeleteFloorOf,
+  logObjectKey,
   logSeqStartOf,
+  readCurrentJson,
+  type Storage,
 } from "@baerly/protocol";
 
 /** A half-open `[start, end)` sequence range. Empty when equal. */
@@ -33,3 +40,132 @@ export const computeRetirableRange = (
   const end = Math.max(start, Math.min(boundary, start + maxDeletes));
   return { start, end };
 };
+
+/** Outcome of one budgeted {@link retireLogRange} call. */
+export interface RetireLogRangeResult {
+  /**
+   * Count of DELETEs issued this call — the authorized range's width. An
+   * already-absent target is not an error (idempotent under crash-repeat, per
+   * the {@link Storage} DELETE contract), so this is a request count, not a
+   * count of objects that were physically present.
+   *
+   * This does NOT cover the call's full subrequest cost: an active pass also
+   * issues 2 GETs (the advisory gate read, then {@link casUpdateCurrentJson}'s
+   * own read) + 1 PUT (the floor CAS), and a no-op pass (empty gate) still
+   * costs 1 GET. A caller budgeting against the 50-subrequest free-tier cap
+   * that {@link LOG_RETENTION_MAX_DELETES_PER_TICK}'s JSDoc names — the
+   * combined GC-sweep + fold + retirement total per tick — must add those
+   * manifest round-trips itself; `deleted` alone undercounts.
+   *
+   * A stored `log_delete_floor` above `log_seq_start` (e.g. a raised window
+   * outrunning a paused fold) makes {@link computeRetirableRange} return an
+   * empty range, so the pass no-ops until the fold floor advances past that
+   * floor plus the window. That is a temporary stall, not a permanent wedge —
+   * the next fold that clears the window unblocks it.
+   */
+  readonly deleted: number;
+}
+
+/**
+ * Delete a budgeted, computed slice of the stale log prefix and advance
+ * `log_delete_floor` to match. Sequence-based: log keys are derivable, so this
+ * never LISTs.
+ *
+ * **The authorized range is computed inside the CAS mutator, against the state
+ * the CAS validates — do not hoist it out.** {@link casUpdateCurrentJson}
+ * performs its own read and CASes against *that* etag, so a range computed from
+ * an earlier read is a plan the CAS never validated. Computing it in the mutator
+ * makes plan and validation atomic: whatever floor this call publishes is the
+ * floor its own DELETEs are authorized by. If the fresh state yields an empty
+ * range (a `restore --force` reseed lowered `log_seq_start` — the one writer
+ * allowed to, `restore.ts:191-206`), the pass aborts with `Conflict` and zero
+ * DELETEs rather than publishing a floor above the live one.
+ *
+ * **CAS before deleting, never after.** Every floor this function publishes
+ * satisfies `end <= log_seq_start - window`, where `window` is the *effective*
+ * window — {@link LOG_RETENTION_SEQ_WINDOW} by default, or `opts.window` when
+ * a caller overrides it (via {@link computeRetirableRange}, which also clamps
+ * a malformed stored floor per `docs/spec/sync-protocol.md` invariant 12).
+ * That bound holds only at the default window: `opts.window` is a test seam
+ * that can shrink or erase the safety margin entirely (this module's own
+ * `{window: 0}` tests push the floor to `log_seq_start` exactly), so it is
+ * never a guarantee a caller passing a non-default `window` gets to rely on.
+ * `log_delete_floor` is monotone under the transition validator regardless of
+ * `window`. So by the time a slot is physically deleted, a durable
+ * certificate that it is gone already exists — which is what makes
+ * `log_delete_floor` usable as a witness of "reclaimed" rather than "folded".
+ * A crash between the CAS and the end of the DELETE loop leaks the remaining
+ * slice permanently below the newly-advanced floor: deliberate, and the
+ * fail-safe direction this program picked — leak, never corruption.
+ *
+ * Why no writer-side fence accompanies this: see the stale-writer bound on
+ * {@link LOG_RETENTION_SEQ_WINDOW} and `docs/adr/002-ephemeral-coordination.md`
+ * § Closed paths.
+ *
+ * @param opts.signal Threaded to every storage call this makes (the gate
+ *   read, the CAS's own read + write, and each DELETE in the loop) — an
+ *   already-aborted signal, or one aborted mid-call, rejects the in-flight
+ *   {@link Storage} operation.
+ * @param opts.window Test seam that overrides {@link LOG_RETENTION_SEQ_WINDOW}.
+ *   NOT a production tuning knob — do not promote this to an env var the way
+ *   `BAERLY_MAINTENANCE_*` tunes the fold/GC budgets. Shrinking it (this
+ *   module's own tests use `{window: 0}`) erases the safety margin described
+ *   above; production call sites should omit it and take the default.
+ * @param opts.maxDeletes Test seam that overrides
+ *   {@link LOG_RETENTION_MAX_DELETES_PER_TICK}. Same caveat as `opts.window`:
+ *   a scoped override for exercising the budget boundary in tests, not a
+ *   knob meant to reach a config surface.
+ * @throws BaerlyError{code:"Conflict"} if the floor CAS loses to another
+ *   `current.json` writer, or if the fresh state authorizes nothing. Callers on
+ *   the maintenance path already treat `Conflict` from `compact()` / `runGc()`
+ *   as an expected, swallowed signal (`maintenance.ts:602-604`); this matches
+ *   that idiom rather than swallowing it here.
+ */
+export async function retireLogRange(
+  storage: Storage,
+  currentJsonKey: string,
+  opts?: { signal?: AbortSignal; window?: number; maxDeletes?: number },
+): Promise<RetireLogRangeResult> {
+  const readOpts = opts?.signal !== undefined ? { signal: opts.signal } : undefined;
+  const read = await readCurrentJson(storage, currentJsonKey, readOpts);
+  if (read === null) {
+    return { deleted: 0 };
+  }
+  // Advisory gate only: skip the CAS's PUT when there is provably nothing to
+  // do. The authorized range is the one computed in the mutator below.
+  const gate = computeRetirableRange(read.json, opts);
+  if (gate.start >= gate.end) {
+    return { deleted: 0 };
+  }
+
+  let range = gate;
+  await casUpdateCurrentJson(
+    storage,
+    currentJsonKey,
+    (current: CurrentJson): CurrentJson => {
+      // Reassigning the enclosing `range` from inside the mutator is only
+      // sound because casUpdateCurrentJson invokes the mutator exactly once
+      // per call (see its JSDoc: multiple invocations only happen if a
+      // *caller* wraps it in a retry loop, and retireLogRange deliberately
+      // does not). So the captured range here is always the one this CAS
+      // just validated. A future caller that adds a retry loop around this
+      // function must re-read the range from the call's result instead of
+      // relying on this closure.
+      range = computeRetirableRange(current, opts);
+      if (range.start >= range.end) {
+        throw new BaerlyError(
+          "Conflict",
+          `retireLogRange: ${currentJsonKey} authorizes no retirable range at CAS time; a concurrent writer moved log_seq_start`,
+        );
+      }
+      return { ...current, log_delete_floor: range.end };
+    },
+    readOpts,
+  );
+
+  const collectionPrefix = currentJsonKey.slice(0, currentJsonKey.lastIndexOf("/"));
+  for (let seq = range.start; seq < range.end; seq++) {
+    await storage.delete(logObjectKey(collectionPrefix, seq), readOpts);
+  }
+  return { deleted: range.end - range.start };
+}


### PR DESCRIPTION
## What & why

`computeRetirableRange` (#131) computed a retirable log range but nothing deleted it. This adds `retireLogRange`, the pass that publishes `log_delete_floor` for a computed slice and then DELETEs that slice. CAS before deleting, never after — a durable certificate that a slot is gone always precedes the slot's physical removal, which is what makes `log_delete_floor` usable as a witness of "reclaimed" rather than "folded". Still unwired and off the public barrel; the wiring PR calls it from both maintenance triggers and removes the `stale-log` discovery it replaces.

## Key points

- The authorized range is computed inside the CAS mutator, not from an earlier read: `casUpdateCurrentJson` performs its own read and CASes against *that* etag, so a range computed outside it is a plan the CAS never validated. A `restore --force` reseed that lowers `log_seq_start` into that gap aborts the pass with `Conflict` and zero DELETEs.
- A crash between the floor CAS and the end of the DELETE loop leaks the remaining slice permanently below the newly-advanced floor. Deliberate, and the fail-safe direction: leak, never corruption.
- `LOG_RETENTION_SEQ_WINDOW` is the stale-writer fence, not only a pre-image cost margin. A committing writer picks its slot at or above the `log_seq_start` it read, and a pass only certifies `seq < log_seq_start - K`, so a commit can land in a certified-deleted slot only if the floor advanced by more than 1024 inside one in-flight commit. The constant's JSDoc previously asserted the opposite ("that coordination must land before deletion is enabled") and now carries the derivation plus a do-not-lower warning.
- Subrequest arithmetic for the wiring PR is recorded on `LOG_RETENTION_MAX_DELETES_PER_TICK`: a retirement pass is ≤23, so GC + retirement is 49 of 50, but compact + retirement is 72 — retirement cannot share a tick with a fold.
- `opts.window` / `opts.maxDeletes` are test seams, not tuning knobs, and the safety bound above holds only at the default window.
- No changeset: unwired and not exported, so there is no user-facing behavior change yet.

## Verification

| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3379 passed, 105 skipped |
| `pnpm bundle-sizes` | ok (14 entries) |

## Notes for reviewers

Start at `retireLogRange` in `packages/server/src/log-retention.ts`. Both discrimination proofs for the new concurrency coverage — a DELETE loop bound to the advisory gate instead of the CAS-validated range, and a dropped `readOpts` on the DELETE call — were confirmed to fail before being reverted.
