### PR TITLE
fix(writer): fail loudly when a commit lands below the certified delete floor

### DIFF
--- a/.changeset/ambiguous-commit.md
+++ b/.changeset/ambiguous-commit.md
@@ -1,0 +1,39 @@
+---
+"@gusto/baerly-storage": minor
+---
+
+A commit whose `log/<seq>` create wins at a sequence the collection has already
+certified deleted now fails with `BaerlyError{code:"AmbiguousCommit"}` instead of
+returning success. That state is reachable when a create request or a lost-ack
+retry straddles a fold plus a log-retirement pass: the object lands beneath every
+reader's floor, so no reader will ever consult it — and whether the mutation
+itself is visible is undecidable from durable state. Either the create re-filled
+a hole retirement had already certified deleted (invisible) or it landed in a
+live empty slot that a fold absorbed before retirement swept it (visible through
+the snapshot); both are reported as ambiguous.
+
+Under this fault the write contract is at-least-once rather than exactly-once.
+The writer cannot determine whether an earlier attempt of its own landed and was
+folded before retirement removed the slot — no durable state distinguishes that
+from a foreign writer's entry being folded instead — so retrying is the intended
+recovery and may apply the mutation a second time. `err.retriable` is `false` so
+a generic conflict-retry wrapper cannot absorb it silently; handle the code
+explicitly. Every other commit path is unchanged and remains exactly-once.
+
+In this release the error is not yet reachable in practice: `log_delete_floor`
+is written only by the log-retirement pass, which nothing calls yet, so on a
+running deployment the floor stays absent and the check always takes its silent
+arm. Handling the code now is forward-looking — a later release wires retirement
+into the maintenance triggers and makes the fault reachable.
+
+`AmbiguousCommit` is a new `BaerlyErrorCode`. It maps to HTTP 409 with a scrubbed
+message and to CLI exit 3.
+
+Cost is one additional GET per commit. A GET is a Class B request while billable
+Class A ops are PUT/LIST (`DeleteObject` is $0 on both R2 and S3), so per-write
+Class A billing is unchanged.
+
+Buckets written by earlier versions need no migration. A bucket whose previous
+GC already swept a long sub-floor log prefix carries `log_delete_floor = 0` for
+those sequences until retirement certifies them, so the check does not cover
+those legacy holes until the floor catches up.

--- a/bundle-sizes.json
+++ b/bundle-sizes.json
@@ -16,9 +16,9 @@
   "entries": {
     "index.js": {
       "tier": "shipped",
-      "raw": 270000,
-      "gz": 85691,
-      "minGz": 21495,
+      "raw": 273137,
+      "gz": 86180,
+      "minGz": 21494,
       "note": "kernel barrel; every consumer pays. Must not pull the observability subgraph — see the dedicated test."
     },
     "client.js": {
@@ -37,8 +37,8 @@
     },
     "cloudflare.js": {
       "tier": "shipped",
-      "raw": 460140,
-      "gz": 139853,
+      "raw": 463277,
+      "gz": 140419,
       "minGz": 45437,
       "note": "Worker isolate cold start. Aggregator: closure includes the index.js and http.js subgraphs, so growth that slips past those entries still surfaces here."
     },
@@ -58,8 +58,8 @@
     },
     "http.js": {
       "tier": "shipped",
-      "raw": 395429,
-      "gz": 119154,
+      "raw": 396517,
+      "gz": 119353,
       "minGz": 37921,
       "note": "server-side. Also inside the cloudflare.js closure, so growth here shows up on that entry too."
     },
@@ -102,12 +102,12 @@
     },
     "node.js": {
       "tier": "tooling",
-      "raw": 625891,
+      "raw": 629028,
       "note": "server-only aggregator. Raw-only dep-creep tripwire; live-external-import creep is caught separately by the bare-specifier allowlist test."
     },
     "dev-vite.js": {
       "tier": "tooling",
-      "raw": 634804,
+      "raw": 637941,
       "note": "dev-only aggregator. Raw-only dep-creep tripwire; see node.js."
     }
   }

--- a/bundle-sizes.json
+++ b/bundle-sizes.json
@@ -16,9 +16,9 @@
   "entries": {
     "index.js": {
       "tier": "shipped",
-      "raw": 259465,
-      "gz": 82093,
-      "minGz": 21148,
+      "raw": 270000,
+      "gz": 85691,
+      "minGz": 21495,
       "note": "kernel barrel; every consumer pays. Must not pull the observability subgraph — see the dedicated test."
     },
     "client.js": {
@@ -30,16 +30,16 @@
     },
     "client-react.js": {
       "tier": "shipped",
-      "raw": 33342,
-      "gz": 10692,
+      "raw": 33812,
+      "gz": 10908,
       "minGz": 4276,
       "note": "browser client + React hooks. React itself is external."
     },
     "cloudflare.js": {
       "tier": "shipped",
-      "raw": 448846,
-      "gz": 136111,
-      "minGz": 44947,
+      "raw": 460140,
+      "gz": 139853,
+      "minGz": 45437,
       "note": "Worker isolate cold start. Aggregator: closure includes the index.js and http.js subgraphs, so growth that slips past those entries still surfaces here."
     },
     "s3.js": {
@@ -58,9 +58,9 @@
     },
     "http.js": {
       "tier": "shipped",
-      "raw": 384516,
-      "gz": 115492,
-      "minGz": 37450,
+      "raw": 395429,
+      "gz": 119154,
+      "minGz": 37921,
       "note": "server-side. Also inside the cloudflare.js closure, so growth here shows up on that entry too."
     },
     "auth.js": {
@@ -72,9 +72,9 @@
     },
     "maintenance.js": {
       "tier": "shipped",
-      "raw": 147935,
-      "gz": 45935,
-      "minGz": 12107,
+      "raw": 150416,
+      "gz": 46702,
+      "minGz": 12173,
       "note": "operator-side; reached from the cloudflare.js closure."
     },
     "observability.js": {
@@ -102,12 +102,12 @@
     },
     "node.js": {
       "tier": "tooling",
-      "raw": 612915,
+      "raw": 625891,
       "note": "server-only aggregator. Raw-only dep-creep tripwire; live-external-import creep is caught separately by the bare-specifier allowlist test."
     },
     "dev-vite.js": {
       "tier": "tooling",
-      "raw": 621828,
+      "raw": 634804,
       "note": "dev-only aggregator. Raw-only dep-creep tripwire; see node.js."
     }
   }

--- a/docs/adr/002-ephemeral-coordination.md
+++ b/docs/adr/002-ephemeral-coordination.md
@@ -127,14 +127,12 @@ is a **graduation signal, not silent breakage**.
   a replay filter (invariant 11). The two histories leave byte-identical durable
   state and demand opposite outcomes, so re-probing silently re-applies a folded
   mutation — clobbering a concurrent newer value, minting a second `lsn` for one
-  logical mutation, and emitting it twice on `/v1/since`. What is planned
-  instead — **not yet implemented** — is an explicit failure keyed on the
-  certified delete floor: a winning create at
-  `seq < min(log_delete_floor, log_seq_start)` throws
-  `BaerlyError{code:"AmbiguousCommit"}`. That would make the write contract
+  logical mutation, and emitting it twice on `/v1/since`. What ships
+  instead is an explicit failure keyed on the certified delete floor: a winning
+  create at `seq < min(log_delete_floor, log_seq_start)` throws
+  `BaerlyError{code:"AmbiguousCommit"}`. That makes the write contract
   at-least-once under this fault, which is a stated contract rather than a silent
-  wrong answer. Until it lands, the schedule above is open: such a create is
-  acknowledged. A pre-create re-read closes neither schedule — a GET cannot
+  wrong answer. A pre-create re-read closes neither schedule — a GET cannot
   constrain a later PUT to a different key, and the lost-ack arm must not re-read
   at all without breaking own-session adoption.
 

--- a/docs/contributing/conventions/observability.md
+++ b/docs/contributing/conventions/observability.md
@@ -154,6 +154,22 @@ The load-bearing kernel metrics today (canonical list in
   CI-gated check).
 - `db.write.index_ops_per_logical_write` — writer histogram
   (`K (PUT) + L (DELETE)` per commit, per-collection label).
+- `db.write.ambiguous_commit_total` — writer counter, labelled by
+  `collection` and `cleanup` (`deleted` / `failed`). A committing create
+  won at a sequence already certified deleted, so the commit failed with
+  `AmbiguousCommit` rather than acknowledging a mutation whose visibility
+  cannot be determined.
+  `cleanup` reports whether the phantom log object was reclaimed. Any
+  sustained rate means writers are pausing across a fold plus a
+  retirement pass. A `failed` rate leaves sub-floor objects behind that
+  GC's `stale-log` arm still reclaims today; they become permanent leaks
+  only once PR 5 replaces that arm with computed-range retirement.
+- `db.write.delete_floor_check_skipped_total` — writer counter, labelled
+  by `collection`. The post-create re-read of `current.json` inside
+  `Writer#assertCommitAboveDeleteFloor` failed with a non-abort error, so
+  the delete-floor check was skipped for that commit instead of
+  evaluated. A sustained rate means the check is not covering the writes
+  it exists to protect, even though no individual commit is rejected.
 - `db.r2.put.412_total` — CAS conflict / `If-Match` / `If-None-Match`
   loss counter.
 - `db.r2.put.429_total` — R2 prefix-partition rate-limit counter.

--- a/docs/spec/causal-consistency-checking.md
+++ b/docs/spec/causal-consistency-checking.md
@@ -303,7 +303,7 @@ dependent, so replay is not fully deterministic.)
 ## Deterministic delete-floor coverage
 
 The optional `current.json.log_delete_floor` safety envelope is covered by
-deterministic protocol, reader-seam, and restore tests:
+deterministic protocol, reader-seam, restore, and commit-path tests:
 
 - optional-field shape and the absent-to-`0` default;
 - transition monotonicity for both `log_seq_start` and
@@ -321,11 +321,37 @@ deterministic protocol, reader-seam, and restore tests:
   aborts the pass with `Conflict` and zero DELETEs; and a rival that
   legally advances `log_delete_floor` in that same gap, after which the
   pass deletes the range its own CAS validated rather than the wider
-  advisory gate; and
+  advisory gate;
 - the deletion/publication crash schedule: a crash mid-DELETE-loop
   leaves the undeleted remainder physically present but already
   certified deleted by the advanced floor — the deliberate fail-safe
-  direction, a leak rather than corruption.
+  direction, a leak rather than corruption; and
+- the commit-path rejection that keys on the same clamped floor
+  (`Writer#assertCommitAboveDeleteFloor`,
+  `packages/server/src/writer.ts`, exercised by
+  `packages/server/src/log-retirement-aba.test.ts`): a create that resolved
+  below `min(log_delete_floor, log_seq_start)` fails with a non-retriable
+  `AmbiguousCommit` because the log object it wrote sits beneath every reader's
+  floor, which does not prove the logical mutation is invisible, under the two
+  schedules that reach it — a create PUT delayed across a fold plus a drained
+  retirement pass, and a lost-ack retry of the same `seq` across the same —
+  with the phantom log object DELETEd best-effort and each rejection counted on
+  `db.write.ambiguous_commit_total`, whose `cleanup` label reports that DELETE
+  and whose failure arm never masks the throw; the check itself sits after both
+  the fresh-win and the own-session-adoption break in the commit loop, so
+  neither path can acknowledge such a commit; the over-rejection guards on the
+  other side of it, namely a commit at the live tail of a collection that now
+  carries a positive floor, the merely-folded band (`log_seq_start` advanced,
+  `log_delete_floor` still absent and so decoding to `0`) which is accepted
+  rather than rejected, and an out-of-bound stored floor which is clamped to
+  `min(log_delete_floor, log_seq_start)` rather than trusted; the one
+  over-rejection that is deliberately accepted, a create folded *and* retired
+  before the post-create read, whose mutation is visible through the snapshot
+  and whose commit fails anyway; and the two-history result that argues for
+  explicit failure over discard-and-re-probe — every object in the bucket at
+  the retry decision point is byte-identical whether the writer's own create
+  or a foreign writer's landed and was folded, and no surviving object names
+  the writer's session.
 
 `retireLogRange` is the first pass to write `log_delete_floor`. It is not
 yet wired into a write-tick call site, so no deletion pass runs in

--- a/docs/spec/sync-protocol.md
+++ b/docs/spec/sync-protocol.md
@@ -516,7 +516,22 @@ These are the load-bearing rules.
    apart. The seams clamp the effective delete floor to
    `min(log_delete_floor, log_seq_start)` rather than trusting the stored
    value — see invariant 12 for why an out-of-bound value is readable at
-   all.
+   all. The commit path checks the same clamped floor. After the
+   committing `log/<seq>` create resolves — on both the fresh-win and the
+   own-session-adoption paths — the writer re-reads `current.json`, and a
+   `seq` below `min(log_delete_floor, log_seq_start)` fails the commit with
+   `BaerlyError{code:"AmbiguousCommit"}`. A winning create means the slot
+   was empty immediately before the PUT, so a sub-floor `seq` proves the
+   object it wrote is beneath every reader's floor. It does **not** prove
+   the logical mutation is invisible: a create that landed live and was
+   then folded *and* retired reads identically here, and is rejected too.
+   That over-rejection is the accepted safe direction. The band
+   `log_delete_floor <= seq < log_seq_start` is **not** a failure — not
+   because it is provably safe, but because it is undecidable the same
+   way (a fold absorbs our own earlier attempt and a foreign entry
+   identically, keeping no writer identity) and rejecting it would fail
+   every ordinary post-fold commit. The invisible half of that band is
+   the residual invariant 14 records.
 6. **`current.json` is compaction state; the commit path does not write
    it.** The compactor's fold CAS is the only steady-state writer of
    the snapshot pointer, `log_seq_start`, and snapshot counters.
@@ -605,6 +620,24 @@ These are the load-bearing rules.
     that unchecked raw PUT could persist
     `log_delete_floor > log_seq_start`. Dropping it resets the new
     generation to no deleted prefix certified.
+
+    The retention window between the two floors
+    (`LOG_RETENTION_SEQ_WINDOW`) is a pre-image cost margin and a rate limit
+    on how fast retirement approaches the live floor. It is **not** a
+    paused-writer fence and no safety property may be derived from it: it
+    bounds no wall-clock and no commit count, so a delayed create PUT, an
+    isolate suspension, or a writer's own transient-retry loop can each
+    straddle an unbounded number of peer commits and folds. What closes that
+    schedule is the commit-path check in invariant 5, which fails rather than
+    acknowledging an invisible mutation.
+
+    The consequence for the write contract is stated rather than hidden: under
+    this fault a commit is **at-least-once**, not exactly-once. The writer
+    cannot determine whether an earlier attempt of its own landed and was
+    folded before retirement removed the slot — the fold keeps no writer
+    identity, so the two histories leave identical durable state (invariant
+    11). Retrying is the intended recovery and may apply the mutation twice.
+
 13. **A `/v1/since` cursor is valid only within the generation that
     minted it.** `current.json` carries an opaque `generation` nonce,
     and the cursor the server hands a long-poll client is
@@ -696,6 +729,16 @@ These are the load-bearing rules.
     that observes it. The consequence is that the grace stops bounding
     anything, and the sweep-time revalidation above becomes the only
     check standing between a mark and its DELETE.
+
+    **The same limitation reaches the log arm, and only PR 5 removes it.**
+    `runGc`'s `stale-log` sweep deletes sub-floor log objects **without**
+    advancing `log_delete_floor`, so a create that re-fills a GC-swept hole is
+    not caught by the commit-path check in invariant 5 — that check keys on the
+    certified floor, and GC certifies nothing. On a node clocked far enough
+    ahead the grace collapses to zero and the window is unbounded. Replacing
+    stale-log discovery with computed-range retirement, which CASes the floor
+    before it deletes, is what closes it; until then the exposure is the
+    pre-existing one this invariant already describes.
 
     **Known limitation: the revalidation is only as fresh as the
     freshest manifest the pass already holds.** `runGc` reads

--- a/packages/protocol/src/collection-api.ts
+++ b/packages/protocol/src/collection-api.ts
@@ -106,6 +106,10 @@ export interface Collection<T extends DocumentData = DocumentData> {
    *
    * @throws BaerlyError{code: "Conflict"} — `_id` collision on
    *         caller-supplied id.
+   * @throws BaerlyError{code: "AmbiguousCommit"} — the committing
+   *         create landed below the collection's certified delete
+   *         floor, so the row may or may not have been inserted.
+   *         Not retriable-by-default; handle the code explicitly.
    * @throws BaerlyError{code: "SchemaError"} — malformed JSON, or
    *         schema-validation failure (when a schema is declared
    *         for the collection via `Db.create({ collections })`).
@@ -127,6 +131,10 @@ export interface Collection<T extends DocumentData = DocumentData> {
    *
    * @throws BaerlyError{code: "Conflict"} — concurrent write lost
    *         the CAS race. Caller's choice whether to retry.
+   * @throws BaerlyError{code: "AmbiguousCommit"} — the committing
+   *         create landed below the collection's certified delete
+   *         floor, so the update may or may not have been applied.
+   *         Not retriable-by-default; handle the code explicitly.
    * @throws BaerlyError{code: "SchemaError"} — patch produced an
    *         invalid doc.
    *
@@ -142,6 +150,11 @@ export interface Collection<T extends DocumentData = DocumentData> {
    * Whole-document replace on one row by primary key. Throws
    * `BaerlyError{code:"NotFound"}` when no row exists at `id`.
    *
+   * @throws BaerlyError{code: "AmbiguousCommit"} — the committing
+   *         create landed below the collection's certified delete
+   *         floor, so the replace may or may not have been applied.
+   *         Not retriable-by-default; handle the code explicitly.
+   *
    * @example
    * ```ts
    * await db.collection("tickets")
@@ -154,6 +167,12 @@ export interface Collection<T extends DocumentData = DocumentData> {
    * Delete one row by primary key. Returns `{ deleted: 0 }` when the
    * id is unknown rather than throwing. For predicate-aware bulk
    * delete, use `.where(predicate).delete()` on {@link Query}.
+   *
+   * @throws BaerlyError{code: "AmbiguousCommit"} — the committing
+   *         create landed below the collection's certified delete
+   *         floor, so the tombstone may or may not have been
+   *         applied. Not retriable-by-default; handle the code
+   *         explicitly.
    *
    * @example
    * ```ts
@@ -391,6 +410,12 @@ export interface Query<T extends DocumentData = DocumentData> {
    *
    * @throws BaerlyError{code: "Conflict"} — concurrent write lost
    *         the CAS race. Caller's choice whether to retry.
+   * @throws BaerlyError{code: "AmbiguousCommit"} — one row's
+   *         committing create landed below the collection's
+   *         certified delete floor. Rows before it in the batch are
+   *         already applied and that row's own fate is unknown; the
+   *         partial-progress `modified` count is NOT returned, so a
+   *         caller that needs to resume must re-read.
    * @throws BaerlyError{code: "SchemaError"} — patch produced an
    *         invalid doc.
    *
@@ -406,6 +431,12 @@ export interface Query<T extends DocumentData = DocumentData> {
   /**
    * Predicate-aware bulk delete: every matching document. For the
    * single-row case prefer {@link Collection.delete}(id).
+   *
+   * @throws BaerlyError{code: "AmbiguousCommit"} — one row's
+   *         committing create landed below the collection's
+   *         certified delete floor. Rows before it in the batch are
+   *         already tombstoned and that row's own fate is unknown;
+   *         the partial-progress `deleted` count is NOT returned.
    *
    * @example
    * ```ts

--- a/packages/protocol/src/constants.ts
+++ b/packages/protocol/src/constants.ts
@@ -188,16 +188,20 @@ export const LOG_FORWARD_PROBE_CAP: number = 100_000;
  * (`docs/spec/scale-ceilings.md` §Per-tier bounds); R2 binding ops count
  * 1:1, and a `ctx.waitUntil` maintenance continuation draws on the
  * same per-invocation budget. One `op:"U"` commit on a single-index
- * collection already costs ~14 before this walk — 1 GET
+ * collection already costs ~15 before this walk — 1 GET
  * `current.json`, ~10 sequential GETs for `findLogTail`'s gallop over
  * a one-fold-interval `tail_hint` lag, 1 index `newKey` PUT, the
- * `log/<seq>` create, 1 stale-key DELETE — and the
+ * `log/<seq>` create, 1 GET re-reading `current.json` after that create
+ * resolves to reject a create that landed below the certified delete floor
+ * (`Writer#assertCommitAboveDeleteFloor`), 1 stale-key DELETE — and the
  * write-tick fold branch it may dispatch costs ~26 more (1 runner GET
  * + `compact()`'s 3 + {@link WRITE_TICK_FOLD_ENTRIES_PER_PASS} log
- * GETs + 2 PUTs). `50 - 14 - 26 = 10`; `PREIMAGE_SCAN_MAX_GETS = 8`
- * leaves two spare subrequests. The walk is strictly SEQUENTIAL, so this is a hard
- * per-request cost, not a fan-out bound like
- * {@link MAX_PARALLEL_LOG_READS}.
+ * GETs + 2 PUTs). `50 - 15 - 26 = 9`; `PREIMAGE_SCAN_MAX_GETS = 8`
+ * leaves one spare subrequest. The post-create delete-floor re-read adds no
+ * billable cost — `billableClassAOps = puts + lists` excludes GET — but it
+ * does consume the subrequest headroom, so this budget cannot rise without
+ * re-deriving the total. The walk is strictly SEQUENTIAL, so this is a hard
+ * per-request cost, not a fan-out bound like {@link MAX_PARALLEL_LOG_READS}.
  *
  * **What that budget actually covers.** The pre-image sits roughly
  * one working-set of seqs back, so 8 reaches a doc rewritten within
@@ -243,15 +247,16 @@ export const PREIMAGE_SCAN_MAX_GETS: number = 8;
  * cost grounds costs pre-image coverage and retirement smoothness; it does not
  * weaken a safety proof, because there was never one here.
  *
- * Withdrawing the claim leaves the stale-writer schedule **open**. Nothing on
- * the commit path compares the committing `seq` against the certified
- * `log_delete_floor` today, so a create that wins below the floor is
- * acknowledged as a successful mutation that no reader can see. The planned
- * replacement is a commit-path check that fails such a create with
- * `BaerlyError{code:"AmbiguousCommit"}` instead of acknowledging it; it is not
- * implemented yet. Do not cite this JSDoc as evidence that the schedule is
- * closed.
+ * Withdrawing the claim does not leave the schedule open, because the commit
+ * path closes it directly. After the committing `log/<seq>` create resolves,
+ * `Writer#assertCommitAboveDeleteFloor` re-reads `current.json` and fails a
+ * create that won at a `seq` below `min(log_delete_floor, log_seq_start)` with
+ * `BaerlyError{code:"AmbiguousCommit"}`, rather than acknowledging a mutation
+ * no reader can see. That check keys on the certified delete floor, not on this
+ * window, which is exactly why the window may keep being a cost margin without
+ * carrying a safety obligation. Do not re-derive a fence from this value.
  *
+ * @see packages/server/src/writer.ts (`Writer#assertCommitAboveDeleteFloor`)
  * @see packages/server/src/log-retention.ts
  * @see docs/spec/sync-protocol.md invariant 12
  * @see docs/adr/002-ephemeral-coordination.md § Closed paths
@@ -277,6 +282,11 @@ export const LOG_RETENTION_SEQ_WINDOW: number = PREIMAGE_SCAN_MAX_GETS * 128;
  *   cannot share a tick with a fold**; the call site has to phase them apart
  *   the way the Cloudflare scheduled handler already alternates compact and
  *   GC.
+ * - The write-tick host request now also spends one `current.json` GET on the
+ *   commit path's certified-delete-floor check, so PR 5's combined arithmetic
+ *   starts one subrequest lower than the scheduled-handler figures above. The
+ *   call site still owes that derivation; nothing here changes the value 20,
+ *   because retirement already cannot share a tick with a fold.
  *
  * A pass whose range is empty returns `{deleted: 0}` and spends 1 GET, so a
  * permanently-stalled retirement is silent — the call site also owes an

--- a/packages/protocol/src/coordination/current-json.ts
+++ b/packages/protocol/src/coordination/current-json.ts
@@ -588,6 +588,18 @@ export const logSeqStartOf = (c: CurrentJson): number => c.log_seq_start;
  */
 export const logDeleteFloorOf = (c: CurrentJson): number => c.log_delete_floor ?? 0;
 
+/**
+ * The certified delete floor: `log_delete_floor` clamped down to
+ * `log_seq_start`. Every consumer of "is `seq` reclaimed" must go through
+ * this clamp rather than trusting the raw stored field — invariant 12
+ * (`docs/spec/sync-protocol.md`) allows an out-of-bound stored floor to be
+ * readable off disk (the single-state read guard deliberately doesn't
+ * reject it, so `admin restore` stays repairable), and an unclamped floor
+ * would report a still-live entry as already deleted.
+ */
+export const certifiedDeleteFloor = (c: CurrentJson): number =>
+  Math.min(logDeleteFloorOf(c), logSeqStartOf(c));
+
 // ---------------------------------------------------------------------
 // Internals
 // ---------------------------------------------------------------------

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -9,6 +9,7 @@ export {
   type WriterFence,
   assertCurrentJsonTransition,
   casUpdateCurrentJson,
+  certifiedDeleteFloor,
   createCurrentJson,
   logDeleteFloorOf,
   logSeqStartOf,

--- a/packages/protocol/src/metrics.ts
+++ b/packages/protocol/src/metrics.ts
@@ -1,5 +1,5 @@
 /**
- * `MetricsRecorder` — internal emission contract for the six
+ * `MetricsRecorder` — internal emission contract for the twelve
  * load-bearing kernel metrics. Writer / compactor / GC emit through
  * an instance of this interface; in production the instance is the
  * per-request `RequestScopedMetricsRecorder` on the active
@@ -19,6 +19,22 @@
  *   - `db.r2.put.429_total` — counter (R2 prefix-partition rate-limit)
  *   - `db.write.index_ops_per_logical_write` — histogram.
  *     `K (PUT) + L (DELETE)` per commit. Per-collection label.
+ *   - `db.write.ambiguous_commit_total` — counter, labelled by `collection`
+ *     and `cleanup` (`deleted` / `failed`). A committing create won at a
+ *     sequence already certified deleted, so the commit failed with
+ *     `AmbiguousCommit` rather than acknowledging a mutation whose
+ *     visibility cannot be determined.
+ *     `cleanup` reports whether the phantom log object was reclaimed. Any
+ *     sustained rate means writers are pausing across a fold plus a
+ *     retirement pass; a `failed` rate leaves behind sub-floor objects that
+ *     GC's `stale-log` arm still reclaims today, and that leak permanently
+ *     only once PR 5 replaces that arm with computed-range retirement
+ *   - `db.write.delete_floor_check_skipped_total` — counter, labelled by
+ *     `collection`. The post-create re-read of `current.json` inside
+ *     `Writer#assertCommitAboveDeleteFloor` failed with a non-abort error, so
+ *     the delete-floor check was skipped for that commit rather than
+ *     evaluated. A sustained rate means the check is not covering the writes
+ *     it exists to protect, even though no individual commit is rejected.
  *   - `db.manifest.lag_window_depth` — gauge (alert at >100)
  *   - `db.gc.entries_swept_per_second` — gauge (livelock indicator when <writes/s)
  *   - `db.orphan.candidate_count` — gauge (`gc/pending.json` depth)

--- a/packages/server/src/collection.ts
+++ b/packages/server/src/collection.ts
@@ -84,12 +84,53 @@ export const makeCollection = <T extends DocumentData>(
      *
      * @throws BaerlyError code="Conflict" — `_id` collision (pre-commit
      *   check) or CAS retry budget exhausted.
+     * @throws BaerlyError code="AmbiguousCommit" — the committing create landed
+     *   below the collection's certified delete floor, so the row may or may not
+     *   have been inserted. Not retriable-by-default; see `Writer.commit`.
      * @throws BaerlyError code="SchemaError" — from the per-collection
      *   `SchemaValidator` threaded via {@link Db.collectionReadContext}.
      */
     insert: (doc) => runInsert<T>(ctx, doc),
+    /**
+     * Update the row at `id` by JSON-merge-patch. Forwards to the
+     * predicate-form `runUpdate` through a `byId` wire, so at most one row
+     * is matched.
+     *
+     * @throws BaerlyError code="Conflict" — CAS retry budget exhausted inside
+     *   `Writer.commit()`.
+     * @throws BaerlyError code="AmbiguousCommit" — the committing create landed
+     *   below the collection's certified delete floor, so the update may or may
+     *   not have been applied. Not retriable-by-default; see `Writer.commit`.
+     * @throws BaerlyError code="SchemaError" — merged post-image rejected by the
+     *   collection's bound validator, or `merge(prev, patch)` produced
+     *   `undefined`.
+     */
     update: (id, patch) => makeQuery<T>(ctx, byId(id)).update(patch),
+    /**
+     * Replace the row at `id` wholesale, preserving doc identity.
+     *
+     * @throws BaerlyError code="NotFound" — no row exists at `id`.
+     * @throws BaerlyError code="Conflict" — CAS retry budget exhausted inside
+     *   `Writer.commit()`.
+     * @throws BaerlyError code="AmbiguousCommit" — the committing create landed
+     *   below the collection's certified delete floor, so the replace may or may
+     *   not have been applied. Not retriable-by-default; see `Writer.commit`.
+     * @throws BaerlyError code="SchemaError" — post-image rejected by the
+     *   collection's bound validator.
+     */
     replace: (id, doc) => runReplaceById<T>(ctx, id, doc),
+    /**
+     * Tombstone the row at `id`. Forwards to the predicate-form `runDelete`
+     * through a `byId` wire, so at most one row is matched. A missing row is
+     * not an error — `deleted` is `0`.
+     *
+     * @throws BaerlyError code="Conflict" — CAS retry budget exhausted inside
+     *   `Writer.commit()`.
+     * @throws BaerlyError code="AmbiguousCommit" — the committing create landed
+     *   below the collection's certified delete floor, so the tombstone may or
+     *   may not have been applied. Not retriable-by-default; see
+     *   `Writer.commit`.
+     */
     delete: (id) => makeQuery<T>(ctx, byId(id)).delete(),
   };
 };

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -1,6 +1,7 @@
 import {
   type BaerlyConfig,
   BaerlyError,
+  certifiedDeleteFloor,
   type Collection,
   type CollectionNames,
   type CurrentJson,
@@ -405,7 +406,7 @@ const assertAtOrAboveLogFloor = (seam: string, seq: number, current: CurrentJson
   // arrives here off disk, and unclamped it would report an entry that is
   // present as already deleted.
   const storedDeleteFloor = logDeleteFloorOf(current);
-  const deleteFloor = Math.min(storedDeleteFloor, floor);
+  const deleteFloor = certifiedDeleteFloor(current);
   // `deleteFloor === 0` means no deleted prefix is certified, so this arm
   // has nothing to say and must stay silent: a negative seq against a
   // zero floor is a fold-floor rejection, and claiming its nonexistent

--- a/packages/server/src/log-retention.ts
+++ b/packages/server/src/log-retention.ts
@@ -98,12 +98,12 @@ export interface RetireLogRangeResult {
  * slice permanently below the newly-advanced floor: deliberate, and the
  * fail-safe direction this program picked — leak, never corruption.
  *
- * The writer-side counterpart belongs on the commit path, not here — and it
- * does not exist yet. {@link LOG_RETENTION_SEQ_WINDOW} is a cost margin and a
- * rate limit, never a fence — see its JSDoc. So nothing currently stops a
- * paused or uncertain writer's create from landing in a slot this pass has
- * already retired, and the commit path acknowledges it. Closing that is
- * planned, as a commit-path check that fails such a create with
+ * The writer-side counterpart lives on the commit path, not here.
+ * {@link LOG_RETENTION_SEQ_WINDOW} is a cost margin and a rate limit, never a
+ * fence — see its JSDoc. What stops a paused or uncertain writer's create from
+ * being acknowledged in a slot this pass has already retired is
+ * `Writer#assertCommitAboveDeleteFloor`, which re-reads the manifest after the
+ * committing create resolves and fails a sub-floor `seq` with
  * `BaerlyError{code:"AmbiguousCommit"}`. See
  * `docs/adr/002-ephemeral-coordination.md` § Closed paths for the two
  * approaches that were tried and rejected, and why that check is what remains.

--- a/packages/server/src/log-retention.ts
+++ b/packages/server/src/log-retention.ts
@@ -11,10 +11,10 @@
 import {
   BaerlyError,
   casUpdateCurrentJson,
+  certifiedDeleteFloor,
   type CurrentJson,
   LOG_RETENTION_MAX_DELETES_PER_TICK,
   LOG_RETENTION_SEQ_WINDOW,
-  logDeleteFloorOf,
   logObjectKey,
   logSeqStartOf,
   readCurrentJson,
@@ -35,7 +35,7 @@ export const computeRetirableRange = (
   const window = opts?.window ?? LOG_RETENTION_SEQ_WINDOW;
   const maxDeletes = opts?.maxDeletes ?? LOG_RETENTION_MAX_DELETES_PER_TICK;
   const liveFloor = logSeqStartOf(current);
-  const start = Math.min(logDeleteFloorOf(current), liveFloor);
+  const start = certifiedDeleteFloor(current);
   const boundary = Math.min(liveFloor - window, liveFloor);
   const end = Math.max(start, Math.min(boundary, start + maxDeletes));
   return { start, end };

--- a/packages/server/src/log-retirement-aba.test.ts
+++ b/packages/server/src/log-retirement-aba.test.ts
@@ -1,0 +1,759 @@
+/**
+ * The pin-4 contract: a commit never acknowledges a mutation no fresh reader
+ * can see.
+ *
+ * Two schedules put a winning `log/<seq>` create into a slot that fold +
+ * retirement already emptied — a delayed create PUT (T1) and a lost-ack retry
+ * of the same seq (T2). Both must fail with `AmbiguousCommit` rather than
+ * returning success. Everything runs against the real `Writer`, `compact()`,
+ * and `retireLogRange`; visibility is checked through a fresh `Db`.
+ */
+
+import {
+  BaerlyError,
+  createCurrentJson,
+  decodeJsonBytes,
+  encodeJsonBytes,
+  type LogEntry,
+  LOG_RETENTION_SEQ_WINDOW,
+  logObjectKey,
+  MemoryStorage,
+  readCurrentJson,
+  type Storage,
+} from "@baerly/protocol";
+import { describe, expect, test } from "vitest";
+import {
+  logStateCurrentJson,
+  seedLogEntries,
+  seedLogEntry,
+} from "../../../tests/fixtures/log-state.ts";
+import { compact } from "./compactor.ts";
+import { Db } from "./db.ts";
+import { retireLogRange } from "./log-retention.ts";
+import {
+  createObservabilityContext,
+  type ObservabilityContext,
+  runWithContext,
+} from "./observability/index.ts";
+import { Writer } from "./writer.ts";
+
+const sumCounter = (ctx: ObservabilityContext, name: string): number =>
+  ctx.recorder
+    .snapshot()
+    .counters.filter((c) => c.name === name)
+    .reduce((acc, c) => acc + c.value, 0);
+
+const CURRENT_KEY = "app/a/tenant/t/manifests/c/current.json";
+const PREFIX = "app/a/tenant/t/manifests/c";
+const DOC_ID = "paused-writer-doc";
+const DOC_BODY = { _id: DOC_ID, source: "paused-writer" } as const;
+
+/** Filler occupies `[1, FILLER_END)`; slot 0 is the contended one. */
+const FILLER_END = LOG_RETENTION_SEQ_WINDOW + 1;
+
+const MAINTENANCE_OFF = createObservabilityContext({ maintenance: { disabled: true } });
+
+const seedManifest = async (storage: Storage): Promise<void> => {
+  await createCurrentJson(storage, CURRENT_KEY, logStateCurrentJson());
+};
+
+/**
+ * Occupy `[1, FILLER_END)`, fold `[0, FILLER_END)`, then drain retirement.
+ * Requires slot 0 to already be occupied — the live range must be dense for
+ * the fold to advance the floor.
+ */
+const advanceFloorAndRetire = async (storage: Storage): Promise<void> => {
+  await seedLogEntries(storage, PREFIX, 1, FILLER_END);
+  const folded = await compact(
+    { storage, currentJsonKey: CURRENT_KEY },
+    { minEntriesToCompact: 1 },
+  );
+  expect(folded).toMatchObject({ written: true, logSeqStartAfter: FILLER_END });
+  for (;;) {
+    const { deleted } = await retireLogRange(storage, CURRENT_KEY);
+    if (deleted === 0) {
+      break;
+    }
+  }
+  const after = await readCurrentJson(storage, CURRENT_KEY);
+  expect(after?.json.log_seq_start).toBe(FILLER_END);
+  expect(after?.json.log_delete_floor).toBe(FILLER_END - LOG_RETENTION_SEQ_WINDOW);
+  await expect(storage.get(logObjectKey(PREFIX, 0))).resolves.toBeNull();
+};
+
+/** Every key/body in the bucket, sorted — the state a recovery predicate could consult. */
+const dumpBucket = async (storage: Storage): Promise<Array<[string, string]>> => {
+  const keys: string[] = [];
+  for await (const entry of storage.list("app/")) {
+    keys.push(entry.key);
+  }
+  const out: Array<[string, string]> = [];
+  for (const key of keys.toSorted()) {
+    const got = await storage.get(key);
+    out.push([key, new TextDecoder().decode(got!.body)]);
+  }
+  return out;
+};
+
+/** Wrap `inner` so the first PUT of `gatedKey` blocks until released. */
+const gatedPutStorage = (
+  inner: Storage,
+  gatedKey: string,
+  behavior: "delay" | "fail",
+): { storage: Storage; reached: Promise<void>; release: () => void } => {
+  let signalReached!: () => void;
+  const reached = new Promise<void>((r) => {
+    signalReached = r;
+  });
+  let signalReleased!: () => void;
+  const released = new Promise<void>((r) => {
+    signalReleased = r;
+  });
+  let firstPut = true;
+  const storage: Storage = {
+    get: (key, opts) => inner.get(key, opts),
+    list: (prefix, opts) => inner.list(prefix, opts),
+    delete: (key, opts) => inner.delete(key, opts),
+    async put(key, body, opts) {
+      if (key === gatedKey && firstPut) {
+        firstPut = false;
+        signalReached();
+        await released;
+        if (behavior === "fail") {
+          throw new BaerlyError("NetworkError", "test: simulated dropped ack on the log create");
+        }
+      }
+      return inner.put(key, body, opts);
+    },
+  };
+  return { storage, reached, release: signalReleased };
+};
+
+/** Wrap `inner` so DELETE of `failKey` always rejects. Everything else passes through. */
+const withFailingDelete = (inner: Storage, failKey: string): Storage => ({
+  get: (key, opts) => inner.get(key, opts),
+  list: (prefix, opts) => inner.list(prefix, opts),
+  put: (key, body, opts) => inner.put(key, body, opts),
+  async delete(key, opts) {
+    if (key === failKey) {
+      throw new BaerlyError(
+        "NetworkError",
+        "test: simulated failure deleting the phantom log object",
+      );
+    }
+    return inner.delete(key, opts);
+  },
+});
+
+describe("log retirement vs. the numbered-log create", () => {
+  test("T1: a create PUT delayed across fold+retirement fails AmbiguousCommit", async () => {
+    const inner = new MemoryStorage();
+    await seedManifest(inner);
+    const gate = gatedPutStorage(inner, logObjectKey(PREFIX, 0), "delay");
+
+    const pausedCommit = runWithContext(MAINTENANCE_OFF, () =>
+      new Writer({ storage: gate.storage, currentJsonKey: CURRENT_KEY }).commit({
+        op: "I",
+        collection: "c",
+        docId: DOC_ID,
+        body: { ...DOC_BODY },
+      }),
+    );
+
+    await gate.reached;
+    await seedLogEntry(inner, PREFIX, 0, { doc_id: "peer-doc", after: { _id: "peer-doc" } });
+    await advanceFloorAndRetire(inner);
+    gate.release();
+
+    await expect(pausedCommit).rejects.toMatchObject({ code: "AmbiguousCommit" });
+    const visible = await Db.create({ storage: inner, app: "a", tenant: "t" })
+      .collection("c")
+      .get(DOC_ID);
+    expect(visible, "a failed commit must leave no half-visible row").toBeUndefined();
+    await expect(
+      inner.get(logObjectKey(PREFIX, 0)),
+      "the phantom object is cleaned up best-effort",
+    ).resolves.toBeNull();
+  });
+
+  test("T2: a lost-ack retry of the same seq across fold+retirement fails AmbiguousCommit", async () => {
+    const inner = new MemoryStorage();
+    await seedManifest(inner);
+    const gate = gatedPutStorage(inner, logObjectKey(PREFIX, 0), "fail");
+
+    const pausedCommit = runWithContext(MAINTENANCE_OFF, () =>
+      new Writer({ storage: gate.storage, currentJsonKey: CURRENT_KEY }).commit({
+        op: "I",
+        collection: "c",
+        docId: DOC_ID,
+        body: { ...DOC_BODY },
+      }),
+    );
+
+    await gate.reached;
+    await seedLogEntry(inner, PREFIX, 0, { doc_id: "peer-doc", after: { _id: "peer-doc" } });
+    await advanceFloorAndRetire(inner);
+    gate.release();
+
+    await expect(pausedCommit).rejects.toMatchObject({ code: "AmbiguousCommit" });
+    const visible = await Db.create({ storage: inner, app: "a", tenant: "t" })
+      .collection("c")
+      .get(DOC_ID);
+    expect(visible).toBeUndefined();
+  });
+
+  test("the ambiguous failure is not retriable", async () => {
+    const inner = new MemoryStorage();
+    await seedManifest(inner);
+    const gate = gatedPutStorage(inner, logObjectKey(PREFIX, 0), "delay");
+
+    const pausedCommit = runWithContext(MAINTENANCE_OFF, () =>
+      new Writer({ storage: gate.storage, currentJsonKey: CURRENT_KEY }).commit({
+        op: "I",
+        collection: "c",
+        docId: DOC_ID,
+        body: { ...DOC_BODY },
+      }),
+    );
+    await gate.reached;
+    await seedLogEntry(inner, PREFIX, 0, { doc_id: "peer-doc", after: { _id: "peer-doc" } });
+    await advanceFloorAndRetire(inner);
+    gate.release();
+
+    await expect(pausedCommit).rejects.toMatchObject({
+      code: "AmbiguousCommit",
+      retriable: false,
+    });
+  });
+
+  test('a rejected commit records db.write.ambiguous_commit_total with cleanup="deleted"', async () => {
+    const inner = new MemoryStorage();
+    await seedManifest(inner);
+    const gate = gatedPutStorage(inner, logObjectKey(PREFIX, 0), "delay");
+    const ctx = createObservabilityContext({ maintenance: { disabled: true } });
+
+    const pausedCommit = runWithContext(ctx, () =>
+      new Writer({ storage: gate.storage, currentJsonKey: CURRENT_KEY }).commit({
+        op: "I",
+        collection: "c",
+        docId: DOC_ID,
+        body: { ...DOC_BODY },
+      }),
+    );
+
+    await gate.reached;
+    await seedLogEntry(inner, PREFIX, 0, { doc_id: "peer-doc", after: { _id: "peer-doc" } });
+    await advanceFloorAndRetire(inner);
+    gate.release();
+
+    await expect(pausedCommit).rejects.toMatchObject({ code: "AmbiguousCommit" });
+    expect(sumCounter(ctx, "db.write.ambiguous_commit_total")).toBe(1);
+    const counter = ctx.recorder
+      .snapshot()
+      .counters.find((c) => c.name === "db.write.ambiguous_commit_total");
+    expect(counter?.labels).toEqual({ collection: "c", cleanup: "deleted" });
+  });
+
+  test("a commit on a collection with a positive delete floor still succeeds at the live tail", async () => {
+    const inner = new MemoryStorage();
+    await seedManifest(inner);
+
+    // Land a real commit at the live tail, with maintenance off.
+    const committed = await runWithContext(MAINTENANCE_OFF, () =>
+      new Writer({ storage: inner, currentJsonKey: CURRENT_KEY }).commit({
+        op: "I",
+        collection: "c",
+        docId: DOC_ID,
+        body: { ...DOC_BODY },
+      }),
+    );
+    expect(committed.entry.seq).toBe(0);
+
+    // Fold past it and retire as far as the window allows. At
+    // LOG_RETENTION_SEQ_WINDOW = 1024 and FILLER_END = 1025 this publishes
+    // log_delete_floor = 1, so seq 0 ends up below the floor, not inside
+    // some "merely folded" band — there is no such band once retirement has
+    // run this far. The point of this test is the *next* commit.
+    await advanceFloorAndRetire(inner);
+    const after = await readCurrentJson(inner, CURRENT_KEY);
+    expect(after?.json.log_delete_floor).toBe(FILLER_END - LOG_RETENTION_SEQ_WINDOW);
+    expect(after?.json.log_seq_start).toBe(FILLER_END);
+
+    // A NEW commit on the same collection must not be rejected merely because
+    // the collection now has a positive delete floor.
+    const next = await runWithContext(MAINTENANCE_OFF, () =>
+      new Writer({ storage: inner, currentJsonKey: CURRENT_KEY }).commit({
+        op: "I",
+        collection: "c",
+        docId: "second-doc",
+        body: { _id: "second-doc" },
+      }),
+    );
+    expect(next.entry.seq).toBeGreaterThanOrEqual(FILLER_END);
+    const visible = await Db.create({ storage: inner, app: "a", tenant: "t" })
+      .collection("c")
+      .get("second-doc");
+    expect(visible).toEqual({ _id: "second-doc" });
+  });
+
+  test("a commit whose entry is folded but not yet retired still succeeds (regression: a bare logSeqStartOf(...) floor would reject this)", async () => {
+    const inner = new MemoryStorage();
+    await seedManifest(inner);
+
+    let signalReached!: () => void;
+    const reached = new Promise<void>((r) => {
+      signalReached = r;
+    });
+    let signalReleased!: () => void;
+    const released = new Promise<void>((r) => {
+      signalReleased = r;
+    });
+    let slotZeroLanded = false;
+    let gatedOnce = false;
+
+    const storage: Storage = {
+      list: (prefix, opts) => inner.list(prefix, opts),
+      delete: (key, opts) => inner.delete(key, opts),
+      async put(key, body, opts) {
+        const res = await inner.put(key, body, opts);
+        if (key === logObjectKey(PREFIX, 0)) {
+          slotZeroLanded = true;
+        }
+        return res;
+      },
+      async get(key, opts) {
+        // Stall the post-create manifest read only.
+        if (key === CURRENT_KEY && slotZeroLanded && !gatedOnce) {
+          gatedOnce = true;
+          signalReached();
+          await released;
+        }
+        return inner.get(key, opts);
+      },
+    };
+
+    const commit = runWithContext(MAINTENANCE_OFF, () =>
+      new Writer({ storage, currentJsonKey: CURRENT_KEY }).commit({
+        op: "I",
+        collection: "c",
+        docId: DOC_ID,
+        body: { ...DOC_BODY },
+      }),
+    );
+
+    await reached;
+    // Fold only — do NOT retire. `log_seq_start` advances to `FILLER_END`
+    // while `log_delete_floor` stays 0.
+    await seedLogEntries(inner, PREFIX, 1, FILLER_END);
+    const folded = await compact(
+      { storage: inner, currentJsonKey: CURRENT_KEY },
+      { minEntriesToCompact: 1 },
+    );
+    expect(folded).toMatchObject({ written: true, logSeqStartAfter: FILLER_END });
+    const midpoint = await readCurrentJson(inner, CURRENT_KEY);
+    expect(midpoint?.json.log_seq_start).toBe(FILLER_END);
+    // `log_delete_floor` is absent (never set), which decodes to 0 via
+    // logDeleteFloorOf — not literally the number 0 on disk.
+    expect(midpoint?.json.log_delete_floor).toBeUndefined();
+    signalReleased();
+
+    // The correct check computes min(0, FILLER_END) = 0 and hits the
+    // "no deleted prefix certified" silent arm, so the commit lands. A
+    // mutant that drops the `Math.min` against `storedDeleteFloor` and
+    // reads a bare `logSeqStartOf(...)` would compute FILLER_END, see
+    // seq 0 below it, and wrongly throw AmbiguousCommit here — that is
+    // exactly the over-broad "reject anything sub-floor" behavior this
+    // check must not have.
+    await expect(commit).resolves.toMatchObject({ entry: { seq: 0 } });
+    const visible = await Db.create({ storage: inner, app: "a", tenant: "t" })
+      .collection("c")
+      .get(DOC_ID);
+    expect(visible).toEqual({ ...DOC_BODY });
+  });
+
+  test("an out-of-bound stored delete floor is clamped, not trusted", async () => {
+    const inner = new MemoryStorage();
+    // log_delete_floor > log_seq_start is readable off disk: the bound is
+    // transition-scoped and assertCurrentJson checks shape only (invariant 12).
+    await createCurrentJson(
+      inner,
+      CURRENT_KEY,
+      logStateCurrentJson({ log_seq_start: 0, tail_hint: 0, log_delete_floor: 500 }),
+    );
+
+    // Clamped to min(500, 0) === 0, so the arm is silent and the commit lands.
+    const committed = await runWithContext(MAINTENANCE_OFF, () =>
+      new Writer({ storage: inner, currentJsonKey: CURRENT_KEY }).commit({
+        op: "I",
+        collection: "c",
+        docId: DOC_ID,
+        body: { ...DOC_BODY },
+      }),
+    );
+    expect(committed.entry.seq).toBe(0);
+    const visible = await Db.create({ storage: inner, app: "a", tenant: "t" })
+      .collection("c")
+      .get(DOC_ID);
+    expect(visible).toEqual({ ...DOC_BODY });
+  });
+
+  test("a failed post-create manifest read skips the check instead of failing the commit", async () => {
+    const inner = new MemoryStorage();
+    await seedManifest(inner);
+
+    let slotZeroLanded = false;
+    let faultFired = false;
+
+    const storage: Storage = {
+      list: (prefix, opts) => inner.list(prefix, opts),
+      delete: (key, opts) => inner.delete(key, opts),
+      async put(key, body, opts) {
+        const res = await inner.put(key, body, opts);
+        if (key === logObjectKey(PREFIX, 0)) {
+          slotZeroLanded = true;
+        }
+        return res;
+      },
+      async get(key, opts) {
+        // Fail the POST-CREATE manifest read only. Step 1's read happens
+        // before slot 0 lands, so it passes through — gating on
+        // `slotZeroLanded` is what makes this exercise the floor check's own
+        // read rather than aborting the commit before it ever gets there.
+        if (key === CURRENT_KEY && slotZeroLanded && !faultFired) {
+          faultFired = true;
+          throw new BaerlyError(
+            "NetworkError",
+            "test: simulated failure reading current.json after the committing create",
+          );
+        }
+        return inner.get(key, opts);
+      },
+    };
+
+    // The create IS the commit. A post-commit safety-net read that blips must
+    // not convert a durable write into a caller-visible failure — least of all
+    // into a `retriable: true` one a generic wrapper would re-run at a fresh
+    // tail, duplicating the mutation.
+    const committed = await runWithContext(MAINTENANCE_OFF, () =>
+      new Writer({ storage, currentJsonKey: CURRENT_KEY }).commit({
+        op: "I",
+        collection: "c",
+        docId: DOC_ID,
+        body: { ...DOC_BODY },
+      }),
+    );
+    expect(faultFired, "the injected read fault must actually have fired").toBe(true);
+    expect(committed.entry.seq).toBe(0);
+
+    const visible = await Db.create({ storage: inner, app: "a", tenant: "t" })
+      .collection("c")
+      .get(DOC_ID);
+    expect(visible, "the committed row is visible to a fresh reader").toEqual({ ...DOC_BODY });
+  });
+
+  test("an aborted post-create manifest read propagates instead of being swallowed", async () => {
+    const inner = new MemoryStorage();
+    await seedManifest(inner);
+
+    let slotZeroLanded = false;
+    let faultFired = false;
+
+    const storage: Storage = {
+      list: (prefix, opts) => inner.list(prefix, opts),
+      delete: (key, opts) => inner.delete(key, opts),
+      async put(key, body, opts) {
+        const res = await inner.put(key, body, opts);
+        if (key === logObjectKey(PREFIX, 0)) {
+          slotZeroLanded = true;
+        }
+        return res;
+      },
+      async get(key, opts) {
+        // Abort the POST-CREATE manifest read only, gated on `slotZeroLanded`
+        // exactly as the sibling above — Step 1's read must pass through so
+        // this exercises the floor check's own read.
+        if (key === CURRENT_KEY && slotZeroLanded && !faultFired) {
+          faultFired = true;
+          const aborted = new Error("test: aborted reading current.json after the create");
+          aborted.name = "AbortError";
+          throw aborted;
+        }
+        return inner.get(key, opts);
+      },
+    };
+
+    // The counterpart to the swallow above: an abort is the caller's own
+    // cancellation, not a transient blip, and it is not a `retriable`
+    // `BaerlyError`, so the re-run hazard that justifies swallowing a
+    // `NetworkError` does not apply. Swallowing it instead reports success for
+    // a cancelled call and — as the crash fuzzer showed — drives every
+    // abort-at-this-GET case into the fully-landed reconciliation branch.
+    await expect(
+      runWithContext(MAINTENANCE_OFF, () =>
+        new Writer({ storage, currentJsonKey: CURRENT_KEY }).commit({
+          op: "I",
+          collection: "c",
+          docId: DOC_ID,
+          body: { ...DOC_BODY },
+        }),
+      ),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(faultFired, "the injected abort must actually have fired").toBe(true);
+
+    // The create already landed; the abort is reported over a durable commit.
+    const visible = await Db.create({ storage: inner, app: "a", tenant: "t" })
+      .collection("c")
+      .get(DOC_ID);
+    expect(visible, "the create that preceded the abort is durable").toEqual({ ...DOC_BODY });
+  });
+
+  test("a create folded AND retired before the post-create read reports AmbiguousCommit", async () => {
+    const inner = new MemoryStorage();
+    await seedManifest(inner);
+
+    let signalReached!: () => void;
+    const reached = new Promise<void>((r) => {
+      signalReached = r;
+    });
+    let signalReleased!: () => void;
+    const released = new Promise<void>((r) => {
+      signalReleased = r;
+    });
+    let slotZeroLanded = false;
+    let gatedOnce = false;
+
+    const storage: Storage = {
+      list: (prefix, opts) => inner.list(prefix, opts),
+      delete: (key, opts) => inner.delete(key, opts),
+      async put(key, body, opts) {
+        const res = await inner.put(key, body, opts);
+        if (key === logObjectKey(PREFIX, 0)) {
+          slotZeroLanded = true;
+        }
+        return res;
+      },
+      async get(key, opts) {
+        // Stall the post-create manifest read only.
+        if (key === CURRENT_KEY && slotZeroLanded && !gatedOnce) {
+          gatedOnce = true;
+          signalReached();
+          await released;
+        }
+        return inner.get(key, opts);
+      },
+    };
+
+    const commit = runWithContext(MAINTENANCE_OFF, () =>
+      new Writer({ storage, currentJsonKey: CURRENT_KEY }).commit({
+        op: "I",
+        collection: "c",
+        docId: DOC_ID,
+        body: { ...DOC_BODY },
+      }),
+    );
+
+    await reached;
+    await advanceFloorAndRetire(inner);
+    signalReleased();
+
+    // The mutation IS visible — it was folded into the snapshot before
+    // retirement removed the slot — and the commit still fails. That is the
+    // accepted, safe-direction over-rejection: the writer cannot tell this
+    // history from a phantom re-fill, so it reports at-least-once rather than
+    // acknowledging on a guess.
+    await expect(commit).rejects.toMatchObject({ code: "AmbiguousCommit" });
+    const visible = await Db.create({ storage: inner, app: "a", tenant: "t" })
+      .collection("c")
+      .get(DOC_ID);
+    expect(visible).toEqual({ ...DOC_BODY });
+  });
+
+  test('a phantom-object DELETE failure still throws AmbiguousCommit and records cleanup="failed"', async () => {
+    const inner = new MemoryStorage();
+    await seedManifest(inner);
+    const phantomKey = logObjectKey(PREFIX, 0);
+    const gate = gatedPutStorage(inner, phantomKey, "delay");
+    const storage = withFailingDelete(gate.storage, phantomKey);
+    const ctx = createObservabilityContext({ maintenance: { disabled: true } });
+
+    const pausedCommit = runWithContext(ctx, () =>
+      new Writer({ storage, currentJsonKey: CURRENT_KEY }).commit({
+        op: "I",
+        collection: "c",
+        docId: DOC_ID,
+        body: { ...DOC_BODY },
+      }),
+    );
+
+    await gate.reached;
+    await seedLogEntry(inner, PREFIX, 0, { doc_id: "peer-doc", after: { _id: "peer-doc" } });
+    await advanceFloorAndRetire(inner);
+    gate.release();
+
+    await expect(
+      pausedCommit,
+      "the cleanup failure must never mask the throw",
+    ).rejects.toMatchObject({ code: "AmbiguousCommit" });
+    expect(sumCounter(ctx, "db.write.ambiguous_commit_total")).toBe(1);
+    const counter = ctx.recorder
+      .snapshot()
+      .counters.find((c) => c.name === "db.write.ambiguous_commit_total");
+    expect(counter?.labels).toEqual({ collection: "c", cleanup: "failed" });
+  });
+
+  /**
+   * Why the answer is an explicit failure and not discard-and-re-probe.
+   *
+   * At the retry decision point the entire bucket is byte-for-byte identical
+   * whether the writer's own create landed and was folded, or a foreign
+   * writer's did. No surviving object names the writer's session. The two
+   * histories require opposite outcomes — adopt the prior completion vs. place
+   * the mutation at the live tail — from identical evidence, so no predicate
+   * over durable state can choose between them. That is why the writer reports
+   * at-least-once instead of guessing.
+   */
+  test("the durable state at the retry decision point cannot distinguish the two histories", async () => {
+    // ── History A: the writer's own create landed at slot 0, then the ack
+    // was lost, the entry was folded, and slot 0 was retired.
+    const runHistoryA = async (): Promise<{
+      dump: Array<[string, string]>;
+      slotZeroBytes: Uint8Array;
+    }> => {
+      const inner = new MemoryStorage();
+      await seedManifest(inner);
+      let reached!: () => void;
+      const reachedFirst = new Promise<void>((r) => {
+        reached = r;
+      });
+      let release!: () => void;
+      const released = new Promise<void>((r) => {
+        release = r;
+      });
+      let dump: Array<[string, string]> = [];
+      let landedBytes: Uint8Array = new Uint8Array(0);
+      let first = true;
+      let secondPut = false;
+      const storage: Storage = {
+        get: (k, o) => inner.get(k, o),
+        list: (p, o) => inner.list(p, o),
+        delete: (k, o) => inner.delete(k, o),
+        async put(k, b, o) {
+          if (k === logObjectKey(PREFIX, 0) && first) {
+            first = false;
+            // Durable, then the ack is dropped.
+            await inner.put(k, b, o);
+            landedBytes = b;
+            reached();
+            await released;
+            throw new BaerlyError("NetworkError", "test: dropped ack after a durable create");
+          }
+          if (k === logObjectKey(PREFIX, 0) && !secondPut) {
+            secondPut = true;
+            // Snapshot the bucket at the retry decision point.
+            dump = await dumpBucket(inner);
+          }
+          return inner.put(k, b, o);
+        },
+      };
+      const commit = runWithContext(MAINTENANCE_OFF, () =>
+        new Writer({ storage, currentJsonKey: CURRENT_KEY }).commit({
+          op: "I",
+          collection: "c",
+          docId: DOC_ID,
+          body: { ...DOC_BODY },
+        }),
+      );
+      await reachedFirst;
+      await advanceFloorAndRetire(inner);
+      release();
+      await expect(commit).rejects.toMatchObject({ code: "AmbiguousCommit" });
+      return { dump, slotZeroBytes: landedBytes };
+    };
+
+    const { dump: dumpA, slotZeroBytes } = await runHistoryA();
+
+    // ── History B: the writer's create never landed. A FOREIGN writer
+    // occupied slot 0 with the same logical mutation (an idempotent
+    // resubmit from another node), which was then folded and retired.
+    //
+    // The foreign entry is derived from A's bytes with only `session` and
+    // the session segment of `lsn` replaced by same-length substitutes, so
+    // the two histories fold byte-identical slices.
+    const runHistoryB = async (): Promise<Array<[string, string]>> => {
+      const landed = decodeJsonBytes<LogEntry>(slotZeroBytes);
+      const foreignSession = "f".repeat(landed.session.length);
+      const foreign: LogEntry = {
+        ...landed,
+        session: foreignSession,
+        lsn: landed.lsn.replace(landed.session, foreignSession),
+      };
+      expect(encodeJsonBytes(foreign).byteLength).toBe(slotZeroBytes.byteLength);
+
+      const inner = new MemoryStorage();
+      await seedManifest(inner);
+      let reached!: () => void;
+      const reachedFirst = new Promise<void>((r) => {
+        reached = r;
+      });
+      let release!: () => void;
+      const released = new Promise<void>((r) => {
+        release = r;
+      });
+      let dump: Array<[string, string]> = [];
+      let first = true;
+      let secondPut = false;
+      const storage: Storage = {
+        get: (k, o) => inner.get(k, o),
+        list: (p, o) => inner.list(p, o),
+        delete: (k, o) => inner.delete(k, o),
+        async put(k, b, o) {
+          if (k === logObjectKey(PREFIX, 0) && first) {
+            first = false;
+            // NOT durable — the create never happened.
+            reached();
+            await released;
+            throw new BaerlyError(
+              "NetworkError",
+              "test: dropped ack on a create that never landed",
+            );
+          }
+          if (k === logObjectKey(PREFIX, 0) && !secondPut) {
+            secondPut = true;
+            dump = await dumpBucket(inner);
+          }
+          return inner.put(k, b, o);
+        },
+      };
+      const commit = runWithContext(MAINTENANCE_OFF, () =>
+        new Writer({ storage, currentJsonKey: CURRENT_KEY }).commit({
+          op: "I",
+          collection: "c",
+          docId: DOC_ID,
+          body: { ...DOC_BODY },
+        }),
+      );
+      await reachedFirst;
+      await inner.put(logObjectKey(PREFIX, 0), encodeJsonBytes(foreign));
+      await advanceFloorAndRetire(inner);
+      release();
+      await expect(commit).rejects.toMatchObject({ code: "AmbiguousCommit" });
+      return dump;
+    };
+
+    const dumpB = await runHistoryB();
+
+    // Non-emptiness guards: an empty-vs-empty comparison below would pass
+    // vacuously and assert nothing — the exact failure mode this test exists
+    // to rule out.
+    expect(dumpA.length, "history A captured a bucket dump").toBeGreaterThan(0);
+    expect(dumpB.length, "history B captured a bucket dump").toBeGreaterThan(0);
+
+    // The decisive claim: nothing durable distinguishes "my create landed
+    // and was folded" from "a foreign create landed and was folded".
+    expect(dumpA.map(([k]) => k)).toEqual(dumpB.map(([k]) => k));
+    expect(dumpA).toEqual(dumpB);
+    // And no surviving object names the writer's own session.
+    const ownSession = decodeJsonBytes<LogEntry>(slotZeroBytes).session;
+    expect(dumpA.filter(([, body]) => body.includes(ownSession))).toEqual([]);
+  });
+});

--- a/packages/server/src/query.ts
+++ b/packages/server/src/query.ts
@@ -359,6 +359,9 @@ const writerFor = (ctx: CollectionReadContext): Writer =>
  *
  * @throws BaerlyError code="Conflict" — `_id` collision (pre-commit check) or
  *   CAS retry budget exhausted inside `Writer.commit()`.
+ * @throws BaerlyError code="AmbiguousCommit" — the committing create landed
+ *   below the collection's certified delete floor, so the row may or may not
+ *   have been inserted. Not retriable-by-default; see `Writer.commit`.
  * @throws BaerlyError code="SchemaError" — from the per-collection
  *   `SchemaValidator` threaded via {@link Db.collectionReadContext}.
  *
@@ -457,6 +460,11 @@ export const runInsert = async <T extends DocumentData>(
  * @throws BaerlyError code="Conflict" — any one row's CAS retry budget
  *   exhausted inside `Writer.commit()`. The partial-progress
  *   `modified` count is NOT returned in that case.
+ * @throws BaerlyError code="AmbiguousCommit" — one row's committing create
+ *   landed below the collection's certified delete floor. Rows before it in
+ *   the batch are already applied and that row's own fate is unknown; the
+ *   partial-progress `modified` count is NOT returned, so a caller that needs
+ *   to resume must re-read. See `Writer.commit`.
  * @throws BaerlyError code="SchemaError" — `merge(prev, patch)` produced
  *   `undefined` (defensive — `Partial<T>` cannot be `null` at the
  *   root in the type system).
@@ -516,6 +524,9 @@ const runUpdate = async <T extends DocumentData>(
  *   the collection's bound validator.
  * @throws BaerlyError code="Conflict" — writer CAS retry budget
  *   exhausted.
+ * @throws BaerlyError code="AmbiguousCommit" — the committing create landed
+ *   below the collection's certified delete floor, so the replace may or may
+ *   not have been applied. See `Writer.commit`.
  */
 export const runReplaceById = async <T extends DocumentData>(
   ctx: CollectionReadContext,
@@ -569,6 +580,10 @@ export const runReplaceById = async <T extends DocumentData>(
  * @throws BaerlyError code="Conflict" — any one row's CAS retry budget
  *   exhausted. The partial-progress `deleted` count is NOT returned
  *   in that case.
+ * @throws BaerlyError code="AmbiguousCommit" — one row's committing create
+ *   landed below the collection's certified delete floor. Rows before it in
+ *   the batch are already tombstoned and that row's own fate is unknown; the
+ *   partial-progress `deleted` count is NOT returned. See `Writer.commit`.
  */
 const runDelete = async <T extends DocumentData>(
   ctx: CollectionReadContext,

--- a/packages/server/src/writer.ts
+++ b/packages/server/src/writer.ts
@@ -50,6 +50,7 @@ import {
   createCurrentJson,
   decodeJsonBytes,
   encodeJsonBytes,
+  logDeleteFloorOf,
   logObjectKey,
   logSeqStartOf,
   mintGeneration,
@@ -81,6 +82,8 @@ import {
 import { getCurrentContext } from "./observability/context.ts";
 
 const CAS_CONFLICT_RESOLUTION = "Re-read and retry.";
+const AMBIGUOUS_COMMIT_RESOLUTION =
+  "Re-read the row before retrying: the mutation may already have been applied.";
 
 const ctxMetrics = (): MetricsRecorder => getCurrentContext()?.recorder ?? noopMetricsRecorder;
 
@@ -291,7 +294,12 @@ export class Writer {
    * DELETE'd after the commit.
    *
    * The hot-path cost under no contention on an unindexed collection is
-   * 1 GET + 1 PUT (the committing `log/<seq>` create); each
+   * 3 GETs + 1 PUT: the Step 1 `current.json` read, `findLogTail`'s
+   * forward probe (one 404 GET when `tail_hint` is accurate, `O(log gap)`
+   * GETs when it lags a fold interval), the committing `log/<seq>`
+   * create, and the post-create `current.json` re-read that rejects a
+   * create landing below the certified delete floor
+   * (`#assertCommitAboveDeleteFloor`). Each
    * declared index that projects a key on this write adds one PUT
    * (new key, before the commit) and, on U/D, up to one DELETE (stale
    * key, after the commit). An in-flight peer write costs one extra GET
@@ -304,6 +312,21 @@ export class Writer {
    * adopts its own lost-ack write or re-probes forward to the next
    * empty slot.
    *
+   * **At-least-once under one fault.** If the committing create wins at a
+   * `seq` the collection has already certified deleted — reachable when a
+   * create PUT or a lost-ack retry straddles a fold plus a retirement pass —
+   * the object it wrote is beneath every reader's floor. The commit then fails
+   * with `AmbiguousCommit` rather than acknowledging a mutation no fresh
+   * reader can see. The writer cannot tell whether an earlier attempt of its
+   * own landed and was folded before retirement removed the slot, so the
+   * mutation may or may not have been applied: retrying is the intended
+   * recovery and may apply it twice. `err.retriable` is `false` precisely so a
+   * generic conflict-retry wrapper cannot absorb this silently. Every other
+   * path remains exactly-once.
+   *
+   * @throws BaerlyError code="AmbiguousCommit" when the committing create
+   *   landed below `min(log_delete_floor, log_seq_start)`. The mutation's fate
+   *   is unknown; see the at-least-once note above.
    * @throws BaerlyError code="Conflict" when a retryable conflict
    *   escapes the single-attempt helper and exhausts the retry budget
    *   (presently unreachable on the log-create 412 path).
@@ -595,6 +618,16 @@ export class Writer {
       seq = await findLogTail(this.#storage, logPrefix, seq + 1);
       entry = mintEntry(seq);
     }
+
+    // ── Step 5a. Refuse a create that re-filled a retired hole. ─────
+    // Both break paths above land here with the resolved committing
+    // `seq`: the fresh win and the own-session adoption. This check
+    // runs BEFORE Step 5b on purpose — an invisible commit must not
+    // get to delete the OLD value's index keys, because the doc's
+    // live value may still BE that old value, and de-indexing it
+    // would be the one failure the hybrid emission polarity exists to
+    // prevent (invariant 7).
+    await this.#assertCommitAboveDeleteFloor(logPrefix, seq, input.collection, errorPrefix);
     const committedEntries: readonly LogEntry[] = [committedEntry];
 
     // ── Step 5b. DELETE stale secondary-index keys (AFTER the commit). ─
@@ -947,6 +980,146 @@ export class Writer {
   }
 
   /**
+   * Fail the commit if the create landed at a sequence the collection has
+   * already certified deleted.
+   *
+   * **What a sub-floor `seq` proves, and what it does not.** A winning
+   * `If-None-Match: "*"` create means the slot was empty immediately before the
+   * PUT, so the object this commit just wrote sits beneath every reader's floor
+   * and no reader will ever consult it. What a sub-floor `seq` does NOT prove
+   * is that the *logical mutation* is invisible. Two histories reach this
+   * branch: the create re-filled a hole retirement had already certified
+   * deleted (invisible — the defect this check exists for), or it landed in a
+   * live empty slot that a fold and then a retirement pass swept out from under
+   * it (visible through the snapshot). That second history is a real
+   * over-rejection, pinned as contract by a test in
+   * `./log-retirement-aba.test.ts`, not an accident. It is the safe direction,
+   * and "What the caller is being told" below is why guessing between the two
+   * is worse than reporting both as ambiguous.
+   *
+   * **`log_delete_floor <= seq < log_seq_start` is NOT a failure.** Not because
+   * that band is provably safe — it is undecidable in the very same way. A
+   * winning create means the slot was empty just before the PUT, so what a fold
+   * absorbed there was either an earlier attempt of ours (mutation visible) or
+   * a foreign writer's entry (ours invisible), and the fold keeps no writer
+   * identity to tell them apart. The band is accepted because keying the check
+   * on `log_seq_start` would reject ordinary post-fold commits — a far
+   * larger harm than the residual it would catch. That residual is the exposure
+   * `docs/spec/sync-protocol.md` invariant 14 records and PR 5 closes.
+   *
+   * The floor is clamped to `min(log_delete_floor, log_seq_start)` for the
+   * reason invariant 12 gives: the `<= log_seq_start` bound is
+   * transition-scoped, so an out-of-bound stored floor is readable off disk
+   * and would otherwise fail a perfectly good commit.
+   *
+   * **What the caller is being told.** Not "your write failed" —
+   * `AmbiguousCommit`. An earlier attempt by this same writer may have landed
+   * and been folded before retirement removed the slot, and nothing durable
+   * distinguishes that history from a foreign writer's entry being folded
+   * instead: the fold keeps no writer identity, tombstones are purged,
+   * `current.json` holds no per-writer completion state, and `writer_fence` is
+   * not a replay filter (invariant 11). So the write contract under this fault
+   * is at-least-once, and re-probing-and-re-applying is emphatically not a
+   * safe default: `LogEntry.after` is a full post-image, so a duplicate
+   * clobbers a concurrent newer value and mints a second `lsn` for one logical
+   * mutation.
+   *
+   * The phantom object is DELETEd best-effort. Today it would also be reclaimed
+   * without this DELETE: `runGc`'s `stale-log` arm marks any `log/<seq>` below
+   * `log_seq_start` with no delete-floor awareness (`./gc.ts` — the mark loop
+   * keys on `seq >= logSeqStart` alone), and the sweep-time rescue spares only
+   * `seq >= log_seq_start`, so a sub-floor phantom is swept once the grace
+   * elapses. PR 5 removes that arm in favour of computed-range retirement, and
+   * from then on this DELETE is the only thing standing between a rejected
+   * commit and a permanently leaked object — which is why it is here now rather
+   * than deferred. Deleting it is safe: no reader may read below the certified
+   * floor (invariant 5), and the one deliberate sub-floor reader,
+   * `#readPreImage`, treats a hole as "keep descending" rather than a stop
+   * signal. A failed cleanup is recorded on the counter and never masks the
+   * throw.
+   *
+   * **The Step 4 additive index keys are left behind.** The failure path does
+   * not roll back the `newKeys` PUTs, and deliberately so — it is the same
+   * benign residual invariant 7 already covers. If the mutation did land, those
+   * keys are correct; if it did not, each is a false-positive candidate that
+   * `matchesWire` drops on read, never a missing one.
+   *
+   * **A failed manifest read skips the check rather than failing the commit —
+   * except an abort, which propagates.** The check runs over an already-durable
+   * create, and an unreadable manifest is no evidence of a sub-floor `seq`, so a
+   * transient read failure is swallowed. An `AbortError` is rethrown instead: it
+   * is the caller's own cancellation rather than a blip, and it carries none of
+   * the `retriable` re-run hazard that motivates swallowing the rest. The skip
+   * is recorded on `db.write.delete_floor_check_skipped_total` so a sustained
+   * rate is visible to an operator rather than silent.
+   *
+   * Cost: one Class B GET per commit.
+   * `billableClassAOps = puts + lists` excludes GET, so billing is unchanged;
+   * the subrequest arithmetic on {@link PREIMAGE_SCAN_MAX_GETS} carries the
+   * re-derivation.
+   *
+   * @throws BaerlyError code="AmbiguousCommit"
+   */
+  async #assertCommitAboveDeleteFloor(
+    logPrefix: string,
+    seq: number,
+    collection: string,
+    errorPrefix: string,
+  ): Promise<void> {
+    let read: CurrentJsonRead | null;
+    try {
+      read = await readCurrentJson(this.#storage, this.#currentJsonKey);
+    } catch (error) {
+      if (isAbortError(error)) {
+        // An abort is the caller's deliberate cancellation, not a transient
+        // blip, and the caller already knows it cancelled. The hazard the
+        // swallow below exists for is specific to `retriable` errors; an
+        // `AbortError` is not one, so rethrowing costs that reasoning nothing.
+        throw error;
+      }
+      // A failed read is not evidence of a sub-floor commit, so skipping the
+      // check preserves the pre-existing commit contract exactly and forgoes
+      // only a safety net on a rare blip. Propagating instead would be worse
+      // than useless: the create already committed, and `NetworkError` is
+      // `retriable`, so a generic retry wrapper would re-run the whole logical
+      // write at a fresh tail — duplicating the mutation and minting a second
+      // `lsn`. The other post-create steps here swallow their non-abort
+      // failures for the same reason (`#cleanupStaleIndexKeysBestEffort`, the
+      // maintenance dispatch). Failing closed is not the answer either
+      // — throwing `AmbiguousCommit` on an unreadable manifest would reject
+      // durable commits far more often than the fault this check catches.
+      ctxMetrics().counter("db.write.delete_floor_check_skipped_total", 1, { collection });
+      return;
+    }
+    if (read === null) {
+      // The manifest vanished between Step 1 and here. Unreachable in
+      // practice (Step 1 read or provisioned it), and a missing manifest
+      // certifies no deleted prefix, so there is nothing to reject against.
+      return;
+    }
+    const storedDeleteFloor = logDeleteFloorOf(read.json);
+    const deleteFloor = Math.min(storedDeleteFloor, logSeqStartOf(read.json));
+    // `deleteFloor === 0` means no deleted prefix is certified — same silent
+    // arm as `Db.assertAtOrAboveLogFloor`.
+    if (deleteFloor <= 0 || seq >= deleteFloor) {
+      return;
+    }
+    let cleanup: "deleted" | "failed" = "deleted";
+    await this.#storage.delete(logObjectKey(logPrefix, seq)).catch(() => {
+      cleanup = "failed";
+    });
+    ctxMetrics().counter("db.write.ambiguous_commit_total", 1, { collection, cleanup });
+    throw new BaerlyError(
+      "AmbiguousCommit",
+      `${errorPrefix}: the committing create at seq ${seq} on ${this.#currentJsonKey} landed below the certified delete floor ${deleteFloor}; that log object is beneath every reader's floor, and this mutation may or may not have been applied by an earlier attempt — retry is at-least-once`,
+      undefined,
+      undefined,
+      undefined,
+      AMBIGUOUS_COMMIT_RESOLUTION,
+    );
+  }
+
+  /**
    * Walk `log/<logSeqStart>.json` … `log/<nextSeq - 1>.json` with
    * bounded parallelism via `walkLogRange`. Materialised entries are
    * discarded — the walk's only job is to surface a hole or a
@@ -1026,6 +1199,19 @@ const isPreconditionFailed = (err: unknown): boolean =>
  */
 const isTransientWrite = (err: unknown): boolean =>
   err instanceof BaerlyError && err.code === "NetworkError";
+
+/**
+ * `true` when a rejection is an `AbortError` — the caller's own cancellation
+ * through an `AbortSignal`, never a transient storage failure. Matched
+ * structurally on `name` rather than `instanceof DOMException` because a host
+ * may surface an abort as a plain `Error` so named (as `Storage` impls and the
+ * test fixtures do). `@baerly/client` carries the same predicate; it is
+ * duplicated rather than shared because `server` may not import `client`
+ * (`scripts/lint-package-layers.mjs`) and one predicate does not earn a new
+ * module in `@baerly/protocol`.
+ */
+const isAbortError = (err: unknown): boolean =>
+  typeof err === "object" && err !== null && "name" in err && err.name === "AbortError";
 
 /**
  * `true` when the underlying storage surfaced an R2 prefix-partition

--- a/packages/server/src/writer.ts
+++ b/packages/server/src/writer.ts
@@ -47,10 +47,10 @@ import {
   type DocumentData,
   type LogEntry,
   type MetricsRecorder,
+  certifiedDeleteFloor,
   createCurrentJson,
   decodeJsonBytes,
   encodeJsonBytes,
-  logDeleteFloorOf,
   logObjectKey,
   logSeqStartOf,
   mintGeneration,
@@ -1097,8 +1097,7 @@ export class Writer {
       // certifies no deleted prefix, so there is nothing to reject against.
       return;
     }
-    const storedDeleteFloor = logDeleteFloorOf(read.json);
-    const deleteFloor = Math.min(storedDeleteFloor, logSeqStartOf(read.json));
+    const deleteFloor = certifiedDeleteFloor(read.json);
     // `deleteFloor === 0` means no deleted prefix is certified — same silent
     // arm as `Db.assertAtOrAboveLogFloor`.
     if (deleteFloor <= 0 || seq >= deleteFloor) {


### PR DESCRIPTION
## What & why

A committing `log/<seq>` create can win at a sequence the collection has already certified deleted — reachable when a create PUT or a lost-ack retry straddles a fold plus a log-retirement pass. The object it writes then sits beneath every reader's floor, so the write is acknowledged but permanently invisible. PR #139 had to withdraw the claim that `LOG_RETENTION_SEQ_WINDOW` fenced this: `K` is not a fence, and no durable state distinguishes the two histories that reach that state.

This closes it by failing loudly instead. After the committing create, `Writer` re-reads `current.json`; if the create landed below `min(log_delete_floor, log_seq_start)`, it best-effort DELETEs the phantom object and throws a new non-retriable `AmbiguousCommit` rather than acknowledging a mutation no fresh reader can see. Under this one fault the write contract becomes at-least-once — the writer cannot tell whether an earlier attempt of its own landed and was folded before retirement removed the slot, so retrying may apply the mutation twice. Every other path remains exactly-once.

## Key points

- `retriable` is `false` precisely so a generic conflict-retry wrapper cannot absorb this silently; `AmbiguousCommit` maps to HTTP 409 and CLI exit 3.
- The check is a safety net, not a precondition: a non-abort failure of its *own* read is swallowed, because propagating would turn a durable commit into a `retriable` `NetworkError` and a retry wrapper would re-run the write at a fresh tail, duplicating the mutation. An abort propagates — swallowing it left the crash fuzzer exploring the post-commit branch on every injected abort, at 5x runtime.
- The band `log_delete_floor <= seq < log_seq_start` is accepted because it is undecidable, not because it is provably safe: rejecting it would fail ordinary post-fold commits, and its invisible half is the residual invariant 14 records.
- Over-rejection guards pin that a merely-folded band, an out-of-bound stored floor, and a live tail all still commit; one test deliberately asserts the accepted over-rejection on a *visible* mutation, as the contract pin it is.
- The error is not yet reachable in production: `log_delete_floor` is written only by `retireLogRange`, which nothing calls.
- The own-session-adoption path reaches the check and is structurally correct, but no test drives it there — pinning it needs a schedule that aborts `retireLogRange`'s DELETE loop after its floor CAS.
- `bundle-sizes.json` was rebaselined twice, in `3b442e65` and `e32d4786`; each commit message accounts for every moved entry.

## Verification

| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3393 passed, 105 skipped |
| `pnpm bundle-sizes` | ok (14 entries), no diff |
| `node scripts/check-spec-drift.ts` | ok (15 codes, 6 operators, 10 routes) |
| `pnpm test:fuzz-maintenance` | 18 passed, 215s |

## Notes for reviewers

Start at Step 5a in `packages/server/src/writer.ts` and its `#assertCommitAboveDeleteFloor`. The abort/non-abort asymmetry in that method's `catch` is load-bearing: a bare `catch` swallows the crash fuzzer's one-shot injected abort, so `commit()` succeeds and every such case runs the expensive reconciliation branch — measured at 1071s and 1162s with a 600s timeout, against 203s at the branch base and 215s here.

`packages/server/src/log-retirement-aba.test.ts` carries the fault schedules, including the two-history indistinguishability result and the guard tests for both failure modes of the check's own read.
