### PR TITLE
feat(protocol): add the AmbiguousCommit error code

### DIFF
--- a/docs/adr/002-ephemeral-coordination.md
+++ b/docs/adr/002-ephemeral-coordination.md
@@ -107,6 +107,36 @@ is a **graduation signal, not silent breakage**.
   long — which is when the read alone sits closest to the 50-subrequest
   ceiling. Anti-precedent: Cassandra's `read_repair_chance`, removed in
   4.0 ([CASSANDRA-13910](https://issues.apache.org/jira/browse/CASSANDRA-13910)).
+- **The log-retention sequence window as a paused-writer fence.** Withdrawn.
+  `LOG_RETENTION_SEQ_WINDOW` was recorded as the reason a stale writer cannot
+  commit into a certified-deleted slot: the floor would have to advance by more
+  than the window "during one in-flight commit". The arithmetic holds and the
+  quantifier does not — one in-flight commit bounds no wall-clock and no commit
+  count, so a delayed create PUT, an isolate suspension, or the writer's own
+  transient-retry loop can each straddle an unbounded number of peer commits and
+  folds. It is a rate x duration assumption in sequences, the same class as
+  `GC_GRACE_PERIOD_MILLIS` in seconds. The window survives as a pre-image cost
+  margin and a retirement rate limit, with no safety property attached.
+- **Post-create manifest revalidation with discard-and-re-probe.** Insufficient,
+  and for a stronger reason than the per-commit GET cost. Re-reading
+  `current.json` after the create detects that the commit landed below the floor,
+  but discarding and re-probing cannot distinguish "my create landed and was
+  folded" from "a foreign create landed and was folded": the fold keeps no writer
+  identity (`SnapshotBody.docs` is `{_id, body}`), tombstones are purged,
+  `current.json` holds no per-writer completion state, and `writer_fence` is not
+  a replay filter (invariant 11). The two histories leave byte-identical durable
+  state and demand opposite outcomes, so re-probing silently re-applies a folded
+  mutation — clobbering a concurrent newer value, minting a second `lsn` for one
+  logical mutation, and emitting it twice on `/v1/since`. What is planned
+  instead — **not yet implemented** — is an explicit failure keyed on the
+  certified delete floor: a winning create at
+  `seq < min(log_delete_floor, log_seq_start)` throws
+  `BaerlyError{code:"AmbiguousCommit"}`. That would make the write contract
+  at-least-once under this fault, which is a stated contract rather than a silent
+  wrong answer. Until it lands, the schedule above is open: such a create is
+  acknowledged. A pre-create re-read closes neither schedule — a GET cannot
+  constrain a later PUT to a different key, and the lost-ack arm must not re-read
+  at all without breaking own-session adoption.
 
 ## What would break the property
 

--- a/docs/guide/cheatsheet.md
+++ b/docs/guide/cheatsheet.md
@@ -80,19 +80,20 @@ and won't typecheck. Pair with `.order({ field: "asc" | "desc" })` and
 One class, `BaerlyError`. Discriminate by `.code` (survives realm
 boundaries), never `instanceof` chains.
 
-| `code`                   | HTTP | When                                                    |
-| ------------------------ | ---- | ------------------------------------------------------- |
-| `InvalidConfig`          | 400  | Bad config/input (bucket, malformed predicate)          |
-| `SchemaError`            | 400  | JSON shape invalid or bound schema rejected the doc     |
-| `Conflict`               | 409  | `insert` `_id` collision (duplicate `_id`)              |
-| `Unauthorized`           | 401  | Verifier returned no identity                           |
-| `AccessDenied`           | 403  | S3 403 or bucket policy denied                          |
-| `NotFound`               | 404  | Row by id not found                                     |
-| `PayloadTooLarge`        | 413  | Body > 1 MiB                                            |
-| `UnsatisfiablePredicate` | 400  | Well-formed predicate that contradicts itself           |
-| `NetworkError`           | 502  | Transport (S3 5xx, retries exhausted)                   |
-| `InvalidResponse`        | 502  | Server returned unparseable body                        |
-| `Internal`               | 500  | Invariant violation — file a bug                        |
+| `code`                   | HTTP | When                                                                   |
+| ------------------------ | ---- | ---------------------------------------------------------------------- |
+| `InvalidConfig`          | 400  | Bad config/input (bucket, malformed predicate)                         |
+| `SchemaError`            | 400  | JSON shape invalid or bound schema rejected the doc                    |
+| `Conflict`               | 409  | `insert` `_id` collision (duplicate `_id`)                             |
+| `AmbiguousCommit`        | 409  | Commit landed below the certified delete floor; retry is at-least-once |
+| `Unauthorized`           | 401  | Verifier returned no identity                                          |
+| `AccessDenied`           | 403  | S3 403 or bucket policy denied                                         |
+| `NotFound`               | 404  | Row by id not found                                                    |
+| `PayloadTooLarge`        | 413  | Body > 1 MiB                                                           |
+| `UnsatisfiablePredicate` | 400  | Well-formed predicate that contradicts itself                          |
+| `NetworkError`           | 502  | Transport (S3 5xx, retries exhausted)                                  |
+| `InvalidResponse`        | 502  | Server returned unparseable body                                       |
+| `Internal`               | 500  | Invariant violation — file a bug                                       |
 
 ## HTTP wire (reach for `curl` only when debugging)
 

--- a/packages/cli/src/bin-runner.ts
+++ b/packages/cli/src/bin-runner.ts
@@ -25,7 +25,7 @@
  *     …)` semantics.
  *   - Maps `BaerlyError.code` through the same 3-bucket exit-code
  *     table the per-subcommand wrappers use (`InvalidConfig → 1`,
- *     `Conflict|Internal|InvalidResponse → 3`, else 2).
+ *     `Conflict|Internal|InvalidResponse|AmbiguousCommit → 3`, else 2).
  */
 
 import {
@@ -43,7 +43,12 @@ const errorToExitCode = (code: string): number => {
   if (code === "InvalidConfig") {
     return 1;
   }
-  if (code === "Conflict" || code === "Internal" || code === "InvalidResponse") {
+  if (
+    code === "Conflict" ||
+    code === "Internal" ||
+    code === "InvalidResponse" ||
+    code === "AmbiguousCommit"
+  ) {
     return 3;
   }
   return 2;

--- a/packages/cli/src/deploy.ts
+++ b/packages/cli/src/deploy.ts
@@ -12,8 +12,9 @@
  *   - 1 user error (InvalidConfig, missing config, unknown target).
  *   - 2 storage / external error (NetworkError, Wrangler returned
  *     non-zero, anything non-BaerlyError).
- *   - 3 protocol invariant (Conflict, Internal, InvalidResponse —
- *     should not happen here unless someone hand-edited mid-flight).
+ *   - 3 protocol invariant (Conflict, Internal, InvalidResponse,
+ *     AmbiguousCommit — should not happen here unless someone
+ *     hand-edited mid-flight).
  */
 
 import { defineCommand, type ArgsDef, type ParsedArgs } from "citty";
@@ -53,7 +54,12 @@ const errorToExitCode = (code: string): number => {
   if (code === "InvalidConfig") {
     return 1;
   }
-  if (code === "Conflict" || code === "Internal" || code === "InvalidResponse") {
+  if (
+    code === "Conflict" ||
+    code === "Internal" ||
+    code === "InvalidResponse" ||
+    code === "AmbiguousCommit"
+  ) {
     return 3;
   }
   return 2;

--- a/packages/cli/src/subcommand.ts
+++ b/packages/cli/src/subcommand.ts
@@ -8,7 +8,7 @@
  *   1. `setJsonMode(args.json === true)` before any emission.
  *   2. A `KNOWN_KEYS` whitelist asserting unknown `--flag` rejection.
  *   3. An `errorToExitCode(code)` mapping —
- *      `InvalidConfig → 1`, `Conflict|Internal|InvalidResponse → 3`,
+ *      `InvalidConfig → 1`, `Conflict|Internal|InvalidResponse|AmbiguousCommit → 3`,
  *      else `2`.
  *   4. `resolveAppTenant(args)` falling back through `baerly.config.*`
  *      to either real values or hard-coded `"app"` / `"tenant"`
@@ -155,7 +155,12 @@ const errorToExitCode = (code: string): number => {
   if (code === "InvalidConfig") {
     return 1;
   }
-  if (code === "Conflict" || code === "Internal" || code === "InvalidResponse") {
+  if (
+    code === "Conflict" ||
+    code === "Internal" ||
+    code === "InvalidResponse" ||
+    code === "AmbiguousCommit"
+  ) {
     return 3;
   }
   return 2;

--- a/packages/protocol/src/constants.ts
+++ b/packages/protocol/src/constants.ts
@@ -232,17 +232,25 @@ export const PREIMAGE_SCAN_MAX_GETS: number = 8;
  * reach a 1024-sequence window while keeping that relationship explicit if the
  * pre-image budget changes.
  *
- * The window also fences a stale writer, which is why it is a safety parameter
- * and not only a pre-image cost margin. A committing writer picks its slot at
- * or above the `max(log_seq_start, tail_hint)` of the manifest it read
- * (`writer.ts:446`), and a pass only certifies
- * `seq < log_seq_start - LOG_RETENTION_SEQ_WINDOW` deleted, so a commit can
- * land in a certified-deleted slot only if `log_seq_start` advanced by more
- * than this window while that single commit was in flight — i.e. only if more
- * than 1024 entries were committed and folded inside one request's commit
- * path. Do not lower this value on cost grounds without re-deriving that
- * bound: it is what closes the paused-writer schedule in place of a
- * commit-path fence.
+ * **This window is NOT a paused-writer fence, and no safety property may be
+ * derived from it.** It is a pre-image cost margin and a rate limit on how fast
+ * retirement approaches the live floor — nothing more. The withdrawn argument
+ * was that a certified-deleted slot needs `log_seq_start` to advance by more
+ * than this window "during one in-flight commit". The arithmetic is correct and
+ * the quantifier is vacuous: one in-flight commit bounds no wall-clock and no
+ * commit count, so this is a rate x duration assumption expressed in sequences,
+ * the same class as `GC_GRACE_PERIOD_MILLIS` in seconds. Lowering the value on
+ * cost grounds costs pre-image coverage and retirement smoothness; it does not
+ * weaken a safety proof, because there was never one here.
+ *
+ * Withdrawing the claim leaves the stale-writer schedule **open**. Nothing on
+ * the commit path compares the committing `seq` against the certified
+ * `log_delete_floor` today, so a create that wins below the floor is
+ * acknowledged as a successful mutation that no reader can see. The planned
+ * replacement is a commit-path check that fails such a create with
+ * `BaerlyError{code:"AmbiguousCommit"}` instead of acknowledging it; it is not
+ * implemented yet. Do not cite this JSDoc as evidence that the schedule is
+ * closed.
  *
  * @see packages/server/src/log-retention.ts
  * @see docs/spec/sync-protocol.md invariant 12

--- a/packages/protocol/src/errors.ts
+++ b/packages/protocol/src/errors.ts
@@ -33,6 +33,26 @@ export type BaerlyErrorCode =
    */
   | "Conflict"
   /**
+   * A committing `log/<seq>` create won at a sequence the collection has
+   * already certified deleted (`seq < min(log_delete_floor, log_seq_start)`),
+   * so the object it wrote is beneath every reader's floor and invisible.
+   *
+   * The logical mutation's fate is genuinely unknown, not merely unreported: an
+   * earlier attempt by the same writer may have landed and been folded into the
+   * snapshot before retirement removed the slot, and no durable state
+   * distinguishes that history from one where a foreign writer's entry was
+   * folded instead (`docs/spec/sync-protocol.md` invariant 11 —
+   * `writer_fence` is not a replay filter — and `SnapshotBody.docs`, which
+   * keeps no writer identity).
+   *
+   * Retrying the same logical write is permitted and is the intended recovery,
+   * but the write contract under this fault is **at-least-once**: a retry may
+   * apply the mutation a second time. That is why this is a distinct code and
+   * why `retriable` is `false` — a generic conflict-retry wrapper must not
+   * absorb it silently. HTTP layer maps this to 409.
+   */
+  | "AmbiguousCommit"
+  /**
    * `Verifier` returned no identity. HTTP server maps to 401.
    * Code is reserved here so the union locks.
    */
@@ -124,6 +144,7 @@ export const ERROR_CODES = [
   "Internal",
   "SchemaError",
   "Conflict",
+  "AmbiguousCommit",
   "Unauthorized",
   "NotFound",
   "PayloadTooLarge",

--- a/packages/protocol/src/spec/ir-schema.test.ts
+++ b/packages/protocol/src/spec/ir-schema.test.ts
@@ -24,9 +24,9 @@ describe("spec IR shared enumerations", () => {
     const _check: readonly BaerlyErrorCode[] = ERROR_CODES;
     void _codeFromTuple;
     void _check;
-    // 14 codes in the live union (verified 2026-06-24). Bump deliberately
+    // 15 codes in the live union (verified 2026-08-14). Bump deliberately
     // when the union changes.
-    expect(ERROR_CODES.length).toBe(14);
+    expect(ERROR_CODES.length).toBe(15);
     expect(new Set(ERROR_CODES).size).toBe(ERROR_CODES.length); // no dupes
   });
 

--- a/packages/server/API.md
+++ b/packages/server/API.md
@@ -353,6 +353,7 @@ try {
 | `Internal`               | 500  | Invariant violation — file a bug                                       |
 | `SchemaError`            | 400  | JSON shape invalid or bound schema rejected the doc                    |
 | `Conflict`               | 409  | CAS retry budget exhausted, or `insert` `_id` collision                |
+| `AmbiguousCommit`        | 409  | Commit landed below the certified delete floor; retry is at-least-once |
 | `Unauthorized`           | 401  | Verifier returned no identity                                          |
 | `NotFound`               | 404  | Row by id not found                                                    |
 | `PayloadTooLarge`        | 413  | Body > 1 MiB cap                                                       |

--- a/packages/server/spec/baerly.spec.json
+++ b/packages/server/spec/baerly.spec.json
@@ -53,6 +53,13 @@
       "summary": "Write conflicted (CAS exhausted, duplicate _id, guarded key)."
     },
     {
+      "code": "AmbiguousCommit",
+      "httpStatus": 409,
+      "retriable": false,
+      "messagePolicy": "scrubbed",
+      "summary": "Commit landed below the certified delete floor; retry is at-least-once."
+    },
+    {
       "code": "Unauthorized",
       "httpStatus": 401,
       "retriable": false,

--- a/packages/server/src/http/router.ts
+++ b/packages/server/src/http/router.ts
@@ -432,6 +432,7 @@ export const ERROR_TO_STATUS: ReadonlyMap<BaerlyErrorCode, HttpStatus> = new Map
   ["AccessDenied", 403],
   ["NotFound", 404],
   ["Conflict", 409],
+  ["AmbiguousCommit", 409],
   ["PayloadTooLarge", 413],
   ["SchemaError", 400],
   ["InvalidConfig", 400],
@@ -471,6 +472,10 @@ const ERROR_CODE_POLICY = {
   AccessDenied: {
     messagePolicy: "scrubbed",
     scrubbedMessage: "access denied",
+  },
+  AmbiguousCommit: {
+    messagePolicy: "scrubbed",
+    scrubbedMessage: "commit outcome is ambiguous; the mutation may or may not have been applied",
   },
   Conflict: {
     messagePolicy: "contextual",

--- a/packages/server/src/log-retention.ts
+++ b/packages/server/src/log-retention.ts
@@ -98,9 +98,15 @@ export interface RetireLogRangeResult {
  * slice permanently below the newly-advanced floor: deliberate, and the
  * fail-safe direction this program picked — leak, never corruption.
  *
- * Why no writer-side fence accompanies this: see the stale-writer bound on
- * {@link LOG_RETENTION_SEQ_WINDOW} and `docs/adr/002-ephemeral-coordination.md`
- * § Closed paths.
+ * The writer-side counterpart belongs on the commit path, not here — and it
+ * does not exist yet. {@link LOG_RETENTION_SEQ_WINDOW} is a cost margin and a
+ * rate limit, never a fence — see its JSDoc. So nothing currently stops a
+ * paused or uncertain writer's create from landing in a slot this pass has
+ * already retired, and the commit path acknowledges it. Closing that is
+ * planned, as a commit-path check that fails such a create with
+ * `BaerlyError{code:"AmbiguousCommit"}`. See
+ * `docs/adr/002-ephemeral-coordination.md` § Closed paths for the two
+ * approaches that were tried and rejected, and why that check is what remains.
  *
  * @param opts.signal Threaded to every storage call this makes (the gate
  *   read, the CAS's own read + write, and each DELETE in the loop) — an

--- a/packages/server/src/spec/ir.test.ts
+++ b/packages/server/src/spec/ir.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { CLIENT_RUNTIME_CODES, ERROR_CODES, PREDICATE_OPS } from "@baerly/protocol";
+import {
+  CLIENT_RUNTIME_CODES,
+  ERROR_CODES,
+  isRetriableCode,
+  PREDICATE_OPS,
+} from "@baerly/protocol";
 import { expectValidAgainstIrSchema } from "../../../../tests/fixtures/ir-schema.ts";
 import { buildSpecIR } from "./ir.ts";
 
@@ -67,6 +72,18 @@ describe("buildSpecIR", () => {
 
   test("serverVersion matches the root package version", () => {
     expect(ir.serverVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  test("AmbiguousCommit is on the contract with a non-retriable 409", () => {
+    const entry = ir.errorCodes.find((e) => e.code === "AmbiguousCommit");
+    expect(entry).toBeDefined();
+    expect(entry?.httpStatus).toBe(409);
+    expect(entry?.retriable).toBe(false);
+    expect(entry?.messagePolicy).toBe("scrubbed");
+  });
+
+  test("AmbiguousCommit is not retriable by default", () => {
+    expect(isRetriableCode("AmbiguousCommit")).toBe(false);
   });
 
   test("declares the /v1 routes including the new /v1/spec", () => {

--- a/packages/server/src/spec/ir.ts
+++ b/packages/server/src/spec/ir.ts
@@ -72,6 +72,7 @@ const ERROR_SUMMARY: Record<BaerlyErrorCode, string> = {
   Internal: "Internal invariant violation — file a bug.",
   SchemaError: "Document body failed schema validation; carries .issues.",
   Conflict: "Write conflicted (CAS exhausted, duplicate _id, guarded key).",
+  AmbiguousCommit: "Commit landed below the certified delete floor; retry is at-least-once.",
   Unauthorized: "Verifier returned no identity.",
   NotFound: "Addressed resource does not exist.",
   PayloadTooLarge: "Request body exceeded MAX_BODY_BYTES.",

--- a/packages/server/src/spec/runtime-spec.test.ts
+++ b/packages/server/src/spec/runtime-spec.test.ts
@@ -7,7 +7,7 @@ describe("buildSpecResponse", () => {
   test("anonymous: static IR only, no collections field", () => {
     const res = buildSpecResponse();
     expect(res.specVersion).toBe("1");
-    expect(res.errorCodes.length).toBe(14);
+    expect(res.errorCodes.length).toBe(15);
     expect("collections" in res).toBe(false);
     expectValidAgainstIrSchema(res);
   });

--- a/tests/integration/bundle-size.test.ts
+++ b/tests/integration/bundle-size.test.ts
@@ -268,6 +268,6 @@ describe("spec artifact emission", () => {
     const ir = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
     expect(ir["specVersion"]).toBe("1");
     expect(Array.isArray(ir["errorCodes"])).toBe(true);
-    expect((ir["errorCodes"] as unknown[]).length).toBe(14);
+    expect((ir["errorCodes"] as unknown[]).length).toBe(15);
   });
 });


### PR DESCRIPTION
## What & why

Adds a public error code, `AmbiguousCommit`, for the fault where a committing `log/<seq>` create wins at a sequence the collection has already certified deleted (`seq < min(log_delete_floor, log_seq_start)`). The object it wrote is beneath every reader's floor and invisible, and the logical mutation's fate is genuinely unknown rather than merely unreported: an earlier attempt by the same writer may have landed and been folded into the snapshot before retirement removed the slot, and no durable state distinguishes that history from one where a foreign writer's entry was folded instead. **Nothing throws this code yet** — the commit-path check that raises it lands in the follow-up PR. This is the additive surface it needs, split out so that PR is only the check and its tests.

`Conflict` cannot carry this. It means "you lost a race, nothing of yours landed, retrying is safe", and both `RETRIABLE_CODES` and the wire `retriable` field encode exactly that. Folding the two would let any generic conflict-retry wrapper convert an ambiguous outcome into a silent duplicate application — the precise distinction the at-least-once contract depends on.

## Key points

- Deliberately **absent from `RETRIABLE_CODES`**, so `err.retriable` is `false`. Retrying is the *available* action, not a *safe* one; a caller must handle it deliberately.
- Also absent from `CLIENT_RUNTIME_CODES` — that set means "never on the wire", and this maps to HTTP 409.
- The `ERROR_TO_STATUS` row is not compile-enforced: it's a `Map`, so omitting it silently yields HTTP 500 instead of 409 and `tsgo` catches nothing. The `ir.test.ts` `httpStatus` assertion is the only gate on that, which is why it exists.
- Message policy is `scrubbed`, not public: the thrown message names the collection's `current.json` key and the committing seq. The `code` carries the caller-actionable meaning.
- CLI exit 3 (protocol invariant), not the generic exit-2 storage bucket — exit 2 reads as "transport hiccup, safe to re-run" to a shell wrapper, and this outcome is not safe to re-run blindly. The three exit-code predicates are textually identical but are three separate literals; each is edited in place rather than extracted to a shared helper.
- `specVersion` is unchanged. `check-version-matrix` reserves a bump for a *shape* change, and this adds an entry to an existing list.
- Also updates three assertions that pinned the error-code count at 14, in `ir-schema.test.ts`, `runtime-spec.test.ts`, and `bundle-size.test.ts`. Each stays an exact-equality pin, now at 15.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3381 passed, 105 skipped |
| `node scripts/check-spec-drift.ts` | ok — 15 codes, up from 14, confirming `baerly.spec.json` was regenerated |
| `pnpm bundle-sizes` | ok (14 entries), zero diff — the new union member and its JSDoc stayed inside the delta gate, so no rebaseline |

## Notes for reviewers

Stacked on #139 — review that first; this PR's base is `pin-4-replacement`, so the diff here is the one commit.

The judgement worth your attention is whether this deserves its own code at all rather than reusing `Conflict`. The cost is one public-API addition across nine sites; the argument is in "What & why" and, durably, in the union member's JSDoc.
