### PR TITLE
fix: consolidate errorToExitCode and update AmbiguousCommit docs

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -38,7 +38,7 @@ path stays small.
 | `0`  | success                             | handler returned normally                                                      |
 | `1`  | user/config error                   | `BaerlyError.code = InvalidConfig`, missing/unknown flag                       |
 | `2`  | storage or external process error   | `BaerlyError.code = NetworkError` / `AccessDenied`, anything non-`BaerlyError` |
-| `3`  | protocol invariant / conflict class | `BaerlyError.code = Conflict` / `Internal` / `InvalidResponse`                 |
+| `3`  | protocol invariant / conflict class | `BaerlyError.code = Conflict` / `Internal` / `InvalidResponse` / `AmbiguousCommit` |
 | `4`  | `admin fsck` findings               | `fsck` walk surfaced ≥1 finding                                                |
 
 ## `--json` mode

--- a/packages/cli/src/admin/dump.ts
+++ b/packages/cli/src/admin/dump.ts
@@ -39,7 +39,8 @@
  *   0 — dump completed.
  *   1 — InvalidConfig (bad bucket URI, missing args).
  *   2 — Storage / Network / Internal protocol violation.
- *   3 — Protocol invariant (Conflict / Internal / InvalidResponse).
+ *   3 — Protocol invariant (Conflict / Internal / InvalidResponse /
+ *       AmbiguousCommit).
  */
 
 import { type Writable } from "node:stream";

--- a/packages/cli/src/admin/rebuild-index.ts
+++ b/packages/cli/src/admin/rebuild-index.ts
@@ -13,7 +13,8 @@
  *           args, unparseable config).
  *   - `2` — storage error (NetworkError, AccessDenied, anything
  *           non-BaerlyError).
- *   - `3` — protocol invariant (Conflict, Internal, InvalidResponse).
+ *   - `3` — protocol invariant (Conflict, Internal, InvalidResponse,
+ *           AmbiguousCommit).
  *
  * Idempotent — re-running on a healthy index is `{ removed: 0,
  * added: 0 }`; re-running after a crashed mid-commit reconciles

--- a/packages/cli/src/bin-runner.ts
+++ b/packages/cli/src/bin-runner.ts
@@ -37,22 +37,7 @@ import {
   showUsage,
 } from "citty";
 import { BaerlyError } from "@baerly/protocol";
-import { emitError, setJsonMode } from "./output.ts";
-
-const errorToExitCode = (code: string): number => {
-  if (code === "InvalidConfig") {
-    return 1;
-  }
-  if (
-    code === "Conflict" ||
-    code === "Internal" ||
-    code === "InvalidResponse" ||
-    code === "AmbiguousCommit"
-  ) {
-    return 3;
-  }
-  return 2;
-};
+import { emitError, setJsonMode, errorToExitCode } from "./output.ts";
 
 const resolve = async <T>(v: Resolvable<T>): Promise<T> => {
   if (typeof v === "function") {

--- a/packages/cli/src/cost.ts
+++ b/packages/cli/src/cost.ts
@@ -27,7 +27,8 @@
  *   1 — InvalidConfig (bad bucket URI, missing args, unknown flag,
  *       insufficient log entries to estimate, dev backend).
  *   2 — Storage / Network error.
- *   3 — Protocol invariant (Conflict / Internal / InvalidResponse).
+ *   3 — Protocol invariant (Conflict / Internal / InvalidResponse /
+ *       AmbiguousCommit).
  */
 
 import { type ArgsDef } from "citty";

--- a/packages/cli/src/deploy.ts
+++ b/packages/cli/src/deploy.ts
@@ -21,7 +21,7 @@ import { defineCommand, type ArgsDef, type ParsedArgs } from "citty";
 import { BaerlyError } from "@baerly/protocol";
 import { loadAppConfig } from "./config.ts";
 import { deployCloudflare } from "./deploy/cloudflare.ts";
-import { emitError, emitSuccess, setJsonMode } from "./output.ts";
+import { emitError, emitSuccess, setJsonMode, errorToExitCode } from "./output.ts";
 
 const DEPLOY_ARGS = {
   target: {
@@ -49,21 +49,6 @@ const KNOWN_KEYS: ReadonlySet<string> = new Set([
   "probe-bucket",
   "_",
 ]);
-
-const errorToExitCode = (code: string): number => {
-  if (code === "InvalidConfig") {
-    return 1;
-  }
-  if (
-    code === "Conflict" ||
-    code === "Internal" ||
-    code === "InvalidResponse" ||
-    code === "AmbiguousCommit"
-  ) {
-    return 3;
-  }
-  return 2;
-};
 
 const handleDeploy = async (args: ParsedArgs<typeof DEPLOY_ARGS>): Promise<number> => {
   setJsonMode(args.json === true);

--- a/packages/cli/src/inspect.ts
+++ b/packages/cli/src/inspect.ts
@@ -39,7 +39,8 @@
  *   0 — inspection ran (status may be "ok" or "error"; both exit 0).
  *   1 — InvalidConfig (bad bucket URI, missing args, unknown flag).
  *   2 — Storage / Network error.
- *   3 — Protocol invariant (Conflict / Internal / InvalidResponse).
+ *   3 — Protocol invariant (Conflict / Internal / InvalidResponse /
+ *       AmbiguousCommit).
  */
 
 import { type ArgsDef } from "citty";

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -81,3 +81,19 @@ export const emitSuccess = (data: Record<string, unknown>): void => {
     process.stdout.write(`${JSON.stringify({ result: data })}\n`);
   }
 };
+
+/** Shared exit-code mapping for caught `BaerlyError`s. */
+export const errorToExitCode = (code: string): number => {
+  if (code === "InvalidConfig") {
+    return 1;
+  }
+  if (
+    code === "Conflict" ||
+    code === "Internal" ||
+    code === "InvalidResponse" ||
+    code === "AmbiguousCommit"
+  ) {
+    return 3;
+  }
+  return 2;
+};

--- a/packages/cli/src/subcommand.ts
+++ b/packages/cli/src/subcommand.ts
@@ -40,7 +40,7 @@ import { defineCommand, parseArgs, type ArgsDef, type ParsedArgs, type CommandDe
 import { BaerlyError } from "@baerly/protocol";
 import { assertPathSegment } from "@baerly/server/_internal/testing";
 import { loadAppConfig } from "./config.ts";
-import { emitError, setJsonMode } from "./output.ts";
+import { emitError, setJsonMode, errorToExitCode } from "./output.ts";
 
 /**
  * Shared citty arg fragments for the flags every operator command
@@ -149,22 +149,6 @@ export interface SubcommandBundle<TArgs extends ArgsDef> {
     options?: { readonly streams?: SubcommandStreams },
   ) => Promise<number>;
 }
-
-/** Shared exit-code mapping for caught `BaerlyError`s. */
-const errorToExitCode = (code: string): number => {
-  if (code === "InvalidConfig") {
-    return 1;
-  }
-  if (
-    code === "Conflict" ||
-    code === "Internal" ||
-    code === "InvalidResponse" ||
-    code === "AmbiguousCommit"
-  ) {
-    return 3;
-  }
-  return 2;
-};
 
 /**
  * Validate a `--collection` arg through the same shared rule the

--- a/packages/protocol/src/errors.test.ts
+++ b/packages/protocol/src/errors.test.ts
@@ -56,6 +56,7 @@ describe("retriable classification", () => {
     expect(isRetriableCode("Conflict")).toBe(true);
     expect(isRetriableCode("SchemaError")).toBe(false);
     expect(isRetriableCode("NotFound")).toBe(false);
+    expect(isRetriableCode("AmbiguousCommit")).toBe(false);
   });
   test("BaerlyError.retriable defaults from code", () => {
     expect(new BaerlyError("Conflict", "x").retriable).toBe(true);

--- a/packages/server/src/spec/ir.test.ts
+++ b/packages/server/src/spec/ir.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, test } from "vitest";
-import {
-  CLIENT_RUNTIME_CODES,
-  ERROR_CODES,
-  isRetriableCode,
-  PREDICATE_OPS,
-} from "@baerly/protocol";
+import { CLIENT_RUNTIME_CODES, ERROR_CODES, PREDICATE_OPS } from "@baerly/protocol";
 import { expectValidAgainstIrSchema } from "../../../../tests/fixtures/ir-schema.ts";
 import { buildSpecIR } from "./ir.ts";
 
@@ -80,10 +75,6 @@ describe("buildSpecIR", () => {
     expect(entry?.httpStatus).toBe(409);
     expect(entry?.retriable).toBe(false);
     expect(entry?.messagePolicy).toBe("scrubbed");
-  });
-
-  test("AmbiguousCommit is not retriable by default", () => {
-    expect(isRetriableCode("AmbiguousCommit")).toBe(false);
   });
 
   test("declares the /v1 routes including the new /v1/spec", () => {


### PR DESCRIPTION
## What & why

Post-merge cleanup for the AmbiguousCommit error code PR: `errorToExitCode` was duplicated verbatim in `bin-runner.ts` and `deploy.ts` instead of shared from `output.ts`, the CLI README's exit-code table and several command header comments never got the new code added, and its `isRetriableCode` test lived in the wrong package.

## Verification

| `pnpm verify:agent` | clean |