### PR TITLE
feat(snapshot): add chunked snapshot manifest/chunk codecs

### DIFF
--- a/packages/server/src/chunked-snapshot-reference.test.ts
+++ b/packages/server/src/chunked-snapshot-reference.test.ts
@@ -1,0 +1,215 @@
+import { fc, test as fcTest } from "@fast-check/vitest";
+import { BaerlyError, type DocumentData, type DocumentValue } from "@baerly/protocol";
+import { describe, expect, test } from "vitest";
+import {
+  foldChunkedSnapshotReference,
+  type ReferenceMutation,
+  type ReferenceRow,
+} from "./chunked-snapshot-reference.ts";
+import { compareDocIds } from "./snapshot-doc-id.ts";
+
+const row = (id: string, version: number): ReferenceRow => ({
+  _id: id,
+  body: {
+    _id: id,
+    version,
+    nested: { active: version % 2 === 0 },
+    labels: [`v${version}`],
+  },
+});
+
+const mutation = (
+  op: "I" | "U",
+  id: string,
+  version: number,
+): Extract<ReferenceMutation, { readonly op: "I" | "U" }> => ({
+  op,
+  doc_id: id,
+  after: row(id, version).body,
+});
+
+const expectInvalidResponse = (action: () => unknown): void => {
+  expect(action).toThrow(BaerlyError);
+  try {
+    action();
+  } catch (error) {
+    expect((error as BaerlyError).code).toBe("InvalidResponse");
+  }
+};
+
+const slowFold = (
+  rows: readonly ReferenceRow[],
+  indexedMutations: readonly { readonly seq: number; readonly mutation: ReferenceMutation }[],
+  floor: number,
+  endExclusive: number,
+): readonly ReferenceRow[] => {
+  const ids = rows.map(({ _id }) => _id);
+  const bodies = rows.map(({ body }) => body);
+  for (const { seq, mutation: entry } of indexedMutations) {
+    if (seq < floor || seq >= endExclusive) {
+      continue;
+    }
+    const index = ids.indexOf(entry.doc_id);
+    if (entry.op === "D") {
+      if (index !== -1) {
+        ids.splice(index, 1);
+        bodies.splice(index, 1);
+      }
+    } else if (index === -1) {
+      ids.push(entry.doc_id);
+      bodies.push(entry.after);
+    } else {
+      bodies[index] = entry.after;
+    }
+  }
+  return ids
+    .map((_id, index) => ({ _id, body: bodies[index]! }))
+    .toSorted((left, right) => compareDocIds(left._id, right._id));
+};
+
+describe("chunked snapshot reference fold", () => {
+  test("applies insert, full-post-image update, and delete", () => {
+    const result = foldChunkedSnapshotReference(
+      [row("b", 0), row("c", 0)],
+      [mutation("I", "a", 1), mutation("U", "b", 2), { op: "D", doc_id: "c" }],
+    );
+
+    expect(result).toEqual([row("a", 1), row("b", 2)]);
+  });
+
+  test("uses last-write-wins semantics for repeated document mutations", () => {
+    expect(
+      foldChunkedSnapshotReference(
+        [row("a", 0)],
+        [
+          mutation("U", "a", 1),
+          { op: "D", doc_id: "a" },
+          mutation("I", "a", 3),
+          mutation("U", "a", 4),
+        ],
+      ),
+    ).toEqual([row("a", 4)]);
+  });
+
+  test("sorts by scalar document order and freezes the emitted collection", () => {
+    const result = foldChunkedSnapshotReference(
+      [row("\u{10000}", 0), row("e\u0301", 0), row("é", 0)],
+      [],
+    );
+
+    expect(result.map(({ _id }) => _id)).toEqual(["e\u0301", "é", "\u{10000}"]);
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(result.every(Object.isFrozen)).toBe(true);
+  });
+
+  test("detaches the result from initial-row bodies without freezing caller input", () => {
+    const input = row("a", 0);
+    const result = foldChunkedSnapshotReference([input], []);
+
+    input.body["version"] = 99;
+    (input.body["nested"] as DocumentData)["active"] = false;
+
+    expect(Object.isFrozen(input.body)).toBe(false);
+    expect(result).toEqual([row("a", 0)]);
+  });
+
+  test("detaches the result from mutation post-images without freezing caller input", () => {
+    const input = mutation("I", "a", 1);
+    const result = foldChunkedSnapshotReference([], [input]);
+
+    input.after["version"] = 99;
+    (input.after["labels"] as DocumentValue[]).push("caller mutation");
+
+    expect(Object.isFrozen(input.after)).toBe(false);
+    expect(result).toEqual([row("a", 1)]);
+  });
+
+  test("deeply freezes nested objects and arrays in emitted bodies", () => {
+    const result = foldChunkedSnapshotReference([row("a", 0)], []);
+    const body = result[0]!.body;
+    const nested = body["nested"] as DocumentData;
+    const labels = body["labels"] as DocumentValue[];
+
+    expect(Object.isFrozen(body)).toBe(true);
+    expect(Object.isFrozen(nested)).toBe(true);
+    expect(Object.isFrozen(labels)).toBe(true);
+    expect(() => {
+      nested["active"] = false;
+    }).toThrow(TypeError);
+    expect(() => labels.push("output mutation")).toThrow(TypeError);
+    expect(result).toEqual([row("a", 0)]);
+  });
+
+  test("rejects duplicate stored IDs but permits repeated mutations", () => {
+    expectInvalidResponse(() => foldChunkedSnapshotReference([row("a", 0), row("a", 1)], []));
+    expect(() =>
+      foldChunkedSnapshotReference([], [mutation("I", "a", 1), mutation("U", "a", 2)]),
+    ).not.toThrow();
+  });
+
+  test("requires every post-image identity to equal its mutation document ID", () => {
+    expectInvalidResponse(() =>
+      foldChunkedSnapshotReference([], [{ op: "I", doc_id: "a", after: { _id: "b", version: 1 } }]),
+    );
+  });
+
+  test.each([
+    ["non-object row", [null], []],
+    ["invalid row ID", [{ _id: "\ud800", body: { _id: "\ud800" } }], []],
+    ["row identity mismatch", [{ _id: "a", body: { _id: "b" } }], []],
+    ["array row body", [{ _id: "a", body: [] }], []],
+    ["null stored value", [{ _id: "a", body: { _id: "a", value: null } }], []],
+    ["non-finite stored number", [{ _id: "a", body: { _id: "a", value: Infinity } }], []],
+    ["non-object mutation", [], [null]],
+    ["unknown mutation op", [], [{ op: "X", doc_id: "a" }]],
+    ["invalid mutation ID", [], [{ op: "D", doc_id: "a/b" }]],
+    ["missing post-image", [], [{ op: "I", doc_id: "a" }]],
+    ["invalid post-image", [], [{ op: "U", doc_id: "a", after: { _id: "a", value: undefined } }]],
+  ])("rejects %s as InvalidResponse", (_label, rows, mutations) => {
+    expectInvalidResponse(() =>
+      foldChunkedSnapshotReference(
+        rows as unknown as readonly ReferenceRow[],
+        mutations as unknown as readonly ReferenceMutation[],
+      ),
+    );
+  });
+});
+
+const idArb = fc.oneof(
+  fc.stringMatching(/^[a-z][a-z0-9]{0,5}$/),
+  fc.constantFrom("é", "e\u0301", "\u{10000}", "\u{1f4a9}"),
+);
+
+fcTest.prop({
+  ids: fc.uniqueArray(idArb, { minLength: 2, maxLength: 12 }),
+  instructions: fc.array(
+    fc.record({
+      op: fc.constantFrom<"I" | "U" | "D">("I", "U", "D"),
+      target: fc.nat(),
+      version: fc.integer(),
+    }),
+    { minLength: 2, maxLength: 30 },
+  ),
+  floor: fc.integer({ min: 7, max: 1000 }),
+  prefixSeed: fc.nat(),
+})(
+  "matches an independent slow model for nonzero floors and deterministic partial prefixes",
+  ({ ids, instructions, floor, prefixSeed }) => {
+    const initialCount = Math.max(1, Math.floor(ids.length / 2));
+    const initial = ids.slice(0, initialCount).map((id, index) => row(id, index));
+    const entries = instructions.map(({ op, target, version }, index) => {
+      const id = ids[target % ids.length]!;
+      const entry: ReferenceMutation = op === "D" ? { op, doc_id: id } : mutation(op, id, version);
+      return { seq: floor + index, mutation: entry };
+    });
+    const prefixLength = 1 + (prefixSeed % (entries.length - 1));
+    const endExclusive = floor + prefixLength;
+    const prefix = entries
+      .filter(({ seq }) => seq >= floor && seq < endExclusive)
+      .map(({ mutation: entry }) => entry);
+
+    expect(foldChunkedSnapshotReference(initial, prefix)).toEqual(
+      slowFold(initial, entries, floor, endExclusive),
+    );
+  },
+);

--- a/packages/server/src/chunked-snapshot-reference.ts
+++ b/packages/server/src/chunked-snapshot-reference.ts
@@ -1,0 +1,161 @@
+import { BaerlyError, type DocumentData, type DocumentValue } from "@baerly/protocol";
+import { assertSnapshotDocId, compareDocIds } from "./snapshot-doc-id.ts";
+
+export interface ReferenceRow {
+  readonly _id: string;
+  readonly body: DocumentData;
+}
+
+export type ReferenceMutation =
+  | {
+      readonly op: "I" | "U";
+      readonly doc_id: string;
+      readonly after: DocumentData;
+    }
+  | { readonly op: "D"; readonly doc_id: string };
+
+export type ReferenceFold = (
+  rows: readonly ReferenceRow[],
+  mutations: readonly ReferenceMutation[],
+) => readonly ReferenceRow[];
+
+function invalid(message: string, cause?: unknown): never {
+  throw new BaerlyError("InvalidResponse", `chunked snapshot reference: ${message}`, cause);
+}
+
+function assertStoredDocId(value: unknown, where: string): asserts value is string {
+  if (typeof value !== "string") {
+    invalid(`${where} must be a string`);
+  }
+  try {
+    assertSnapshotDocId(value);
+  } catch (error) {
+    invalid(`${where} is invalid`, error);
+  }
+}
+
+function assertDocumentValue(value: unknown, where: string, ancestors: Set<object>): void {
+  if (typeof value === "string" || typeof value === "boolean") {
+    return;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      invalid(`${where} must contain only finite numbers`);
+    }
+    return;
+  }
+  if (value === null || typeof value !== "object") {
+    invalid(`${where} contains a value outside DocumentData`);
+  }
+  if (ancestors.has(value)) {
+    invalid(`${where} contains a cycle`);
+  }
+  ancestors.add(value);
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index++) {
+      if (!Object.hasOwn(value, index)) {
+        invalid(`${where} contains a sparse array`);
+      }
+      assertDocumentValue(value[index], `${where}[${index}]`, ancestors);
+    }
+  } else {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      invalid(`${where} must contain only plain objects`);
+    }
+    if (Object.getOwnPropertySymbols(value).length !== 0) {
+      invalid(`${where} must not contain symbol keys`);
+    }
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    for (const [key, descriptor] of Object.entries(descriptors)) {
+      if (!descriptor.enumerable || !("value" in descriptor)) {
+        invalid(`${where}.${key} must be an enumerable data property`);
+      }
+      assertDocumentValue(descriptor.value, `${where}.${key}`, ancestors);
+    }
+  }
+  ancestors.delete(value);
+}
+
+function assertDocument(value: unknown, id: string, where: string): asserts value is DocumentData {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    invalid(`${where} must be a document object`);
+  }
+  assertDocumentValue(value, where, new Set<object>());
+  const storedId = Object.getOwnPropertyDescriptor(value, "_id")?.value;
+  assertStoredDocId(storedId, `${where}._id`);
+  if (storedId !== id) {
+    invalid(`${where}._id must equal ${where === "row.body" ? "row._id" : "mutation.doc_id"}`);
+  }
+}
+
+function assertObject(value: unknown, where: string): asserts value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    invalid(`${where} must be an object`);
+  }
+}
+
+function cloneAndFreezeValue(value: DocumentValue): DocumentValue {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return Object.freeze(value.map(cloneAndFreezeValue)) as unknown as DocumentValue;
+  }
+  const cloned: DocumentData = {};
+  for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(value))) {
+    Object.defineProperty(cloned, key, {
+      value: cloneAndFreezeValue(descriptor.value as DocumentValue),
+      enumerable: true,
+      configurable: false,
+      writable: false,
+    });
+  }
+  return Object.freeze(cloned) as DocumentData;
+}
+
+const cloneAndFreezeDocument = (document: DocumentData): DocumentData =>
+  cloneAndFreezeValue(document) as DocumentData;
+
+export const foldChunkedSnapshotReference: ReferenceFold = (rows, mutations) => {
+  if (!Array.isArray(rows)) {
+    invalid("rows must be an array");
+  }
+  if (!Array.isArray(mutations)) {
+    invalid("mutations must be an array");
+  }
+
+  const documents = new Map<string, DocumentData>();
+  for (const candidate of rows as readonly unknown[]) {
+    assertObject(candidate, "row");
+    assertStoredDocId(candidate["_id"], "row._id");
+    const id = candidate["_id"];
+    assertDocument(candidate["body"], id, "row.body");
+    if (documents.has(id)) {
+      invalid("rows contain a duplicate _id");
+    }
+    documents.set(id, cloneAndFreezeDocument(candidate["body"]));
+  }
+
+  for (const candidate of mutations as readonly unknown[]) {
+    assertObject(candidate, "mutation");
+    const op = candidate["op"];
+    if (op !== "I" && op !== "U" && op !== "D") {
+      invalid("mutation.op must be I, U, or D");
+    }
+    assertStoredDocId(candidate["doc_id"], "mutation.doc_id");
+    const id = candidate["doc_id"];
+    if (op === "D") {
+      documents.delete(id);
+    } else {
+      assertDocument(candidate["after"], id, "mutation.after");
+      documents.set(id, cloneAndFreezeDocument(candidate["after"]));
+    }
+  }
+
+  return Object.freeze(
+    [...documents]
+      .map(([_id, body]) => Object.freeze({ _id, body }))
+      .toSorted((left, right) => compareDocIds(left._id, right._id)),
+  );
+};

--- a/packages/server/src/snapshot-chunk.test.ts
+++ b/packages/server/src/snapshot-chunk.test.ts
@@ -1,0 +1,415 @@
+import { fc, test as fcTest } from "@fast-check/vitest";
+import { BaerlyError, type DocumentData, encodeJsonBytes, snapshotHash } from "@baerly/protocol";
+import { describe, expect, test } from "vitest";
+import {
+  decodeSnapshotChunk,
+  encodeSnapshotChunk,
+  snapshotChunkKey,
+  type SnapshotChunk,
+} from "./snapshot-chunk.ts";
+import { compareDocIds } from "./snapshot-doc-id.ts";
+import type { SnapshotChunkDescriptor } from "./snapshot-manifest.ts";
+
+const prefix = "app/demo/tenant/acme/manifests/tickets";
+const incarnation = "00112233445566778899aabbccddeeff";
+const otherIncarnation = "ffeeddccbbaa99887766554433221100";
+
+const chunk = (overrides: Partial<SnapshotChunk> = {}): SnapshotChunk => ({
+  schema_version: 2,
+  collection: "tickets",
+  incarnation,
+  first_id: "a",
+  last_id: "é",
+  docs: [
+    { _id: "a", value: 1 },
+    { _id: "é", value: "nfd" },
+    { _id: "é", value: "nfc" },
+  ],
+  ...overrides,
+});
+
+const keyFor = async (bytes: Uint8Array, bodyIncarnation = incarnation): Promise<string> =>
+  snapshotChunkKey(prefix, bodyIncarnation, await snapshotHash(bytes));
+
+const descriptorFor = async (
+  bytes: Uint8Array,
+  value: SnapshotChunk,
+  overrides: Partial<SnapshotChunkDescriptor> = {},
+): Promise<SnapshotChunkDescriptor> => ({
+  first_id: value.first_id,
+  last_id: value.last_id,
+  key: await keyFor(bytes, value.incarnation),
+  byte_length: bytes.byteLength,
+  row_count: value.docs.length,
+  ...overrides,
+});
+
+const decode = async (
+  bytes: Uint8Array,
+  value: SnapshotChunk,
+  overrides: Partial<SnapshotChunkDescriptor> = {},
+): Promise<SnapshotChunk> => {
+  const descriptor = await descriptorFor(bytes, value, overrides);
+  return decodeSnapshotChunk(bytes, descriptor.key, "tickets", descriptor);
+};
+
+const expectInvalidResponse = async (operation: Promise<unknown>): Promise<void> => {
+  await expect(operation).rejects.toBeInstanceOf(BaerlyError);
+  await expect(operation).rejects.toMatchObject({ code: "InvalidResponse" });
+};
+
+describe("snapshot chunk codec", () => {
+  test("pins the accepted three-row bytes and key", async () => {
+    const value = chunk();
+    const bytes = encodeSnapshotChunk(value);
+    expect(new TextDecoder().decode(bytes)).toBe(
+      '{"schema_version":2,"collection":"tickets","incarnation":"00112233445566778899aabbccddeeff","first_id":"a","last_id":"é","docs":[{"_id":"a","value":1},{"_id":"é","value":"nfd"},{"_id":"é","value":"nfc"}]}',
+    );
+    expect(bytes.byteLength).toBe(208);
+    const descriptor = await descriptorFor(bytes, value);
+    expect(descriptor.key).toBe(
+      `${prefix}/_v2/snapshot/chunks/${incarnation}/sha256/96ae5ba511993addb97ba19c51004528a6cb5c278610352eb4478f4436a4315a.json`,
+    );
+    await expect(
+      decodeSnapshotChunk(bytes, descriptor.key, "tickets", descriptor),
+    ).resolves.toEqual(value);
+  });
+
+  test("pins a single-row chunk and a 4,096-row boundary chunk", async () => {
+    const single = chunk({ first_id: "a", last_id: "a", docs: [{ value: 1, _id: "a" }] });
+    const singleBytes = encodeSnapshotChunk(single);
+    expect(new TextDecoder().decode(singleBytes)).toBe(
+      '{"schema_version":2,"collection":"tickets","incarnation":"00112233445566778899aabbccddeeff","first_id":"a","last_id":"a","docs":[{"_id":"a","value":1}]}',
+    );
+    await expect(keyFor(singleBytes)).resolves.toBe(
+      `${prefix}/_v2/snapshot/chunks/${incarnation}/sha256/f8ffeec92ecfab1fe15a089ad9416550cbca3f47e2b5a67983be9a5c5e0367a2.json`,
+    );
+
+    const docs = Array.from({ length: 4096 }, (_, index) => ({
+      _id: `id${index.toString().padStart(4, "0")}`,
+      value: index,
+    }));
+    const boundary = chunk({ first_id: "id0000", last_id: "id4095", docs });
+    const boundaryBytes = encodeSnapshotChunk(boundary);
+    expect(boundaryBytes.byteLength).toBe(121_910);
+    await expect(keyFor(boundaryBytes)).resolves.toBe(
+      `${prefix}/_v2/snapshot/chunks/${incarnation}/sha256/2c6542fa5c534d7011bbc7a5b98084402c8e13ecd0103413ad1ebeb5f58c1d08.json`,
+    );
+    await expect(decode(boundaryBytes, boundary)).resolves.toEqual(boundary);
+  });
+
+  test("canonicalizes document members recursively in deterministic ECMAScript order", async () => {
+    const value = chunk({
+      first_id: "a",
+      last_id: "a",
+      docs: [
+        {
+          z: { zebra: true, alpha: false, 10: "ten", 2: "two" },
+          _id: "a",
+          a: [{ z: 1, a: 2 }],
+        },
+      ],
+    });
+    const bytes = encodeSnapshotChunk(value);
+    expect(new TextDecoder().decode(bytes)).toContain(
+      '"docs":[{"_id":"a","a":[{"a":2,"z":1}],"z":{"2":"two","10":"ten","alpha":false,"zebra":true}}]',
+    );
+    const decoded = await decode(bytes, {
+      ...value,
+      docs: [
+        { _id: "a", a: [{ a: 2, z: 1 }], z: { 2: "two", 10: "ten", alpha: false, zebra: true } },
+      ],
+    });
+    expect(decoded.docs[0]).toEqual(value.docs[0]);
+  });
+
+  test.each<[string, Record<string, unknown>]>([
+    ["unknown envelope field", { ...chunk(), surprise: true }],
+    ["unsupported schema", { ...chunk(), schema_version: 3 }],
+    ["invalid incarnation", { ...chunk(), incarnation: incarnation.toUpperCase() }],
+    ["empty document list", { ...chunk(), first_id: "a", last_id: "a", docs: [] }],
+    ["missing _id", { ...chunk(), first_id: "a", last_id: "a", docs: [{ value: 1 }] }],
+    [
+      "invalid scalar ID",
+      { ...chunk(), first_id: "\ud800", last_id: "\ud800", docs: [{ _id: "\ud800" }] },
+    ],
+    [
+      "null stored value",
+      { ...chunk(), first_id: "a", last_id: "a", docs: [{ _id: "a", value: null }] },
+    ],
+    ["non-object document", { ...chunk(), first_id: "a", last_id: "a", docs: ["a"] }],
+    [
+      "duplicate IDs",
+      { ...chunk(), first_id: "a", last_id: "a", docs: [{ _id: "a" }, { _id: "a" }] },
+    ],
+    [
+      "decreasing IDs",
+      { ...chunk(), first_id: "b", last_id: "a", docs: [{ _id: "b" }, { _id: "a" }] },
+    ],
+    ["wrong first range", { ...chunk(), first_id: "b" }],
+    ["wrong last range", { ...chunk(), last_id: "z" }],
+  ])("rejects stored %s", async (_label, body) => {
+    const bytes = encodeJsonBytes(body);
+    const bodyIncarnation = String(body["incarnation"]);
+    const key = await keyFor(
+      bytes,
+      /^[0-9a-f]{32}$/.test(bodyIncarnation) ? bodyIncarnation : incarnation,
+    );
+    const descriptor: SnapshotChunkDescriptor = {
+      first_id: String(body["first_id"]),
+      last_id: String(body["last_id"]),
+      key,
+      byte_length: bytes.byteLength,
+      row_count: Array.isArray(body["docs"]) ? body["docs"].length : 1,
+    };
+    await expectInvalidResponse(decodeSnapshotChunk(bytes, key, "tickets", descriptor));
+  });
+
+  test("rejects 4,097 rows and an over-1-MiB canonical body", async () => {
+    const tooManyDocs = Array.from({ length: 4097 }, (_, index) => ({
+      _id: `id${index.toString().padStart(4, "0")}`,
+    }));
+    const tooMany = chunk({ first_id: "id0000", last_id: "id4096", docs: tooManyDocs });
+    const tooManyBytes = encodeJsonBytes(tooMany);
+    await expectInvalidResponse(decode(tooManyBytes, tooMany));
+
+    const oversized = chunk({
+      first_id: "a",
+      last_id: "a",
+      docs: [{ _id: "a", value: "x".repeat(1_048_576) }],
+    });
+    const oversizedBytes = encodeJsonBytes(oversized);
+    await expectInvalidResponse(decode(oversizedBytes, oversized));
+  });
+
+  test.each<[string, Partial<SnapshotChunkDescriptor> & { readonly expectedCollection?: string }]>([
+    ["collection", { expectedCollection: "other" }],
+    ["descriptor key", { key: "wrong" }],
+    ["descriptor byte length", { byte_length: 1 }],
+    ["descriptor row count", { row_count: 2 }],
+    ["descriptor first ID", { first_id: "b" }],
+    ["descriptor last ID", { last_id: "z" }],
+  ])("rejects wrong %s claims", async (_label, claim) => {
+    const value = chunk();
+    const bytes = encodeSnapshotChunk(value);
+    const validDescriptor = await descriptorFor(bytes, value);
+    const expectedCollection = claim.expectedCollection ?? "tickets";
+    const suppliedKey = claim.key ?? validDescriptor.key;
+    const suppliedDescriptor = { ...validDescriptor, ...claim, key: suppliedKey };
+    await expectInvalidResponse(
+      decodeSnapshotChunk(bytes, suppliedKey, expectedCollection, suppliedDescriptor),
+    );
+  });
+
+  test("rejects key/body incarnation disagreement but accepts an older reused chunk", async () => {
+    const value = chunk();
+    const bytes = encodeSnapshotChunk(value);
+    const digest = await snapshotHash(bytes);
+    const wrongKey = snapshotChunkKey(prefix, otherIncarnation, digest);
+    await expectInvalidResponse(
+      decodeSnapshotChunk(bytes, wrongKey, "tickets", {
+        ...(await descriptorFor(bytes, value)),
+        key: wrongKey,
+      }),
+    );
+
+    const reused = chunk({ incarnation: otherIncarnation });
+    const reusedBytes = encodeSnapshotChunk(reused);
+    const reusedDescriptor = await descriptorFor(reusedBytes, reused);
+    await expect(
+      decodeSnapshotChunk(reusedBytes, reusedDescriptor.key, "tickets", reusedDescriptor),
+    ).resolves.toEqual(reused);
+  });
+
+  test.each([
+    ["wrong version", (key: string) => key.replace("/_v2/", "/_v3/")],
+    ["wrong artifact kind", (key: string) => key.replace("/chunks/", "/manifests/")],
+    ["wrong algorithm", (key: string) => key.replace("/sha256/", "/sha1/")],
+    ["uppercase digest", (key: string) => key.replace(/[a-f](?=[0-9a-f]{0,63}\.json$)/, "A")],
+    ["short digest", (key: string) => key.replace(/[0-9a-f]\.json$/, ".json")],
+    ["wrong suffix", (key: string) => key.replace(".json", ".bin")],
+    ["extra segment", (key: string) => key.replace("/sha256/", "/extra/sha256/")],
+    ["empty prefix segment", (key: string) => key.replace("/_v2/", "//_v2/")],
+  ])("rejects a key with %s", async (_label, corrupt) => {
+    const value = chunk();
+    const bytes = encodeSnapshotChunk(value);
+    const descriptor = await descriptorFor(bytes, value);
+    const key = corrupt(descriptor.key);
+    await expectInvalidResponse(decodeSnapshotChunk(bytes, key, "tickets", { ...descriptor, key }));
+  });
+
+  test("rejects malformed, truncated, noncanonical, duplicate-member, and digest-mismatched bytes", async () => {
+    const value = chunk();
+    const malformed = new TextEncoder().encode("{");
+    await expectInvalidResponse(decode(malformed, value));
+
+    const canonical = encodeSnapshotChunk(value);
+    const truncated = canonical.slice(0, -1);
+    await expectInvalidResponse(decode(truncated, value));
+
+    const spaced = new TextEncoder().encode(
+      new TextDecoder().decode(canonical).replace(":2", ": 2"),
+    );
+    await expectInvalidResponse(decode(spaced, value));
+
+    const duplicate = new TextEncoder().encode(
+      new TextDecoder()
+        .decode(canonical)
+        .replace('"schema_version":2', '"schema_version":2,"schema_version":2'),
+    );
+    await expectInvalidResponse(decode(duplicate, value));
+
+    const changed = canonical.slice();
+    changed[changed.length - 2] = changed[changed.length - 2]! ^ 1;
+    const descriptor = await descriptorFor(canonical, value);
+    await expectInvalidResponse(
+      decodeSnapshotChunk(changed, descriptor.key, "tickets", {
+        ...descriptor,
+        byte_length: changed.byteLength,
+      }),
+    );
+  });
+
+  test("decodes one private byte snapshot when the caller mutates the input during hashing", async () => {
+    const value = chunk({ first_id: "a", last_id: "a", docs: [{ _id: "a", value: 1 }] });
+    const bytes = encodeSnapshotChunk(value);
+    const descriptor = await descriptorFor(bytes, value);
+    const pending = decodeSnapshotChunk(bytes, descriptor.key, "tickets", descriptor);
+    const marker = new TextEncoder().encode('"value":1');
+    const offset = bytes.findIndex((_byte, index) =>
+      marker.every((expected, markerIndex) => bytes[index + markerIndex] === expected),
+    );
+    expect(offset).toBeGreaterThanOrEqual(0);
+    bytes[offset + marker.length - 1] = "2".charCodeAt(0);
+
+    await expect(pending).resolves.toEqual(value);
+  });
+
+  test("rejects an oversized body before allocating a private copy", async () => {
+    const bytes = new Uint8Array(1024 * 1024 + 1);
+    let copied = false;
+    Object.defineProperty(bytes, "slice", {
+      value: () => {
+        copied = true;
+        throw new Error("oversized input must not be copied");
+      },
+    });
+    const key = snapshotChunkKey(prefix, incarnation, "0".repeat(64));
+
+    await expectInvalidResponse(
+      decodeSnapshotChunk(bytes, key, "tickets", {
+        first_id: "a",
+        last_id: "a",
+        key,
+        byte_length: bytes.byteLength,
+        row_count: 1,
+      }),
+    );
+    expect(copied).toBe(false);
+  });
+
+  test("normalizes pathological stored and caller nesting as BaerlyError", async () => {
+    const depth = 15_000;
+    const raw = `{"schema_version":2,"collection":"tickets","incarnation":"${incarnation}","first_id":"a","last_id":"a","docs":[{"_id":"a","value":${"[".repeat(depth)}true${"]".repeat(depth)}}]}`;
+    const bytes = new TextEncoder().encode(raw);
+    const key = await keyFor(bytes);
+    await expectInvalidResponse(
+      decodeSnapshotChunk(bytes, key, "tickets", {
+        first_id: "a",
+        last_id: "a",
+        key,
+        byte_length: bytes.byteLength,
+        row_count: 1,
+      }),
+    );
+
+    let nested: unknown = true;
+    for (let level = 0; level < depth; level++) {
+      nested = [nested];
+    }
+    expect(() =>
+      encodeSnapshotChunk(
+        chunk({
+          first_id: "a",
+          last_id: "a",
+          docs: [{ _id: "a", value: nested }] as unknown as DocumentData[],
+        }),
+      ),
+    ).toThrowError(expect.objectContaining({ code: "InvalidConfig" }));
+  });
+
+  test("rejects invalid caller values as InvalidConfig", () => {
+    expect(() => snapshotChunkKey(prefix, incarnation, "A".repeat(64))).toThrowError(
+      expect.objectContaining({ code: "InvalidConfig" }),
+    );
+    expect(() =>
+      encodeSnapshotChunk(
+        chunk({
+          first_id: "a",
+          last_id: "a",
+          docs: [{ _id: "a", value: null }] as unknown as DocumentData[],
+        }),
+      ),
+    ).toThrowError(expect.objectContaining({ code: "InvalidConfig" }));
+
+    const symbolField = Object.assign(chunk(), { [Symbol("unknown")]: true });
+    expect(() => encodeSnapshotChunk(symbolField)).toThrowError(
+      expect.objectContaining({ code: "InvalidConfig" }),
+    );
+
+    const accessorArray: unknown[] = [];
+    Object.defineProperty(accessorArray, 0, { enumerable: true, get: () => "value" });
+    accessorArray.length = 1;
+    expect(() =>
+      encodeSnapshotChunk(
+        chunk({
+          first_id: "a",
+          last_id: "a",
+          docs: [{ _id: "a", value: accessorArray }] as unknown as DocumentData[],
+        }),
+      ),
+    ).toThrowError(expect.objectContaining({ code: "InvalidConfig" }));
+  });
+});
+
+const idArb = fc.oneof(
+  fc.stringMatching(/^[a-z][a-z0-9]{0,5}$/),
+  fc.constantFrom("é", "e\u0301", "\u{10000}", "\u{1f600}"),
+);
+const valueArb = fc.oneof(fc.string(), fc.integer(), fc.boolean());
+
+fcTest.prop({
+  rows: fc.uniqueArray(fc.tuple(idArb, valueArb), {
+    minLength: 1,
+    maxLength: 24,
+    selector: ([id]) => id,
+  }),
+})("round-trips generated rows with deterministic bytes and keys", async ({ rows }) => {
+  const docs = rows
+    .map(([id, value]) => ({ value, nested: { z: true, a: false }, _id: id }))
+    .toSorted((left, right) => compareDocIds(left._id, right._id));
+  const value = chunk({ first_id: docs[0]!._id, last_id: docs.at(-1)!._id, docs });
+  const first = encodeSnapshotChunk(value);
+  const second = encodeSnapshotChunk(value);
+  expect(second).toEqual(first);
+  const firstKey = await keyFor(first);
+  await expect(keyFor(second)).resolves.toBe(firstKey);
+  await expect(decode(first, value)).resolves.toEqual({
+    ...value,
+    docs,
+  });
+});
+
+fcTest.prop({ value: valueArb })(
+  "changing only the incarnation changes canonical bytes and artifact keys",
+  async ({ value: field }) => {
+    const firstValue = chunk({ first_id: "a", last_id: "a", docs: [{ _id: "a", value: field }] });
+    const secondValue = { ...firstValue, incarnation: otherIncarnation };
+    const first = encodeSnapshotChunk(firstValue);
+    const second = encodeSnapshotChunk(secondValue);
+    expect(first).not.toEqual(second);
+    const firstKey = await keyFor(first);
+    const secondKey = await keyFor(second, otherIncarnation);
+    expect(firstKey).not.toBe(secondKey);
+  },
+);

--- a/packages/server/src/snapshot-chunk.ts
+++ b/packages/server/src/snapshot-chunk.ts
@@ -1,0 +1,379 @@
+import {
+  BaerlyError,
+  decodeJsonBytes,
+  type DocumentData,
+  type DocumentValue,
+  encodeJsonBytes,
+  MAX_KEY_BYTES,
+  snapshotHash,
+} from "@baerly/protocol";
+import { assertKeyWithinLimit } from "./key-limit.ts";
+import { assertPathSegment } from "./path-segment.ts";
+import { assertSnapshotDocId, compareDocIds } from "./snapshot-doc-id.ts";
+import type { SnapshotChunkDescriptor } from "./snapshot-manifest.ts";
+
+const SNAPSHOT_CHUNK_SCHEMA_VERSION = 2;
+const MAX_CHUNK_BYTES = 1024 * 1024;
+const MAX_CHUNK_ROWS = 4096;
+const INCARNATION_PATTERN = /^[0-9a-f]{32}$/;
+const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
+const CHUNK_KEY_PATTERN =
+  /^(.+)\/_v2\/snapshot\/chunks\/([0-9a-f]{32})\/sha256\/([0-9a-f]{64})\.json$/;
+const utf8 = new TextEncoder();
+
+export interface SnapshotChunk {
+  readonly schema_version: number;
+  readonly collection: string;
+  readonly incarnation: string;
+  readonly first_id: string;
+  readonly last_id: string;
+  readonly docs: readonly DocumentData[];
+}
+
+interface ParsedChunkKey {
+  readonly prefix: string;
+  readonly incarnation: string;
+  readonly digest: string;
+}
+
+function invalid(
+  code: "InvalidConfig" | "InvalidResponse",
+  message: string,
+  cause?: unknown,
+): never {
+  throw new BaerlyError(code, `snapshot chunk: ${message}`, cause);
+}
+
+function normalizeCodecFailure<T>(
+  code: "InvalidConfig" | "InvalidResponse",
+  operation: () => T,
+): T {
+  try {
+    return operation();
+  } catch (error) {
+    if (error instanceof BaerlyError) {
+      throw error;
+    }
+    invalid(code, "body exceeds supported JSON validation depth", error);
+  }
+}
+
+function assertExactFields(
+  value: unknown,
+  expected: readonly string[],
+  where: string,
+  code: "InvalidConfig" | "InvalidResponse",
+): asserts value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    invalid(code, `${where} must be an object`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  const keys = Object.keys(descriptors);
+  if (
+    (prototype !== Object.prototype && prototype !== null) ||
+    Object.getOwnPropertySymbols(value).length !== 0 ||
+    keys.length !== expected.length ||
+    expected.some((key) => {
+      const descriptor = descriptors[key];
+      return descriptor === undefined || !descriptor.enumerable || !("value" in descriptor);
+    })
+  ) {
+    invalid(code, `${where} must contain exactly the required fields`);
+  }
+}
+
+function assertCallerSegment(value: unknown, role: string): asserts value is string {
+  if (typeof value !== "string") {
+    invalid("InvalidConfig", `${role} must be a string`);
+  }
+  try {
+    assertPathSegment(value, role);
+  } catch (error) {
+    invalid("InvalidConfig", `${role} is invalid`, error);
+  }
+}
+
+function assertStoredDocId(value: unknown, where: string): asserts value is string {
+  if (typeof value !== "string") {
+    invalid("InvalidResponse", `${where} must be a string`);
+  }
+  try {
+    assertSnapshotDocId(value);
+  } catch (error) {
+    invalid("InvalidResponse", `${where} is invalid`, error);
+  }
+}
+
+function isArrayIndex(key: string): boolean {
+  const value = Number(key);
+  return Number.isInteger(value) && value >= 0 && value < 0xffff_ffff && String(value) === key;
+}
+
+function canonicalKeyOrder(left: string, right: string): number {
+  const leftIndex = isArrayIndex(left);
+  const rightIndex = isArrayIndex(right);
+  if (leftIndex && rightIndex) {
+    return Number(left) - Number(right);
+  }
+  if (leftIndex !== rightIndex) {
+    return leftIndex ? -1 : 1;
+  }
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
+}
+
+function canonicalizeDocumentValue(
+  value: unknown,
+  code: "InvalidConfig" | "InvalidResponse",
+  where: string,
+  ancestors: Set<object>,
+): DocumentValue {
+  if (typeof value === "string" || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      invalid(code, `${where} must contain only finite numbers`);
+    }
+    return value;
+  }
+  if (value === null || typeof value !== "object") {
+    invalid(code, `${where} contains a value outside DocumentData`);
+  }
+  if (ancestors.has(value)) {
+    invalid(code, `${where} contains a cycle`);
+  }
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const keys = Object.keys(value);
+      if (
+        Object.getOwnPropertySymbols(value).length !== 0 ||
+        keys.length !== value.length ||
+        keys.some((key, index) => {
+          const descriptor = Object.getOwnPropertyDescriptor(value, key);
+          return (
+            key !== String(index) ||
+            descriptor === undefined ||
+            !descriptor.enumerable ||
+            !("value" in descriptor)
+          );
+        })
+      ) {
+        invalid(code, `${where} must be a dense array without extra properties`);
+      }
+      return value.map((entry, index) =>
+        canonicalizeDocumentValue(entry, code, `${where}[${index}]`, ancestors),
+      );
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      invalid(code, `${where} must contain only plain objects`);
+    }
+    if (Object.getOwnPropertySymbols(value).length !== 0) {
+      invalid(code, `${where} must not contain symbol keys`);
+    }
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    const output: DocumentData = {};
+    for (const key of Object.keys(descriptors).toSorted(canonicalKeyOrder)) {
+      const descriptor = descriptors[key]!;
+      if (!descriptor.enumerable || !("value" in descriptor)) {
+        invalid(code, `${where}.${key} must be an enumerable data property`);
+      }
+      Object.defineProperty(output, key, {
+        value: canonicalizeDocumentValue(descriptor.value, code, `${where}.${key}`, ancestors),
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+    return output;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function canonicalizeDocument(
+  value: unknown,
+  code: "InvalidConfig" | "InvalidResponse",
+  where: string,
+): DocumentData {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    invalid(code, `${where} must be a document object`);
+  }
+  const canonical = canonicalizeDocumentValue(
+    value,
+    code,
+    where,
+    new Set<object>(),
+  ) as DocumentData;
+  const id = Object.getOwnPropertyDescriptor(canonical, "_id")?.value;
+  if (code === "InvalidConfig") {
+    assertCallerSegment(id, `${where}._id`);
+    try {
+      assertSnapshotDocId(id);
+    } catch (error) {
+      invalid(code, `${where}._id is invalid`, error);
+    }
+  } else {
+    assertStoredDocId(id, `${where}._id`);
+  }
+  return canonical;
+}
+
+function canonicalizeChunk(
+  value: unknown,
+  code: "InvalidConfig" | "InvalidResponse",
+): SnapshotChunk {
+  assertExactFields(
+    value,
+    ["schema_version", "collection", "incarnation", "first_id", "last_id", "docs"],
+    "body",
+    code,
+  );
+  if (value["schema_version"] !== SNAPSHOT_CHUNK_SCHEMA_VERSION) {
+    invalid(code, "unsupported schema_version");
+  }
+  if (typeof value["collection"] !== "string") {
+    invalid(code, "collection must be a string");
+  }
+  if (code === "InvalidConfig") {
+    assertCallerSegment(value["collection"], "collection");
+  }
+  if (typeof value["incarnation"] !== "string" || !INCARNATION_PATTERN.test(value["incarnation"])) {
+    invalid(code, "incarnation must be 32 lowercase hex characters");
+  }
+  if (!Array.isArray(value["docs"])) {
+    invalid(code, "docs must be an array");
+  }
+  if (value["docs"].length === 0 || value["docs"].length > MAX_CHUNK_ROWS) {
+    invalid(code, `docs must contain 1 through ${MAX_CHUNK_ROWS} documents`);
+  }
+
+  const docs = value["docs"].map((document, index) =>
+    canonicalizeDocument(document, code, `docs[${index}]`),
+  );
+  for (let index = 1; index < docs.length; index++) {
+    if (compareDocIds(docs[index - 1]!["_id"] as string, docs[index]!["_id"] as string) >= 0) {
+      invalid(code, "document IDs must be strictly increasing");
+    }
+  }
+  const firstId = docs[0]!["_id"] as string;
+  const lastId = docs.at(-1)!["_id"] as string;
+  if (value["first_id"] !== firstId || value["last_id"] !== lastId) {
+    invalid(code, "first_id and last_id must match the document range");
+  }
+
+  return {
+    schema_version: SNAPSHOT_CHUNK_SCHEMA_VERSION,
+    collection: value["collection"],
+    incarnation: value["incarnation"],
+    first_id: firstId,
+    last_id: lastId,
+    docs,
+  };
+}
+
+function parseChunkKey(key: string, code: "InvalidConfig" | "InvalidResponse"): ParsedChunkKey {
+  if (utf8.encode(key).byteLength > MAX_KEY_BYTES) {
+    invalid(code, `key exceeds ${MAX_KEY_BYTES} bytes`);
+  }
+  const match = CHUNK_KEY_PATTERN.exec(key);
+  if (match === null) {
+    invalid(code, "key does not match the schema-v2 chunk grammar");
+  }
+  if (match[1]!.endsWith("/")) {
+    invalid(code, "key collection prefix contains an empty trailing segment");
+  }
+  return { prefix: match[1]!, incarnation: match[2]!, digest: match[3]! };
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  return left.byteLength === right.byteLength && left.every((byte, index) => byte === right[index]);
+}
+
+export const encodeSnapshotChunk = (chunk: SnapshotChunk): Uint8Array => {
+  return normalizeCodecFailure("InvalidConfig", () => {
+    const canonical = canonicalizeChunk(chunk, "InvalidConfig");
+    const bytes = encodeJsonBytes(canonical);
+    if (bytes.byteLength > MAX_CHUNK_BYTES) {
+      invalid("InvalidConfig", `canonical body exceeds ${MAX_CHUNK_BYTES} bytes`);
+    }
+    return bytes;
+  });
+};
+
+export const snapshotChunkKey = (
+  collectionPrefix: string,
+  incarnation: string,
+  digest: string,
+): string => {
+  if (collectionPrefix.length === 0 || collectionPrefix.endsWith("/")) {
+    invalid("InvalidConfig", "collection prefix must be non-empty without a trailing slash");
+  }
+  if (!INCARNATION_PATTERN.test(incarnation)) {
+    invalid("InvalidConfig", "incarnation must be 32 lowercase hex characters");
+  }
+  if (!DIGEST_PATTERN.test(digest)) {
+    invalid("InvalidConfig", "digest must be 64 lowercase hex characters");
+  }
+  const key = `${collectionPrefix}/_v2/snapshot/chunks/${incarnation}/sha256/${digest}.json`;
+  assertKeyWithinLimit(key);
+  return key;
+};
+
+export const decodeSnapshotChunk = async (
+  bytes: Uint8Array,
+  key: string,
+  expectedCollection: string,
+  descriptor: SnapshotChunkDescriptor,
+): Promise<SnapshotChunk> => {
+  if (bytes.byteLength === 0 || bytes.byteLength > MAX_CHUNK_BYTES) {
+    invalid("InvalidResponse", "body length is outside the chunk ceiling");
+  }
+  const bodyBytes = bytes.slice();
+  const parsedKey = parseChunkKey(key, "InvalidResponse");
+  if (descriptor.key !== key || descriptor.byte_length !== bodyBytes.byteLength) {
+    invalid("InvalidResponse", "body does not match its descriptor key or byte length");
+  }
+  const digest = await snapshotHash(bodyBytes);
+  if (digest !== parsedKey.digest) {
+    invalid("InvalidResponse", "body digest does not match its key");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = decodeJsonBytes(bodyBytes);
+  } catch (error) {
+    invalid("InvalidResponse", "body is not valid JSON", error);
+  }
+  const canonical = normalizeCodecFailure("InvalidResponse", () => {
+    const value = canonicalizeChunk(parsed, "InvalidResponse");
+    const canonicalBytes = encodeJsonBytes(value);
+    if (!equalBytes(bodyBytes, canonicalBytes)) {
+      invalid("InvalidResponse", "body is not canonical JSON");
+    }
+    return value;
+  });
+  if (canonical.collection !== expectedCollection) {
+    invalid("InvalidResponse", "body collection does not match the expected collection");
+  }
+  if (canonical.incarnation !== parsedKey.incarnation) {
+    invalid("InvalidResponse", "body incarnation does not match its key");
+  }
+  if (
+    canonical.first_id !== descriptor.first_id ||
+    canonical.last_id !== descriptor.last_id ||
+    canonical.docs.length !== descriptor.row_count
+  ) {
+    invalid("InvalidResponse", "body range or row count does not match its descriptor");
+  }
+  return canonical;
+};

--- a/packages/server/src/snapshot-doc-id.test.ts
+++ b/packages/server/src/snapshot-doc-id.test.ts
@@ -1,0 +1,117 @@
+import { fc, test as fcTest } from "@fast-check/vitest";
+import { BaerlyError } from "@baerly/protocol";
+import { describe, expect, test } from "vitest";
+import { MAX_SEGMENT_BYTES } from "./path-segment.ts";
+import { assertSnapshotDocId, compareDocIds } from "./snapshot-doc-id.ts";
+
+const sign = (value: number): number => {
+  if (value < 0) {
+    return -1;
+  }
+  if (value > 0) {
+    return 1;
+  }
+  return 0;
+};
+
+const encoder = new TextEncoder();
+const compareUtf8Bytes = (left: string, right: string): number => {
+  const leftBytes = encoder.encode(left);
+  const rightBytes = encoder.encode(right);
+  const length = Math.min(leftBytes.length, rightBytes.length);
+  for (let offset = 0; offset < length; offset++) {
+    if (leftBytes[offset] !== rightBytes[offset]) {
+      return leftBytes[offset]! < rightBytes[offset]! ? -1 : 1;
+    }
+  }
+  return sign(leftBytes.length - rightBytes.length);
+};
+
+// `binary` spans Unicode scalar values, including astral code points, but
+// excludes unpaired UTF-16 surrogates. It keeps all comparator properties in
+// the `utf8-scalar-v1` domain.
+const scalarStringArb = fc.string({ unit: "binary" });
+const pathSafeScalarIdArb = fc
+  .array(fc.constantFrom("a", "Z", "0", "-", ".", "é", "e", "\u0301", "\u{10000}"), {
+    minLength: 1,
+    maxLength: 50,
+  })
+  .map((units) => units.join(""))
+  .filter((id) => id !== "." && id !== "..");
+
+describe("snapshot document IDs", () => {
+  test.each([
+    "",
+    "a/b",
+    ".",
+    "..",
+    "../victim",
+    "_internal",
+    "with\u0000null",
+    "tab\tchar",
+    "del\u007fchar",
+    "x".repeat(MAX_SEGMENT_BYTES + 1),
+    "\ud800",
+    "\udc00",
+    "x\ud800",
+    "\udc00x",
+  ])("rejects %j as InvalidConfig", (id) => {
+    expect(() => assertSnapshotDocId(id)).toThrow(BaerlyError);
+    try {
+      assertSnapshotDocId(id);
+    } catch (error) {
+      expect((error as BaerlyError).code).toBe("InvalidConfig");
+    }
+  });
+
+  test.each(["ascii", "é", "e\u0301", "\ud83d\udca9"])("accepts %j", (id) => {
+    expect(() => assertSnapshotDocId(id)).not.toThrow();
+  });
+
+  test("orders ASCII, BMP, non-BMP, escaped scalars, and prefixes by utf8-scalar-v1", () => {
+    for (const [left, right, expected] of [
+      ["a", "aa", -1],
+      ["a\\b", "aa", -1],
+      ["e\u0301", "é", -1],
+      ["\ue000", "\u{10000}", -1],
+      ["\u{10000}", "\u{1f4a9}", -1],
+    ] as const) {
+      expect(compareDocIds(left, right)).toBe(expected);
+    }
+  });
+
+  fcTest.prop({ id: pathSafeScalarIdArb })("accepts generated path-safe scalar IDs", ({ id }) => {
+    expect(() => assertSnapshotDocId(id)).not.toThrow();
+  });
+
+  fcTest.prop({ left: scalarStringArb, right: scalarStringArb })(
+    "is antisymmetric",
+    ({ left, right }) => {
+      const reverse = sign(compareDocIds(right, left));
+      expect(sign(compareDocIds(left, right))).toBe(reverse === 0 ? 0 : -reverse);
+    },
+  );
+
+  fcTest.prop({ left: scalarStringArb, middle: scalarStringArb, right: scalarStringArb })(
+    "is transitive",
+    ({ left, middle, right }) => {
+      if (compareDocIds(left, middle) <= 0 && compareDocIds(middle, right) <= 0) {
+        expect(compareDocIds(left, right)).toBeLessThanOrEqual(0);
+      }
+    },
+  );
+
+  fcTest.prop({ prefix: scalarStringArb, suffix: fc.string({ unit: "binary", minLength: 1 }) })(
+    "puts a proper prefix first",
+    ({ prefix, suffix }) => {
+      expect(compareDocIds(prefix, prefix + suffix)).toBe(-1);
+    },
+  );
+
+  fcTest.prop({ left: scalarStringArb, right: scalarStringArb })(
+    "matches lexicographic UTF-8 byte order",
+    ({ left, right }) => {
+      expect(compareDocIds(left, right)).toBe(compareUtf8Bytes(left, right));
+    },
+  );
+});

--- a/packages/server/src/snapshot-doc-id.ts
+++ b/packages/server/src/snapshot-doc-id.ts
@@ -1,0 +1,44 @@
+import { BaerlyError } from "@baerly/protocol";
+import { assertPathSegment } from "./path-segment.ts";
+
+/**
+ * Guard a document ID admitted to the scalar-ordered snapshot layout.
+ *
+ * The existing path-segment rules protect key and filesystem safety. Snapshot
+ * IDs additionally must be Unicode scalar-value strings, so their UTF-8
+ * encoding and `utf8-scalar-v1` ordering are unambiguous.
+ */
+export const assertSnapshotDocId = (id: string): void => {
+  assertPathSegment(id, "_id");
+  for (let offset = 0; offset < id.length; offset++) {
+    const unit = id.charCodeAt(offset);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = id.charCodeAt(offset + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        throw new BaerlyError("InvalidConfig", "_id may not contain isolated UTF-16 surrogates");
+      }
+      offset++;
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      throw new BaerlyError("InvalidConfig", "_id may not contain isolated UTF-16 surrogates");
+    }
+  }
+};
+
+/** Compare scalar-value strings by their UTF-8 lexicographic order. */
+export const compareDocIds = (left: string, right: string): number => {
+  let leftOffset = 0;
+  let rightOffset = 0;
+  while (leftOffset < left.length && rightOffset < right.length) {
+    const leftPoint = left.codePointAt(leftOffset)!;
+    const rightPoint = right.codePointAt(rightOffset)!;
+    if (leftPoint !== rightPoint) {
+      return leftPoint < rightPoint ? -1 : 1;
+    }
+    leftOffset += leftPoint > 0xffff ? 2 : 1;
+    rightOffset += rightPoint > 0xffff ? 2 : 1;
+  }
+  if (leftOffset === left.length && rightOffset === right.length) {
+    return 0;
+  }
+  return leftOffset === left.length ? -1 : 1;
+};

--- a/packages/server/src/snapshot-manifest.test.ts
+++ b/packages/server/src/snapshot-manifest.test.ts
@@ -1,0 +1,342 @@
+import { fc, test as fcTest } from "@fast-check/vitest";
+import { BaerlyError, encodeJsonBytes, snapshotHash } from "@baerly/protocol";
+import { describe, expect, test } from "vitest";
+import {
+  decodeSnapshotManifest,
+  encodeSnapshotManifest,
+  snapshotManifestKey,
+  type SnapshotChunkDescriptor,
+  type SnapshotManifest,
+} from "./snapshot-manifest.ts";
+import { compareDocIds } from "./snapshot-doc-id.ts";
+
+const prefix = "app/demo/tenant/acme/manifests/tickets";
+const incarnation = "00112233445566778899aabbccddeeff";
+const otherIncarnation = "ffeeddccbbaa99887766554433221100";
+const fixedChunkKey = `${prefix}/_v2/snapshot/chunks/${incarnation}/sha256/96ae5ba511993addb97ba19c51004528a6cb5c278610352eb4478f4436a4315a.json`;
+
+const descriptor = (overrides: Partial<SnapshotChunkDescriptor> = {}): SnapshotChunkDescriptor => ({
+  first_id: "a",
+  last_id: "é",
+  key: fixedChunkKey,
+  byte_length: 208,
+  row_count: 3,
+  ...overrides,
+});
+
+const manifest = (overrides: Partial<SnapshotManifest> = {}): SnapshotManifest => ({
+  schema_version: 2,
+  collection: "tickets",
+  log_seq_start: 41,
+  incarnation,
+  collation: "utf8-scalar-v1",
+  chunks: [descriptor()],
+  ...overrides,
+});
+
+const keyFor = async (bytes: Uint8Array, bodyIncarnation = incarnation): Promise<string> =>
+  snapshotManifestKey(prefix, bodyIncarnation, await snapshotHash(bytes));
+
+const expectInvalidResponse = async (operation: Promise<unknown>): Promise<void> => {
+  await expect(operation).rejects.toBeInstanceOf(BaerlyError);
+  await expect(operation).rejects.toMatchObject({ code: "InvalidResponse" });
+};
+
+describe("snapshot manifest codec", () => {
+  test("pins the empty manifest bytes and key", async () => {
+    const value = manifest({ log_seq_start: 0, chunks: [] });
+    const bytes = encodeSnapshotManifest(value);
+    expect(new TextDecoder().decode(bytes)).toBe(
+      '{"schema_version":2,"collection":"tickets","log_seq_start":0,"incarnation":"00112233445566778899aabbccddeeff","collation":"utf8-scalar-v1","chunks":[]}',
+    );
+    expect(bytes.byteLength).toBe(151);
+    const key = await keyFor(bytes);
+    expect(key).toBe(
+      `${prefix}/_v2/snapshot/manifests/${incarnation}/sha256/049126f9dd4797176ce68f5faa2f86923eead5ac692b915715a9a766a369e696.json`,
+    );
+    await expect(decodeSnapshotManifest(bytes, key, "tickets", 0)).resolves.toEqual(value);
+  });
+
+  test("pins the accepted one-descriptor manifest vector", async () => {
+    const value = manifest();
+    const bytes = encodeSnapshotManifest(value);
+    expect(new TextDecoder().decode(bytes)).toBe(
+      '{"schema_version":2,"collection":"tickets","log_seq_start":41,"incarnation":"00112233445566778899aabbccddeeff","collation":"utf8-scalar-v1","chunks":[{"first_id":"a","last_id":"é","key":"app/demo/tenant/acme/manifests/tickets/_v2/snapshot/chunks/00112233445566778899aabbccddeeff/sha256/96ae5ba511993addb97ba19c51004528a6cb5c278610352eb4478f4436a4315a.json","byte_length":208,"row_count":3}]}',
+    );
+    expect(bytes.byteLength).toBe(392);
+    const key = await keyFor(bytes);
+    expect(key).toBe(
+      `${prefix}/_v2/snapshot/manifests/${incarnation}/sha256/a82e680f7c003264d47a0ac3180f31eff3a8220518ec9b80dedc31be210944bf.json`,
+    );
+    await expect(decodeSnapshotManifest(bytes, key, "tickets", 41)).resolves.toEqual(value);
+  });
+
+  test("pins a multi-chunk manifest to deterministic bytes and a content key", async () => {
+    const value = manifest({
+      chunks: [
+        descriptor(),
+        descriptor({
+          first_id: "😀",
+          last_id: "😁",
+          key: `${prefix}/_v2/snapshot/chunks/${otherIncarnation}/sha256/${"1".repeat(64)}.json`,
+          byte_length: 144,
+          row_count: 2,
+        }),
+      ],
+    });
+    const bytes = encodeSnapshotManifest(value);
+    expect(new TextDecoder().decode(bytes)).toBe(
+      `{"schema_version":2,"collection":"tickets","log_seq_start":41,"incarnation":"${incarnation}","collation":"utf8-scalar-v1","chunks":[{"first_id":"a","last_id":"é","key":"${fixedChunkKey}","byte_length":208,"row_count":3},{"first_id":"😀","last_id":"😁","key":"${prefix}/_v2/snapshot/chunks/${otherIncarnation}/sha256/${"1".repeat(64)}.json","byte_length":144,"row_count":2}]}`,
+    );
+    const key = await keyFor(bytes);
+    expect(key).toBe(
+      `${prefix}/_v2/snapshot/manifests/${incarnation}/sha256/e3eefbe4d5e2cf5c5aafe515d3ba7b81196828c95b76ab6b961b5589671cae82.json`,
+    );
+    await expect(decodeSnapshotManifest(bytes, key, "tickets", 41)).resolves.toEqual(value);
+  });
+
+  test.each([
+    ["unknown envelope field", { ...manifest(), surprise: true }],
+    ["unsupported schema", { ...manifest(), schema_version: 3 }],
+    ["unsafe log floor", { ...manifest(), log_seq_start: Number.MAX_SAFE_INTEGER + 1 }],
+    ["fractional log floor", { ...manifest(), log_seq_start: 1.5 }],
+    ["negative log floor", { ...manifest(), log_seq_start: -1 }],
+    ["wrong collation", { ...manifest(), collation: "locale" }],
+    ["invalid incarnation", { ...manifest(), incarnation: incarnation.toUpperCase() }],
+    ["unknown descriptor field", { ...manifest(), chunks: [{ ...descriptor(), surprise: true }] }],
+    ["invalid first scalar", { ...manifest(), chunks: [descriptor({ first_id: "\ud800" })] }],
+    ["reversed descriptor range", { ...manifest(), chunks: [descriptor({ first_id: "😀" })] }],
+    ["zero byte length", { ...manifest(), chunks: [descriptor({ byte_length: 0 })] }],
+    ["oversized byte length", { ...manifest(), chunks: [descriptor({ byte_length: 1_048_577 })] }],
+    ["zero row count", { ...manifest(), chunks: [descriptor({ row_count: 0 })] }],
+    ["oversized row count", { ...manifest(), chunks: [descriptor({ row_count: 4097 })] }],
+    [
+      "duplicate chunk key",
+      {
+        ...manifest(),
+        chunks: [descriptor({ first_id: "a", last_id: "b" }), descriptor({ first_id: "c" })],
+      },
+    ],
+    [
+      "overlapping ranges",
+      {
+        ...manifest(),
+        chunks: [
+          descriptor({ first_id: "a", last_id: "m" }),
+          descriptor({ first_id: "m", last_id: "z", key: fixedChunkKey.replace("96ae", "16ae") }),
+        ],
+      },
+    ],
+  ])("rejects stored %s", async (_label, body) => {
+    const bytes = encodeJsonBytes(body);
+    const keyIncarnation = /^[0-9a-f]{32}$/.test(String(body.incarnation))
+      ? String(body.incarnation)
+      : incarnation;
+    await expectInvalidResponse(
+      decodeSnapshotManifest(bytes, await keyFor(bytes, keyIncarnation), "tickets", 41),
+    );
+  });
+
+  test("accepts descriptor gaps but rejects more than 32 descriptors", async () => {
+    const gapped = manifest({
+      chunks: [
+        descriptor({ first_id: "a", last_id: "b" }),
+        descriptor({
+          first_id: "y",
+          last_id: "z",
+          key: fixedChunkKey.replace("96ae", "16ae"),
+        }),
+      ],
+    });
+    const bytes = encodeSnapshotManifest(gapped);
+    await expect(
+      decodeSnapshotManifest(bytes, await keyFor(bytes), "tickets", 41),
+    ).resolves.toEqual(gapped);
+
+    const tooMany = manifest({
+      chunks: Array.from({ length: 33 }, (_, index) => {
+        const id = `id${index.toString().padStart(2, "0")}`;
+        return descriptor({
+          first_id: id,
+          last_id: id,
+          key: `${prefix}/_v2/snapshot/chunks/${incarnation}/sha256/${index.toString(16).padStart(64, "0")}.json`,
+          byte_length: 1,
+          row_count: 1,
+        });
+      }),
+    });
+    const tooManyBytes = encodeJsonBytes(tooMany);
+    await expectInvalidResponse(
+      decodeSnapshotManifest(tooManyBytes, await keyFor(tooManyBytes), "tickets", 41),
+    );
+  });
+
+  test.each([
+    ["wrong collection", "other", 41],
+    ["wrong expected floor", "tickets", 42],
+  ])("rejects %s", async (_label, expectedCollection, expectedFloor) => {
+    const bytes = encodeSnapshotManifest(manifest());
+    await expectInvalidResponse(
+      decodeSnapshotManifest(bytes, await keyFor(bytes), expectedCollection, expectedFloor),
+    );
+  });
+
+  test("rejects key/body incarnation and collection-prefix disagreement", async () => {
+    const bytes = encodeSnapshotManifest(manifest());
+    const digest = await snapshotHash(bytes);
+    await expectInvalidResponse(
+      decodeSnapshotManifest(
+        bytes,
+        snapshotManifestKey(prefix, otherIncarnation, digest),
+        "tickets",
+        41,
+      ),
+    );
+
+    const wrongPrefix = manifest({
+      chunks: [descriptor({ key: fixedChunkKey.replace(prefix, "app/other") })],
+    });
+    const wrongPrefixBytes = encodeSnapshotManifest(wrongPrefix);
+    await expectInvalidResponse(
+      decodeSnapshotManifest(wrongPrefixBytes, await keyFor(wrongPrefixBytes), "tickets", 41),
+    );
+  });
+
+  test.each([
+    ["wrong version", (key: string) => key.replace("/_v2/", "/_v3/")],
+    ["wrong artifact kind", (key: string) => key.replace("/manifests/", "/chunks/")],
+    ["wrong algorithm", (key: string) => key.replace("/sha256/", "/sha1/")],
+    ["uppercase digest", (key: string) => key.replace(/[a-f](?=[0-9a-f]{0,63}\.json$)/, "A")],
+    ["short digest", (key: string) => key.replace(/[0-9a-f]\.json$/, ".json")],
+    ["wrong suffix", (key: string) => key.replace(".json", ".bin")],
+    ["extra segment", (key: string) => key.replace("/sha256/", "/extra/sha256/")],
+    ["empty prefix segment", (key: string) => key.replace("/_v2/", "//_v2/")],
+  ])("rejects a key with %s", async (_label, corrupt) => {
+    const bytes = encodeSnapshotManifest(manifest());
+    await expectInvalidResponse(
+      decodeSnapshotManifest(bytes, corrupt(await keyFor(bytes)), "tickets", 41),
+    );
+  });
+
+  test("rejects malformed, truncated, noncanonical, duplicate-member, and digest-mismatched bytes", async () => {
+    const malformed = new TextEncoder().encode("{");
+    await expectInvalidResponse(
+      decodeSnapshotManifest(malformed, await keyFor(malformed), "tickets", 41),
+    );
+
+    const canonical = encodeSnapshotManifest(manifest());
+    const truncated = canonical.slice(0, -1);
+    await expectInvalidResponse(
+      decodeSnapshotManifest(truncated, await keyFor(truncated), "tickets", 41),
+    );
+
+    const spaced = new TextEncoder().encode(
+      new TextDecoder().decode(canonical).replace(":2", ": 2"),
+    );
+    await expectInvalidResponse(
+      decodeSnapshotManifest(spaced, await keyFor(spaced), "tickets", 41),
+    );
+
+    const duplicate = new TextEncoder().encode(
+      new TextDecoder()
+        .decode(canonical)
+        .replace('"schema_version":2', '"schema_version":2,"schema_version":2'),
+    );
+    await expectInvalidResponse(
+      decodeSnapshotManifest(duplicate, await keyFor(duplicate), "tickets", 41),
+    );
+
+    const changed = canonical.slice();
+    changed[changed.length - 2] = changed[changed.length - 2]! ^ 1;
+    await expectInvalidResponse(
+      decodeSnapshotManifest(changed, await keyFor(canonical), "tickets", 41),
+    );
+  });
+
+  test("decodes one private byte snapshot when the caller mutates the input during hashing", async () => {
+    const value = manifest();
+    const bytes = encodeSnapshotManifest(value);
+    const key = await keyFor(bytes);
+    const pending = decodeSnapshotManifest(bytes, key, "tickets", 41);
+    const originalKey = value.chunks[0]!.key;
+    const marker = new TextEncoder().encode(originalKey);
+    const offset = bytes.findIndex((_byte, index) =>
+      marker.every((expected, markerIndex) => bytes[index + markerIndex] === expected),
+    );
+    expect(offset).toBeGreaterThanOrEqual(0);
+    bytes[offset + originalKey.lastIndexOf("/") + 1] = "8".charCodeAt(0);
+
+    await expect(pending).resolves.toEqual(value);
+  });
+
+  test("rejects an oversized body before allocating a private copy", async () => {
+    const bytes = new Uint8Array(64 * 1024 + 1);
+    let copied = false;
+    Object.defineProperty(bytes, "slice", {
+      value: () => {
+        copied = true;
+        throw new Error("oversized input must not be copied");
+      },
+    });
+    const key = snapshotManifestKey(prefix, incarnation, "0".repeat(64));
+
+    await expectInvalidResponse(decodeSnapshotManifest(bytes, key, "tickets", 41));
+    expect(copied).toBe(false);
+  });
+
+  test("rejects invalid caller keys and manifests as InvalidConfig", () => {
+    expect(() => snapshotManifestKey(prefix, incarnation, "A".repeat(64))).toThrowError(
+      expect.objectContaining({ code: "InvalidConfig" }),
+    );
+    expect(() =>
+      encodeSnapshotManifest({ ...manifest(), chunks: [descriptor({ first_id: "\ud800" })] }),
+    ).toThrowError(expect.objectContaining({ code: "InvalidConfig" }));
+
+    const symbolField = Object.assign(manifest(), { [Symbol("unknown")]: true });
+    expect(() => encodeSnapshotManifest(symbolField)).toThrowError(
+      expect.objectContaining({ code: "InvalidConfig" }),
+    );
+  });
+});
+
+const idArb = fc.oneof(
+  fc.stringMatching(/^[a-z][a-z0-9]{0,5}$/),
+  fc.constantFrom("é", "e\u0301", "\u{10000}", "\u{1f600}"),
+);
+
+fcTest.prop({
+  ids: fc.uniqueArray(idArb, { maxLength: 12 }),
+  floor: fc.maxSafeNat(),
+  seed: fc.nat(),
+})("round-trips generated descriptors deterministically", async ({ ids, floor, seed }) => {
+  const ordered = ids.toSorted(compareDocIds);
+  const chunks = ordered.map((id, index) =>
+    descriptor({
+      first_id: id,
+      last_id: id,
+      key: `${prefix}/_v2/snapshot/chunks/${incarnation}/sha256/${(seed + index).toString(16).padStart(64, "0").slice(-64)}.json`,
+      byte_length: 1 + ((seed + index) % 1_048_576),
+      row_count: 1 + ((seed + index) % 4096),
+    }),
+  );
+  const value = manifest({ log_seq_start: floor, chunks });
+  const first = encodeSnapshotManifest(value);
+  const second = encodeSnapshotManifest(value);
+  expect(second).toEqual(first);
+  const key = await keyFor(first);
+  await expect(decodeSnapshotManifest(first, key, "tickets", floor)).resolves.toEqual(value);
+});
+
+fcTest.prop({ floor: fc.maxSafeNat() })(
+  "changing only the incarnation changes canonical bytes and artifact keys",
+  async ({ floor }) => {
+    const first = encodeSnapshotManifest(manifest({ log_seq_start: floor, chunks: [] }));
+    const second = encodeSnapshotManifest(
+      manifest({ log_seq_start: floor, incarnation: otherIncarnation, chunks: [] }),
+    );
+    expect(first).not.toEqual(second);
+    const firstKey = await keyFor(first);
+    const secondKey = await keyFor(second, otherIncarnation);
+    expect(firstKey).not.toBe(secondKey);
+  },
+);

--- a/packages/server/src/snapshot-manifest.ts
+++ b/packages/server/src/snapshot-manifest.ts
@@ -1,0 +1,320 @@
+import {
+  BaerlyError,
+  decodeJsonBytes,
+  encodeJsonBytes,
+  MAX_KEY_BYTES,
+  snapshotHash,
+} from "@baerly/protocol";
+import { assertKeyWithinLimit } from "./key-limit.ts";
+import { assertPathSegment } from "./path-segment.ts";
+import { assertSnapshotDocId, compareDocIds } from "./snapshot-doc-id.ts";
+
+const SNAPSHOT_MANIFEST_SCHEMA_VERSION = 2;
+const MAX_MANIFEST_BYTES = 64 * 1024;
+const MAX_MANIFEST_CHUNKS = 32;
+const MAX_CHUNK_BYTES = 1024 * 1024;
+const MAX_CHUNK_ROWS = 4096;
+const INCARNATION_PATTERN = /^[0-9a-f]{32}$/;
+const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
+const MANIFEST_KEY_PATTERN =
+  /^(.+)\/_v2\/snapshot\/manifests\/([0-9a-f]{32})\/sha256\/([0-9a-f]{64})\.json$/;
+const CHUNK_KEY_PATTERN =
+  /^(.+)\/_v2\/snapshot\/chunks\/([0-9a-f]{32})\/sha256\/([0-9a-f]{64})\.json$/;
+const utf8 = new TextEncoder();
+
+export interface SnapshotChunkDescriptor {
+  readonly first_id: string;
+  readonly last_id: string;
+  readonly key: string;
+  readonly byte_length: number;
+  readonly row_count: number;
+}
+
+export interface SnapshotManifest {
+  readonly schema_version: number;
+  readonly collection: string;
+  readonly log_seq_start: number;
+  readonly incarnation: string;
+  readonly collation: "utf8-scalar-v1";
+  readonly chunks: readonly SnapshotChunkDescriptor[];
+}
+
+interface ParsedArtifactKey {
+  readonly prefix: string;
+  readonly incarnation: string;
+  readonly digest: string;
+}
+
+function invalid(
+  code: "InvalidConfig" | "InvalidResponse",
+  message: string,
+  cause?: unknown,
+): never {
+  throw new BaerlyError(code, `snapshot manifest: ${message}`, cause);
+}
+
+function normalizeCodecFailure<T>(
+  code: "InvalidConfig" | "InvalidResponse",
+  operation: () => T,
+): T {
+  try {
+    return operation();
+  } catch (error) {
+    if (error instanceof BaerlyError) {
+      throw error;
+    }
+    invalid(code, "body exceeds supported JSON validation depth", error);
+  }
+}
+
+function assertExactFields(
+  value: unknown,
+  expected: readonly string[],
+  where: string,
+  code: "InvalidConfig" | "InvalidResponse",
+): asserts value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    invalid(code, `${where} must be an object`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  const keys = Object.keys(descriptors);
+  if (
+    (prototype !== Object.prototype && prototype !== null) ||
+    Object.getOwnPropertySymbols(value).length !== 0 ||
+    keys.length !== expected.length ||
+    expected.some((key) => {
+      const descriptor = descriptors[key];
+      return descriptor === undefined || !descriptor.enumerable || !("value" in descriptor);
+    })
+  ) {
+    invalid(code, `${where} must contain exactly the required fields`);
+  }
+}
+
+function assertStoredDocId(value: unknown, where: string): asserts value is string {
+  if (typeof value !== "string") {
+    invalid("InvalidResponse", `${where} must be a string`);
+  }
+  try {
+    assertSnapshotDocId(value);
+  } catch (error) {
+    invalid("InvalidResponse", `${where} is invalid`, error);
+  }
+}
+
+function assertCallerDocId(value: unknown, where: string): asserts value is string {
+  if (typeof value !== "string") {
+    invalid("InvalidConfig", `${where} must be a string`);
+  }
+  try {
+    assertSnapshotDocId(value);
+  } catch (error) {
+    invalid("InvalidConfig", `${where} is invalid`, error);
+  }
+}
+
+function parseArtifactKey(
+  key: unknown,
+  kind: "manifest" | "chunk",
+  code: "InvalidConfig" | "InvalidResponse",
+): ParsedArtifactKey {
+  if (typeof key !== "string" || utf8.encode(key).byteLength > MAX_KEY_BYTES) {
+    invalid(code, `${kind} key is invalid or exceeds ${MAX_KEY_BYTES} bytes`);
+  }
+  const match = (kind === "manifest" ? MANIFEST_KEY_PATTERN : CHUNK_KEY_PATTERN).exec(key);
+  if (match === null) {
+    invalid(code, `${kind} key does not match the schema-v2 grammar`);
+  }
+  if (match[1]!.endsWith("/")) {
+    invalid(code, `${kind} key collection prefix contains an empty trailing segment`);
+  }
+  return { prefix: match[1]!, incarnation: match[2]!, digest: match[3]! };
+}
+
+function positiveSafeInteger(
+  value: unknown,
+  maximum: number,
+  where: string,
+  code: "InvalidConfig" | "InvalidResponse",
+): asserts value is number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0 || (value as number) > maximum) {
+    invalid(code, `${where} must be a positive safe integer at most ${maximum}`);
+  }
+}
+
+function canonicalizeManifest(
+  value: unknown,
+  code: "InvalidConfig" | "InvalidResponse",
+  expectedPrefix?: string,
+): SnapshotManifest {
+  assertExactFields(
+    value,
+    ["schema_version", "collection", "log_seq_start", "incarnation", "collation", "chunks"],
+    "body",
+    code,
+  );
+  if (value["schema_version"] !== SNAPSHOT_MANIFEST_SCHEMA_VERSION) {
+    invalid(code, "unsupported schema_version");
+  }
+  if (typeof value["collection"] !== "string") {
+    invalid(code, "collection must be a string");
+  }
+  if (code === "InvalidConfig") {
+    try {
+      assertPathSegment(value["collection"], "collection");
+    } catch (error) {
+      invalid(code, "collection is invalid", error);
+    }
+  }
+  if (!Number.isSafeInteger(value["log_seq_start"]) || (value["log_seq_start"] as number) < 0) {
+    invalid(code, "log_seq_start must be a non-negative safe integer");
+  }
+  if (typeof value["incarnation"] !== "string" || !INCARNATION_PATTERN.test(value["incarnation"])) {
+    invalid(code, "incarnation must be 32 lowercase hex characters");
+  }
+  if (value["collation"] !== "utf8-scalar-v1") {
+    invalid(code, "unsupported collation");
+  }
+  if (!Array.isArray(value["chunks"]) || value["chunks"].length > MAX_MANIFEST_CHUNKS) {
+    invalid(code, `chunks must be an array of at most ${MAX_MANIFEST_CHUNKS} descriptors`);
+  }
+
+  const seenKeys = new Set<string>();
+  const chunks = value["chunks"].map((candidate, index): SnapshotChunkDescriptor => {
+    const where = `chunks[${index}]`;
+    assertExactFields(
+      candidate,
+      ["first_id", "last_id", "key", "byte_length", "row_count"],
+      where,
+      code,
+    );
+    if (code === "InvalidConfig") {
+      assertCallerDocId(candidate["first_id"], `${where}.first_id`);
+      assertCallerDocId(candidate["last_id"], `${where}.last_id`);
+    } else {
+      assertStoredDocId(candidate["first_id"], `${where}.first_id`);
+      assertStoredDocId(candidate["last_id"], `${where}.last_id`);
+    }
+    if (compareDocIds(candidate["first_id"], candidate["last_id"]) > 0) {
+      invalid(code, `${where} range is reversed`);
+    }
+    const descriptorKey = candidate["key"];
+    if (typeof descriptorKey !== "string") {
+      invalid(code, `${where}.key must be a string`);
+    }
+    const parsedKey = parseArtifactKey(descriptorKey, "chunk", code);
+    if (expectedPrefix !== undefined && parsedKey.prefix !== expectedPrefix) {
+      invalid(code, `${where}.key belongs to another collection prefix`);
+    }
+    positiveSafeInteger(candidate["byte_length"], MAX_CHUNK_BYTES, `${where}.byte_length`, code);
+    positiveSafeInteger(candidate["row_count"], MAX_CHUNK_ROWS, `${where}.row_count`, code);
+    if (seenKeys.has(descriptorKey)) {
+      invalid(code, "descriptor keys must be unique");
+    }
+    seenKeys.add(descriptorKey);
+    return {
+      first_id: candidate["first_id"],
+      last_id: candidate["last_id"],
+      key: descriptorKey,
+      byte_length: candidate["byte_length"],
+      row_count: candidate["row_count"],
+    };
+  });
+
+  for (let index = 1; index < chunks.length; index++) {
+    const previous = chunks[index - 1]!;
+    const current = chunks[index]!;
+    if (
+      compareDocIds(previous.first_id, current.first_id) >= 0 ||
+      compareDocIds(previous.last_id, current.first_id) >= 0
+    ) {
+      invalid(code, "descriptor ranges must be strictly increasing and non-overlapping");
+    }
+  }
+
+  return {
+    schema_version: SNAPSHOT_MANIFEST_SCHEMA_VERSION,
+    collection: value["collection"],
+    log_seq_start: value["log_seq_start"] as number,
+    incarnation: value["incarnation"],
+    collation: "utf8-scalar-v1",
+    chunks,
+  };
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  return left.byteLength === right.byteLength && left.every((byte, index) => byte === right[index]);
+}
+
+export const encodeSnapshotManifest = (manifest: SnapshotManifest): Uint8Array => {
+  return normalizeCodecFailure("InvalidConfig", () => {
+    const canonical = canonicalizeManifest(manifest, "InvalidConfig");
+    const bytes = encodeJsonBytes(canonical);
+    if (bytes.byteLength > MAX_MANIFEST_BYTES) {
+      invalid("InvalidConfig", `canonical body exceeds ${MAX_MANIFEST_BYTES} bytes`);
+    }
+    return bytes;
+  });
+};
+
+export const snapshotManifestKey = (
+  collectionPrefix: string,
+  incarnation: string,
+  digest: string,
+): string => {
+  if (collectionPrefix.length === 0 || collectionPrefix.endsWith("/")) {
+    invalid("InvalidConfig", "collection prefix must be non-empty without a trailing slash");
+  }
+  if (!INCARNATION_PATTERN.test(incarnation)) {
+    invalid("InvalidConfig", "incarnation must be 32 lowercase hex characters");
+  }
+  if (!DIGEST_PATTERN.test(digest)) {
+    invalid("InvalidConfig", "digest must be 64 lowercase hex characters");
+  }
+  const key = `${collectionPrefix}/_v2/snapshot/manifests/${incarnation}/sha256/${digest}.json`;
+  assertKeyWithinLimit(key);
+  return key;
+};
+
+export const decodeSnapshotManifest = async (
+  bytes: Uint8Array,
+  key: string,
+  expectedCollection: string,
+  expectedLogSeqStart: number,
+): Promise<SnapshotManifest> => {
+  if (bytes.byteLength === 0 || bytes.byteLength > MAX_MANIFEST_BYTES) {
+    invalid("InvalidResponse", "body length is outside the manifest ceiling");
+  }
+  const bodyBytes = bytes.slice();
+  const parsedKey = parseArtifactKey(key, "manifest", "InvalidResponse");
+  const digest = await snapshotHash(bodyBytes);
+  if (digest !== parsedKey.digest) {
+    invalid("InvalidResponse", "body digest does not match its key");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = decodeJsonBytes(bodyBytes);
+  } catch (error) {
+    invalid("InvalidResponse", "body is not valid JSON", error);
+  }
+  const canonical = normalizeCodecFailure("InvalidResponse", () => {
+    const value = canonicalizeManifest(parsed, "InvalidResponse", parsedKey.prefix);
+    const canonicalBytes = encodeJsonBytes(value);
+    if (!equalBytes(bodyBytes, canonicalBytes)) {
+      invalid("InvalidResponse", "body is not canonical JSON");
+    }
+    return value;
+  });
+  if (canonical.collection !== expectedCollection) {
+    invalid("InvalidResponse", "body collection does not match the expected collection");
+  }
+  if (canonical.log_seq_start !== expectedLogSeqStart) {
+    invalid("InvalidResponse", "body log_seq_start does not match the expected floor");
+  }
+  if (canonical.incarnation !== parsedKey.incarnation) {
+    invalid("InvalidResponse", "body incarnation does not match its key");
+  }
+  return canonical;
+};


### PR DESCRIPTION
## What & why

Lays the pure, unwired codec layer for ADR-007's chunked snapshot layout: scalar UTF-8 document-ID ordering, strict manifest/chunk (de)serialization with exact-field validation, and an independent reference fold oracle used to differentially test the eventual production fold against a naive whole-collection rebuild. None of this is called from `writer.ts`/`compactor.ts` yet — activation is deferred to the future atomic format cut per the ADR.

## Key points

- `compareDocIds` compares by UTF-8 code point rather than UTF-16 code unit, so surrogate-pair IDs sort the same as their UTF-8 bytes on the wire.
- Manifest/chunk decoding uses an exact-fields check (own-enumerable-keys-only, no prototype pollution, no symbol keys) rather than a permissive parse, matching the strict-reader stance the rest of the protocol layer takes.
- `chunked-snapshot-reference.ts` is a second, independent fold implementation whose only job is to disagree with the real chunked fold if it's wrong — not a production code path.

## Verification

Not independently re-run for this PR; author validated locally, CI runs the full gate on the PR.