### PR TITLE
docs(server): define public log-helper retention floors

### DIFF
--- a/packages/server/src/log-tail.test.ts
+++ b/packages/server/src/log-tail.test.ts
@@ -70,6 +70,20 @@ describe("probeTailFrom", () => {
     expect(result.entries.map((entry) => entry.seq)).not.toContain(9);
   });
 
+  test("a reclaimed prefix makes a sub-floor hint report a false tail", async () => {
+    const storage = new MemoryStorage();
+    const logSeqStart = 5;
+    await seedLogEntries(storage, PREFIX, logSeqStart, 8);
+
+    await expect(probeTailFrom(storage, PREFIX, 0)).resolves.toEqual({
+      tail: 0,
+      entries: [],
+    });
+    const safe = await probeTailFrom(storage, PREFIX, logSeqStart);
+    expect(safe.tail).toBe(8);
+    expect(safe.entries.map((entry) => entry.seq)).toEqual([5, 6, 7]);
+  });
+
   test("cap exhausted: THROWS Internal instead of silently truncating", async () => {
     // A dense run longer than the cap means the true tail is past the cap.
     // Returning `hint+cap` would silently truncate every downstream read

--- a/packages/server/src/log-tail.ts
+++ b/packages/server/src/log-tail.ts
@@ -75,9 +75,19 @@ export const probeTailChunk = async (
 /**
  * Discover the true committed tail and fold entries in `[hint, tail)`.
  * `tail` is the first empty seq (>= hint); `entries` are the
- * LogEntries in `[hint, tail)` in seq order. `cap` bounds the walk;
- * exhausting it THROWS `Internal` (never silently truncates) — see
- * the cap-exhaustion comment below.
+ * LogEntries in `[hint, tail)` in seq order.
+ *
+ * Retention precondition: derive `hint` from a fresh `current.json` read
+ * and require `hint >= current.log_seq_start`; the usual start is
+ * `Math.max(current.log_seq_start, current.tail_hint)`. The floor and hint
+ * must come from that same manifest read. Entries below the floor may
+ * already be reclaimed, and this probe interprets the first missing slot
+ * as the tail. A sub-floor hint may therefore report a false tail and omit
+ * later live entries. This storage-level helper intentionally accepts no
+ * manifest and cannot enforce the precondition for its caller.
+ *
+ * `cap` bounds the walk; exhausting it THROWS `Internal` (never silently
+ * truncates) — see the cap-exhaustion comment below.
  */
 export const probeTailFrom = async (
   storage: Storage,

--- a/packages/server/src/log-walk.test.ts
+++ b/packages/server/src/log-walk.test.ts
@@ -137,6 +137,17 @@ describe("walkLogRange", () => {
     });
   });
 
+  test("a reclaimed prefix makes a sub-floor walk throw Internal", async () => {
+    const storage = new MemoryStorage();
+    const logSeqStart = 5;
+    await seedRange(storage, logSeqStart, 8);
+
+    await expect(walkLogRange(storage, PREFIX, 0, 8)).rejects.toMatchObject({
+      code: "Internal",
+    });
+    await expect(walkLogRange(storage, PREFIX, logSeqStart, 8)).resolves.toHaveLength(3);
+  });
+
   test("throws InvalidResponse on a malformed body", async () => {
     const inner = new MemoryStorage();
     await inner.put(`${PREFIX}/log/0.json`, new TextEncoder().encode("not json"));

--- a/packages/server/src/log-walk.ts
+++ b/packages/server/src/log-walk.ts
@@ -94,6 +94,14 @@ const readLogEntryWithBytes = async (
  * in chunks of {@link MAX_PARALLEL_LOG_READS} concurrent GETs.
  * Returns the materialised entries in seq order.
  *
+ * Retention precondition: derive `fromSeq` from a fresh `current.json`
+ * read and require `fromSeq >= current.log_seq_start`. The floor and
+ * starting sequence must come from that same manifest read. Entries below
+ * the floor may already be reclaimed; a sub-floor walk that reaches one of
+ * those holes throws `Internal` even when later live entries still exist.
+ * This storage-level helper intentionally accepts no manifest and cannot
+ * enforce the precondition for its caller.
+ *
  * Empty range (`fromSeq >= toSeqExclusive`) returns `[]` and issues
  * zero GETs.
  *

--- a/scripts/check-exports.mjs
+++ b/scripts/check-exports.mjs
@@ -175,6 +175,38 @@ void runScheduledMaintenance;
 `,
   },
   {
+    name: "positive-public-log-helper-surface",
+    expect: "compiles",
+    source: `
+import {
+  probeTailFrom,
+  type Storage,
+  walkLogRange,
+} from "@gusto/baerly-storage";
+
+declare const storage: Storage;
+declare const signal: AbortSignal;
+
+const walkSignature: (
+  storage: Storage,
+  logPrefix: string,
+  fromSeq: number,
+  toSeqExclusive: number,
+  opts?: { signal?: AbortSignal },
+) => Promise<Array<{ seq: number }>> = walkLogRange;
+
+const probeSignature: (
+  storage: Storage,
+  logPrefix: string,
+  hint: number,
+  opts?: { signal?: AbortSignal; cap?: number },
+) => Promise<{ tail: number; entries: Array<{ seq: number }> }> = probeTailFrom;
+
+void walkSignature(storage, "app/a/tenant/t/manifests/c", 5, 9, { signal });
+void probeSignature(storage, "app/a/tenant/t/manifests/c", 9, { signal, cap: 32 });
+`,
+  },
+  {
     name: "negative-internal-compact-options-from-root",
     expect: "fails",
     codes: ["TS2305", "TS2724"],

--- a/tests/integration/public-surface.test.ts
+++ b/tests/integration/public-surface.test.ts
@@ -25,13 +25,15 @@ import { describe, expect, test } from "vitest";
 // ---------------------------------------------------------------------------
 // @gusto/baerly-storage (root barrel)
 // ---------------------------------------------------------------------------
-import { BaerlyError, Db, MemoryStorage } from "@gusto/baerly-storage";
+import { BaerlyError, Db, MemoryStorage, probeTailFrom, walkLogRange } from "@gusto/baerly-storage";
 
 describe("@gusto/baerly-storage", () => {
   test("imports resolve", () => {
     expect(typeof Db).toBe("function");
     expect(typeof BaerlyError).toBe("function");
     expect(typeof MemoryStorage).toBe("function");
+    expect(typeof walkLogRange).toBe("function");
+    expect(typeof probeTailFrom).toBe("function");
   });
 });
 


### PR DESCRIPTION
## What & why

`walkLogRange` and `probeTailFrom` are public root exports that take bare sequence numbers, so they cannot validate that their start sits at or above the caller's retention floor. Once PR 5 makes log reclamation live, a sub-floor start becomes reachable — and the two helpers fail differently: the strict walk throws `Internal` at a reclaimed hole, while the tolerant probe reads that hole as the tail and silently returns a false tail below still-live entries. This PR states that precondition on both helpers, characterizes both failure modes, and pins both names plus their existing call shapes on the packed consumer surface. No signature changes, no runtime changes.

## Key points

- Both signatures are byte-identical; the diff on `log-walk.ts` / `log-tail.ts` is comment lines only. The helpers stay manifest-free — threading a manifest in, or adding a runtime guard, would move the floor check off the caller that already holds a fresh `current.json`.
- Neither helper is marked `@deprecated`: this preserves the supported surface and there is no replacement API to point at.
- The precondition lives in JSDoc rather than the `API.md` quickref. It ships to consumers on the packed declarations (`dist/index-*.d.ts`, immediately above `declare const walkLogRange`), and `API.md` stays the curated recommended surface rather than advertising a primitive that can silently truncate a read.
- The new `check-exports.mjs` fixture compiles against the real packed tarball, so it covers the root barrel, rolldown's declaration output, the published export map, and consumer type resolution together.
- All 8 production callers and all 13 test callers were re-audited and already satisfy the precondition — every production call derives its start from the same fresh manifest as the surrounding operation. No caller changed. The `Db.probeLogTail` seam additionally rejects sub-floor input via `assertAtOrAboveLogFloor` before probing.
- No changeset: PR 5 owns the behavior change that makes reclamation live.

## Verification

| Command | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3381 passed, 105 skipped |
| `pnpm verify:package` | packed-surface gate passed (9 attributed fixtures, 14 published subpaths) |
| `pnpm bundle-sizes` | ok (14 entries) — JSDoc growth stayed inside the delta gate, no rebaseline |

Infra-gated suites (Minio, credentials, Workerd) were not run; this change touches no adapter or storage path.

## Notes for reviewers

Start with the two JSDoc blocks, then the two characterization tests that pin the asymmetry — `log-walk.test.ts` asserts the loud `Internal`, `log-tail.test.ts` asserts the silent `{ tail: 0, entries: [] }`. Both pass against unmodified runtime code; they exist to name the retention scenario that makes the existing behavior newly reachable after PR 5, not to drive a fix.
