### PR TITLE
test(bench): preregister chunked-snapshot workload ceiling contract

### DIFF
--- a/bench/measurement/workload-ceiling-contract.test.ts
+++ b/bench/measurement/workload-ceiling-contract.test.ts
@@ -115,6 +115,15 @@ describe("workload-ceiling study contract", () => {
     ).toBe(true);
   });
 
+  test("bounds general index-routed reads by the descriptor ceiling", () => {
+    expect(WORKLOAD_CEILING_STUDY.read_fan_out_limits).toEqual({
+      point: 1,
+      "bounded-range": 8,
+      "index-routed": 32,
+      complete: 32,
+    });
+  });
+
   test("admits only complete deployed Workers evidence", () => {
     const deployedEvidence: WorkloadCeilingStudyEvidence = {
       source: "deployed-workers",

--- a/bench/measurement/workload-ceiling-contract.test.ts
+++ b/bench/measurement/workload-ceiling-contract.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "vitest";
+import {
+  satisfiesWorkloadCeilingAdmission,
+  type WorkloadCeilingStudyEvidence,
+  WORKLOAD_CEILING_STUDY,
+} from "./workload-ceiling-contract.ts";
+
+describe("workload-ceiling study contract", () => {
+  test("contains finite workload and admission axes", () => {
+    expect(WORKLOAD_CEILING_STUDY.id).toBe("baerly.workload-ceiling/chunked-snapshot/v1");
+    expect(WORKLOAD_CEILING_STUDY.collection_bytes.length).toBeGreaterThan(1);
+    expect(WORKLOAD_CEILING_STUDY.collection_rows.length).toBeGreaterThan(1);
+    expect(WORKLOAD_CEILING_STUDY.document_bytes.length).toBeGreaterThan(1);
+    expect(WORKLOAD_CEILING_STUDY.mutation_localities).toEqual(["hot-key", "uniform"]);
+    expect(WORKLOAD_CEILING_STUDY.read_shapes).toEqual([
+      "point",
+      "bounded-range",
+      "index-routed",
+      "complete",
+    ]);
+    expect(WORKLOAD_CEILING_STUDY.admission.requires_deployed_workers).toBe(true);
+    expect(WORKLOAD_CEILING_STUDY.axis_sweeps.byte_axis).toEqual({
+      document_bytes: 2048,
+      collection_bytes_measure: "encoded-snapshot-bytes",
+    });
+    expect(WORKLOAD_CEILING_STUDY.axis_sweeps.row_axis).toEqual({
+      document_bytes: 256,
+      collection_rows_measure: "rows",
+    });
+  });
+
+  test("uses unique positive ascending numeric cells", () => {
+    for (const cells of [
+      WORKLOAD_CEILING_STUDY.collection_bytes,
+      WORKLOAD_CEILING_STUDY.collection_rows,
+      WORKLOAD_CEILING_STUDY.document_bytes,
+      WORKLOAD_CEILING_STUDY.manifest_descriptors,
+    ]) {
+      expect(cells.every((value) => Number.isSafeInteger(value) && value > 0)).toBe(true);
+      expect(cells).toEqual([...new Set(cells)].toSorted((a, b) => a - b));
+    }
+  });
+
+  test("keeps cross-field cells within the preregistered envelope", () => {
+    expect(WORKLOAD_CEILING_STUDY.changed_byte_fractions.length).toBeGreaterThan(0);
+    expect(
+      WORKLOAD_CEILING_STUDY.changed_byte_fractions.every(
+        (fraction) => Number.isFinite(fraction) && fraction > 0 && fraction <= 1,
+      ),
+    ).toBe(true);
+    expect(WORKLOAD_CEILING_STUDY.changed_byte_fractions).toEqual(
+      [...new Set(WORKLOAD_CEILING_STUDY.changed_byte_fractions)].toSorted((a, b) => a - b),
+    );
+    expect(WORKLOAD_CEILING_STUDY.mutation_mixes.length).toBeGreaterThan(0);
+    expect(
+      WORKLOAD_CEILING_STUDY.mutation_mixes.every(
+        ({ insert, update, delete: remove }) =>
+          [insert, update, remove].every(
+            (weight) => Number.isFinite(weight) && weight > 0 && weight <= 1,
+          ) && Math.abs(insert + update + remove - 1) <= Number.EPSILON,
+      ),
+    ).toBe(true);
+    expect(new Set(WORKLOAD_CEILING_STUDY.mutation_mixes.map(({ id }) => id)).size).toBe(
+      WORKLOAD_CEILING_STUDY.mutation_mixes.length,
+    );
+
+    const dominantOperation = {
+      "insert-heavy": "insert",
+      "update-heavy": "update",
+      "delete-heavy": "delete",
+    } as const;
+    for (const mix of WORKLOAD_CEILING_STUDY.mutation_mixes) {
+      const dominant = dominantOperation[mix.id as keyof typeof dominantOperation];
+      expect(dominant).toBeDefined();
+      const weights = { insert: mix.insert, update: mix.update, delete: mix.delete };
+      const alternatives = Object.entries(weights)
+        .filter(([operation]) => operation !== dominant)
+        .map(([, weight]) => weight);
+      expect(weights[dominant]).toBeGreaterThan(Math.max(...alternatives));
+    }
+
+    expect(WORKLOAD_CEILING_STUDY.collection_bytes).toContain(512 * 1024);
+    expect(WORKLOAD_CEILING_STUDY.collection_rows).toContain(2048);
+    expect(WORKLOAD_CEILING_STUDY.document_bytes).toEqual(expect.arrayContaining([1024, 5 * 1024]));
+    expect(WORKLOAD_CEILING_STUDY.collection_bytes.some((bytes) => bytes > 512 * 1024)).toBe(true);
+    expect(WORKLOAD_CEILING_STUDY.collection_rows.some((rows) => rows > 2048)).toBe(true);
+
+    const { byte_axis: byteTarget, row_axis: rowTarget } =
+      WORKLOAD_CEILING_STUDY.minimum_useful_targets;
+    expect(byteTarget).toEqual({
+      collection_bytes: 1024 * 1024,
+      document_bytes: 2048,
+    });
+    expect(rowTarget).toEqual({
+      collection_rows: 4096,
+      document_bytes: 256,
+    });
+    expect(WORKLOAD_CEILING_STUDY.collection_bytes).toContain(byteTarget.collection_bytes);
+    expect(WORKLOAD_CEILING_STUDY.document_bytes).toContain(byteTarget.document_bytes);
+    expect(WORKLOAD_CEILING_STUDY.collection_rows).toContain(rowTarget.collection_rows);
+    expect(WORKLOAD_CEILING_STUDY.document_bytes).toContain(rowTarget.document_bytes);
+
+    const manifestCeiling = Math.max(...WORKLOAD_CEILING_STUDY.manifest_descriptors);
+    expect(Object.keys(WORKLOAD_CEILING_STUDY.read_fan_out_limits).toSorted()).toEqual(
+      [...WORKLOAD_CEILING_STUDY.read_shapes].toSorted(),
+    );
+    expect(
+      Object.values(WORKLOAD_CEILING_STUDY.read_fan_out_limits).every(
+        (limit) =>
+          Number.isSafeInteger(limit) &&
+          limit > 0 &&
+          limit <= manifestCeiling &&
+          WORKLOAD_CEILING_STUDY.manifest_descriptors.includes(limit),
+      ),
+    ).toBe(true);
+  });
+
+  test("admits only complete deployed Workers evidence", () => {
+    const deployedEvidence: WorkloadCeilingStudyEvidence = {
+      source: "deployed-workers",
+      profile: "cf-free",
+      has_zero_failures_upper_bound: true,
+      statistics: ["p50", "p95", "p99"],
+      has_repeated_tail_drain: true,
+    };
+
+    expect(satisfiesWorkloadCeilingAdmission(deployedEvidence)).toBe(true);
+    expect(satisfiesWorkloadCeilingAdmission({ ...deployedEvidence, source: "node" })).toBe(false);
+    expect(satisfiesWorkloadCeilingAdmission({ ...deployedEvidence, source: "miniflare" })).toBe(
+      false,
+    );
+    expect(
+      satisfiesWorkloadCeilingAdmission({
+        ...deployedEvidence,
+        statistics: ["p50", "p95"],
+      }),
+    ).toBe(false);
+    expect(satisfiesWorkloadCeilingAdmission({ ...deployedEvidence, profile: "cf-paid" })).toBe(
+      false,
+    );
+    expect(satisfiesWorkloadCeilingAdmission({ ...deployedEvidence, profile: "node" })).toBe(false);
+    expect(
+      satisfiesWorkloadCeilingAdmission({
+        ...deployedEvidence,
+        has_zero_failures_upper_bound: false,
+      }),
+    ).toBe(false);
+    expect(
+      satisfiesWorkloadCeilingAdmission({
+        ...deployedEvidence,
+        has_repeated_tail_drain: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/bench/measurement/workload-ceiling-contract.ts
+++ b/bench/measurement/workload-ceiling-contract.ts
@@ -1,0 +1,139 @@
+export type WorkloadCeilingReadShape = "point" | "bounded-range" | "index-routed" | "complete";
+
+export type WorkloadCeilingEvidenceSource = "deployed-workers" | "node" | "miniflare";
+
+export type WorkloadCeilingEvidenceProfile = "cf-free" | "cf-paid" | "node";
+
+export type WorkloadCeilingStatistic = "p50" | "p95" | "p99";
+
+/**
+ * Fixed input space for the unreleased chunked-snapshot study. This contract is
+ * measurement-only: it does not change a shipped ceiling or production export.
+ */
+export interface WorkloadCeilingStudyContract {
+  readonly id: "baerly.workload-ceiling/chunked-snapshot/v1";
+  readonly collection_bytes: readonly number[];
+  readonly collection_rows: readonly number[];
+  readonly document_bytes: readonly number[];
+  readonly changed_byte_fractions: readonly number[];
+  readonly mutation_localities: readonly ["hot-key", "uniform"];
+  readonly mutation_mixes: readonly {
+    readonly id: string;
+    readonly insert: number;
+    readonly update: number;
+    readonly delete: number;
+  }[];
+  readonly manifest_descriptors: readonly number[];
+  readonly read_shapes: readonly ["point", "bounded-range", "index-routed", "complete"];
+  readonly read_fan_out_limits: Readonly<Record<WorkloadCeilingReadShape, number>>;
+  /** Independent fixtures prevent the byte and row fold gates from being conflated. */
+  readonly axis_sweeps: {
+    readonly byte_axis: {
+      readonly document_bytes: 2048;
+      readonly collection_bytes_measure: "encoded-snapshot-bytes";
+    };
+    readonly row_axis: {
+      readonly document_bytes: 256;
+      readonly collection_rows_measure: "rows";
+    };
+  };
+  readonly minimum_useful_targets: {
+    readonly byte_axis: {
+      readonly collection_bytes: number;
+      readonly document_bytes: 2048;
+    };
+    readonly row_axis: {
+      readonly collection_rows: number;
+      readonly document_bytes: 256;
+    };
+  };
+  readonly admission: {
+    readonly primary_profile: "cf-free";
+    readonly requires_deployed_workers: true;
+    readonly requires_zero_failures_upper_bound: true;
+    readonly required_statistics: readonly ["p50", "p95", "p99"];
+    readonly requires_repeated_tail_drain: true;
+    readonly accepted_evidence_sources: readonly ["deployed-workers"];
+  };
+}
+
+/** Minimal evidence record shared by this preregistration and later bench work. */
+export interface WorkloadCeilingStudyEvidence {
+  readonly source: WorkloadCeilingEvidenceSource;
+  readonly profile: WorkloadCeilingEvidenceProfile;
+  readonly has_zero_failures_upper_bound: boolean;
+  readonly statistics: readonly WorkloadCeilingStatistic[];
+  readonly has_repeated_tail_drain: boolean;
+}
+
+/** The explicit study axes, targets, and admission requirements live here. */
+export const WORKLOAD_CEILING_STUDY = {
+  id: "baerly.workload-ceiling/chunked-snapshot/v1",
+  collection_bytes: [512 * 1024, 1024 * 1024, 2 * 1024 * 1024, 4 * 1024 * 1024],
+  collection_rows: [2048, 4096, 8192, 16_384],
+  document_bytes: [256, 1024, 2048, 5 * 1024],
+  changed_byte_fractions: [0.01, 0.1, 1],
+  mutation_localities: ["hot-key", "uniform"],
+  mutation_mixes: [
+    { id: "insert-heavy", insert: 0.8, update: 0.15, delete: 0.05 },
+    { id: "update-heavy", insert: 0.05, update: 0.9, delete: 0.05 },
+    { id: "delete-heavy", insert: 0.1, update: 0.1, delete: 0.8 },
+  ],
+  manifest_descriptors: [1, 8, 32],
+  read_shapes: ["point", "bounded-range", "index-routed", "complete"],
+  read_fan_out_limits: {
+    point: 1,
+    "bounded-range": 8,
+    "index-routed": 1,
+    complete: 32,
+  },
+  axis_sweeps: {
+    byte_axis: {
+      document_bytes: 2048,
+      collection_bytes_measure: "encoded-snapshot-bytes",
+    },
+    row_axis: {
+      document_bytes: 256,
+      collection_rows_measure: "rows",
+    },
+  },
+  minimum_useful_targets: {
+    byte_axis: {
+      collection_bytes: 1024 * 1024,
+      document_bytes: 2048,
+    },
+    row_axis: {
+      collection_rows: 4096,
+      document_bytes: 256,
+    },
+  },
+  admission: {
+    primary_profile: "cf-free",
+    requires_deployed_workers: true,
+    requires_zero_failures_upper_bound: true,
+    required_statistics: ["p50", "p95", "p99"],
+    requires_repeated_tail_drain: true,
+    accepted_evidence_sources: ["deployed-workers"],
+  },
+} as const satisfies WorkloadCeilingStudyContract;
+
+/**
+ * The study's deliberately small admission predicate. It evaluates only
+ * preregistered evidence fields; provision, collection, and telemetry details
+ * remain the concern of the later measurement harness.
+ */
+export const satisfiesWorkloadCeilingAdmission = (
+  evidence: WorkloadCeilingStudyEvidence,
+): boolean => {
+  const admission = WORKLOAD_CEILING_STUDY.admission;
+  const acceptedSources: readonly WorkloadCeilingEvidenceSource[] =
+    admission.accepted_evidence_sources;
+
+  return (
+    (!admission.requires_deployed_workers || acceptedSources.includes(evidence.source)) &&
+    evidence.profile === admission.primary_profile &&
+    (!admission.requires_zero_failures_upper_bound || evidence.has_zero_failures_upper_bound) &&
+    admission.required_statistics.every((statistic) => evidence.statistics.includes(statistic)) &&
+    (!admission.requires_repeated_tail_drain || evidence.has_repeated_tail_drain)
+  );
+};

--- a/bench/measurement/workload-ceiling-contract.ts
+++ b/bench/measurement/workload-ceiling-contract.ts
@@ -84,7 +84,7 @@ export const WORKLOAD_CEILING_STUDY = {
   read_fan_out_limits: {
     point: 1,
     "bounded-range": 8,
-    "index-routed": 1,
+    "index-routed": 32,
     complete: 32,
   },
   axis_sweeps: {

--- a/bench/measurement/workload-ceiling-journals.test.ts
+++ b/bench/measurement/workload-ceiling-journals.test.ts
@@ -1,0 +1,607 @@
+import { describe, expect, test } from "vitest";
+import { encodeJsonBytes, snapshotHash } from "@baerly/protocol";
+import {
+  ARTIFACT_LIST_PAGE_SIZE,
+  ARTIFACT_GC_EXPECTED_BODIES,
+  CLOUDFLARE_FREE_OUTER_OPERATION_LIMIT,
+  EXPECTED_WORKLOAD_CEILING_JOURNALS,
+  PUBLISHER_EXPECTED_BODIES,
+  type ChunkedStorageScenario,
+  type ExpectedScenarioJournalStep,
+  artifactDeleteAuthorityTupleSha256,
+  validatesArtifactDeleteAuthority,
+} from "./workload-ceiling-journals.ts";
+
+const scenarios = [
+  "cas-win",
+  "cas-loss",
+  "storage-retry",
+  "orphan-mark",
+  "artifact-fence-win",
+  "artifact-fence-conflict",
+  "artifact-fence-resume",
+  "artifact-fence-exhausted",
+  "bounded-list-page",
+] as const;
+
+const stepsOf = (scenario: ChunkedStorageScenario): readonly ExpectedScenarioJournalStep[] =>
+  EXPECTED_WORKLOAD_CEILING_JOURNALS[scenario].steps;
+
+describe("workload-ceiling storage journal fixtures", () => {
+  test("pins one deeply immutable exact fixture for every scenario", () => {
+    expect(Object.keys(EXPECTED_WORKLOAD_CEILING_JOURNALS)).toEqual(scenarios);
+
+    for (const scenario of scenarios) {
+      const fixture = EXPECTED_WORKLOAD_CEILING_JOURNALS[scenario];
+      expect(fixture.scenario).toBe(scenario);
+      expect(Object.isFrozen(fixture)).toBe(true);
+      expect(Object.isFrozen(fixture.steps)).toBe(true);
+      expect(fixture.steps.every(Object.isFrozen)).toBe(true);
+      expect(fixture.outer_operation_count).toBe(fixture.steps.length);
+      expect(fixture.outer_operation_count).toBeLessThanOrEqual(
+        CLOUDFLARE_FREE_OUTER_OPERATION_LIMIT,
+      );
+    }
+  });
+
+  test("keeps each publisher attempt in the four durable phases", () => {
+    for (const scenario of ["cas-win", "cas-loss", "storage-retry"] as const) {
+      const fixture = EXPECTED_WORKLOAD_CEILING_JOURNALS[scenario];
+      for (const attempt of fixture.publication_attempts) {
+        const indexed = fixture.steps
+          .map((step, index) => ({ step, index }))
+          .filter(({ step }) => step.attempt_id === attempt.attempt_id);
+        const chunkPuts = indexed.filter(
+          ({ step }) => step.method === "put" && step.key_class === "chunk",
+        );
+        const manifestPut = indexed.find(
+          ({ step }) => step.method === "put" && step.key_class === "manifest",
+        );
+        const headCas = indexed.find(
+          ({ step }) =>
+            step.method === "put" && step.key_class === "current" && step.condition === "if-match",
+        );
+
+        expect(chunkPuts.length).toBeGreaterThan(0);
+        expect(manifestPut).toBeDefined();
+        expect(headCas).toBeDefined();
+        expect(Math.max(...chunkPuts.map(({ index }) => index))).toBeLessThan(
+          manifestPut?.index ?? -1,
+        );
+        expect(manifestPut?.index).toBeLessThan(headCas?.index ?? -1);
+        expect(
+          indexed.filter(
+            ({ step, index }) =>
+              index > (headCas?.index ?? -1) &&
+              step.method === "put" &&
+              (step.key_class === "chunk" || step.key_class === "manifest"),
+          ),
+        ).toEqual([]);
+      }
+    }
+  });
+
+  test("retains one incarnation for a storage retry and mints a new one on restart", () => {
+    const retry = EXPECTED_WORKLOAD_CEILING_JOURNALS["storage-retry"];
+    expect(retry.publication_attempts).toHaveLength(1);
+    const retryChunkPuts = retry.steps.filter(
+      (step) => step.method === "put" && step.key_class === "chunk",
+    );
+    expect(retryChunkPuts.map((step) => step.key)).toEqual([
+      retryChunkPuts[0]?.key,
+      retryChunkPuts[0]?.key,
+    ]);
+    expect(retryChunkPuts.map((step) => step.outcome)).toEqual(["error", "ok"]);
+
+    const loss = EXPECTED_WORKLOAD_CEILING_JOURNALS["cas-loss"];
+    expect(loss.publication_attempts).toHaveLength(2);
+    const [first, restarted] = loss.publication_attempts;
+    expect(first?.incarnation).not.toBe(restarted?.incarnation);
+    const artifactKeysByAttempt = new Map<string, Set<string>>();
+    for (const attempt of loss.publication_attempts) {
+      const artifactPuts = loss.steps.filter(
+        (step) =>
+          step.attempt_id === attempt.attempt_id &&
+          step.method === "put" &&
+          (step.key_class === "chunk" || step.key_class === "manifest"),
+      );
+      expect(artifactPuts.every((step) => step.key?.includes(attempt.incarnation))).toBe(true);
+      artifactKeysByAttempt.set(
+        attempt.attempt_id,
+        new Set(artifactPuts.flatMap((step) => (step.key === undefined ? [] : [step.key]))),
+      );
+    }
+    const firstKeys = artifactKeysByAttempt.get(first?.attempt_id ?? "missing") ?? new Set();
+    const restartedKeys =
+      artifactKeysByAttempt.get(restarted?.attempt_id ?? "missing") ?? new Set();
+    expect(firstKeys.intersection(restartedKeys)).toEqual(new Set());
+  });
+
+  test("binds every publisher attempt to its captured head and canonical PUT bodies", async () => {
+    type PublisherFixtureProjection = {
+      readonly publisher_bodies?: Readonly<Record<string, unknown>>;
+    };
+    type PublisherStepProjection = ExpectedScenarioJournalStep & {
+      readonly put_body_id?: string;
+    };
+
+    for (const scenario of ["cas-win", "cas-loss", "storage-retry"] as const) {
+      const fixture = EXPECTED_WORKLOAD_CEILING_JOURNALS[scenario];
+      const publisherBodies = (fixture as typeof fixture & PublisherFixtureProjection)
+        .publisher_bodies;
+      expect(publisherBodies).toBeDefined();
+
+      for (const attempt of fixture.publication_attempts) {
+        const attemptSteps = stepsOf(scenario).filter(
+          (step) => step.attempt_id === attempt.attempt_id,
+        );
+        const headGet = attemptSteps.find(
+          (step) => step.method === "get" && step.key_class === "current",
+        );
+        const headCas = attemptSteps.find(
+          (step) => step.method === "put" && step.key_class === "current",
+        );
+        expect(headGet?.result_etag).toBe(headCas?.if_match);
+
+        for (const step of attemptSteps.filter((entry) => entry.method === "put")) {
+          const bodyId = (step as PublisherStepProjection).put_body_id;
+          expect(bodyId).toBeDefined();
+          if (bodyId === undefined || publisherBodies === undefined) {
+            continue;
+          }
+          const body = publisherBodies[bodyId];
+          expect(body).toBeDefined();
+          if (body !== undefined) {
+            await expect(snapshotHash(encodeJsonBytes(body))).resolves.toBe(step.put_sha256);
+            if (step.key_class === "chunk" || step.key_class === "manifest") {
+              expect(step.key).toContain(`/sha256/${step.put_sha256 ?? "missing"}.json`);
+            }
+          }
+        }
+      }
+    }
+
+    const retry = stepsOf("storage-retry").filter(
+      (step) => step.method === "put" && step.key_class === "chunk",
+    ) as readonly PublisherStepProjection[];
+    expect(
+      retry.map((step) => [
+        step.key,
+        step.incarnation,
+        step.put_body_id,
+        step.put_sha256,
+        step.if_none_match,
+      ]),
+    ).toEqual([
+      [
+        retry[0]?.key,
+        retry[0]?.incarnation,
+        retry[0]?.put_body_id,
+        retry[0]?.put_sha256,
+        retry[0]?.if_none_match,
+      ],
+      [
+        retry[0]?.key,
+        retry[0]?.incarnation,
+        retry[0]?.put_body_id,
+        retry[0]?.put_sha256,
+        retry[0]?.if_none_match,
+      ],
+    ]);
+
+    const loss = EXPECTED_WORKLOAD_CEILING_JOURNALS["cas-loss"];
+    const [lost, restarted] = loss.publication_attempts;
+    const currentPutFor = (attemptId: string | undefined): PublisherStepProjection | undefined =>
+      stepsOf("cas-loss").find(
+        (step) =>
+          step.attempt_id === attemptId && step.method === "put" && step.key_class === "current",
+      );
+    expect(currentPutFor(lost?.attempt_id)?.put_body_id).not.toBe(
+      currentPutFor(restarted?.attempt_id)?.put_body_id,
+    );
+    expect(currentPutFor(lost?.attempt_id)?.put_sha256).not.toBe(
+      currentPutFor(restarted?.attempt_id)?.put_sha256,
+    );
+    const currentGetFor = (
+      attemptId: string | undefined,
+    ): ExpectedScenarioJournalStep | undefined =>
+      stepsOf("cas-loss").find(
+        (step) =>
+          step.attempt_id === attemptId && step.method === "get" && step.key_class === "current",
+      );
+    expect(currentGetFor(lost?.attempt_id)?.result_etag).not.toBe(
+      currentGetFor(restarted?.attempt_id)?.result_etag,
+    );
+
+    const before = PUBLISHER_EXPECTED_BODIES["current-before-publish"];
+    const assertCurrentTransition = (
+      current: {
+        readonly schema_version: number;
+        readonly layout_version: number;
+        readonly collection: string;
+        readonly snapshot: string;
+        readonly log_seq_start: number;
+        readonly snapshot_bytes: number;
+        readonly snapshot_rows: number;
+        readonly tail_hint: number;
+        readonly writer_fence: typeof before.writer_fence;
+        readonly generation: string;
+        readonly artifact_gc_epoch: number;
+      },
+      manifest: {
+        readonly collection: string;
+        readonly log_seq_start: number;
+        readonly chunks: readonly {
+          readonly byte_length: number;
+          readonly row_count: number;
+        }[];
+      },
+      expectedManifestKey: string | undefined,
+      captured: {
+        readonly tail_hint: number;
+        readonly writer_fence: typeof before.writer_fence;
+        readonly generation: string;
+        readonly artifact_gc_epoch: number;
+      },
+    ): void => {
+      expect(current.schema_version).toBe(4);
+      expect(current.layout_version).toBe(2);
+      expect(current.collection).toBe(manifest.collection);
+      expect(current.snapshot).toBe(expectedManifestKey);
+      expect(current.log_seq_start).toBe(manifest.log_seq_start);
+      expect(current.snapshot_bytes).toBe(
+        manifest.chunks.reduce((sum, descriptor) => sum + descriptor.byte_length, 0),
+      );
+      expect(current.snapshot_rows).toBe(
+        manifest.chunks.reduce((sum, descriptor) => sum + descriptor.row_count, 0),
+      );
+      expect(current.tail_hint).toBe(captured.tail_hint);
+      expect(current.writer_fence).toEqual(captured.writer_fence);
+      expect(current.generation).toBe(captured.generation);
+      expect(current.artifact_gc_epoch).toBe(captured.artifact_gc_epoch);
+    };
+    const casWinManifestKey = stepsOf("cas-win").find(
+      (step) => step.method === "put" && step.key_class === "manifest",
+    )?.key;
+    assertCurrentTransition(
+      PUBLISHER_EXPECTED_BODIES["current-a"],
+      PUBLISHER_EXPECTED_BODIES["manifest-a"],
+      casWinManifestKey,
+      before,
+    );
+    const restartedManifestKey = stepsOf("cas-loss").find(
+      (step) =>
+        step.attempt_id === restarted?.attempt_id &&
+        step.method === "put" &&
+        step.key_class === "manifest",
+    )?.key;
+    assertCurrentTransition(
+      PUBLISHER_EXPECTED_BODIES["current-b"],
+      PUBLISHER_EXPECTED_BODIES["manifest-b"],
+      restartedManifestKey,
+      PUBLISHER_EXPECTED_BODIES["current-after-winner"],
+    );
+
+    const encodedLength = (value: unknown): number => encodeJsonBytes(value).byteLength;
+    expect(
+      PUBLISHER_EXPECTED_BODIES["manifest-a"].chunks.map((chunk) => chunk.byte_length),
+    ).toEqual([
+      encodedLength(PUBLISHER_EXPECTED_BODIES["chunk-a1"]),
+      encodedLength(PUBLISHER_EXPECTED_BODIES["chunk-a2"]),
+    ]);
+    expect(PUBLISHER_EXPECTED_BODIES["manifest-b"].chunks[0]?.byte_length).toBe(
+      encodedLength(PUBLISHER_EXPECTED_BODIES["chunk-b"]),
+    );
+  });
+
+  test("pins the fence-win, conflict, resume, and exhaustion journals exactly", () => {
+    expect(
+      stepsOf("artifact-fence-win").map(({ method, key_class, condition, outcome }) => ({
+        method,
+        key_class,
+        condition,
+        outcome,
+      })),
+    ).toEqual([
+      { method: "get", key_class: "current", condition: undefined, outcome: "ok" },
+      { method: "get", key_class: "manifest", condition: undefined, outcome: "ok" },
+      { method: "put", key_class: "current", condition: "if-match", outcome: "ok" },
+      { method: "put", key_class: "gc-pending", condition: "if-match", outcome: "ok" },
+      { method: "delete", key_class: "chunk", condition: undefined, outcome: "ok" },
+      { method: "delete", key_class: "manifest", condition: undefined, outcome: "ok" },
+      { method: "put", key_class: "gc-pending", condition: "if-match", outcome: "ok" },
+    ]);
+
+    expect(
+      EXPECTED_WORKLOAD_CEILING_JOURNALS["artifact-fence-conflict"].steps.map(
+        ({ method, key_class, outcome }) => [method, key_class, outcome],
+      ),
+    ).toEqual([
+      ["get", "current", "ok"],
+      ["get", "manifest", "ok"],
+      ["put", "current", "conflict"],
+      ["get", "current", "ok"],
+      ["get", "manifest", "ok"],
+    ]);
+
+    const resume = EXPECTED_WORKLOAD_CEILING_JOURNALS["artifact-fence-resume"];
+    expect(resume.steps[0]).toMatchObject({ method: "get", key_class: "gc-pending" });
+    expect(resume.steps.slice(1, 5).map((step) => [step.method, step.key_class])).toEqual([
+      ["get", "current"],
+      ["get", "manifest"],
+      ["put", "current"],
+      ["put", "gc-pending"],
+    ]);
+    expect(resume.delete_authority?.candidate_keys).toEqual(
+      resume.resumed_from_authority?.candidate_keys,
+    );
+    expect(resume.delete_authority?.artifact_gc_epoch).toBe(
+      (resume.resumed_from_authority?.artifact_gc_epoch ?? -1) + 1,
+    );
+
+    const exhausted = EXPECTED_WORKLOAD_CEILING_JOURNALS["artifact-fence-exhausted"];
+    expect(exhausted.captured_artifact_gc_epoch).toBe(Number.MAX_SAFE_INTEGER);
+    expect(stepsOf("artifact-fence-exhausted").some((step) => step.method === "put")).toBe(false);
+    expect(stepsOf("artifact-fence-exhausted").some((step) => step.method === "delete")).toBe(
+      false,
+    );
+  });
+
+  test("ties every DELETE to the exact fenced authority and counts every outer operation", () => {
+    for (const scenario of ["artifact-fence-win", "artifact-fence-resume"] as const) {
+      const fixture = EXPECTED_WORKLOAD_CEILING_JOURNALS[scenario];
+      const authority = fixture.delete_authority;
+      expect(authority).toBeDefined();
+      expect(fixture.delete_authorized).toBe(true);
+      expect(
+        fixture.steps.filter((step) => step.method === "delete").map((step) => step.key),
+      ).toEqual(authority?.candidate_keys);
+
+      const accounted = stepsOf(scenario).reduce(
+        (count, step) =>
+          count +
+          Number(
+            step.method === "get" ||
+              step.method === "put" ||
+              step.method === "delete" ||
+              step.method === "list",
+          ),
+        0,
+      );
+      expect(accounted).toBe(fixture.outer_operation_count);
+    }
+
+    expect(
+      EXPECTED_WORKLOAD_CEILING_JOURNALS["artifact-fence-resume"].steps.filter(
+        (step) => step.method === "get" && step.key_class === "gc-pending",
+      ),
+    ).toHaveLength(1);
+  });
+
+  test("validates the canonical authority digest and rejects corrupt or unfenced pending state", async () => {
+    const authority = EXPECTED_WORKLOAD_CEILING_JOURNALS["artifact-fence-win"].delete_authority;
+    expect(authority).toBeDefined();
+    if (authority === undefined) {
+      return;
+    }
+
+    await expect(
+      artifactDeleteAuthorityTupleSha256({
+        artifact_gc_epoch: authority.artifact_gc_epoch,
+        fence_etag: authority.fence_etag,
+        candidate_keys: authority.candidate_keys,
+      }),
+    ).resolves.toBe(authority.tuple_sha256);
+    await expect(
+      validatesArtifactDeleteAuthority(authority, {
+        artifact_gc_epoch: authority.artifact_gc_epoch,
+        fence_etag: authority.fence_etag,
+        collection_prefix: "tenants/study/collections/items",
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      validatesArtifactDeleteAuthority(
+        { ...authority, tuple_sha256: "0".repeat(64) },
+        {
+          artifact_gc_epoch: authority.artifact_gc_epoch,
+          fence_etag: authority.fence_etag,
+          collection_prefix: "tenants/study/collections/items",
+        },
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      validatesArtifactDeleteAuthority(authority, {
+        artifact_gc_epoch: authority.artifact_gc_epoch + 1,
+        fence_etag: authority.fence_etag,
+        collection_prefix: "tenants/study/collections/items",
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      validatesArtifactDeleteAuthority(authority, {
+        artifact_gc_epoch: authority.artifact_gc_epoch,
+        fence_etag: '"different-fence"',
+        collection_prefix: "tenants/study/collections/items",
+      }),
+    ).resolves.toBe(false);
+
+    const crossCollectionKey = authority.candidate_keys[0]?.replace(
+      "tenants/study/collections/items/",
+      "tenants/study/collections/other/",
+    );
+    expect(crossCollectionKey).toBeDefined();
+    if (crossCollectionKey === undefined) {
+      return;
+    }
+    const crossCollectionTuple = {
+      artifact_gc_epoch: authority.artifact_gc_epoch,
+      fence_etag: authority.fence_etag,
+      candidate_keys: [crossCollectionKey],
+    } as const;
+    const crossCollectionAuthority = {
+      ...crossCollectionTuple,
+      tuple_sha256: await artifactDeleteAuthorityTupleSha256(crossCollectionTuple),
+    };
+    await expect(
+      validatesArtifactDeleteAuthority(crossCollectionAuthority, {
+        artifact_gc_epoch: authority.artifact_gc_epoch,
+        fence_etag: authority.fence_etag,
+        collection_prefix: "tenants/study/collections/items",
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      validatesArtifactDeleteAuthority(authority, {
+        artifact_gc_epoch: authority.artifact_gc_epoch,
+        fence_etag: authority.fence_etag,
+        collection_prefix: "",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  test("pins exact If-Match tokens and canonical bytes for every PUT", async () => {
+    for (const scenario of scenarios) {
+      for (const step of stepsOf(scenario)) {
+        if (step.method !== "put") {
+          continue;
+        }
+        expect(step.put_sha256).toMatch(/^[0-9a-f]{64}$/);
+        if (step.condition === "if-match") {
+          expect(step.if_match).toMatch(/^".+"$/);
+          expect(step.if_none_match).toBeUndefined();
+        } else if (step.condition === "if-none-match") {
+          expect(step.if_none_match).toBe("*");
+          expect(step.if_match).toBeUndefined();
+        }
+      }
+    }
+
+    const before = ARTIFACT_GC_EXPECTED_BODIES.current_before_fence;
+    const after = ARTIFACT_GC_EXPECTED_BODIES.current_after_fence;
+    const { artifact_gc_epoch: beforeEpoch, ...beforeRest } = before;
+    const { artifact_gc_epoch: afterEpoch, ...afterRest } = after;
+    expect(afterRest).toEqual(beforeRest);
+    expect(afterEpoch).toBe(beforeEpoch + 1);
+    const { artifact_gc_epoch: resumedEpoch, ...resumedRest } =
+      ARTIFACT_GC_EXPECTED_BODIES.current_after_resume_fence;
+    expect(resumedRest).toEqual(afterRest);
+    expect(resumedEpoch).toBe(afterEpoch + 1);
+
+    const winSteps = stepsOf("artifact-fence-win");
+    const winPuts = winSteps.filter((step) => step.method === "put");
+    await expect(snapshotHash(encodeJsonBytes(after))).resolves.toBe(winPuts[0]?.put_sha256);
+    await expect(
+      snapshotHash(encodeJsonBytes(ARTIFACT_GC_EXPECTED_BODIES.pending_authority_8)),
+    ).resolves.toBe(winPuts[1]?.put_sha256);
+    await expect(
+      snapshotHash(encodeJsonBytes(ARTIFACT_GC_EXPECTED_BODIES.pending_completion)),
+    ).resolves.toBe(winPuts[2]?.put_sha256);
+
+    expect(
+      winPuts.map(({ key, if_match, put_sha256 }) => ({
+        key,
+        options: { if_match },
+        put: { sha256: put_sha256 },
+      })),
+    ).toEqual([
+      {
+        key: "tenants/study/collections/items/current.json",
+        options: { if_match: '"head-epoch-7"' },
+        put: { sha256: winPuts[0]?.put_sha256 },
+      },
+      {
+        key: "tenants/study/collections/items/gc/pending.json",
+        options: { if_match: '"pending-before-fence"' },
+        put: { sha256: winPuts[1]?.put_sha256 },
+      },
+      {
+        key: "tenants/study/collections/items/gc/pending.json",
+        options: { if_match: '"pending-authority-8"' },
+        put: { sha256: winPuts[2]?.put_sha256 },
+      },
+    ]);
+    expect(winSteps[0]?.result_etag).toBe(winPuts[0]?.if_match);
+    expect(winPuts[0]?.result_etag).toBe(
+      EXPECTED_WORKLOAD_CEILING_JOURNALS["artifact-fence-win"].delete_authority.fence_etag,
+    );
+    expect(winPuts[1]?.result_etag).toBe(winPuts[2]?.if_match);
+
+    const resumeSteps = stepsOf("artifact-fence-resume");
+    const resumePuts = resumeSteps.filter((step) => step.method === "put");
+    await expect(
+      snapshotHash(encodeJsonBytes(ARTIFACT_GC_EXPECTED_BODIES.current_after_resume_fence)),
+    ).resolves.toBe(resumePuts[0]?.put_sha256);
+    await expect(
+      snapshotHash(encodeJsonBytes(ARTIFACT_GC_EXPECTED_BODIES.pending_authority_9)),
+    ).resolves.toBe(resumePuts[1]?.put_sha256);
+    await expect(
+      snapshotHash(encodeJsonBytes(ARTIFACT_GC_EXPECTED_BODIES.pending_completion)),
+    ).resolves.toBe(resumePuts[2]?.put_sha256);
+    expect(resumePuts.map((step) => step.if_match)).toEqual([
+      '"head-epoch-8"',
+      '"pending-authority-8"',
+      '"pending-authority-9"',
+    ]);
+    expect(resumeSteps[0]?.result_etag).toBe(resumePuts[1]?.if_match);
+    expect(resumeSteps[1]?.result_etag).toBe(resumePuts[0]?.if_match);
+    expect(resumePuts[0]?.result_etag).toBe(
+      EXPECTED_WORKLOAD_CEILING_JOURNALS["artifact-fence-resume"].delete_authority.fence_etag,
+    );
+    expect(resumePuts[1]?.result_etag).toBe(resumePuts[2]?.if_match);
+  });
+
+  test("hashes durable fixtures as explicit insertion-order protocol bytes", async () => {
+    const chunkA1 = PUBLISHER_EXPECTED_BODIES["chunk-a1"];
+    expect(new TextDecoder().decode(encodeJsonBytes(chunkA1))).toBe(
+      '{"schema_version":2,"collection":"items","incarnation":"11111111111111111111111111111111","first_id":"a","last_id":"m","docs":[{"_id":"a","value":"alpha"},{"_id":"m","value":"middle"}]}',
+    );
+
+    for (const scenario of ["cas-win", "cas-loss", "storage-retry"] as const) {
+      const fixture = EXPECTED_WORKLOAD_CEILING_JOURNALS[scenario];
+      const bodies: Readonly<Record<string, unknown>> = fixture.publisher_bodies;
+      for (const step of stepsOf(scenario).filter((entry) => entry.method === "put")) {
+        expect(step.put_body_id).toBeDefined();
+        if (step.put_body_id !== undefined) {
+          const body = bodies[step.put_body_id];
+          expect(body).toBeDefined();
+          if (body !== undefined) {
+            await expect(snapshotHash(encodeJsonBytes(body))).resolves.toBe(step.put_sha256);
+          }
+        }
+      }
+    }
+
+    const authority = EXPECTED_WORKLOAD_CEILING_JOURNALS["artifact-fence-win"].delete_authority;
+    const authorityTuple = {
+      artifact_gc_epoch: authority.artifact_gc_epoch,
+      fence_etag: authority.fence_etag,
+      candidate_keys: authority.candidate_keys,
+    } as const;
+    expect(new TextDecoder().decode(encodeJsonBytes(authorityTuple))).toBe(
+      `{"artifact_gc_epoch":8,"fence_etag":"\\"head-epoch-8\\"","candidate_keys":["${authority.candidate_keys[0] ?? "missing"}","${authority.candidate_keys[1] ?? "missing"}"]}`,
+    );
+    await expect(snapshotHash(encodeJsonBytes(authorityTuple))).resolves.toBe(
+      authority.tuple_sha256,
+    );
+
+    const winPuts = stepsOf("artifact-fence-win").filter((step) => step.method === "put");
+    for (const [step, body] of [
+      [winPuts[0], ARTIFACT_GC_EXPECTED_BODIES.current_after_fence],
+      [winPuts[1], ARTIFACT_GC_EXPECTED_BODIES.pending_authority_8],
+      [winPuts[2], ARTIFACT_GC_EXPECTED_BODIES.pending_completion],
+    ] as const) {
+      await expect(snapshotHash(encodeJsonBytes(body))).resolves.toBe(step?.put_sha256);
+    }
+  });
+
+  test("uses an explicit bounded LIST page size and never treats discovery as authority", () => {
+    const bounded = EXPECTED_WORKLOAD_CEILING_JOURNALS["bounded-list-page"];
+    const listSteps = bounded.steps.filter((step) => step.method === "list");
+    expect(listSteps).toHaveLength(2);
+    expect(listSteps.every((step) => step.max_keys === ARTIFACT_LIST_PAGE_SIZE)).toBe(true);
+    expect(listSteps.every((step) => step.max_keys !== undefined && step.max_keys > 0)).toBe(true);
+
+    const marked = EXPECTED_WORKLOAD_CEILING_JOURNALS["orphan-mark"];
+    expect(marked.delete_authorized).toBe(false);
+    expect(stepsOf("orphan-mark").some((step) => step.method === "delete")).toBe(false);
+    expect(stepsOf("orphan-mark").some((step) => step.method === "put")).toBe(false);
+  });
+});

--- a/bench/measurement/workload-ceiling-journals.ts
+++ b/bench/measurement/workload-ceiling-journals.ts
@@ -1,0 +1,797 @@
+import { encodeJsonBytes, snapshotHash } from "@baerly/protocol";
+
+export type ChunkedStorageScenario =
+  | "cas-win"
+  | "cas-loss"
+  | "storage-retry"
+  | "orphan-mark"
+  | "artifact-fence-win"
+  | "artifact-fence-conflict"
+  | "artifact-fence-resume"
+  | "artifact-fence-exhausted"
+  | "bounded-list-page";
+
+export interface ExpectedJournalStep {
+  readonly method: "get" | "put" | "delete" | "list";
+  readonly key_class: "current" | "manifest" | "chunk" | "gc-pending" | "artifact-prefix";
+  readonly condition?: "if-match" | "if-none-match";
+  readonly outcome: "ok" | "conflict" | "error";
+}
+
+export interface ExpectedArtifactDeleteAuthority {
+  readonly artifact_gc_epoch: number;
+  readonly fence_etag: string;
+  readonly candidate_keys: readonly string[];
+  readonly tuple_sha256: string;
+}
+
+/** Exact-key metadata used when normalizing a concrete Storage journal. */
+export interface ExpectedScenarioJournalStep extends ExpectedJournalStep {
+  readonly key?: string;
+  readonly attempt_id?: string;
+  readonly incarnation?: string;
+  readonly max_keys?: number;
+  readonly if_match?: string;
+  readonly if_none_match?: "*";
+  readonly put_sha256?: string;
+  readonly put_body_id?: string;
+  readonly result_etag?: string;
+}
+
+export interface ExpectedPublicationAttempt {
+  readonly attempt_id: string;
+  readonly incarnation: string;
+}
+
+export const CLOUDFLARE_FREE_OUTER_OPERATION_LIMIT = 50;
+export const ARTIFACT_LIST_PAGE_SIZE = 32;
+
+const COLLECTION_PREFIX = "tenants/study/collections/items";
+const CURRENT_KEY = `${COLLECTION_PREFIX}/current.json`;
+const PENDING_KEY = `${COLLECTION_PREFIX}/gc/pending.json`;
+const CAPTURED_INCARNATION = "00000000000000000000000000000000";
+const INCARNATION_A = "11111111111111111111111111111111";
+const INCARNATION_B = "22222222222222222222222222222222";
+const INCARNATION_C = "33333333333333333333333333333333";
+const WINNER_INCARNATION = "44444444444444444444444444444444";
+const DIGEST_A = "a".repeat(64);
+const DIGEST_B = "b".repeat(64);
+const DIGEST_C = "c".repeat(64);
+const DIGEST_D = "d".repeat(64);
+const PUBLISH_CHUNK_A1_SHA256 = "45c800e509b91ae5722ef1d036d7b93c5a11305bc5ac9945b7dc59219898dad6";
+const PUBLISH_CHUNK_A2_SHA256 = "2f63343b2a27ddd3db5b75f0b331d0847ff60dd62582fa0723db124b91ab6f72";
+const PUBLISH_CHUNK_B_SHA256 = "ee07043308d45ac1a95880ffbdd627f4c715989af9169616007e544686b56c23";
+const PUBLISH_MANIFEST_A_SHA256 =
+  "025745adb81c417a5de5cb8e78e2fc878fa68dd64b10f90fdc7f0d900ef1e141";
+const PUBLISH_MANIFEST_B_SHA256 =
+  "8f197009ca0937f9331bc08809087f03c7cf0372060e7440b7ab6ccbdad4209a";
+const PUBLISH_CURRENT_A_SHA256 = "518009ea4217972c8feff45bcba1f233ef68a26da01f90700dfb6aa1c47478c3";
+const PUBLISH_CURRENT_B_SHA256 = "0710ed851ddd95a4600e02b34ea2bb54659d9b8544dc8a91e8b474574dc79784";
+
+const chunkKey = (incarnation: string, digest: string): string =>
+  `${COLLECTION_PREFIX}/_v2/snapshot/chunks/${incarnation}/sha256/${digest}.json`;
+const manifestKey = (incarnation: string, digest: string): string =>
+  `${COLLECTION_PREFIX}/_v2/snapshot/manifests/${incarnation}/sha256/${digest}.json`;
+
+const CHUNK_A = chunkKey(INCARNATION_A, PUBLISH_CHUNK_A1_SHA256);
+const CHUNK_B = chunkKey(INCARNATION_A, PUBLISH_CHUNK_A2_SHA256);
+const MANIFEST_A = manifestKey(INCARNATION_A, PUBLISH_MANIFEST_A_SHA256);
+const CHUNK_C = chunkKey(INCARNATION_B, PUBLISH_CHUNK_B_SHA256);
+const MANIFEST_B = manifestKey(INCARNATION_B, PUBLISH_MANIFEST_B_SHA256);
+const CAPTURED_MANIFEST = manifestKey(CAPTURED_INCARNATION, DIGEST_D);
+const WINNER_MANIFEST = manifestKey(WINNER_INCARNATION, DIGEST_C);
+const ORPHAN_CHUNK = chunkKey(INCARNATION_C, DIGEST_A);
+const ORPHAN_MANIFEST = manifestKey(INCARNATION_C, DIGEST_B);
+
+const deepFreeze = <T>(value: T): T => {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value)) {
+    return value;
+  }
+  for (const child of Object.values(value)) {
+    deepFreeze(child);
+  }
+  return Object.freeze(value);
+};
+
+const defineFixture = <
+  const T extends {
+    readonly scenario: ChunkedStorageScenario;
+    readonly steps: readonly ExpectedScenarioJournalStep[];
+  },
+>(
+  fixture: T,
+): T & { readonly outer_operation_count: number } =>
+  deepFreeze({ ...fixture, outer_operation_count: fixture.steps.length });
+
+interface ArtifactDeleteAuthorityTuple {
+  readonly artifact_gc_epoch: number;
+  readonly fence_etag: string;
+  readonly candidate_keys: readonly string[];
+}
+
+export const artifactDeleteAuthorityTupleSha256 = (
+  tuple: ArtifactDeleteAuthorityTuple,
+): Promise<string> =>
+  snapshotHash(
+    encodeJsonBytes({
+      artifact_gc_epoch: tuple.artifact_gc_epoch,
+      fence_etag: tuple.fence_etag,
+      candidate_keys: tuple.candidate_keys,
+    }),
+  );
+
+const ARTIFACT_KEY_SUFFIX_PATTERN =
+  /^\/_v2\/snapshot\/(?:chunks\/[0-9a-f]{32}|manifests\/[0-9a-f]{32})\/sha256\/[0-9a-f]{64}\.json$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+
+const isValidCollectionPrefix = (prefix: string): boolean =>
+  prefix.length > 0 &&
+  !prefix.startsWith("/") &&
+  !prefix.endsWith("/") &&
+  !prefix.includes("//") &&
+  !prefix.includes("\\") &&
+  ![...prefix].some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 0x1f || codePoint === 0x7f || (codePoint >= 0xd800 && codePoint <= 0xdfff);
+  }) &&
+  prefix.split("/").every((segment) => segment !== "." && segment !== "..");
+
+/** Fail-closed validation for benchmark fixtures modelling persisted authority. */
+export const validatesArtifactDeleteAuthority = async (
+  authority: ExpectedArtifactDeleteAuthority,
+  fencedHead: {
+    readonly artifact_gc_epoch: number;
+    readonly fence_etag: string;
+    readonly collection_prefix: string;
+  },
+): Promise<boolean> => {
+  if (
+    !Number.isSafeInteger(authority.artifact_gc_epoch) ||
+    authority.artifact_gc_epoch < 0 ||
+    authority.artifact_gc_epoch !== fencedHead.artifact_gc_epoch ||
+    authority.fence_etag !== fencedHead.fence_etag ||
+    authority.fence_etag.length === 0 ||
+    authority.candidate_keys.length === 0 ||
+    !isValidCollectionPrefix(fencedHead.collection_prefix) ||
+    !SHA256_PATTERN.test(authority.tuple_sha256)
+  ) {
+    return false;
+  }
+  const sortedUnique = [...new Set(authority.candidate_keys)].toSorted();
+  if (
+    sortedUnique.length !== authority.candidate_keys.length ||
+    !sortedUnique.every((key, index) => key === authority.candidate_keys[index]) ||
+    !sortedUnique.every(
+      (key) =>
+        key.startsWith(fencedHead.collection_prefix) &&
+        ARTIFACT_KEY_SUFFIX_PATTERN.test(key.slice(fencedHead.collection_prefix.length)),
+    )
+  ) {
+    return false;
+  }
+  return (await artifactDeleteAuthorityTupleSha256(authority)) === authority.tuple_sha256;
+};
+
+const FENCE_WIN_AUTHORITY = deepFreeze({
+  artifact_gc_epoch: 8,
+  fence_etag: '"head-epoch-8"',
+  candidate_keys: [ORPHAN_CHUNK, ORPHAN_MANIFEST],
+  tuple_sha256: "a397309f5a6fb788666d5f99a5cc1b3d418e09b7209f1e8fd214f32f42abf2be",
+} as const satisfies ExpectedArtifactDeleteAuthority);
+
+const RESUMED_FROM_AUTHORITY = deepFreeze({
+  artifact_gc_epoch: 8,
+  fence_etag: '"head-epoch-8"',
+  candidate_keys: [ORPHAN_MANIFEST],
+  tuple_sha256: "8adae8c0e886017f18f5946b83a6ded2541e68637aaba232b06499889ae2662d",
+} as const satisfies ExpectedArtifactDeleteAuthority);
+
+const RESUME_DELETE_AUTHORITY = deepFreeze({
+  artifact_gc_epoch: 9,
+  fence_etag: '"head-epoch-9"',
+  candidate_keys: [ORPHAN_MANIFEST],
+  tuple_sha256: "b9e0939aad1745a8cab4737ad2e712a72c772bb75a9ba0ddb08be57057f55de5",
+} as const satisfies ExpectedArtifactDeleteAuthority);
+
+const CURRENT_BEFORE_FENCE = deepFreeze({
+  schema_version: 4,
+  collection: "items",
+  layout_version: 2,
+  snapshot: CAPTURED_MANIFEST,
+  tail_hint: 150,
+  log_seq_start: 100,
+  writer_fence: {
+    epoch: 5,
+    owner: "study-worker@fixture",
+    claimed_at: "2026-08-14T00:00:00.000Z",
+    lease_until: "2026-08-14T00:05:00.000Z",
+  },
+  snapshot_bytes: 786_432,
+  snapshot_rows: 2_048,
+  mean_entry_bytes: 384,
+  last_warned_seq: 120,
+  log_delete_floor: 84,
+  generation: "study-generation-7",
+  artifact_gc_epoch: 7,
+} as const);
+
+const CURRENT_AFTER_FENCE = deepFreeze({ ...CURRENT_BEFORE_FENCE, artifact_gc_epoch: 8 } as const);
+const CURRENT_AFTER_RESUME_FENCE = deepFreeze({
+  ...CURRENT_AFTER_FENCE,
+  artifact_gc_epoch: 9,
+} as const);
+
+export const ARTIFACT_GC_EXPECTED_BODIES = deepFreeze({
+  current_before_fence: CURRENT_BEFORE_FENCE,
+  current_after_fence: CURRENT_AFTER_FENCE,
+  current_after_resume_fence: CURRENT_AFTER_RESUME_FENCE,
+  pending_authority_8: {
+    schema: "baerly.artifact-delete-authority/v1",
+    authority: FENCE_WIN_AUTHORITY,
+  },
+  pending_authority_9: {
+    schema: "baerly.artifact-delete-authority/v1",
+    authority: RESUME_DELETE_AUTHORITY,
+  },
+  pending_completion: {
+    schema: "baerly.artifact-delete-authority/v1",
+    authority: null,
+  },
+} as const);
+
+const CURRENT_AFTER_FENCE_SHA256 =
+  "dd4f966a2ac7f68258f3bc56784a0cbb1307685dfffe1070a5547d607c3215e2";
+const CURRENT_AFTER_RESUME_FENCE_SHA256 =
+  "b6db369edbe50aacb5d8b9558609d0a5eec952649dd3b48cd7e82c897d3d646f";
+const PENDING_AUTHORITY_8_SHA256 =
+  "33c7f6841b8575d3ae1d73b45aa8296313ddc94872bfdc9d8c57bf701c3bf163";
+const PENDING_AUTHORITY_9_SHA256 =
+  "abd039e3a30e5a2a10a5d8c0ca4013d7756f7faba597dd0260aef0668fc40975";
+const PENDING_COMPLETION_SHA256 =
+  "42ef0f40ee5a68a6b09a28080a618bfa71694da00e30d866e29ff94b6987903b";
+
+const PUBLISH_CHUNK_A1_BODY = deepFreeze({
+  schema_version: 2,
+  collection: "items",
+  incarnation: INCARNATION_A,
+  first_id: "a",
+  last_id: "m",
+  docs: [
+    { _id: "a", value: "alpha" },
+    { _id: "m", value: "middle" },
+  ],
+} as const);
+
+const PUBLISH_CHUNK_A2_BODY = deepFreeze({
+  schema_version: 2,
+  collection: "items",
+  incarnation: INCARNATION_A,
+  first_id: "n",
+  last_id: "z",
+  docs: [
+    { _id: "n", value: "next" },
+    { _id: "z", value: "omega" },
+  ],
+} as const);
+
+const PUBLISH_CHUNK_B_BODY = deepFreeze({
+  schema_version: 2,
+  collection: "items",
+  incarnation: INCARNATION_B,
+  first_id: "a",
+  last_id: "z",
+  docs: [
+    { _id: "a", value: "alpha-2" },
+    { _id: "z", value: "omega-2" },
+  ],
+} as const);
+
+const PUBLISH_MANIFEST_A_BODY = deepFreeze({
+  schema_version: 2,
+  collection: "items",
+  log_seq_start: 120,
+  incarnation: INCARNATION_A,
+  collation: "utf8-scalar-v1",
+  chunks: [
+    { first_id: "a", last_id: "m", key: CHUNK_A, byte_length: 185, row_count: 2 },
+    { first_id: "n", last_id: "z", key: CHUNK_B, byte_length: 183, row_count: 2 },
+  ],
+} as const);
+
+const PUBLISH_MANIFEST_B_BODY = deepFreeze({
+  schema_version: 2,
+  collection: "items",
+  log_seq_start: 120,
+  incarnation: INCARNATION_B,
+  collation: "utf8-scalar-v1",
+  chunks: [{ first_id: "a", last_id: "z", key: CHUNK_C, byte_length: 188, row_count: 2 }],
+} as const);
+
+const PUBLISH_CURRENT_A_BODY = deepFreeze({
+  ...CURRENT_BEFORE_FENCE,
+  snapshot: MANIFEST_A,
+  log_seq_start: 120,
+  snapshot_bytes: 368,
+  snapshot_rows: 4,
+} as const);
+
+const PUBLISH_CURRENT_B_BODY = deepFreeze({
+  ...CURRENT_BEFORE_FENCE,
+  snapshot: MANIFEST_B,
+  log_seq_start: 120,
+  snapshot_bytes: 188,
+  snapshot_rows: 2,
+} as const);
+
+export const PUBLISHER_EXPECTED_BODIES = deepFreeze({
+  "chunk-a1": PUBLISH_CHUNK_A1_BODY,
+  "chunk-a2": PUBLISH_CHUNK_A2_BODY,
+  "chunk-b": PUBLISH_CHUNK_B_BODY,
+  "manifest-a": PUBLISH_MANIFEST_A_BODY,
+  "manifest-b": PUBLISH_MANIFEST_B_BODY,
+  "current-a": PUBLISH_CURRENT_A_BODY,
+  "current-b": PUBLISH_CURRENT_B_BODY,
+  "current-before-publish": CURRENT_BEFORE_FENCE,
+  "current-after-winner": {
+    ...CURRENT_BEFORE_FENCE,
+    snapshot: WINNER_MANIFEST,
+    log_seq_start: 110,
+    snapshot_bytes: 700_000,
+    snapshot_rows: 1_900,
+  },
+} as const);
+
+const casWin = defineFixture({
+  scenario: "cas-win",
+  publisher_bodies: PUBLISHER_EXPECTED_BODIES,
+  publication_attempts: [{ attempt_id: "publish-1", incarnation: INCARNATION_A }],
+  steps: [
+    {
+      method: "get",
+      key_class: "current",
+      key: CURRENT_KEY,
+      result_etag: '"head-before-publish"',
+      outcome: "ok",
+      attempt_id: "publish-1",
+    },
+    {
+      method: "get",
+      key_class: "manifest",
+      key: CAPTURED_MANIFEST,
+      outcome: "ok",
+      attempt_id: "publish-1",
+    },
+    {
+      method: "put",
+      key_class: "chunk",
+      key: CHUNK_A,
+      incarnation: INCARNATION_A,
+      condition: "if-none-match",
+      if_none_match: "*",
+      put_sha256: PUBLISH_CHUNK_A1_SHA256,
+      put_body_id: "chunk-a1",
+      outcome: "ok",
+      attempt_id: "publish-1",
+    },
+    {
+      method: "put",
+      key_class: "chunk",
+      key: CHUNK_B,
+      incarnation: INCARNATION_A,
+      condition: "if-none-match",
+      if_none_match: "*",
+      put_sha256: PUBLISH_CHUNK_A2_SHA256,
+      put_body_id: "chunk-a2",
+      outcome: "ok",
+      attempt_id: "publish-1",
+    },
+    {
+      method: "put",
+      key_class: "manifest",
+      key: MANIFEST_A,
+      incarnation: INCARNATION_A,
+      condition: "if-none-match",
+      if_none_match: "*",
+      put_sha256: PUBLISH_MANIFEST_A_SHA256,
+      put_body_id: "manifest-a",
+      outcome: "ok",
+      attempt_id: "publish-1",
+    },
+    {
+      method: "put",
+      key_class: "current",
+      key: CURRENT_KEY,
+      condition: "if-match",
+      if_match: '"head-before-publish"',
+      put_sha256: PUBLISH_CURRENT_A_SHA256,
+      put_body_id: "current-a",
+      outcome: "ok",
+      attempt_id: "publish-1",
+    },
+  ],
+} as const);
+
+const casLoss = defineFixture({
+  scenario: "cas-loss",
+  publisher_bodies: PUBLISHER_EXPECTED_BODIES,
+  publication_attempts: [
+    { attempt_id: "publish-lost", incarnation: INCARNATION_A },
+    { attempt_id: "publish-restarted", incarnation: INCARNATION_B },
+  ],
+  steps: [
+    {
+      method: "get",
+      key_class: "current",
+      key: CURRENT_KEY,
+      result_etag: '"head-before-publish"',
+      outcome: "ok",
+      attempt_id: "publish-lost",
+    },
+    {
+      method: "get",
+      key_class: "manifest",
+      key: CAPTURED_MANIFEST,
+      outcome: "ok",
+      attempt_id: "publish-lost",
+    },
+    {
+      method: "put",
+      key_class: "chunk",
+      key: CHUNK_A,
+      incarnation: INCARNATION_A,
+      condition: "if-none-match",
+      if_none_match: "*",
+      put_sha256: PUBLISH_CHUNK_A1_SHA256,
+      put_body_id: "chunk-a1",
+      outcome: "ok",
+      attempt_id: "publish-lost",
+    },
+    {
+      method: "put",
+      key_class: "manifest",
+      key: MANIFEST_A,
+      incarnation: INCARNATION_A,
+      condition: "if-none-match",
+      if_none_match: "*",
+      put_sha256: PUBLISH_MANIFEST_A_SHA256,
+      put_body_id: "manifest-a",
+      outcome: "ok",
+      attempt_id: "publish-lost",
+    },
+    {
+      method: "put",
+      key_class: "current",
+      key: CURRENT_KEY,
+      condition: "if-match",
+      if_match: '"head-before-publish"',
+      put_sha256: PUBLISH_CURRENT_A_SHA256,
+      put_body_id: "current-a",
+      outcome: "conflict",
+      attempt_id: "publish-lost",
+    },
+    {
+      method: "get",
+      key_class: "current",
+      key: CURRENT_KEY,
+      result_etag: '"head-after-winner"',
+      outcome: "ok",
+      attempt_id: "publish-restarted",
+    },
+    {
+      method: "get",
+      key_class: "manifest",
+      key: WINNER_MANIFEST,
+      outcome: "ok",
+      attempt_id: "publish-restarted",
+    },
+    {
+      method: "put",
+      key_class: "chunk",
+      key: CHUNK_C,
+      incarnation: INCARNATION_B,
+      condition: "if-none-match",
+      if_none_match: "*",
+      put_sha256: PUBLISH_CHUNK_B_SHA256,
+      put_body_id: "chunk-b",
+      outcome: "ok",
+      attempt_id: "publish-restarted",
+    },
+    {
+      method: "put",
+      key_class: "manifest",
+      key: MANIFEST_B,
+      incarnation: INCARNATION_B,
+      condition: "if-none-match",
+      if_none_match: "*",
+      put_sha256: PUBLISH_MANIFEST_B_SHA256,
+      put_body_id: "manifest-b",
+      outcome: "ok",
+      attempt_id: "publish-restarted",
+    },
+    {
+      method: "put",
+      key_class: "current",
+      key: CURRENT_KEY,
+      condition: "if-match",
+      if_match: '"head-after-winner"',
+      put_sha256: PUBLISH_CURRENT_B_SHA256,
+      put_body_id: "current-b",
+      outcome: "ok",
+      attempt_id: "publish-restarted",
+    },
+  ],
+} as const);
+
+const storageRetry = defineFixture({
+  scenario: "storage-retry",
+  publisher_bodies: PUBLISHER_EXPECTED_BODIES,
+  publication_attempts: [{ attempt_id: "publish-retry", incarnation: INCARNATION_A }],
+  steps: [
+    {
+      method: "get",
+      key_class: "current",
+      key: CURRENT_KEY,
+      result_etag: '"head-before-publish"',
+      outcome: "ok",
+      attempt_id: "publish-retry",
+    },
+    {
+      method: "get",
+      key_class: "manifest",
+      key: CAPTURED_MANIFEST,
+      outcome: "ok",
+      attempt_id: "publish-retry",
+    },
+    {
+      method: "put",
+      key_class: "chunk",
+      key: CHUNK_A,
+      incarnation: INCARNATION_A,
+      condition: "if-none-match",
+      if_none_match: "*",
+      put_sha256: PUBLISH_CHUNK_A1_SHA256,
+      put_body_id: "chunk-a1",
+      outcome: "error",
+      attempt_id: "publish-retry",
+    },
+    {
+      method: "put",
+      key_class: "chunk",
+      key: CHUNK_A,
+      incarnation: INCARNATION_A,
+      condition: "if-none-match",
+      if_none_match: "*",
+      put_sha256: PUBLISH_CHUNK_A1_SHA256,
+      put_body_id: "chunk-a1",
+      outcome: "ok",
+      attempt_id: "publish-retry",
+    },
+    {
+      method: "put",
+      key_class: "manifest",
+      key: MANIFEST_A,
+      incarnation: INCARNATION_A,
+      condition: "if-none-match",
+      if_none_match: "*",
+      put_sha256: PUBLISH_MANIFEST_A_SHA256,
+      put_body_id: "manifest-a",
+      outcome: "ok",
+      attempt_id: "publish-retry",
+    },
+    {
+      method: "put",
+      key_class: "current",
+      key: CURRENT_KEY,
+      condition: "if-match",
+      if_match: '"head-before-publish"',
+      put_sha256: PUBLISH_CURRENT_A_SHA256,
+      put_body_id: "current-a",
+      outcome: "ok",
+      attempt_id: "publish-retry",
+    },
+  ],
+} as const);
+
+const orphanMark = defineFixture({
+  scenario: "orphan-mark",
+  delete_authorized: false,
+  steps: [
+    {
+      method: "list",
+      key_class: "artifact-prefix",
+      key: `${COLLECTION_PREFIX}/_v2/snapshot/chunks/`,
+      max_keys: ARTIFACT_LIST_PAGE_SIZE,
+      outcome: "ok",
+    },
+    {
+      method: "get",
+      key_class: "current",
+      key: CURRENT_KEY,
+      result_etag: '"head-epoch-7"',
+      outcome: "ok",
+    },
+    { method: "get", key_class: "manifest", key: CAPTURED_MANIFEST, outcome: "ok" },
+  ],
+} as const);
+
+const artifactFenceWin = defineFixture({
+  scenario: "artifact-fence-win",
+  captured_artifact_gc_epoch: 7,
+  delete_authorized: true,
+  delete_authority: FENCE_WIN_AUTHORITY,
+  steps: [
+    {
+      method: "get",
+      key_class: "current",
+      key: CURRENT_KEY,
+      result_etag: '"head-epoch-7"',
+      outcome: "ok",
+    },
+    { method: "get", key_class: "manifest", key: CAPTURED_MANIFEST, outcome: "ok" },
+    {
+      method: "put",
+      key_class: "current",
+      key: CURRENT_KEY,
+      condition: "if-match",
+      if_match: '"head-epoch-7"',
+      put_sha256: CURRENT_AFTER_FENCE_SHA256,
+      result_etag: '"head-epoch-8"',
+      outcome: "ok",
+    },
+    {
+      method: "put",
+      key_class: "gc-pending",
+      key: PENDING_KEY,
+      condition: "if-match",
+      if_match: '"pending-before-fence"',
+      put_sha256: PENDING_AUTHORITY_8_SHA256,
+      result_etag: '"pending-authority-8"',
+      outcome: "ok",
+    },
+    { method: "delete", key_class: "chunk", key: ORPHAN_CHUNK, outcome: "ok" },
+    { method: "delete", key_class: "manifest", key: ORPHAN_MANIFEST, outcome: "ok" },
+    {
+      method: "put",
+      key_class: "gc-pending",
+      key: PENDING_KEY,
+      condition: "if-match",
+      if_match: '"pending-authority-8"',
+      put_sha256: PENDING_COMPLETION_SHA256,
+      result_etag: '"pending-complete-8"',
+      outcome: "ok",
+    },
+  ],
+} as const);
+
+const artifactFenceConflict = defineFixture({
+  scenario: "artifact-fence-conflict",
+  captured_artifact_gc_epoch: 7,
+  delete_authorized: false,
+  steps: [
+    {
+      method: "get",
+      key_class: "current",
+      key: CURRENT_KEY,
+      result_etag: '"head-epoch-7"',
+      outcome: "ok",
+    },
+    { method: "get", key_class: "manifest", key: CAPTURED_MANIFEST, outcome: "ok" },
+    {
+      method: "put",
+      key_class: "current",
+      key: CURRENT_KEY,
+      condition: "if-match",
+      if_match: '"head-epoch-7"',
+      put_sha256: CURRENT_AFTER_FENCE_SHA256,
+      outcome: "conflict",
+    },
+    {
+      method: "get",
+      key_class: "current",
+      key: CURRENT_KEY,
+      result_etag: '"head-after-publisher"',
+      outcome: "ok",
+    },
+    { method: "get", key_class: "manifest", key: WINNER_MANIFEST, outcome: "ok" },
+  ],
+} as const);
+
+const artifactFenceResume = defineFixture({
+  scenario: "artifact-fence-resume",
+  captured_artifact_gc_epoch: 8,
+  delete_authorized: true,
+  resumed_from_authority: RESUMED_FROM_AUTHORITY,
+  delete_authority: RESUME_DELETE_AUTHORITY,
+  steps: [
+    {
+      method: "get",
+      key_class: "gc-pending",
+      key: PENDING_KEY,
+      result_etag: '"pending-authority-8"',
+      outcome: "ok",
+    },
+    {
+      method: "get",
+      key_class: "current",
+      key: CURRENT_KEY,
+      result_etag: '"head-epoch-8"',
+      outcome: "ok",
+    },
+    { method: "get", key_class: "manifest", key: CAPTURED_MANIFEST, outcome: "ok" },
+    {
+      method: "put",
+      key_class: "current",
+      key: CURRENT_KEY,
+      condition: "if-match",
+      if_match: '"head-epoch-8"',
+      put_sha256: CURRENT_AFTER_RESUME_FENCE_SHA256,
+      result_etag: '"head-epoch-9"',
+      outcome: "ok",
+    },
+    {
+      method: "put",
+      key_class: "gc-pending",
+      key: PENDING_KEY,
+      condition: "if-match",
+      if_match: '"pending-authority-8"',
+      put_sha256: PENDING_AUTHORITY_9_SHA256,
+      result_etag: '"pending-authority-9"',
+      outcome: "ok",
+    },
+    { method: "delete", key_class: "manifest", key: ORPHAN_MANIFEST, outcome: "ok" },
+    {
+      method: "put",
+      key_class: "gc-pending",
+      key: PENDING_KEY,
+      condition: "if-match",
+      if_match: '"pending-authority-9"',
+      put_sha256: PENDING_COMPLETION_SHA256,
+      result_etag: '"pending-complete-9"',
+      outcome: "ok",
+    },
+  ],
+} as const);
+
+const artifactFenceExhausted = defineFixture({
+  scenario: "artifact-fence-exhausted",
+  captured_artifact_gc_epoch: Number.MAX_SAFE_INTEGER,
+  delete_authorized: false,
+  steps: [
+    { method: "get", key_class: "current", key: CURRENT_KEY, outcome: "ok" },
+    { method: "get", key_class: "manifest", key: CAPTURED_MANIFEST, outcome: "ok" },
+  ],
+} as const);
+
+const boundedListPage = defineFixture({
+  scenario: "bounded-list-page",
+  delete_authorized: false,
+  steps: [
+    {
+      method: "list",
+      key_class: "artifact-prefix",
+      key: `${COLLECTION_PREFIX}/_v2/snapshot/chunks/`,
+      max_keys: ARTIFACT_LIST_PAGE_SIZE,
+      outcome: "ok",
+    },
+    {
+      method: "list",
+      key_class: "artifact-prefix",
+      key: `${COLLECTION_PREFIX}/_v2/snapshot/manifests/`,
+      max_keys: ARTIFACT_LIST_PAGE_SIZE,
+      outcome: "ok",
+    },
+  ],
+} as const);
+
+/** Independent expected journals; no production publisher or GC code is imported. */
+export const EXPECTED_WORKLOAD_CEILING_JOURNALS = deepFreeze({
+  "cas-win": casWin,
+  "cas-loss": casLoss,
+  "storage-retry": storageRetry,
+  "orphan-mark": orphanMark,
+  "artifact-fence-win": artifactFenceWin,
+  "artifact-fence-conflict": artifactFenceConflict,
+  "artifact-fence-resume": artifactFenceResume,
+  "artifact-fence-exhausted": artifactFenceExhausted,
+  "bounded-list-page": boundedListPage,
+} as const satisfies Record<ChunkedStorageScenario, unknown>);


### PR DESCRIPTION
## What & why

Preregisters the input space and admission criteria for the still-unreleased chunked-snapshot capacity study (`WorkloadCeilingStudyContract`) before any measurement is taken, and defines the exact expected Storage journals (CAS fences, publication races, artifact-GC resume/exhaustion, bounded LIST paging) that a chunked-snapshot implementation must produce. This is measurement/contract scaffolding only — it doesn't change a shipped ceiling or production export.

## Key points

- Preregistering the contract ahead of the implementation is deliberate: it fixes admission criteria (zero-failures upper bound, p50/p95/p99, repeated tail drain, deployed-Workers-only evidence) before any run could bias them.
- Read-shape fan-out limits (`point: 1`, `bounded-range: 8`, `index-routed: 32`, `complete: 32`) were revised mid-branch to model index-routed reads' real fan-out instead of treating them like a point read.
- Journal fixtures cover both artifact-fence outcomes (win/conflict/resume/exhausted) and ordinary publication CAS win/loss, matching ADR-007's storage-native GC fence design.

## Verification

Not independently re-run for this PR; author validated locally, CI runs the full gate on the PR.