### PR TITLE
docs(protocol): withdraw the sequence-window fence claim, record the hole it leaves

### DIFF
--- a/docs/adr/002-ephemeral-coordination.md
+++ b/docs/adr/002-ephemeral-coordination.md
@@ -107,6 +107,36 @@ is a **graduation signal, not silent breakage**.
   long — which is when the read alone sits closest to the 50-subrequest
   ceiling. Anti-precedent: Cassandra's `read_repair_chance`, removed in
   4.0 ([CASSANDRA-13910](https://issues.apache.org/jira/browse/CASSANDRA-13910)).
+- **The log-retention sequence window as a paused-writer fence.** Withdrawn.
+  `LOG_RETENTION_SEQ_WINDOW` was recorded as the reason a stale writer cannot
+  commit into a certified-deleted slot: the floor would have to advance by more
+  than the window "during one in-flight commit". The arithmetic holds and the
+  quantifier does not — one in-flight commit bounds no wall-clock and no commit
+  count, so a delayed create PUT, an isolate suspension, or the writer's own
+  transient-retry loop can each straddle an unbounded number of peer commits and
+  folds. It is a rate x duration assumption in sequences, the same class as
+  `GC_GRACE_PERIOD_MILLIS` in seconds. The window survives as a pre-image cost
+  margin and a retirement rate limit, with no safety property attached.
+- **Post-create manifest revalidation with discard-and-re-probe.** Insufficient,
+  and for a stronger reason than the per-commit GET cost. Re-reading
+  `current.json` after the create detects that the commit landed below the floor,
+  but discarding and re-probing cannot distinguish "my create landed and was
+  folded" from "a foreign create landed and was folded": the fold keeps no writer
+  identity (`SnapshotBody.docs` is `{_id, body}`), tombstones are purged,
+  `current.json` holds no per-writer completion state, and `writer_fence` is not
+  a replay filter (invariant 11). The two histories leave byte-identical durable
+  state and demand opposite outcomes, so re-probing silently re-applies a folded
+  mutation — clobbering a concurrent newer value, minting a second `lsn` for one
+  logical mutation, and emitting it twice on `/v1/since`. What is planned
+  instead — **not yet implemented** — is an explicit failure keyed on the
+  certified delete floor: a winning create at
+  `seq < min(log_delete_floor, log_seq_start)` throws
+  `BaerlyError{code:"AmbiguousCommit"}`. That would make the write contract
+  at-least-once under this fault, which is a stated contract rather than a silent
+  wrong answer. Until it lands, the schedule above is open: such a create is
+  acknowledged. A pre-create re-read closes neither schedule — a GET cannot
+  constrain a later PUT to a different key, and the lost-ack arm must not re-read
+  at all without breaking own-session adoption.
 
 ## What would break the property
 

--- a/packages/protocol/src/constants.ts
+++ b/packages/protocol/src/constants.ts
@@ -232,17 +232,25 @@ export const PREIMAGE_SCAN_MAX_GETS: number = 8;
  * reach a 1024-sequence window while keeping that relationship explicit if the
  * pre-image budget changes.
  *
- * The window also fences a stale writer, which is why it is a safety parameter
- * and not only a pre-image cost margin. A committing writer picks its slot at
- * or above the `max(log_seq_start, tail_hint)` of the manifest it read
- * (`writer.ts:446`), and a pass only certifies
- * `seq < log_seq_start - LOG_RETENTION_SEQ_WINDOW` deleted, so a commit can
- * land in a certified-deleted slot only if `log_seq_start` advanced by more
- * than this window while that single commit was in flight — i.e. only if more
- * than 1024 entries were committed and folded inside one request's commit
- * path. Do not lower this value on cost grounds without re-deriving that
- * bound: it is what closes the paused-writer schedule in place of a
- * commit-path fence.
+ * **This window is NOT a paused-writer fence, and no safety property may be
+ * derived from it.** It is a pre-image cost margin and a rate limit on how fast
+ * retirement approaches the live floor — nothing more. The withdrawn argument
+ * was that a certified-deleted slot needs `log_seq_start` to advance by more
+ * than this window "during one in-flight commit". The arithmetic is correct and
+ * the quantifier is vacuous: one in-flight commit bounds no wall-clock and no
+ * commit count, so this is a rate x duration assumption expressed in sequences,
+ * the same class as `GC_GRACE_PERIOD_MILLIS` in seconds. Lowering the value on
+ * cost grounds costs pre-image coverage and retirement smoothness; it does not
+ * weaken a safety proof, because there was never one here.
+ *
+ * Withdrawing the claim leaves the stale-writer schedule **open**. Nothing on
+ * the commit path compares the committing `seq` against the certified
+ * `log_delete_floor` today, so a create that wins below the floor is
+ * acknowledged as a successful mutation that no reader can see. The planned
+ * replacement is a commit-path check that fails such a create with
+ * `BaerlyError{code:"AmbiguousCommit"}` instead of acknowledging it; it is not
+ * implemented yet. Do not cite this JSDoc as evidence that the schedule is
+ * closed.
  *
  * @see packages/server/src/log-retention.ts
  * @see docs/spec/sync-protocol.md invariant 12

--- a/packages/server/src/log-retention.ts
+++ b/packages/server/src/log-retention.ts
@@ -98,9 +98,15 @@ export interface RetireLogRangeResult {
  * slice permanently below the newly-advanced floor: deliberate, and the
  * fail-safe direction this program picked — leak, never corruption.
  *
- * Why no writer-side fence accompanies this: see the stale-writer bound on
- * {@link LOG_RETENTION_SEQ_WINDOW} and `docs/adr/002-ephemeral-coordination.md`
- * § Closed paths.
+ * The writer-side counterpart belongs on the commit path, not here — and it
+ * does not exist yet. {@link LOG_RETENTION_SEQ_WINDOW} is a cost margin and a
+ * rate limit, never a fence — see its JSDoc. So nothing currently stops a
+ * paused or uncertain writer's create from landing in a slot this pass has
+ * already retired, and the commit path acknowledges it. Closing that is
+ * planned, as a commit-path check that fails such a create with
+ * `BaerlyError{code:"AmbiguousCommit"}`. See
+ * `docs/adr/002-ephemeral-coordination.md` § Closed paths for the two
+ * approaches that were tried and rejected, and why that check is what remains.
  *
  * @param opts.signal Threaded to every storage call this makes (the gate
  *   read, the CAS's own read + write, and each DELETE in the loop) — an


### PR DESCRIPTION
## What & why

`LOG_RETENTION_SEQ_WINDOW`'s JSDoc documented the window as the reason a paused writer cannot commit into a `log/<seq>` slot the collection has already certified deleted, and `log-retention.ts` cited ADR-002 for the same argument. The claim is false: the window bounds a distance in sequences, not wall-clock and not a commit count, so a delayed create PUT, an isolate suspension, or a writer's own transient-retry loop can each straddle an unbounded number of peer commits and folds. It is a rate × duration assumption expressed in sequences, the same class as `GC_GRACE_PERIOD_MILLIS` in seconds. This withdraws the claim from both places that cite it, records the withdrawal in ADR-002, and states plainly at all three sites that the stale-writer schedule is now **open** — a create winning below the certified floor is acknowledged, and nothing on the commit path stops it. The window itself survives unchanged as a pre-image cost margin and a rate limit on how fast retirement approaches the live floor; only the safety property is removed.

## Key points

- The constant's value and its `PREIMAGE_SCAN_MAX_GETS * 128` derivation are untouched. This removes a claim, not a mechanism.
- `log-retention.ts` forward-referenced ADR-002 § Closed paths for "why no writer-side fence accompanies this", and that section never described one — `grep -c 'writer-side fence'` over the ADR returned `0`. The citation now points at the two rejected approaches the ADR actually records.
- ADR-002 also gains the reason post-create manifest revalidation with discard-and-re-probe is insufficient: the fold keeps no writer identity, so "my create landed and was folded" and "a foreign writer's did" leave byte-identical durable state while demanding opposite outcomes.
- An earlier revision of this PR credited a commit-path check, `Writer#assertCommitAboveDeleteFloor`, with closing the schedule. That method does not exist yet, so all three sites now name it as the *planned* replacement and say the schedule is open until it lands. Landing a fresh unbacked safety claim while withdrawing an old one defeats the purpose of the PR.
- Zero behavior change. No exported value, type, or signature moves, and there are no tests because there is nothing new to exercise.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3379 passed, 105 skipped |
| `pnpm bundle-sizes` | ok (14 entries), zero diff — the added JSDoc stayed inside the delta gate, so no rebaseline |

## Notes for reviewers

The product of this PR is prose that will be cited as a safety argument for years, so the question worth your attention is whether the withdrawal is *correct*, not whether the diff is clean. The load-bearing assertion is that "during one in-flight commit" quantifies nothing: it bounds neither elapsed time nor the number of peer commits and folds that can interleave.

The second thing worth checking is that the prose is now honest about tense. After this PR the repo documents a known open hole and no longer claims a fence anywhere. The commit-path check that closes it, and the `AmbiguousCommit` code it throws, arrive in follow-up PRs; the one that implements the check flips these three sites to the present tense.
