### PR TITLE
test: bound load-sensitive workloads without weakening their gates

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -286,8 +286,8 @@ Three behaviours to know before you consume a snapshot:
 
 `billingClassOf` implements the [cost-model](../docs/about/cost-model.md)
 definition — puts and lists bill, DELETE is $0. That is one definition,
-not a resolution: a test records all three live and mutually
-inconsistent definitions in the tree as evidence for their owner. Note
+not a resolution: a test records the live and mutually inconsistent
+definitions still in the tree as evidence for their owner. Note
 it counts `Storage` calls, not billable requests, so against a remote
 backend that paginates or retries inside one call it understates Class A.
 

--- a/bench/load-harness/tests/dataset.test.ts
+++ b/bench/load-harness/tests/dataset.test.ts
@@ -21,20 +21,13 @@ describe("dataset determinism", () => {
       schema: { collection: "notes" },
       recordSizeBuckets: tinyBodies,
     });
-    expect(a.totalRecords).toBe(b.totalRecords);
-    expect(a.totalBytes).toBe(b.totalBytes);
-    for (let i = 0; i < a.tenants.length; i++) {
-      const ta = a.tenants[i]!;
-      const tb = b.tenants[i]!;
-      expect(ta.tenantId).toBe(tb.tenantId);
-      expect(ta.records.length).toBe(tb.records.length);
-      for (let j = 0; j < ta.records.length; j++) {
-        expect(ta.records[j]!.recordId).toBe(tb.records[j]!.recordId);
-        expect(ta.records[j]!.bytes).toBe(tb.records[j]!.bytes);
-        // Byte-level body comparison
-        expect([...ta.records[j]!.bodyBytes]).toEqual([...tb.records[j]!.bodyBytes]);
-      }
-    }
+    // Whole-dataset deep equality covers every field (tenantId, record
+    // counts and IDs, bytes, bodyBytes, timestamps, popularity rank,
+    // traffic share, totals) in one comparison. Vitest compares
+    // Uint8Array values byte-for-byte, so this is still an exact
+    // byte-identical check — just without per-record assertion/spread
+    // overhead that dominated this test's wall-clock under load.
+    expect(a).toEqual(b);
   });
 
   test("tenant-size distribution roughly matches the buckets", () => {

--- a/bench/measurement/storage-journal.test.ts
+++ b/bench/measurement/storage-journal.test.ts
@@ -463,19 +463,24 @@ describe("operation journal", () => {
 describe("billing class", () => {
   /**
    * ONE definition, deliberately NOT a resolution. Manifest §11 item 1 records
-   * three live and mutually inconsistent "Class A" definitions in this repo:
+   * three live and mutually inconsistent "Class A" definitions in this repo.
+   * D1 is now closed — `reads-pure.test.ts` counted put + delete and has since
+   * been moved onto the shared fixture's `classAOps`, i.e. D2 — leaving two:
    *
-   *   D1  packages/server/src/reads-pure.test.ts   put + delete
-   *   D2  tests/integration/maintenance-e2e.test.ts put + delete + list
-   *   D3  docs/about/cost-model.md                 put + list   (DELETE is $0)
-   *       — matching bench/storage.ts's `billableClassAOps` getter and
-   *         coordination design §4.5's `billableClassAOps = puts + lists`
+   *   D2  tests/fixtures/counting-storage.ts  put + delete + list
+   *       — `classAOps`; a subrequest/op count, DELETE included because it is
+   *         still a real CF subrequest. Backs the published "< 1 Class A op /
+   *         writer / hour" claim via `maintenance-e2e.test.ts`, and the
+   *         read-purity CI gate via `reads-pure.test.ts`.
+   *   D3  docs/about/cost-model.md            put + list   (DELETE is $0)
+   *       — a dollar cost. Matches `billableClassAOps` on both that fixture
+   *         and bench/storage.ts, and coordination design §4.5's
+   *         `billableClassAOps = puts + lists`. Governs the fold program's
+   *         cost arguments.
    *
-   * D1 governs a CI gate; D2 backs the published "< 1 Class A op / writer /
-   * hour" claim; D3 governs the fold program's cost arguments. The journal uses
-   * D3 because that is what §4.5 binds it to. This test exists so the
-   * disagreement is discoverable evidence for the Protocol/product owner named
-   * in §11, not so this lane resolves it.
+   * The journal uses D3 because that is what §4.5 binds it to. This test
+   * exists so the remaining disagreement is discoverable evidence for the
+   * Protocol/product owner named in §11, not so this lane resolves it.
    */
   test("uses the cost-model definition: puts and lists bill, deletes are free", () => {
     expect(billingClassOf("put")).toBe("A");

--- a/packages/server/src/reads-pure.test.ts
+++ b/packages/server/src/reads-pure.test.ts
@@ -18,8 +18,8 @@
  * is OVER the fold-trigger ratio (derived tail estimate ≥ snapshot_bytes AND
  * derived estimate ≥ MAINTENANCE_MIN_LIVE_BYTES) — the exact condition that
  * would cause the write-tick to fire maintenance — repeated reads
- * through the collection API produce ZERO mutating storage
- * ops and leave `current.json` byte-identical.
+ * through the collection API produce ZERO Class A storage ops
+ * (PUT / DELETE / LIST) and leave `current.json` byte-identical.
  */
 
 import {
@@ -31,13 +31,12 @@ import {
   MemoryStorage,
   readCurrentJson,
   type Storage,
-  type StorageGetOptions,
-  type StorageGetResult,
-  type StorageListEntry,
-  type StoragePutOptions,
-  type StoragePutResult,
 } from "@baerly/protocol";
 import { describe, expect, test, vi } from "vitest";
+import {
+  type CountingStorage,
+  wrapCountingStorage,
+} from "../../../tests/fixtures/counting-storage.ts";
 import { Db } from "./db.ts";
 import { createObservabilityContext, runWithContext } from "./observability/context.ts";
 import { Writer } from "./writer.ts";
@@ -100,55 +99,32 @@ const seedOverRatio = async (n: number): Promise<MemoryStorage> => {
   return storage;
 };
 
-// ── Counting proxy (mutation guard: PUT + DELETE) ──────────────────────
+// ── Counting (guard predicate: Class A = PUT + DELETE + LIST) ──────────
 //
-// Reuses the same shape as the `countingStorage` helper in
-// `maintenance.test.ts`. `mutatingOps()` sums PUT + DELETE because this file
-// is a MUTATION guard: its job is proving a read leaves the bucket
-// byte-identical, and PUT + DELETE is exactly the set that could change
-// it. Cost-accounting coverage uses a separate counting fixture and test.
+// The predicate is the shared fixture's `classAOps` (PUT + DELETE +
+// LIST), not just PUT + DELETE, because this file's job is proving a
+// read leaves the bucket byte-identical AND enumerates nothing — and
+// because `maintenance-e2e.test.ts`'s idle-reader gate delegates its
+// repetition coverage here, on that same definition.
+//
+// Dollar cost is a separate concern: `read-class-a-cost.test.ts` pins
+// per-terminal cost with `billableClassAOps` (PUT + LIST, DELETE
+// being $0), including the one LIST an indexed `.where()` legitimately
+// issues. Collections here are unindexed, so zero is correct under
+// either definition.
 
-interface CountingProxy {
-  readonly storage: Storage;
-  readonly mutatingOps: () => number;
-  readonly report: () => Record<string, number>;
-}
-
-const countingProxy = (inner: Storage): CountingProxy => {
-  const counts = { get: 0, put: 0, delete: 0, list: 0 };
-  const wrapper: Storage = {
-    async get(key: string, opts?: StorageGetOptions): Promise<StorageGetResult | null> {
-      counts.get += 1;
-      return inner.get(key, opts);
-    },
-    async put(key: string, body: Uint8Array, opts?: StoragePutOptions): Promise<StoragePutResult> {
-      counts.put += 1;
-      return inner.put(key, body, opts);
-    },
-    async delete(key: string, opts?: { signal?: AbortSignal }): Promise<void> {
-      counts.delete += 1;
-      return inner.delete(key, opts);
-    },
-    list(
-      prefix: string,
-      opts?: { startAfter?: string; maxKeys?: number; signal?: AbortSignal },
-    ): AsyncIterable<StorageListEntry> {
-      counts.list += 1;
-      return inner.list(prefix, opts);
-    },
-  };
-  return {
-    storage: wrapper,
-    mutatingOps: (): number => counts.put + counts.delete,
-    report: (): Record<string, number> => ({ ...counts }),
-  };
-};
+const report = (counting: CountingStorage): Record<string, number> => ({
+  get: counting.gets,
+  put: counting.puts,
+  delete: counting.deletes,
+  list: counting.lists,
+});
 
 // ── Tests ──────────────────────────────────────────────────────────────
 
 describe("reads are pure — never tick maintenance", () => {
   test(
-    "many reads over an over-ratio collection produce ZERO mutating ops",
+    "many reads over an over-ratio collection produce ZERO Class A ops",
     { timeout: 30_000 },
     async () => {
       // 60 entries — well over the CLOUDFLARE_FREE_TIER minEntriesToCompact
@@ -156,8 +132,8 @@ describe("reads are pure — never tick maintenance", () => {
       // sets mean_entry_bytes = RATIO_TRIPPING_MEAN, snapshot_bytes = 0
       // ⇒ ratio = 1.0 ≥ MAINTENANCE_TARGET_RATIO = 1.0.
       const inner = await seedOverRatio(60);
-      const proxy = countingProxy(inner);
-      const db = makeDb(proxy.storage);
+      const counting = wrapCountingStorage(inner);
+      const db = makeDb(counting.storage);
 
       // Take a snapshot of current.json BEFORE the reads.
       const beforeBody = await inner.get(currentJsonKey());
@@ -174,9 +150,11 @@ describe("reads are pure — never tick maintenance", () => {
         await db.collection(COLL).count();
       }
 
-      // Assert: ZERO mutating ops across all reads.
-      const mutatingOps = proxy.mutatingOps();
-      expect(mutatingOps, `Expected 0 mutating ops; got ${JSON.stringify(proxy.report())}`).toBe(0);
+      // Assert: ZERO Class A ops (PUT/DELETE/LIST) across all reads.
+      expect(
+        counting.classAOps,
+        `Expected 0 Class A ops; got ${JSON.stringify(report(counting))}`,
+      ).toBe(0);
 
       // Assert: current.json is byte-identical — no fold happened.
       const afterBody = await inner.get(currentJsonKey());
@@ -191,8 +169,7 @@ describe("reads are pure — never tick maintenance", () => {
     { timeout: 30_000 },
     async () => {
       const inner = await seedOverRatio(60);
-      const proxy = countingProxy(inner);
-      const db = makeDb(proxy.storage);
+      const db = makeDb(inner);
 
       const key = currentJsonKey();
       const beforeResult = await readCurrentJson(inner, key);
@@ -236,8 +213,8 @@ describe("reads are pure — never tick maintenance", () => {
       // Maintenance dispatch lives ONLY in Writer.#singleAttemptCommit
       // (via `getCurrentContext()?.maintenance`), not in query.ts.
       const inner = await seedOverRatio(60);
-      const proxy = countingProxy(inner);
-      const db = makeDb(proxy.storage);
+      const counting = wrapCountingStorage(inner);
+      const db = makeDb(counting.storage);
 
       const dispatchSpy = vi.fn<(task: () => Promise<void>) => void | Promise<void>>(() => {
         // If this is ever called from a read, the test will fail.
@@ -266,10 +243,10 @@ describe("reads are pure — never tick maintenance", () => {
         "dispatch spy was called — a read path consulted the maintenance context",
       ).not.toHaveBeenCalled();
 
-      // Mutating ops are still zero.
+      // Class A ops are still zero.
       expect(
-        proxy.mutatingOps(),
-        `Expected 0 mutating ops; got ${JSON.stringify(proxy.report())}`,
+        counting.classAOps,
+        `Expected 0 Class A ops; got ${JSON.stringify(report(counting))}`,
       ).toBe(0);
     },
   );

--- a/tests/integration/maintenance-e2e.test.ts
+++ b/tests/integration/maintenance-e2e.test.ts
@@ -16,9 +16,9 @@
  *       separately),
  *   (c) `current.json.snapshot !== null` and `log_seq_start` has
  *       advanced to within a small live tail of `tail_hint`,
- *   (d) an idle reader doing 1800 `tbl.where({}).all()` calls (≈ 1 hour
- *       at 2s polling) issues < 1 Class A op (PUT / DELETE / LIST).
- *       Real expectation: exactly 0.
+ *   (d) an idle reader doing 10 `tbl.where({}).all()` calls, projected to
+ *       an hour at 2s polling (1800 calls), issues < 1 Class A op
+ *       (PUT / DELETE / LIST). Real expectation: exactly 0.
  *
  * Variants: `memory` (zero infra, < 3s) and `local-fs` (real I/O, < 30s).
  * The `node-minio` and `cloudflare-r2` variants are deferred per the
@@ -286,8 +286,9 @@ describe("Synthetic 5000-entry end-to-end gate", () => {
           // `current.json` + the snapshot + the live-tail log entries, all
           // by deterministic key → all `get`). A small sample proves the
           // per-poll rate is exactly zero; `reads-pure.test.ts` already
-          // covers the broader repetition/mutation-spy guard, so this gate
-          // doesn't need to replay all 1800 polls to defend the projection.
+          // covers the broader repetition/Class-A-spy guard (PUT + DELETE +
+          // LIST, not just mutation), so this gate doesn't need to replay
+          // all 1800 polls to defend the projection.
           //
           // For broader workload analysis, see bench/README.md — the load
           // harness externalizes derived.class_a_per_tenant_per_hour.

--- a/tests/integration/maintenance-e2e.test.ts
+++ b/tests/integration/maintenance-e2e.test.ts
@@ -280,26 +280,30 @@ describe("Synthetic 5000-entry end-to-end gate", () => {
           // log-tail path should be GET-only.
           const counting = wrapCountingStorage(storage);
 
-          // 1 hour at a 2-second poll cadence = 1800 reads. The
-          // published cost model is "< 1 Class A op / writer / hour"
-          // for an idle reader; the real expectation is exactly 0
-          // (the reader only walks `current.json` + the snapshot +
-          // the live-tail log entries, all by deterministic key →
-          // all `get`).
+          // The published cost model is "< 1 Class A op / writer / hour"
+          // for an idle reader at a 2-second poll cadence (1800 polls/hour);
+          // the real expectation is exactly 0 (the reader only walks
+          // `current.json` + the snapshot + the live-tail log entries, all
+          // by deterministic key → all `get`). A small sample proves the
+          // per-poll rate is exactly zero; `reads-pure.test.ts` already
+          // covers the broader repetition/mutation-spy guard, so this gate
+          // doesn't need to replay all 1800 polls to defend the projection.
           //
           // For broader workload analysis, see bench/README.md — the load
           // harness externalizes derived.class_a_per_tenant_per_hour.
           const db = Db.create({ storage: counting.storage, app: APP, tenant: TENANT });
           const tbl = db.collection(COLLECTION) as Collection<Ticket>;
-          const T = 1800;
-          for (let i = 0; i < T; i++) {
+          const SAMPLE_POLLS = 10;
+          const HOURLY_POLLS = 1800;
+          for (let i = 0; i < SAMPLE_POLLS; i++) {
             await tbl.where({}).all();
           }
-          expect(counting.classAOps).toBeLessThan(1);
           // Strengthen: the documented expectation is exactly 0. If
           // this ever flips to 1 we want to know immediately — a LIST
           // or PUT crept into the read path.
           expect(counting.classAOps).toBe(0);
+          const projectedClassAOpsPerHour = (counting.classAOps / SAMPLE_POLLS) * HOURLY_POLLS;
+          expect(projectedClassAOpsPerHour).toBeLessThan(1);
         },
       );
     });

--- a/tests/integration/maintenance-profile-equivalence.test.ts
+++ b/tests/integration/maintenance-profile-equivalence.test.ts
@@ -210,7 +210,7 @@ describe("MaintenanceProfile cross-profile correctness", () => {
 
       test(
         "(A) materialized state is byte-for-byte identical across every profile (and the fold/GC-disabled reference)",
-        // 120s is contention headroom for four 512-commit replays. Disabled
+        // 120s is contention headroom for four 128-commit replays. Disabled
         // maintenance still refreshes tail_hint periodically; the maintained
         // profiles additionally run cadence-driven GC plus one cold-start
         // fold, whose LocalFs prefix lists repeatedly walk the bucket.

--- a/tests/integration/maintenance-profile-equivalence.test.ts
+++ b/tests/integration/maintenance-profile-equivalence.test.ts
@@ -71,14 +71,22 @@ interface Ticket extends BaseTicket {
   rev: number;
 }
 
-const bootstrap = (storage: Storage): Promise<void> =>
-  bootstrapCurrentJson(storage, "profile-equivalence");
-
 const WORKING_SET = 50; // bounded live doc set ⇒ constant live floor
 const BODY_BYTES = 2000; // bodies big enough that the ratio gate trips and folds fire
-// Exact cold-start first-fold threshold: 64 KiB live-byte floor / 128 B
-// per-entry estimate. This guarantees one fold while bounding four replays.
-const TOTAL_OPS = 512;
+
+const bootstrap = (storage: Storage): Promise<void> =>
+  // Pre-stamp mean_entry_bytes to this suite's real ~2 KB body size so the
+  // ratio TRIGGER's live-tail estimate reflects it from the first write,
+  // instead of the small cold-start fallback (128 B) that would otherwise
+  // require a much longer tail before the first fold fires.
+  bootstrapCurrentJson(storage, "profile-equivalence", BODY_BYTES);
+
+// 128 * BODY_BYTES (2000) = 256 KiB, well above the 64 KiB live-byte fold
+// floor once mean_entry_bytes is pre-stamped — well above
+// minEntriesToCompact (50) too, so every profile still lands a snapshot
+// and advances log_seq_start, and fold progress still diverges across
+// profiles (see the non-vacuity assertions in case (A) below).
+const TOTAL_OPS = 128;
 
 interface Op {
   readonly op: "I" | "U" | "D";

--- a/tests/unit/read-class-a-cost.test.ts
+++ b/tests/unit/read-class-a-cost.test.ts
@@ -6,10 +6,12 @@
 //     per equality value, so `$in` over N values costs N calls.
 //
 // `packages/server/src/reads-pure.test.ts` guards the neighbouring but
-// distinct property — that a read mutates nothing — on a PUT + DELETE
-// predicate. That predicate cannot see a LIST, and LIST is Class A on both
-// R2 and S3, so it cannot gate the cost claim. This file uses
-// `billableClassAOps` (PUT + LIST) for that.
+// distinct property — that repeated reads over an over-ratio collection
+// neither mutate nor enumerate — on `classAOps` (PUT + DELETE + LIST) over
+// unindexed collections only. That gate cannot express the indexed
+// exception below, and it counts DELETE, which is $0. This file uses
+// `billableClassAOps` (PUT + LIST) because the claim it gates is a dollar
+// cost.
 //
 // Assertions here pin each counter individually rather than a sum. A sum of
 // non-negative counters at zero is also satisfied by a read that did no work


### PR DESCRIPTION
## What & why

Three suites timed out under machine contention even though every assertion still passed once given more wall-clock — the work itself, not a hang, was the bottleneck. `maintenance-e2e`'s idle-reader cost-model gate replayed 1,800 identical reads, `maintenance-profile-equivalence`'s case (A) sized its replays off a cold-start byte estimate that under-counted its real ~2 KB bodies, and `dataset.test.ts`'s determinism check spent its time in per-record assertions/spreads rather than dataset generation. Each is now bounded to the work its assertions actually need, so timeouts stay meaningful without being raised.

Bounding the idle-reader gate to a 10-poll sample means it now leans on `reads-pure.test.ts` for repetition coverage, so this also widens that gate to hold the weight: it summed PUT + DELETE, which cannot see a LIST, and LIST is Class A on both R2 and S3. A regression routing an unindexed scan into one of `query.ts`'s index-walk branches would have passed both gates before and fails now.

## Key points

- Idle-reader gate: samples 10 polls instead of 1,800 and projects the same rate to the documented 1,800-poll hour. The projection is only defensible because `reads-pure.test.ts` gates the same Class A definition — that pairing is the substance of this PR, not an incidental cleanup.
- `reads-pure.test.ts` asserts on the shared fixture's `classAOps` (PUT + DELETE + LIST) and drops its local counting proxy, which the widening had made a byte-for-byte duplicate of that fixture. The LIST arm is not vacuous: `query.ts:822/873/901` are live LIST call sites on the indexed paths.
- Folding `reads-pure` onto the shared fixture closes D1 of the three inconsistent in-tree "Class A" definitions recorded in `bench/measurement/storage-journal.test.ts`. Two remain; that JSDoc now separates them by what they measure (subrequest count vs. dollars) rather than by site, and still defers the ruling to the owner named in Manifest §11 rather than declaring it resolved.
- Profile-equivalence case (A): pre-stamps `mean_entry_bytes` (an existing `bootstrap()` parameter) to the suite's real body size instead of relying on the small cold-start fallback, so `TOTAL_OPS` drops from 512 to 128 while still clearing the fold-trigger floor and every non-vacuity assertion.
- Dataset determinism: replaces the nested per-record loop and `Uint8Array` spreads with one `expect(a).toEqual(b)` — Vitest compares `Uint8Array` byte-for-byte, so this is the same byte-identical check over strictly more fields, not a weaker one.
- No timeout constants changed; no assertions dropped or weakened.

## Verification

| gate | result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3379 passed, 105 skipped |
| stress load, measured on `bb4b5a97` (multiple concurrent `pnpm test:agent` + `pnpm verify:agent`, load avg ~27/12 cores — above what originally reproduced the timeouts) | idle-reader ~3.3s (limit 30s), profile-equiv (A) ~9.7s (limit 120s), dataset ~2.5s (limit 5s) |

Unchanged code reliably reproduced the idle-reader timeout under the same stress load, confirming the fix addresses the actual failure condition. The two maintenance suites are the ones that flake by timeout rather than by assertion, so their green runs here are single-run evidence, not a flake-rate measurement.

## Notes for reviewers

Start at `packages/server/src/reads-pure.test.ts` — the predicate change there is what licenses the 10-poll sample in `maintenance-e2e`. `tests/unit/read-class-a-cost.test.ts`, `bench/measurement/storage-journal.test.ts`, and `bench/README.md` are all consequences of that one change: each described `reads-pure`'s predicate as PUT + DELETE, and `read-class-a-cost` justified its own predicate by that narrower one.
