### PR TITLE
feat(bench): add deployed workload-ceiling evidence harness

### DIFF
--- a/bench/measurement/cli-entrypoint.ts
+++ b/bench/measurement/cli-entrypoint.ts
@@ -1,0 +1,13 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export async function runAsCliEntrypoint(
+  moduleUrl: string,
+  main: () => Promise<number>,
+): Promise<void> {
+  const isCli =
+    process.argv[1] !== undefined && fileURLToPath(moduleUrl) === resolve(process.argv[1]!);
+  if (isCli) {
+    process.exitCode = await main();
+  }
+}

--- a/bench/measurement/workload-ceiling-collect.test.ts
+++ b/bench/measurement/workload-ceiling-collect.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "vitest";
+import { WorkloadCeilingHarnessError } from "./workload-ceiling-harness.ts";
 import {
   extractWorkloadCeilingRawEvent,
   queryWorkersInvocationsAdaptive,
   resolveCollectOutDir,
+  resolveCollectWindow,
   WORKLOAD_CEILING_WORKER_NAME,
 } from "./workload-ceiling-collect.ts";
 
@@ -134,5 +136,96 @@ describe("queryWorkersInvocationsAdaptive", () => {
         fetchImpl: fetchStub,
       }),
     ).rejects.toThrow("HTTP 403");
+  });
+
+  test("a 200 carrying GraphQL errors throws instead of returning a null-data envelope", async () => {
+    // Cloudflare's Analytics API reports query-level failures — an unknown
+    // field, an out-of-scope token — as HTTP 200 with {errors, data: null}.
+    // Returning that body would let `extractRows` read it as zero rows and
+    // record a legitimate-looking `missing-terminal-event`, silently
+    // converting an auth or schema mistake into study evidence.
+    const fetchStub = (async () =>
+      new Response(
+        JSON.stringify({
+          data: null,
+          errors: [{ message: "authentication error", path: ["viewer", "accounts"] }],
+        }),
+        { status: 200 },
+      )) as typeof fetch;
+    await expect(
+      queryWorkersInvocationsAdaptive({
+        accountTag: "acct",
+        apiToken: "tok",
+        window,
+        fetchImpl: fetchStub,
+      }),
+    ).rejects.toThrow(/GraphQL query returned errors[\s\S]*authentication error/);
+  });
+
+  test("a 200 with an empty errors array is not treated as a failure", async () => {
+    const fetchStub = (async () =>
+      new Response(JSON.stringify({ ...envelope([]), errors: [] }), {
+        status: 200,
+      })) as typeof fetch;
+    await expect(
+      queryWorkersInvocationsAdaptive({
+        accountTag: "acct",
+        apiToken: "tok",
+        window,
+        fetchImpl: fetchStub,
+      }),
+    ).resolves.toMatchObject({ errors: [] });
+  });
+});
+
+describe("resolveCollectWindow", () => {
+  const now = new Date("2026-08-18T00:30:00.000Z");
+
+  test("unset defaults to the ten minutes ending now", () => {
+    expect(resolveCollectWindow({}, now)).toEqual({
+      gte: "2026-08-18T00:20:00.000Z",
+      lt: "2026-08-18T00:30:00.000Z",
+    });
+  });
+
+  test("an explicit end still defaults the start ten minutes before it", () => {
+    expect(
+      resolveCollectWindow({ WORKLOAD_CEILING_WINDOW_END: "2026-08-18T00:05:00Z" }, now),
+    ).toEqual({ gte: "2026-08-17T23:55:00.000Z", lt: "2026-08-18T00:05:00.000Z" });
+  });
+
+  test.each([
+    ["WORKLOAD_CEILING_WINDOW_END", { WORKLOAD_CEILING_WINDOW_END: "not-a-timestamp" }],
+    ["WORKLOAD_CEILING_WINDOW_START", { WORKLOAD_CEILING_WINDOW_START: "yesterday-ish" }],
+  ] as const)("a malformed %s fails by name, not as a bare RangeError", (field, env) => {
+    try {
+      resolveCollectWindow(env, now);
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(WorkloadCeilingHarnessError);
+      expect((error as WorkloadCeilingHarnessError).field).toBe(field);
+    }
+  });
+
+  test("an inverted window is rejected — it would resolve no rows and read as a missed run", () => {
+    try {
+      resolveCollectWindow(
+        {
+          WORKLOAD_CEILING_WINDOW_START: "2026-08-18T00:10:00Z",
+          WORKLOAD_CEILING_WINDOW_END: "2026-08-18T00:05:00Z",
+        },
+        now,
+      );
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(WorkloadCeilingHarnessError);
+      expect((error as WorkloadCeilingHarnessError).field).toBe("WORKLOAD_CEILING_WINDOW_START");
+    }
+  });
+
+  test("a blank value falls back to the default like unset", () => {
+    expect(resolveCollectWindow({ WORKLOAD_CEILING_WINDOW_END: "   " }, now).lt).toBe(
+      "2026-08-18T00:30:00.000Z",
+    );
   });
 });

--- a/bench/measurement/workload-ceiling-collect.test.ts
+++ b/bench/measurement/workload-ceiling-collect.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "vitest";
+import {
+  extractWorkloadCeilingRawEvent,
+  queryWorkersInvocationsAdaptive,
+  resolveCollectOutDir,
+  WORKLOAD_CEILING_WORKER_NAME,
+} from "./workload-ceiling-collect.ts";
+
+const window = { gte: "2026-08-18T00:00:00Z", lt: "2026-08-18T00:01:00Z" };
+
+const envelope = (rows: readonly unknown[]) => ({
+  data: { viewer: { accounts: [{ workersInvocationsAdaptive: rows }] } },
+});
+
+const row = (sum: { cpuTime: number; requests: number }) => ({
+  dimensions: {
+    datetime: "2026-08-18T00:00:10.000Z",
+    scriptName: "baerly-storage",
+    scriptVersion: "v1.2.3",
+    status: "ok",
+    coloCode: "SJC",
+  },
+  sum,
+});
+
+const input = (graphqlResponse: unknown) => ({
+  graphqlResponse,
+  run_id: "run-1",
+  scenario_id: "scen-1",
+  compatibility_date: "2026-08-15",
+  window,
+  observed_at: "2026-08-18T00:02:00Z",
+});
+
+describe("extractWorkloadCeilingRawEvent", () => {
+  test("maps exactly one single-request row to a resolved event", () => {
+    const event = extractWorkloadCeilingRawEvent(
+      input(envelope([row({ cpuTime: 12_345, requests: 1 })])),
+    );
+    expect(event.outcome).toBe("ok");
+    expect(event.cpu_ms).toBe(12.345);
+    expect(event.script_version).toBe("v1.2.3");
+    expect(event.colo).toBe("SJC");
+    expect(event.runtime_period).toBe(`${window.gte}/${window.lt}`);
+  });
+
+  test("zero rows is an explicit missing-terminal-event", () => {
+    const event = extractWorkloadCeilingRawEvent(input(envelope([])));
+    expect(event.outcome).toBe("missing-terminal-event");
+    expect(event.cpu_ms).toBeNull();
+  });
+
+  test("two rows is an explicit missing-terminal-event", () => {
+    const event = extractWorkloadCeilingRawEvent(
+      input(envelope([row({ cpuTime: 1, requests: 1 }), row({ cpuTime: 2, requests: 1 })])),
+    );
+    expect(event.outcome).toBe("missing-terminal-event");
+  });
+
+  test("a multi-request aggregate row is unresolved, never summed-and-guessed", () => {
+    // Two invocations collapsed into one minute bucket would arrive as a
+    // single row carrying requests: 2 with summed cpuTime.
+    const event = extractWorkloadCeilingRawEvent(
+      input(envelope([row({ cpuTime: 25_000, requests: 2 })])),
+    );
+    expect(event.outcome).toBe("missing-terminal-event");
+    expect(event.cpu_ms).toBeNull();
+  });
+
+  test("a malformed row is filtered out, not trusted", () => {
+    const event = extractWorkloadCeilingRawEvent(input(envelope([{ dimensions: {}, sum: {} }])));
+    expect(event.outcome).toBe("missing-terminal-event");
+  });
+
+  test("an unrecognized envelope shape is unresolved, never a throw", () => {
+    const event = extractWorkloadCeilingRawEvent(input({ data: null }));
+    expect(event.outcome).toBe("missing-terminal-event");
+  });
+});
+
+describe("resolveCollectOutDir", () => {
+  test("unset falls back to the shared default results directory", () => {
+    expect(resolveCollectOutDir({})).toBe("bench/results/workload-ceiling");
+  });
+
+  test("blank falls back like unset — a blank dir would resolve to the filesystem root", () => {
+    expect(resolveCollectOutDir({ WORKLOAD_CEILING_OUT_DIR: "  " })).toBe(
+      "bench/results/workload-ceiling",
+    );
+  });
+
+  test("a set value is used verbatim, enabling per-implementation directories", () => {
+    expect(resolveCollectOutDir({ WORKLOAD_CEILING_OUT_DIR: "bench/results/wc/control" })).toBe(
+      "bench/results/wc/control",
+    );
+  });
+});
+
+describe("queryWorkersInvocationsAdaptive", () => {
+  test("queries the fixed study scriptName with the exact window", async () => {
+    const calls: unknown[] = [];
+    const fetchStub = (async (_url: string | URL | Request, init?: RequestInit) => {
+      calls.push(JSON.parse(String(init?.body)));
+      return new Response(JSON.stringify(envelope([])), { status: 200 });
+    }) as typeof fetch;
+
+    await queryWorkersInvocationsAdaptive({
+      accountTag: "acct",
+      apiToken: "tok",
+      window,
+      fetchImpl: fetchStub,
+    });
+
+    expect(calls).toEqual([
+      {
+        query: expect.stringContaining("workersInvocationsAdaptive"),
+        variables: {
+          accountTag: "acct",
+          scriptName: WORKLOAD_CEILING_WORKER_NAME,
+          gte: window.gte,
+          lt: window.lt,
+        },
+      },
+    ]);
+  });
+
+  test("a non-ok HTTP response throws with the status", async () => {
+    const fetchStub = (async () => new Response("{}", { status: 403 })) as typeof fetch;
+    await expect(
+      queryWorkersInvocationsAdaptive({
+        accountTag: "acct",
+        apiToken: "tok",
+        window,
+        fetchImpl: fetchStub,
+      }),
+    ).rejects.toThrow("HTTP 403");
+  });
+});

--- a/bench/measurement/workload-ceiling-collect.ts
+++ b/bench/measurement/workload-ceiling-collect.ts
@@ -16,9 +16,8 @@
  * the `workersInvocationsAdaptive` dataset directly.
  */
 import { mkdir, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 import { loadCloudflareDeployCreds } from "../../tests/fixtures/endpoint-creds.ts";
+import { runAsCliEntrypoint } from "./cli-entrypoint.ts";
 import {
   decodeWorkloadCeilingRawEvent,
   encodeWorkloadCeilingRawEvent,
@@ -112,12 +111,20 @@ export const queryWorkersInvocationsAdaptive = async (
       },
     }),
   });
-  const body: unknown = await response.json();
+
   if (!response.ok) {
-    throw new Error(
-      `workers invocations query failed with HTTP ${response.status}: ${JSON.stringify(body)}`,
-    );
+    const text = await response.text();
+    throw new Error(`workers invocations query failed with HTTP ${response.status}: ${text}`);
   }
+
+  const body: unknown = await response.json();
+
+  // GraphQL errors arrive as HTTP 200 with {errors: [...], data: null}
+  const errors = (body as { errors?: unknown[] })?.errors;
+  if (errors !== undefined && errors.length > 0) {
+    throw new Error(`GraphQL query returned errors: ${JSON.stringify(errors)}`);
+  }
+
   return body;
 };
 
@@ -190,7 +197,9 @@ export function extractWorkloadCeilingRawEvent(
 ): WorkloadCeilingRawEvent {
   const rows = extractRows(input.graphqlResponse);
   const runtimePeriod = `${input.window.gte}/${input.window.lt}`;
-  if (rows.length !== 1) {
+
+  // Zero rows, more than one row, or multi-request aggregation → unresolved
+  if (rows.length !== 1 || rows[0]!.sum.requests !== 1) {
     return missingTerminalWorkloadCeilingRawEvent({
       run_id: input.run_id,
       scenario_id: input.scenario_id,
@@ -202,24 +211,8 @@ export function extractWorkloadCeilingRawEvent(
       observed_at: input.observed_at,
     });
   }
+
   const row = rows[0]!;
-  // workersInvocationsAdaptive rows are minute-bucketed aggregates. With the
-  // shared fixed scriptName, two invocations inside one minute collapse into
-  // a single row with SUMMED cpuTime — one plausible-looking, silently wrong
-  // number. A matched row must represent exactly one request or the window
-  // did not resolve this invocation.
-  if (row.sum.requests !== 1) {
-    return missingTerminalWorkloadCeilingRawEvent({
-      run_id: input.run_id,
-      scenario_id: input.scenario_id,
-      script_version: "unresolved",
-      compatibility_date: input.compatibility_date,
-      runtime_period: runtimePeriod,
-      colo: "unknown",
-      thermal_class: "unknown",
-      observed_at: input.observed_at,
-    });
-  }
   return {
     run_id: input.run_id,
     scenario_id: input.scenario_id,
@@ -371,8 +364,4 @@ async function main(): Promise<number> {
 // directly (`node --import ./bench/register-hooks.mjs …`), never when a test
 // imports it — `CF_API_TOKEN`/`CF_ACCOUNT_ID` or a credentials file being
 // present in the environment must not turn an import into a live network call.
-const isCli =
-  process.argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(process.argv[1]!);
-if (isCli) {
-  process.exitCode = await main();
-}
+await runAsCliEntrypoint(import.meta.url, main);

--- a/bench/measurement/workload-ceiling-collect.ts
+++ b/bench/measurement/workload-ceiling-collect.ts
@@ -237,10 +237,11 @@ export function extractWorkloadCeilingRawEvent(
 }
 
 /**
- * CLI entrypoint (`pnpm bench:workload-ceiling:collect`). Reads a
- * provisioning report written by `workload-ceiling-provision.ts`, queries
- * the platform, stores the unmodified response, then the derived strict
- * event.
+ * CLI entrypoint (`pnpm bench:workload-ceiling:collect`). Takes the run's join
+ * identifiers from the environment (it reads no provisioning report — the
+ * `run_id` an operator passes here is the one
+ * `workload-ceiling-provision.ts` printed), queries the platform, stores the
+ * unmodified response, then the derived strict event.
  *
  * Required auth: `CF_API_TOKEN` + `CF_ACCOUNT_ID` env vars (the same source
  * variables `tests/integration/day-one-handshake.test.ts` reads — never
@@ -251,7 +252,9 @@ export function extractWorkloadCeilingRawEvent(
  * Required env: `WORKLOAD_CEILING_RUN_ID`, `WORKLOAD_CEILING_SCENARIO_ID`,
  * `WORKLOAD_CEILING_COMPATIBILITY_DATE`.
  * Optional: `WORKLOAD_CEILING_WINDOW_START` / `WORKLOAD_CEILING_WINDOW_END`
- * (RFC 3339; default to a 10-minute window ending now), and
+ * (RFC 3339; default to a 10-minute window ending now — see
+ * {@link resolveCollectWindow}, which rejects an unparseable or inverted
+ * window by name), and
  * `WORKLOAD_CEILING_OUT_DIR` (where `raw-*` / `event-*` are written; see
  * {@link resolveCollectOutDir} — set it per implementation so compare
  * receives two clean directories).
@@ -282,6 +285,52 @@ export function resolveCollectOutDir(env: Record<string, string | undefined>): s
 // (or the usage error) — never pass validation as real credentials.
 const present = (value: string | undefined): value is string =>
   value !== undefined && value.trim() !== "";
+
+/** Parses one operator-supplied window bound, naming the offending env var on rejection. */
+const parseWindowBound = (name: string, value: string): string => {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new WorkloadCeilingHarnessError(
+      name,
+      `must be an RFC 3339 timestamp; got ${JSON.stringify(value)}`,
+    );
+  }
+  return parsed.toISOString();
+};
+
+/**
+ * Pure. Resolves the collection window, rejecting an unparseable operator-set
+ * bound by name.
+ *
+ * Every other operator-supplied input to this CLI fails with an explicit,
+ * named usage error, and these two must too. Unvalidated, a malformed
+ * `WORKLOAD_CEILING_WINDOW_END` either reaches `new Date(NaN).toISOString()`
+ * and throws a bare `RangeError: Invalid time value` naming nothing, or — with
+ * `WINDOW_START` also set — passes a garbage timestamp straight into the
+ * GraphQL query, where it comes back as a window that resolved no rows and
+ * reads as a missed invocation rather than a typo. The runbook's whole
+ * correctness argument rests on these two bounds, so they fail loud.
+ */
+export function resolveCollectWindow(
+  env: Record<string, string | undefined>,
+  now: Date,
+): WorkloadCeilingCollectWindow {
+  const rawEnd = env["WORKLOAD_CEILING_WINDOW_END"];
+  const end = present(rawEnd)
+    ? parseWindowBound("WORKLOAD_CEILING_WINDOW_END", rawEnd)
+    : now.toISOString();
+  const rawStart = env["WORKLOAD_CEILING_WINDOW_START"];
+  const start = present(rawStart)
+    ? parseWindowBound("WORKLOAD_CEILING_WINDOW_START", rawStart)
+    : new Date(new Date(end).getTime() - 10 * 60_000).toISOString();
+  if (new Date(start).getTime() >= new Date(end).getTime()) {
+    throw new WorkloadCeilingHarnessError(
+      "WORKLOAD_CEILING_WINDOW_START",
+      `must be strictly before WORKLOAD_CEILING_WINDOW_END; got ${start} >= ${end}`,
+    );
+  }
+  return { gte: start, lt: end };
+}
 
 async function main(): Promise<number> {
   const deployCreds =
@@ -314,11 +363,15 @@ async function main(): Promise<number> {
   }
 
   const now = new Date();
-  const windowEnd = process.env["WORKLOAD_CEILING_WINDOW_END"] ?? now.toISOString();
-  const windowStart =
-    process.env["WORKLOAD_CEILING_WINDOW_START"] ??
-    new Date(new Date(windowEnd).getTime() - 10 * 60_000).toISOString();
-  const window: WorkloadCeilingCollectWindow = { gte: windowStart, lt: windowEnd };
+  let window: WorkloadCeilingCollectWindow;
+  try {
+    window = resolveCollectWindow(process.env, now);
+  } catch (error) {
+    console.error(
+      `workload-ceiling-collect: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return 1;
+  }
 
   const graphqlResponse = await queryWorkersInvocationsAdaptive({
     accountTag,

--- a/bench/measurement/workload-ceiling-collect.ts
+++ b/bench/measurement/workload-ceiling-collect.ts
@@ -1,0 +1,378 @@
+/**
+ * Raw event collection for the deployed workload-ceiling study (parent plan
+ * Task 8 Step 6).
+ *
+ * Queries the OFFICIAL platform telemetry source — the GraphQL Analytics
+ * API's `workersInvocationsAdaptive` dataset — bounded by the study's fixed
+ * `scriptName` (see `bench/workload-ceiling-worker/README.md` §"Join
+ * mechanism") and an explicit, narrow time window. Stores the UNMODIFIED
+ * response before deriving its strict `WorkloadCeilingRawEvent`, and
+ * represents a collection window that closes without a matching row as an
+ * explicit `missing-terminal-event` outcome rather than dropping the
+ * invocation.
+ *
+ * Docs this rests on: `bench/workload-ceiling-worker/README.md` §"Platform
+ * documentation this rests on" links the GraphQL Analytics API reference and
+ * the `workersInvocationsAdaptive` dataset directly.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadCloudflareDeployCreds } from "../../tests/fixtures/endpoint-creds.ts";
+import {
+  decodeWorkloadCeilingRawEvent,
+  encodeWorkloadCeilingRawEvent,
+  missingTerminalWorkloadCeilingRawEvent,
+  WorkloadCeilingHarnessError,
+  type WorkloadCeilingRawEvent,
+  type WorkloadCeilingThermalClass,
+} from "./workload-ceiling-harness.ts";
+
+const GRAPHQL_ENDPOINT = "https://api.cloudflare.com/client/v4/graphql";
+
+/**
+ * The single already-deployed Worker this Step 10 smoke run targets (see
+ * `bench/workload-ceiling-worker/README.md` §"Join mechanism" and §"Token
+ * scope"). A per-run uniquely-named deployment would disambiguate concurrent
+ * or repeated invocations by `scriptName` alone; reusing one fixed name
+ * means disambiguation for this one-off run rests entirely on the narrow
+ * `WorkloadCeilingCollectWindow` bounding the single invocation. That's an
+ * accepted narrowing for Task 8's single authorized smoke run — a later,
+ * bulk multi-run study (out of this plan's scope) would need to restore
+ * per-run uniqueness or another explicit correlation mechanism.
+ */
+export const WORKLOAD_CEILING_WORKER_NAME = "baerly-storage";
+
+export interface WorkloadCeilingCollectWindow {
+  readonly gte: string;
+  readonly lt: string;
+}
+
+export interface WorkloadCeilingCollectInput {
+  readonly accountTag: string;
+  readonly apiToken: string;
+  readonly window: WorkloadCeilingCollectWindow;
+  readonly fetchImpl?: typeof fetch;
+}
+
+// Cloudflare's Analytics GraphQL schema is nonstandard: it defines a
+// lowercase `string` scalar and its documented examples use
+// `$accountTag: string!` verbatim. `Time` is likewise their custom scalar.
+// Field names here (`cpuTime`, `requests`) follow the dataset docs the
+// README links; the Step 10 smoke run verifies them live against the
+// verbatim-persisted raw response.
+const WORKERS_INVOCATIONS_QUERY = `
+  query WorkloadCeilingInvocations(
+    $accountTag: string!
+    $scriptName: string!
+    $gte: Time!
+    $lt: Time!
+  ) {
+    viewer {
+      accounts(filter: { accountTag: $accountTag }) {
+        workersInvocationsAdaptive(
+          limit: 10
+          filter: { scriptName: $scriptName, datetime_geq: $gte, datetime_lt: $lt }
+        ) {
+          dimensions {
+            datetime
+            scriptName
+            scriptVersion
+            status
+            coloCode
+          }
+          sum {
+            cpuTime
+            requests
+          }
+        }
+      }
+    }
+  }
+`;
+
+/** The one HTTP call to the official platform telemetry source. Returns the response UNPARSED-into-any-study-shape — callers persist it verbatim before deriving anything. */
+export const queryWorkersInvocationsAdaptive = async (
+  input: WorkloadCeilingCollectInput,
+): Promise<unknown> => {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const response = await fetchImpl(GRAPHQL_ENDPOINT, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${input.apiToken}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      query: WORKERS_INVOCATIONS_QUERY,
+      variables: {
+        accountTag: input.accountTag,
+        scriptName: WORKLOAD_CEILING_WORKER_NAME,
+        gte: input.window.gte,
+        lt: input.window.lt,
+      },
+    }),
+  });
+  const body: unknown = await response.json();
+  if (!response.ok) {
+    throw new Error(
+      `workers invocations query failed with HTTP ${response.status}: ${JSON.stringify(body)}`,
+    );
+  }
+  return body;
+};
+
+interface GraphQlInvocationRow {
+  readonly dimensions: {
+    readonly datetime: string;
+    readonly scriptName: string;
+    readonly scriptVersion: string;
+    readonly status: string;
+    readonly coloCode: string;
+  };
+  readonly sum: { readonly cpuTime: number; readonly requests: number };
+}
+
+/**
+ * Extracts the invocation rows from the GraphQL envelope, or `[]` for any
+ * shape this reader does not recognize — never throws on a malformed or
+ * empty response, because the caller's job at that point is to represent
+ * the invocation as unresolved, not to crash the collection run.
+ */
+function extractRows(response: unknown): readonly GraphQlInvocationRow[] {
+  const rows =
+    (
+      response as {
+        readonly data?: {
+          readonly viewer?: {
+            readonly accounts?: readonly {
+              readonly workersInvocationsAdaptive?: readonly unknown[];
+            }[];
+          };
+        };
+      }
+    )?.data?.viewer?.accounts?.[0]?.workersInvocationsAdaptive ?? [];
+  return rows.filter((row): row is GraphQlInvocationRow => {
+    const r = row as Partial<GraphQlInvocationRow> | null;
+    return (
+      r !== null &&
+      typeof r === "object" &&
+      typeof r.dimensions?.datetime === "string" &&
+      typeof r.dimensions.scriptName === "string" &&
+      typeof r.dimensions.scriptVersion === "string" &&
+      typeof r.dimensions.status === "string" &&
+      typeof r.dimensions.coloCode === "string" &&
+      typeof r.sum?.cpuTime === "number" &&
+      typeof r.sum?.requests === "number"
+    );
+  });
+}
+
+export interface ExtractWorkloadCeilingRawEventInput {
+  readonly graphqlResponse: unknown;
+  readonly run_id: string;
+  readonly scenario_id: string;
+  readonly compatibility_date: string;
+  readonly window: WorkloadCeilingCollectWindow;
+  readonly observed_at: string;
+}
+
+/**
+ * Pure. Reduces one already-fetched GraphQL response to a strict
+ * `WorkloadCeilingRawEvent`. Zero rows, more than one row, or a single
+ * row aggregating more than one request are all treated the same way —
+ * the collection window did not resolve to exactly one single-request
+ * invocation — and become an explicit `missing-terminal-event`, never a
+ * silently dropped run and never a guess at which of several rows was
+ * "the" invocation.
+ */
+export function extractWorkloadCeilingRawEvent(
+  input: ExtractWorkloadCeilingRawEventInput,
+): WorkloadCeilingRawEvent {
+  const rows = extractRows(input.graphqlResponse);
+  const runtimePeriod = `${input.window.gte}/${input.window.lt}`;
+  if (rows.length !== 1) {
+    return missingTerminalWorkloadCeilingRawEvent({
+      run_id: input.run_id,
+      scenario_id: input.scenario_id,
+      script_version: "unresolved",
+      compatibility_date: input.compatibility_date,
+      runtime_period: runtimePeriod,
+      colo: "unknown",
+      thermal_class: "unknown",
+      observed_at: input.observed_at,
+    });
+  }
+  const row = rows[0]!;
+  // workersInvocationsAdaptive rows are minute-bucketed aggregates. With the
+  // shared fixed scriptName, two invocations inside one minute collapse into
+  // a single row with SUMMED cpuTime — one plausible-looking, silently wrong
+  // number. A matched row must represent exactly one request or the window
+  // did not resolve this invocation.
+  if (row.sum.requests !== 1) {
+    return missingTerminalWorkloadCeilingRawEvent({
+      run_id: input.run_id,
+      scenario_id: input.scenario_id,
+      script_version: "unresolved",
+      compatibility_date: input.compatibility_date,
+      runtime_period: runtimePeriod,
+      colo: "unknown",
+      thermal_class: "unknown",
+      observed_at: input.observed_at,
+    });
+  }
+  return {
+    run_id: input.run_id,
+    scenario_id: input.scenario_id,
+    script_version: row.dimensions.scriptVersion,
+    compatibility_date: input.compatibility_date,
+    runtime_period: runtimePeriod,
+    colo: row.dimensions.coloCode,
+    thermal_class: "unknown" satisfies WorkloadCeilingThermalClass,
+    outcome: row.dimensions.status,
+    // UNITS ASSUMPTION: `workersInvocationsAdaptive`'s `sum.cpuTime` is
+    // reported in microseconds per the dataset documentation linked from
+    // `bench/workload-ceiling-worker/README.md` §"Platform documentation
+    // this rests on" (GraphQL Analytics API → workersInvocationsAdaptive
+    // metrics), so /1000 reaches the ms this study reports everywhere
+    // else. The Step 10 smoke run MUST cross-check this assumption against
+    // the verbatim-persisted raw response (`raw-<runId>.json`) — a
+    // milliseconds-reported field would make every cpu_ms 1000× too small —
+    // before the study trusts any number derived from it.
+    cpu_ms: row.sum.cpuTime / 1000,
+    observed_at: input.observed_at,
+  };
+}
+
+/**
+ * CLI entrypoint (`pnpm bench:workload-ceiling:collect`). Reads a
+ * provisioning report written by `workload-ceiling-provision.ts`, queries
+ * the platform, stores the unmodified response, then the derived strict
+ * event.
+ *
+ * Required auth: `CF_API_TOKEN` + `CF_ACCOUNT_ID` env vars (the same source
+ * variables `tests/integration/day-one-handshake.test.ts` reads — never
+ * `wrangler login`), or, when either is unset, a repo-scoped
+ * `credentials/cloudflare-deploy.json` (gitignored — see
+ * {@link loadCloudflareDeployCreds}). The env vars win when both are
+ * present, so a CI override never silently loses to a stale local file.
+ * Required env: `WORKLOAD_CEILING_RUN_ID`, `WORKLOAD_CEILING_SCENARIO_ID`,
+ * `WORKLOAD_CEILING_COMPATIBILITY_DATE`.
+ * Optional: `WORKLOAD_CEILING_WINDOW_START` / `WORKLOAD_CEILING_WINDOW_END`
+ * (RFC 3339; default to a 10-minute window ending now), and
+ * `WORKLOAD_CEILING_OUT_DIR` (where `raw-*` / `event-*` are written; see
+ * {@link resolveCollectOutDir} — set it per implementation so compare
+ * receives two clean directories).
+ */
+const WORKLOAD_CEILING_COLLECT_DEFAULT_OUT_DIR = "bench/results/workload-ceiling";
+
+/**
+ * Pure. Resolves the directory this CLI writes `raw-<runId>.json` and
+ * `event-<runId>.json` to. Unset (or blank) → the shared default above.
+ *
+ * `WORKLOAD_CEILING_OUT_DIR` exists because the runbook's smoke run
+ * invokes the Worker once per implementation and
+ * `workload-ceiling-compare.ts` joins TWO event directories — one per
+ * side. Both implementations reuse the same `scenario_id`s, so collecting
+ * both sides into the one default directory makes every scenario arrive
+ * twice there and get evicted as a duplicate, leaving zero pairs. Each
+ * invocation must route its artifacts to its own side's directory; this
+ * resolver is the only place that routing is decided.
+ */
+export function resolveCollectOutDir(env: Record<string, string | undefined>): string {
+  const outDir = env["WORKLOAD_CEILING_OUT_DIR"];
+  return outDir !== undefined && outDir.trim() !== ""
+    ? outDir
+    : WORKLOAD_CEILING_COLLECT_DEFAULT_OUT_DIR;
+}
+
+// Blank-but-defined env values must fall through to the credentials file
+// (or the usage error) — never pass validation as real credentials.
+const present = (value: string | undefined): value is string =>
+  value !== undefined && value.trim() !== "";
+
+async function main(): Promise<number> {
+  const deployCreds =
+    !present(process.env["CF_API_TOKEN"]) || !present(process.env["CF_ACCOUNT_ID"])
+      ? await loadCloudflareDeployCreds()
+      : null;
+  const apiToken = present(process.env["CF_API_TOKEN"])
+    ? process.env["CF_API_TOKEN"]
+    : deployCreds?.api_token;
+  const accountTag = present(process.env["CF_ACCOUNT_ID"])
+    ? process.env["CF_ACCOUNT_ID"]
+    : deployCreds?.account_id;
+  const runId = process.env["WORKLOAD_CEILING_RUN_ID"];
+  const scenarioId = process.env["WORKLOAD_CEILING_SCENARIO_ID"];
+  const compatibilityDate = process.env["WORKLOAD_CEILING_COMPATIBILITY_DATE"];
+  if (
+    apiToken === undefined ||
+    accountTag === undefined ||
+    runId === undefined ||
+    scenarioId === undefined ||
+    compatibilityDate === undefined
+  ) {
+    console.error(
+      "workload-ceiling-collect: requires CF_API_TOKEN + CF_ACCOUNT_ID " +
+        "(env vars or credentials/cloudflare-deploy.json), plus " +
+        "WORKLOAD_CEILING_RUN_ID, WORKLOAD_CEILING_SCENARIO_ID, and " +
+        "WORKLOAD_CEILING_COMPATIBILITY_DATE in the environment.",
+    );
+    return 1;
+  }
+
+  const now = new Date();
+  const windowEnd = process.env["WORKLOAD_CEILING_WINDOW_END"] ?? now.toISOString();
+  const windowStart =
+    process.env["WORKLOAD_CEILING_WINDOW_START"] ??
+    new Date(new Date(windowEnd).getTime() - 10 * 60_000).toISOString();
+  const window: WorkloadCeilingCollectWindow = { gte: windowStart, lt: windowEnd };
+
+  const graphqlResponse = await queryWorkersInvocationsAdaptive({
+    accountTag,
+    apiToken,
+    window,
+  });
+
+  const outDir = resolveCollectOutDir(process.env);
+  await mkdir(outDir, { recursive: true });
+  const rawPath = `${outDir}/raw-${runId}.json`;
+  await writeFile(rawPath, JSON.stringify(graphqlResponse, null, 2));
+  console.log(`wrote unmodified platform response to ${rawPath}`);
+
+  const event = extractWorkloadCeilingRawEvent({
+    graphqlResponse,
+    run_id: runId,
+    scenario_id: scenarioId,
+    compatibility_date: compatibilityDate,
+    window,
+    observed_at: now.toISOString(),
+  });
+
+  let encoded: string;
+  try {
+    encoded = encodeWorkloadCeilingRawEvent(event);
+    // Round-trip through the strict decoder too, so a malformed event can
+    // never reach disk under the name the compare step trusts.
+    decodeWorkloadCeilingRawEvent(encoded);
+  } catch (error) {
+    const detail = error instanceof WorkloadCeilingHarnessError ? error.message : String(error);
+    console.error(`workload-ceiling-collect: derived event failed strict validation: ${detail}`);
+    return 1;
+  }
+  const eventPath = `${outDir}/event-${runId}.json`;
+  await writeFile(eventPath, encoded);
+  console.log(
+    `wrote strict event to ${eventPath} (outcome=${event.outcome}, cpu_ms=${String(event.cpu_ms)})`,
+  );
+  return 0;
+}
+
+// CLI entrypoint guard: `main()` runs only when this module is executed
+// directly (`node --import ./bench/register-hooks.mjs …`), never when a test
+// imports it — `CF_API_TOKEN`/`CF_ACCOUNT_ID` or a credentials file being
+// present in the environment must not turn an import into a live network call.
+const isCli =
+  process.argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(process.argv[1]!);
+if (isCli) {
+  process.exitCode = await main();
+}

--- a/bench/measurement/workload-ceiling-compare.test.ts
+++ b/bench/measurement/workload-ceiling-compare.test.ts
@@ -86,6 +86,18 @@ describe("matchWorkloadCeilingEvents", () => {
     );
     expect(matched.incomplete).toEqual([{ scenario_id: "s1", reason: "unresolved-cpu" }]);
   });
+
+  test("a non-ok outcome carrying a partial cpu_ms still rejects the pair", () => {
+    // The platform reports a partial CPU number alongside `exceededCpu`, and
+    // the harness codec preserves that shape — so cpu_ms being non-null is
+    // not evidence the invocation resolved.
+    const matched = matchWorkloadCeilingEvents(
+      [event({ scenario_id: "s1", cpu_ms: 10 })],
+      [event({ scenario_id: "s1", cpu_ms: 50, outcome: "exceededCpu" })],
+    );
+    expect(matched.pairs).toEqual([]);
+    expect(matched.incomplete).toEqual([{ scenario_id: "s1", reason: "unresolved-cpu" }]);
+  });
 });
 
 describe("buildWorkloadCeilingComparisonReport", () => {
@@ -133,6 +145,25 @@ describe("buildWorkloadCeilingComparisonReport", () => {
     expect(report.zero_failure_upper_bound.control).toEqual(
       clopperPearsonZeroFailureUpper(3, 0.95),
     );
+  });
+
+  test("a non-ok event carrying a partial cpu_ms counts as a failure, not a success", () => {
+    // The anti-conservative reading the invalid marker exists to prevent: an
+    // `exceededCpu` invocation the platform reported a partial CPU number for
+    // is a real observed failure. Counting it toward the success denominator
+    // would hand this side a valid-looking zero-failure bound.
+    const controlAll = [
+      ...control,
+      event({ scenario_id: "s3", cpu_ms: 50, outcome: "exceededCpu" }),
+    ];
+    const matched = matchWorkloadCeilingEvents(controlAll, candidate);
+    const report = buildWorkloadCeilingComparisonReport(
+      reportInput(matched, controlAll, candidate),
+    );
+    expect(report.zero_failure_upper_bound.control).toEqual({
+      invalid: "failures-present",
+      failure_count: 1,
+    });
   });
 
   test("an empty event list clamps the Clopper-Pearson denominator to one", () => {

--- a/bench/measurement/workload-ceiling-compare.test.ts
+++ b/bench/measurement/workload-ceiling-compare.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "vitest";
+import { clopperPearsonZeroFailureUpper } from "./statistics.ts";
+import {
+  WorkloadCeilingHarnessError,
+  type WorkloadCeilingRawEvent,
+} from "./workload-ceiling-harness.ts";
+import {
+  buildWorkloadCeilingComparisonReport,
+  matchWorkloadCeilingEvents,
+  readEventsFromDirectory,
+} from "./workload-ceiling-compare.ts";
+
+const event = (over: Partial<WorkloadCeilingRawEvent>): WorkloadCeilingRawEvent => ({
+  run_id: "r1",
+  scenario_id: "s0",
+  script_version: "v1",
+  compatibility_date: "2026-08-15",
+  runtime_period: "a/b",
+  colo: "SJC",
+  thermal_class: "unknown",
+  outcome: "ok",
+  cpu_ms: 10,
+  observed_at: "2026-08-18T00:00:00Z",
+  ...over,
+});
+
+const reportInput = (
+  matched: ReturnType<typeof matchWorkloadCeilingEvents>,
+  controlEvents: readonly WorkloadCeilingRawEvent[],
+  candidateEvents: readonly WorkloadCeilingRawEvent[],
+) => ({
+  matched,
+  controlEvents,
+  candidateEvents,
+  confidence: 0.95,
+  seed: 0,
+  resamples: 50,
+});
+
+describe("matchWorkloadCeilingEvents", () => {
+  test("pairs control and candidate sharing scenario and deployment metadata", () => {
+    const matched = matchWorkloadCeilingEvents(
+      [event({ scenario_id: "s1", cpu_ms: 10 })],
+      [event({ scenario_id: "s1", cpu_ms: 20 })],
+    );
+    expect(matched.pairs).toHaveLength(1);
+    expect(matched.incomplete).toEqual([]);
+    expect(matched.pairs[0]!.control.cpu_ms).toBe(10);
+  });
+
+  test.each([
+    ["missing-candidate", [event({ scenario_id: "s1" })], []],
+    ["missing-control", [], [event({ scenario_id: "s1" })]],
+  ] as const)("%s is reported by name", (reason, control, candidate) => {
+    const matched = matchWorkloadCeilingEvents(control, candidate);
+    expect(matched.pairs).toEqual([]);
+    expect(matched.incomplete).toEqual([{ scenario_id: "s1", reason }]);
+  });
+
+  test("duplicate scenarios are evicted and reported on the side they occur", () => {
+    const matched = matchWorkloadCeilingEvents(
+      [event({ scenario_id: "s1", cpu_ms: 1 }), event({ scenario_id: "s1", cpu_ms: 2 })],
+      [event({ scenario_id: "s1", cpu_ms: 3 })],
+    );
+    expect(matched.pairs).toEqual([]);
+    expect(matched.incomplete).toContainEqual({
+      scenario_id: "s1",
+      reason: "duplicate-scenario",
+    });
+  });
+
+  test("deployment metadata mismatch rejects the pair", () => {
+    const matched = matchWorkloadCeilingEvents(
+      [event({ scenario_id: "s1", script_version: "v1" })],
+      [event({ scenario_id: "s1", script_version: "v2" })],
+    );
+    expect(matched.incomplete).toEqual([
+      { scenario_id: "s1", reason: "deployment-metadata-mismatch" },
+    ]);
+  });
+
+  test("a null cpu_ms on either side rejects the pair as unresolved-cpu", () => {
+    const matched = matchWorkloadCeilingEvents(
+      [event({ scenario_id: "s1", cpu_ms: 10 })],
+      [event({ scenario_id: "s1", cpu_ms: null, outcome: "exceededCpu" })],
+    );
+    expect(matched.incomplete).toEqual([{ scenario_id: "s1", reason: "unresolved-cpu" }]);
+  });
+});
+
+describe("buildWorkloadCeilingComparisonReport", () => {
+  const control = [
+    event({ scenario_id: "s1", cpu_ms: 10 }),
+    event({ scenario_id: "s2", cpu_ms: 20 }),
+  ];
+  const candidate = [
+    event({ scenario_id: "s1", cpu_ms: 15 }),
+    event({ scenario_id: "s2", cpu_ms: 25 }),
+  ];
+
+  test("reports quantiles and a deterministic bootstrap interval", () => {
+    const matched = matchWorkloadCeilingEvents(control, candidate);
+    const report = buildWorkloadCeilingComparisonReport(reportInput(matched, control, candidate));
+    expect(report.pair_count).toBe(2);
+    // r7 interpolation: p50 of two values sits halfway between them.
+    expect(report.control_cpu_ms.p50.value).toBe(15);
+    expect(report.candidate_cpu_ms.p50.value).toBe(20);
+    const again = buildWorkloadCeilingComparisonReport(reportInput(matched, control, candidate));
+    expect(again.paired_candidate_over_control_ratio).toEqual(
+      report.paired_candidate_over_control_ratio,
+    );
+  });
+
+  test("zero pairs throws WorkloadCeilingHarnessError on the pairs field", () => {
+    try {
+      buildWorkloadCeilingComparisonReport(reportInput(matchWorkloadCeilingEvents([], []), [], []));
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(WorkloadCeilingHarnessError);
+      expect((error as WorkloadCeilingHarnessError).field).toBe("pairs");
+    }
+  });
+
+  test("failure budget is computed over ALL collected events, not surviving pairs", () => {
+    // Duplicate s1 on the control side evicts it from pairing, but all
+    // three control attempts still count toward the failure budget.
+    const controlAll = [...control, event({ scenario_id: "s1", cpu_ms: 99 })];
+    const matched = matchWorkloadCeilingEvents(controlAll, candidate);
+    expect(matched.pairs).toHaveLength(1); // only s2 survives
+    const report = buildWorkloadCeilingComparisonReport(
+      reportInput(matched, controlAll, candidate),
+    );
+    expect(report.zero_failure_upper_bound.control).toEqual(
+      clopperPearsonZeroFailureUpper(3, 0.95),
+    );
+  });
+
+  test("an empty event list clamps the Clopper-Pearson denominator to one", () => {
+    const matched = matchWorkloadCeilingEvents(control, candidate);
+    const report = buildWorkloadCeilingComparisonReport(reportInput(matched, [], []));
+    expect(report.zero_failure_upper_bound.control).toEqual(
+      clopperPearsonZeroFailureUpper(1, 0.95),
+    );
+  });
+
+  test("a side with unresolved events is marked invalid, never given an anti-conservative bound", () => {
+    // One exceededCpu attempt on the control side only. The zero-failure
+    // formula (1 - c^(1/n)) has no honest reading at F > 0 — with the
+    // current N−F denominator MORE failures would tighten it — so the
+    // control side must be reported as invalid by name, while the
+    // all-resolved candidate side still gets its valid bound.
+    const controlAll = [
+      ...control,
+      event({ scenario_id: "s3", cpu_ms: null, outcome: "exceededCpu" }),
+    ];
+    const matched = matchWorkloadCeilingEvents(controlAll, candidate);
+    expect(matched.incomplete).toContainEqual({ scenario_id: "s3", reason: "missing-candidate" });
+    const report = buildWorkloadCeilingComparisonReport(
+      reportInput(matched, controlAll, candidate),
+    );
+    expect(report.zero_failure_upper_bound.control).toEqual({
+      invalid: "failures-present",
+      failure_count: 1,
+    });
+    expect(report.zero_failure_upper_bound.candidate).toEqual(
+      clopperPearsonZeroFailureUpper(candidate.length, 0.95),
+    );
+  });
+});
+
+describe("readEventsFromDirectory failure mode", () => {
+  test("a missing directory rejects loudly instead of looking like no data", async () => {
+    await expect(readEventsFromDirectory("bench/results/definitely-missing-dir")).rejects.toThrow(
+      /cannot read events directory/,
+    );
+  });
+});

--- a/bench/measurement/workload-ceiling-compare.ts
+++ b/bench/measurement/workload-ceiling-compare.ts
@@ -21,9 +21,9 @@
  * `{ invalid: "failures-present", failure_count }` instead, because the
  * zero-failure formula has no honest extension to F > 0 (see
  * {@link WorkloadCeilingZeroFailureBoundInvalid}). An incomplete pair (missing a side,
- * mismatched deployment metadata, or either side lacking a resolved
- * `cpu_ms`) is rejected from the paired statistics rather than silently
- * imputed, and is reported separately.
+ * mismatched deployment metadata, or either side failing to resolve to a
+ * usable `ok` measurement) is rejected from the paired statistics rather than
+ * silently imputed, and is reported separately.
  */
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { runAsCliEntrypoint } from "./cli-entrypoint.ts";
@@ -46,14 +46,21 @@ function deploymentKey(event: WorkloadCeilingRawEvent): string {
   return `${event.compatibility_date}|${event.script_version}`;
 }
 
-// Narrows a raw event to the resolved type. Callers must have already
-// checked `cpu_ms !== null` — that check is what makes the single `!`
-// here justified; `matchWorkloadCeilingEvents` does so immediately
-// before every call.
-const resolved = (e: WorkloadCeilingRawEvent): ResolvedWorkloadCeilingRawEvent => ({
-  ...e,
-  cpu_ms: e.cpu_ms!,
-});
+/**
+ * The single definition of "this invocation resolved to a usable
+ * measurement": the collection window produced a CPU number AND the platform
+ * classified the invocation as `ok`.
+ *
+ * The `cpu_ms !== null` half alone is NOT sufficient. A non-`ok` outcome can
+ * still carry a partial CPU number — the platform reports one for
+ * `exceededCpu`, and `workload-ceiling-harness.ts` preserves that shape
+ * deliberately. Both the pairing logic and the per-side failure-budget count
+ * MUST read this one predicate: a side that observed a real failed
+ * invocation must never receive a valid-looking zero-failure bound, which is
+ * exactly what counting such an event as a success would produce.
+ */
+const isResolvedOk = (event: WorkloadCeilingRawEvent): event is ResolvedWorkloadCeilingRawEvent =>
+  event.cpu_ms !== null && event.outcome === "ok";
 
 /** A WorkloadCeilingRawEvent whose collection window resolved to exactly one single-request invocation. */
 export type ResolvedWorkloadCeilingRawEvent = Omit<WorkloadCeilingRawEvent, "cpu_ms"> & {
@@ -103,7 +110,7 @@ function indexByScenario(
 
 /**
  * Pure. Joins by `scenario_id`, then by deployment metadata, then requires
- * both sides to carry a resolved `cpu_ms`. Every rejection is reported by
+ * both sides to satisfy {@link isResolvedOk}. Every rejection is reported by
  * name — this function never drops a scenario silently.
  */
 export function matchWorkloadCeilingEvents(
@@ -131,21 +138,11 @@ export function matchWorkloadCeilingEvents(
       incomplete.push({ scenario_id: scenarioId, reason: "deployment-metadata-mismatch" });
       continue;
     }
-    if (control.cpu_ms === null || candidate.cpu_ms === null) {
+    if (!isResolvedOk(control) || !isResolvedOk(candidate)) {
       incomplete.push({ scenario_id: scenarioId, reason: "unresolved-cpu" });
       continue;
     }
-
-    // Reject non-"ok" outcomes even if cpu_ms is present (e.g., exceededCpu)
-    if (control.outcome !== "ok" || candidate.outcome !== "ok") {
-      incomplete.push({ scenario_id: scenarioId, reason: "unresolved-cpu" });
-      continue;
-    }
-    pairs.push({
-      scenario_id: scenarioId,
-      control: resolved(control),
-      candidate: resolved(candidate),
-    });
+    pairs.push({ scenario_id: scenarioId, control, candidate });
   }
   return {
     pairs,
@@ -155,7 +152,9 @@ export function matchWorkloadCeilingEvents(
 
 /**
  * A side of the comparison whose collected events include at least one
- * unresolved (`cpu_ms: null`) invocation. The zero-failure Clopper-Pearson
+ * invocation that did not resolve to a usable measurement — either
+ * `cpu_ms: null`, or a non-`ok` outcome that still carried a partial CPU
+ * number (see {@link isResolvedOk}). The zero-failure Clopper-Pearson
  * formula (`1 − c^(1/n)`) is valid only at zero observed failures: `n`
  * counts successes, so plugging any success-count-derived denominator in
  * at F > 0 is anti-conservative (more failures would TIGHTEN the bound —
@@ -192,8 +191,8 @@ export interface WorkloadCeilingComparisonReport {
   readonly paired_candidate_over_control_ratio: BootstrapResult<"paired-ratio-bootstrap-v1">;
   /**
    * Over ALL collected events on each side, including incomplete/unresolved
-   * ones — the study's failure budget. Valid ONLY for a side with zero
-   * unresolved events: a side with ≥ 1 failure carries
+   * ones — the study's failure budget. Valid ONLY for a side on which every
+   * event satisfies {@link isResolvedOk}: a side with ≥ 1 failure carries
    * `{ invalid: "failures-present", failure_count }` instead of a bound
    * (see {@link WorkloadCeilingZeroFailureBoundInvalid} for why the
    * zero-failure formula has no honest F > 0 reading).
@@ -220,7 +219,7 @@ const zeroFailureUpperBound = (
   events: readonly WorkloadCeilingRawEvent[],
   confidence: number,
 ): WorkloadCeilingZeroFailureBound => {
-  const failures = events.filter((event) => event.cpu_ms === null).length;
+  const failures = events.filter((event) => !isResolvedOk(event)).length;
   if (failures > 0) {
     return { invalid: "failures-present", failure_count: failures };
   }

--- a/bench/measurement/workload-ceiling-compare.ts
+++ b/bench/measurement/workload-ceiling-compare.ts
@@ -26,8 +26,7 @@
  * imputed, and is reported separately.
  */
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { runAsCliEntrypoint } from "./cli-entrypoint.ts";
 import {
   clopperPearsonZeroFailureUpper,
   pairedRatioBootstrap,
@@ -133,6 +132,12 @@ export function matchWorkloadCeilingEvents(
       continue;
     }
     if (control.cpu_ms === null || candidate.cpu_ms === null) {
+      incomplete.push({ scenario_id: scenarioId, reason: "unresolved-cpu" });
+      continue;
+    }
+
+    // Reject non-"ok" outcomes even if cpu_ms is present (e.g., exceededCpu)
+    if (control.outcome !== "ok" || candidate.outcome !== "ok") {
       incomplete.push({ scenario_id: scenarioId, reason: "unresolved-cpu" });
       continue;
     }
@@ -367,8 +372,4 @@ async function main(): Promise<number> {
 // CLI entrypoint guard: `main()` runs only when this module is executed
 // directly, never when a test imports it — an import must not read event
 // directories or write comparison artifacts off the environment.
-const isCli =
-  process.argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(process.argv[1]!);
-if (isCli) {
-  process.exitCode = await main();
-}
+await runAsCliEntrypoint(import.meta.url, main);

--- a/bench/measurement/workload-ceiling-compare.ts
+++ b/bench/measurement/workload-ceiling-compare.ts
@@ -1,0 +1,374 @@
+/**
+ * Matched comparison for the deployed workload-ceiling study (parent plan
+ * Task 8 Step 7).
+ *
+ * Joins `monolithic-control` and `chunked-candidate` raw events
+ * (`workload-ceiling-harness.ts`, produced by `workload-ceiling-collect.ts`)
+ * by `scenario_id` PLUS deployment metadata — `compatibility_date` and
+ * `script_version` must agree, because this study's Worker
+ * (`bench/workload-ceiling-worker/src/index.ts`) serves both
+ * implementations from the SAME deployed script, branching on the request's
+ * `implementation` field. Two events under the same scenario but different
+ * deployment metadata were not measured on the same runtime build and are
+ * NOT a valid pair.
+ *
+ * Every number this module reports comes from a tagged algorithm in
+ * `statistics.ts` — p50/p95/p99 via `quantileEstimate`, the paired
+ * candidate/control ratio via `pairedRatioBootstrap`, and the zero-failure
+ * upper bound on unresolved/failed invocations via
+ * `clopperPearsonZeroFailureUpper` — computed per side ONLY over sides that
+ * observed zero unresolved invocations; a side with any failure is marked
+ * `{ invalid: "failures-present", failure_count }` instead, because the
+ * zero-failure formula has no honest extension to F > 0 (see
+ * {@link WorkloadCeilingZeroFailureBoundInvalid}). An incomplete pair (missing a side,
+ * mismatched deployment metadata, or either side lacking a resolved
+ * `cpu_ms`) is rejected from the paired statistics rather than silently
+ * imputed, and is reported separately.
+ */
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  clopperPearsonZeroFailureUpper,
+  pairedRatioBootstrap,
+  quantileEstimate,
+  type BootstrapResult,
+  type ClopperPearsonZeroFailureResult,
+  type PairedValue,
+  type QuantileEstimate,
+} from "./statistics.ts";
+import {
+  decodeWorkloadCeilingRawEvent,
+  WorkloadCeilingHarnessError,
+  type WorkloadCeilingRawEvent,
+} from "./workload-ceiling-harness.ts";
+
+function deploymentKey(event: WorkloadCeilingRawEvent): string {
+  return `${event.compatibility_date}|${event.script_version}`;
+}
+
+// Narrows a raw event to the resolved type. Callers must have already
+// checked `cpu_ms !== null` — that check is what makes the single `!`
+// here justified; `matchWorkloadCeilingEvents` does so immediately
+// before every call.
+const resolved = (e: WorkloadCeilingRawEvent): ResolvedWorkloadCeilingRawEvent => ({
+  ...e,
+  cpu_ms: e.cpu_ms!,
+});
+
+/** A WorkloadCeilingRawEvent whose collection window resolved to exactly one single-request invocation. */
+export type ResolvedWorkloadCeilingRawEvent = Omit<WorkloadCeilingRawEvent, "cpu_ms"> & {
+  readonly cpu_ms: number;
+};
+
+export interface WorkloadCeilingComparisonPair {
+  readonly scenario_id: string;
+  readonly control: ResolvedWorkloadCeilingRawEvent;
+  readonly candidate: ResolvedWorkloadCeilingRawEvent;
+}
+
+export interface WorkloadCeilingIncompletePair {
+  readonly scenario_id: string;
+  readonly reason:
+    | "missing-control"
+    | "missing-candidate"
+    | "duplicate-scenario"
+    | "deployment-metadata-mismatch"
+    | "unresolved-cpu";
+}
+
+export interface WorkloadCeilingMatchedComparison {
+  readonly pairs: readonly WorkloadCeilingComparisonPair[];
+  readonly incomplete: readonly WorkloadCeilingIncompletePair[];
+}
+
+function indexByScenario(
+  events: readonly WorkloadCeilingRawEvent[],
+  incomplete: WorkloadCeilingIncompletePair[],
+): Map<string, WorkloadCeilingRawEvent> {
+  const byScenario = new Map<string, WorkloadCeilingRawEvent>();
+  const duplicates = new Set<string>();
+  for (const event of events) {
+    if (byScenario.has(event.scenario_id)) {
+      duplicates.add(event.scenario_id);
+      continue;
+    }
+    byScenario.set(event.scenario_id, event);
+  }
+  for (const scenarioId of duplicates) {
+    byScenario.delete(scenarioId);
+    incomplete.push({ scenario_id: scenarioId, reason: "duplicate-scenario" });
+  }
+  return byScenario;
+}
+
+/**
+ * Pure. Joins by `scenario_id`, then by deployment metadata, then requires
+ * both sides to carry a resolved `cpu_ms`. Every rejection is reported by
+ * name — this function never drops a scenario silently.
+ */
+export function matchWorkloadCeilingEvents(
+  controlEvents: readonly WorkloadCeilingRawEvent[],
+  candidateEvents: readonly WorkloadCeilingRawEvent[],
+): WorkloadCeilingMatchedComparison {
+  const incomplete: WorkloadCeilingIncompletePair[] = [];
+  const controlByScenario = indexByScenario(controlEvents, incomplete);
+  const candidateByScenario = indexByScenario(candidateEvents, incomplete);
+
+  const scenarioIds = new Set([...controlByScenario.keys(), ...candidateByScenario.keys()]);
+  const pairs: WorkloadCeilingComparisonPair[] = [];
+  for (const scenarioId of [...scenarioIds].toSorted()) {
+    const control = controlByScenario.get(scenarioId);
+    const candidate = candidateByScenario.get(scenarioId);
+    if (control === undefined) {
+      incomplete.push({ scenario_id: scenarioId, reason: "missing-control" });
+      continue;
+    }
+    if (candidate === undefined) {
+      incomplete.push({ scenario_id: scenarioId, reason: "missing-candidate" });
+      continue;
+    }
+    if (deploymentKey(control) !== deploymentKey(candidate)) {
+      incomplete.push({ scenario_id: scenarioId, reason: "deployment-metadata-mismatch" });
+      continue;
+    }
+    if (control.cpu_ms === null || candidate.cpu_ms === null) {
+      incomplete.push({ scenario_id: scenarioId, reason: "unresolved-cpu" });
+      continue;
+    }
+    pairs.push({
+      scenario_id: scenarioId,
+      control: resolved(control),
+      candidate: resolved(candidate),
+    });
+  }
+  return {
+    pairs,
+    incomplete: incomplete.toSorted((a, b) => a.scenario_id.localeCompare(b.scenario_id)),
+  };
+}
+
+/**
+ * A side of the comparison whose collected events include at least one
+ * unresolved (`cpu_ms: null`) invocation. The zero-failure Clopper-Pearson
+ * formula (`1 − c^(1/n)`) is valid only at zero observed failures: `n`
+ * counts successes, so plugging any success-count-derived denominator in
+ * at F > 0 is anti-conservative (more failures would TIGHTEN the bound —
+ * the opposite of the intended failure-budget reading), and the general
+ * F > 0 bound needs a Beta inverse (bisection over the Binomial CDF),
+ * deliberately out of scope for a bench tool. Reported by name — never
+ * dropped silently, and never filled in with a number the formula cannot
+ * honestly produce.
+ */
+export interface WorkloadCeilingZeroFailureBoundInvalid {
+  readonly invalid: "failures-present";
+  readonly failure_count: number;
+}
+
+/** Per side: a valid zero-failure bound, or the explicit invalidity marker above. */
+export type WorkloadCeilingZeroFailureBound =
+  | ClopperPearsonZeroFailureResult
+  | WorkloadCeilingZeroFailureBoundInvalid;
+
+export interface WorkloadCeilingComparisonReport {
+  readonly pair_count: number;
+  readonly incomplete_count: number;
+  readonly incomplete: readonly WorkloadCeilingIncompletePair[];
+  readonly control_cpu_ms: {
+    readonly p50: QuantileEstimate;
+    readonly p95: QuantileEstimate;
+    readonly p99: QuantileEstimate;
+  };
+  readonly candidate_cpu_ms: {
+    readonly p50: QuantileEstimate;
+    readonly p95: QuantileEstimate;
+    readonly p99: QuantileEstimate;
+  };
+  readonly paired_candidate_over_control_ratio: BootstrapResult<"paired-ratio-bootstrap-v1">;
+  /**
+   * Over ALL collected events on each side, including incomplete/unresolved
+   * ones — the study's failure budget. Valid ONLY for a side with zero
+   * unresolved events: a side with ≥ 1 failure carries
+   * `{ invalid: "failures-present", failure_count }` instead of a bound
+   * (see {@link WorkloadCeilingZeroFailureBoundInvalid} for why the
+   * zero-failure formula has no honest F > 0 reading).
+   */
+  readonly zero_failure_upper_bound: {
+    readonly control: WorkloadCeilingZeroFailureBound;
+    readonly candidate: WorkloadCeilingZeroFailureBound;
+  };
+}
+
+const quantiles = (values: readonly number[]) => ({
+  p50: quantileEstimate(values, 0.5, "quantile-r7-v1"),
+  p95: quantileEstimate(values, 0.95, "quantile-r7-v1"),
+  p99: quantileEstimate(values, 0.99, "quantile-r7-v1"),
+});
+
+/**
+ * Per-side failure-budget assessment. F = 0 → the exact one-sided
+ * zero-failure bound (attempts clamped to ≥ 1 so an empty event list still
+ * yields the maximally-wide n = 1 bound rather than throwing); F > 0 → the
+ * explicit invalidity marker, never an anti-conservative number.
+ */
+const zeroFailureUpperBound = (
+  events: readonly WorkloadCeilingRawEvent[],
+  confidence: number,
+): WorkloadCeilingZeroFailureBound => {
+  const failures = events.filter((event) => event.cpu_ms === null).length;
+  if (failures > 0) {
+    return { invalid: "failures-present", failure_count: failures };
+  }
+  return clopperPearsonZeroFailureUpper(Math.max(1, events.length), confidence);
+};
+
+/**
+ * Pure. Builds the full comparison report from a matched set plus the two
+ * complete (pre-matching) event lists — the failure budget is deliberately
+ * assessed over every collected attempt, not just the pairs that survived
+ * matching, so a run that failed to resolve on one side still counts
+ * against that side: it surfaces there as an explicit failures-present
+ * marker, since the zero-failure bound itself is only computed at F = 0.
+ */
+export function buildWorkloadCeilingComparisonReport(input: {
+  readonly matched: WorkloadCeilingMatchedComparison;
+  readonly controlEvents: readonly WorkloadCeilingRawEvent[];
+  readonly candidateEvents: readonly WorkloadCeilingRawEvent[];
+  readonly confidence: number;
+  readonly seed: number;
+  readonly resamples: number;
+}): WorkloadCeilingComparisonReport {
+  const { matched } = input;
+  if (matched.pairs.length === 0) {
+    throw new WorkloadCeilingHarnessError("pairs", "no complete pairs to compare");
+  }
+  const controlValues = matched.pairs.map((pair) => pair.control.cpu_ms);
+  const candidateValues = matched.pairs.map((pair) => pair.candidate.cpu_ms);
+  const pairedValues: PairedValue[] = matched.pairs.map((pair) => ({
+    pair_id: pair.scenario_id,
+    baseline: pair.control.cpu_ms,
+    candidate: pair.candidate.cpu_ms,
+  }));
+
+  return {
+    pair_count: matched.pairs.length,
+    incomplete_count: matched.incomplete.length,
+    incomplete: matched.incomplete,
+    control_cpu_ms: quantiles(controlValues),
+    candidate_cpu_ms: quantiles(candidateValues),
+    paired_candidate_over_control_ratio: pairedRatioBootstrap(pairedValues, {
+      seed: input.seed,
+      resamples: input.resamples,
+      confidence: input.confidence,
+      inclusion_unit: "complete-pair",
+    }),
+    zero_failure_upper_bound: {
+      control: zeroFailureUpperBound(input.controlEvents, input.confidence),
+      candidate: zeroFailureUpperBound(input.candidateEvents, input.confidence),
+    },
+  };
+}
+
+/**
+ * Reads every `event-*.json` under `dir`. A directory that cannot be read
+ * (missing, mistyped, permission-denied) fails LOUDLY — it must never look
+ * like a directory that legitimately holds no events, which would surface
+ * downstream as a confusing all-scenarios-missing pairing failure.
+ */
+export async function readEventsFromDirectory(
+  dir: string,
+): Promise<readonly WorkloadCeilingRawEvent[]> {
+  let allEntries: readonly string[];
+  try {
+    allEntries = await readdir(dir);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code ?? "unknown";
+    throw new Error(
+      `workload-ceiling-compare: cannot read events directory ${dir} (${code}) — ` +
+        `a mistyped or unreadable directory must not look like an empty one`,
+      { cause: error },
+    );
+  }
+  const entries = allEntries.filter((name) => name.startsWith("event-") && name.endsWith(".json"));
+  const events: WorkloadCeilingRawEvent[] = [];
+  for (const entry of entries) {
+    const raw = await readFile(`${dir}/${entry}`, "utf8");
+    events.push(decodeWorkloadCeilingRawEvent(raw));
+  }
+  return events;
+}
+
+/**
+ * CLI entrypoint (`pnpm bench:workload-ceiling:compare`). Reads every
+ * `event-*.json` `workload-ceiling-collect.ts` wrote under two directories —
+ * one per implementation — and prints + persists the matched comparison.
+ *
+ * Required env: `WORKLOAD_CEILING_CONTROL_DIR`, `WORKLOAD_CEILING_CANDIDATE_DIR`.
+ * Optional: `WORKLOAD_CEILING_CONFIDENCE` (default `0.95`),
+ * `WORKLOAD_CEILING_BOOTSTRAP_SEED` (default `0`),
+ * `WORKLOAD_CEILING_BOOTSTRAP_RESAMPLES` (default `2000`).
+ */
+async function main(): Promise<number> {
+  const controlDir = process.env["WORKLOAD_CEILING_CONTROL_DIR"];
+  const candidateDir = process.env["WORKLOAD_CEILING_CANDIDATE_DIR"];
+  if (controlDir === undefined || candidateDir === undefined) {
+    console.error(
+      "workload-ceiling-compare: requires WORKLOAD_CEILING_CONTROL_DIR and " +
+        "WORKLOAD_CEILING_CANDIDATE_DIR — directories of event-*.json files " +
+        "written by workload-ceiling-collect.ts.",
+    );
+    return 1;
+  }
+
+  const controlEvents = await readEventsFromDirectory(controlDir);
+  const candidateEvents = await readEventsFromDirectory(candidateDir);
+  const matched = matchWorkloadCeilingEvents(controlEvents, candidateEvents);
+
+  if (matched.pairs.length === 0) {
+    console.error(
+      `workload-ceiling-compare: no complete pairs (${matched.incomplete.length} incomplete). ` +
+        "Nothing to compare.",
+    );
+    for (const entry of matched.incomplete) {
+      console.error(`  - ${entry.scenario_id}: ${entry.reason}`);
+    }
+    return 1;
+  }
+
+  const report = buildWorkloadCeilingComparisonReport({
+    matched,
+    controlEvents,
+    candidateEvents,
+    confidence: Number(process.env["WORKLOAD_CEILING_CONFIDENCE"] ?? 0.95),
+    seed: Number(process.env["WORKLOAD_CEILING_BOOTSTRAP_SEED"] ?? 0),
+    resamples: Number(process.env["WORKLOAD_CEILING_BOOTSTRAP_RESAMPLES"] ?? 2000),
+  });
+
+  console.log(`pairs: ${report.pair_count}, incomplete: ${report.incomplete_count}`);
+  console.log(
+    `control cpu_ms p50/p95/p99: ${report.control_cpu_ms.p50.value}/${report.control_cpu_ms.p95.value}/${report.control_cpu_ms.p99.value}`,
+  );
+  console.log(
+    `candidate cpu_ms p50/p95/p99: ${report.candidate_cpu_ms.p50.value}/${report.candidate_cpu_ms.p95.value}/${report.candidate_cpu_ms.p99.value}`,
+  );
+  console.log(
+    `paired candidate/control ratio: point=${report.paired_candidate_over_control_ratio.point} ` +
+      `interval=[${report.paired_candidate_over_control_ratio.interval.lower}, ${report.paired_candidate_over_control_ratio.interval.upper}]`,
+  );
+
+  const outDir = "bench/results/workload-ceiling";
+  await mkdir(outDir, { recursive: true });
+  const outPath = `${outDir}/comparison-${Date.now()}.json`;
+  await writeFile(outPath, JSON.stringify(report, null, 2));
+  console.log(`wrote ${outPath}`);
+  return 0;
+}
+
+// CLI entrypoint guard: `main()` runs only when this module is executed
+// directly, never when a test imports it — an import must not read event
+// directories or write comparison artifacts off the environment.
+const isCli =
+  process.argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(process.argv[1]!);
+if (isCli) {
+  process.exitCode = await main();
+}

--- a/bench/measurement/workload-ceiling-harness.test.ts
+++ b/bench/measurement/workload-ceiling-harness.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "vitest";
+import {
+  decodeWorkloadCeilingRawEvent,
+  decodeWorkloadCeilingRunRequest,
+  encodeWorkloadCeilingRawEvent,
+  encodeWorkloadCeilingRunRequest,
+  missingTerminalWorkloadCeilingRawEvent,
+  WORKLOAD_CEILING_CONTRACT_ID,
+  type WorkloadCeilingRawEvent,
+  type WorkloadCeilingRunRequest,
+} from "./workload-ceiling-harness.ts";
+
+const VALID_REQUEST: WorkloadCeilingRunRequest = {
+  contract_id: WORKLOAD_CEILING_CONTRACT_ID,
+  run_id: "run-0001",
+  scenario_id: "byte-axis/collection-1mib/doc-2048/hot-key",
+  implementation: "chunked-candidate",
+  fixture_prefix: "tenants/study/collections/workload-ceiling-run-0001",
+};
+
+const VALID_OK_EVENT: WorkloadCeilingRawEvent = {
+  run_id: "run-0001",
+  scenario_id: "byte-axis/collection-1mib/doc-2048/hot-key",
+  script_version: "abc123",
+  compatibility_date: "2026-08-01",
+  runtime_period: "2026-08-15T00:00:00.000Z/2026-08-15T00:05:00.000Z",
+  colo: "SJC",
+  thermal_class: "warm",
+  outcome: "ok",
+  cpu_ms: 12.5,
+  observed_at: "2026-08-15T00:01:00.000Z",
+};
+
+describe("WorkloadCeilingRunRequest codec", () => {
+  test("round-trips a valid request through canonical serialization", () => {
+    const encoded = encodeWorkloadCeilingRunRequest(VALID_REQUEST);
+    expect(decodeWorkloadCeilingRunRequest(encoded)).toEqual(VALID_REQUEST);
+  });
+
+  test("canonical serialization is stable regardless of caller field order", () => {
+    const reordered = {
+      fixture_prefix: VALID_REQUEST.fixture_prefix,
+      scenario_id: VALID_REQUEST.scenario_id,
+      run_id: VALID_REQUEST.run_id,
+      implementation: VALID_REQUEST.implementation,
+      contract_id: VALID_REQUEST.contract_id,
+    } as WorkloadCeilingRunRequest;
+    expect(encodeWorkloadCeilingRunRequest(reordered)).toBe(
+      encodeWorkloadCeilingRunRequest(VALID_REQUEST),
+    );
+  });
+
+  test("rejects a body with an unknown field", () => {
+    const withExtra = JSON.stringify({ ...VALID_REQUEST, extra_field: "nope" });
+    expect(() => decodeWorkloadCeilingRunRequest(withExtra)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+
+  test("rejects a body missing a required field", () => {
+    const { fixture_prefix: _drop, ...rest } = VALID_REQUEST;
+    const missing = JSON.stringify(rest);
+    expect(() => decodeWorkloadCeilingRunRequest(missing)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+
+  test("rejects an unknown contract_id", () => {
+    const wrongContract = JSON.stringify({
+      ...VALID_REQUEST,
+      contract_id: "baerly.workload-ceiling/chunked-snapshot/v2",
+    });
+    expect(() => decodeWorkloadCeilingRunRequest(wrongContract)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+
+  test("rejects an invalid implementation value", () => {
+    const badImplementation = JSON.stringify({ ...VALID_REQUEST, implementation: "hybrid" });
+    expect(() => decodeWorkloadCeilingRunRequest(badImplementation)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+
+  test("rejects a fixture_prefix with a leading slash or dot segment", () => {
+    for (const fixture_prefix of ["/absolute/prefix", "tenants/../escape", "tenants//double"]) {
+      const bad = JSON.stringify({ ...VALID_REQUEST, fixture_prefix });
+      expect(() => decodeWorkloadCeilingRunRequest(bad)).toThrowError(
+        expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+      );
+    }
+  });
+
+  test("rejects non-canonical JSON bytes (whitespace) even when the parsed value is valid", () => {
+    const encoded = encodeWorkloadCeilingRunRequest(VALID_REQUEST);
+    const withWhitespace = `${encoded} `;
+    expect(() => decodeWorkloadCeilingRunRequest(withWhitespace)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+});
+
+describe("WorkloadCeilingRawEvent codec", () => {
+  test("round-trips a valid ok event through canonical serialization", () => {
+    const encoded = encodeWorkloadCeilingRawEvent(VALID_OK_EVENT);
+    expect(decodeWorkloadCeilingRawEvent(encoded)).toEqual(VALID_OK_EVENT);
+  });
+
+  test("preserves exceededCpu as an explicit outcome with a null cpu_ms", () => {
+    const exceeded: WorkloadCeilingRawEvent = {
+      ...VALID_OK_EVENT,
+      outcome: "exceededCpu",
+      cpu_ms: null,
+    };
+    const encoded = encodeWorkloadCeilingRawEvent(exceeded);
+    const decoded = decodeWorkloadCeilingRawEvent(encoded);
+    expect(decoded.outcome).toBe("exceededCpu");
+    expect(decoded.cpu_ms).toBeNull();
+  });
+
+  test("preserves exceededCpu when the platform still reports a partial cpu_ms", () => {
+    const exceeded: WorkloadCeilingRawEvent = {
+      ...VALID_OK_EVENT,
+      outcome: "exceededCpu",
+      cpu_ms: 50,
+    };
+    const decoded = decodeWorkloadCeilingRawEvent(encodeWorkloadCeilingRawEvent(exceeded));
+    expect(decoded.outcome).toBe("exceededCpu");
+    expect(decoded.cpu_ms).toBe(50);
+  });
+
+  test("represents a missing terminal event explicitly rather than dropping the invocation", () => {
+    const missing = missingTerminalWorkloadCeilingRawEvent({
+      run_id: VALID_OK_EVENT.run_id,
+      scenario_id: VALID_OK_EVENT.scenario_id,
+      script_version: VALID_OK_EVENT.script_version,
+      compatibility_date: VALID_OK_EVENT.compatibility_date,
+      runtime_period: VALID_OK_EVENT.runtime_period,
+      colo: VALID_OK_EVENT.colo,
+      thermal_class: "unknown",
+      observed_at: VALID_OK_EVENT.observed_at,
+    });
+    expect(missing.outcome).toBe("missing-terminal-event");
+    expect(missing.cpu_ms).toBeNull();
+    const roundTripped = decodeWorkloadCeilingRawEvent(encodeWorkloadCeilingRawEvent(missing));
+    expect(roundTripped).toEqual(missing);
+  });
+
+  test("refuses to synthesize a cpu_ms for a missing-terminal-event outcome", () => {
+    const withFabricatedCpu = JSON.stringify({
+      ...VALID_OK_EVENT,
+      outcome: "missing-terminal-event",
+      cpu_ms: 9.9,
+    });
+    expect(() => decodeWorkloadCeilingRawEvent(withFabricatedCpu)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+
+  test("refuses a null cpu_ms on an ok outcome", () => {
+    const withoutCpu = JSON.stringify({ ...VALID_OK_EVENT, cpu_ms: null });
+    expect(() => decodeWorkloadCeilingRawEvent(withoutCpu)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+
+  test("rejects a body with an unknown field", () => {
+    const withExtra = JSON.stringify({ ...VALID_OK_EVENT, extra: true });
+    expect(() => decodeWorkloadCeilingRawEvent(withExtra)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+
+  test("rejects a body missing cpu_ms rather than defaulting it", () => {
+    const { cpu_ms: _drop, ...rest } = VALID_OK_EVENT;
+    const missing = JSON.stringify(rest);
+    expect(() => decodeWorkloadCeilingRawEvent(missing)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+
+  test("rejects an unknown thermal_class", () => {
+    const bad = JSON.stringify({ ...VALID_OK_EVENT, thermal_class: "toasty" });
+    expect(() => decodeWorkloadCeilingRawEvent(bad)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+
+  test("rejects a negative cpu_ms", () => {
+    const bad = JSON.stringify({ ...VALID_OK_EVENT, cpu_ms: -1 });
+    expect(() => decodeWorkloadCeilingRawEvent(bad)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+
+  test("rejects a malformed observed_at timestamp", () => {
+    const bad = JSON.stringify({ ...VALID_OK_EVENT, observed_at: "not-a-timestamp" });
+    expect(() => decodeWorkloadCeilingRawEvent(bad)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+});

--- a/bench/measurement/workload-ceiling-harness.ts
+++ b/bench/measurement/workload-ceiling-harness.ts
@@ -1,0 +1,326 @@
+/**
+ * Strict wire codecs for the deployed workload-ceiling evidence harness
+ * (parent plan Task 8).
+ *
+ * Two shapes cross the trust boundary between the local measurement tooling
+ * and the deployed study Worker:
+ *
+ *  - `WorkloadCeilingRunRequest` — what `workload-ceiling-provision.ts` /
+ *    a future orchestrator sends to invoke one authenticated run against one
+ *    exact fixture.
+ *  - `WorkloadCeilingRawEvent` — the strict normalized shape
+ *    `workload-ceiling-collect.ts` derives from the official platform
+ *    telemetry source. The Worker never emits this itself and never
+ *    self-reports CPU (Task 8 Steps 5-6; see `bench/workload-ceiling-worker/README.md`
+ *    for the platform documentation this rests on).
+ *
+ * Both codecs reject any field outside their exact set and round-trip
+ * through `canonical-json.ts`'s sorted-key canonical form — the same
+ * byte-stability discipline `snapshot-manifest.ts` / `snapshot-chunk.ts` use
+ * for durable wire shapes, applied here to a measurement-only wire shape.
+ *
+ * This module is measurement-only: importing it changes no production
+ * behavior and it is not reachable from `packages/server/src/index.ts`.
+ */
+import { canonicalJson, type CanonicalJsonValue } from "./canonical-json.ts";
+
+export const WORKLOAD_CEILING_CONTRACT_ID = "baerly.workload-ceiling/chunked-snapshot/v1" as const;
+
+export const WORKLOAD_CEILING_IMPLEMENTATIONS = [
+  "monolithic-control",
+  "chunked-candidate",
+] as const;
+export type WorkloadCeilingImplementation = (typeof WORKLOAD_CEILING_IMPLEMENTATIONS)[number];
+
+export interface WorkloadCeilingRunRequest {
+  readonly contract_id: typeof WORKLOAD_CEILING_CONTRACT_ID;
+  readonly run_id: string;
+  readonly scenario_id: string;
+  readonly implementation: WorkloadCeilingImplementation;
+  readonly fixture_prefix: string;
+}
+
+export const WORKLOAD_CEILING_THERMAL_CLASSES = ["warm", "cold", "unknown"] as const;
+export type WorkloadCeilingThermalClass = (typeof WORKLOAD_CEILING_THERMAL_CLASSES)[number];
+
+/**
+ * Known outcome strings this harness gives special handling to. `outcome`
+ * on the wire (see {@link WorkloadCeilingRawEvent}) is a plain `string`, not
+ * a union of this list — the platform's own invocation-outcome vocabulary
+ * (linked from the harness Worker README) is not this repo's to close over,
+ * and a future outcome string must still decode. Two entries are load-bearing
+ * here regardless:
+ *
+ *  - `"exceededCpu"` — reproduced verbatim from the platform's own
+ *    vocabulary so a study reader can grep the platform docs for the exact
+ *    string; this module never remaps or drops it.
+ *  - `"missing-terminal-event"` — not a platform outcome. It is what
+ *    `workload-ceiling-collect.ts` records when the bounded collection
+ *    window closes without a matching terminal telemetry row, so an
+ *    unresolved invocation is an explicit study outcome instead of a
+ *    silently dropped run.
+ */
+export const WORKLOAD_CEILING_KNOWN_OUTCOMES = [
+  "ok",
+  "exceededCpu",
+  "exceededMemory",
+  "scriptThrewException",
+  "responseStreamDisconnected",
+  "missing-terminal-event",
+] as const;
+export type WorkloadCeilingKnownOutcome = (typeof WORKLOAD_CEILING_KNOWN_OUTCOMES)[number];
+
+export interface WorkloadCeilingRawEvent {
+  readonly run_id: string;
+  readonly scenario_id: string;
+  readonly script_version: string;
+  readonly compatibility_date: string;
+  readonly runtime_period: string;
+  readonly colo: string;
+  readonly thermal_class: WorkloadCeilingThermalClass;
+  readonly outcome: string;
+  readonly cpu_ms: number | null;
+  readonly observed_at: string;
+}
+
+/**
+ * Invalid input to a harness codec. Assert on `code`, never on `message`
+ * (repo test convention: docs/contributing/conventions/tests.md §"Asserting
+ * on errors").
+ */
+export class WorkloadCeilingHarnessError extends Error {
+  readonly code = "WorkloadCeilingHarnessInvalid" as const;
+  readonly field: string;
+  constructor(field: string, detail: string, cause?: unknown) {
+    super(
+      `bench/measurement/workload-ceiling-harness: invalid ${field} — ${detail}`,
+      cause === undefined ? undefined : { cause },
+    );
+    this.name = "WorkloadCeilingHarnessError";
+    this.field = field;
+  }
+}
+
+function invalid(field: string, detail: string, cause?: unknown): never {
+  throw new WorkloadCeilingHarnessError(field, detail, cause);
+}
+
+function assertExactFields(
+  value: unknown,
+  fields: readonly string[],
+  where: string,
+): asserts value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    invalid(where, "must be a plain object");
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    invalid(where, "must be a plain object");
+  }
+  const expected = new Set(fields);
+  const seen = new Set<string>();
+  for (const key of Object.keys(value)) {
+    if (!expected.has(key)) {
+      invalid(where, `unknown field ${key}`);
+    }
+    seen.add(key);
+  }
+  for (const field of fields) {
+    if (!seen.has(field)) {
+      invalid(where, `missing field ${field}`);
+    }
+  }
+}
+
+function assertNonEmptyString(value: unknown, field: string): asserts value is string {
+  if (typeof value !== "string" || value.trim() === "") {
+    invalid(field, "must be a nonempty string");
+  }
+}
+
+/** Round-trips `value` through the harness's canonical serialization and returns the bytes. */
+function toCanonicalJson(value: CanonicalJsonValue, where: string): string {
+  try {
+    return canonicalJson(value);
+  } catch (error) {
+    invalid(where, "is not representable as canonical JSON", error);
+  }
+}
+
+function parseJson(raw: string, where: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    invalid(where, "is not valid JSON", error);
+  }
+}
+
+const RUN_REQUEST_FIELDS = [
+  "contract_id",
+  "run_id",
+  "scenario_id",
+  "implementation",
+  "fixture_prefix",
+] as const;
+
+function canonicalizeRunRequest(value: unknown): WorkloadCeilingRunRequest {
+  assertExactFields(value, RUN_REQUEST_FIELDS, "run request");
+  if (value["contract_id"] !== WORKLOAD_CEILING_CONTRACT_ID) {
+    invalid("contract_id", `must be ${WORKLOAD_CEILING_CONTRACT_ID}`);
+  }
+  assertNonEmptyString(value["run_id"], "run_id");
+  assertNonEmptyString(value["scenario_id"], "scenario_id");
+  const implementation = value["implementation"];
+  if (!(WORKLOAD_CEILING_IMPLEMENTATIONS as readonly unknown[]).includes(implementation)) {
+    invalid(
+      "implementation",
+      `must be one of ${WORKLOAD_CEILING_IMPLEMENTATIONS.join(", ")}; got ${String(implementation)}`,
+    );
+  }
+  assertNonEmptyString(value["fixture_prefix"], "fixture_prefix");
+  const fixturePrefix = value["fixture_prefix"];
+  if (
+    fixturePrefix.startsWith("/") ||
+    fixturePrefix.endsWith("/") ||
+    fixturePrefix.includes("//") ||
+    fixturePrefix.split("/").some((segment) => segment === "." || segment === "..")
+  ) {
+    invalid("fixture_prefix", "must be a clean relative key prefix");
+  }
+  return {
+    contract_id: WORKLOAD_CEILING_CONTRACT_ID,
+    run_id: value["run_id"],
+    scenario_id: value["scenario_id"],
+    implementation: implementation as WorkloadCeilingImplementation,
+    fixture_prefix: fixturePrefix,
+  };
+}
+
+/** Canonical-JSON-serializes a validated request. Rejects a request outside the exact field set. */
+export const encodeWorkloadCeilingRunRequest = (request: WorkloadCeilingRunRequest): string => {
+  const canonical = canonicalizeRunRequest(request);
+  return toCanonicalJson(canonical as unknown as CanonicalJsonValue, "run request");
+};
+
+/**
+ * Decodes and validates a `WorkloadCeilingRunRequest`. Rejects any field
+ * outside the exact set, an invalid `implementation`, and any body whose
+ * bytes are not already the canonical serialization of its own parsed
+ * value (RFC 8785 sorted-key form via `canonical-json.ts`).
+ */
+export const decodeWorkloadCeilingRunRequest = (raw: string): WorkloadCeilingRunRequest => {
+  const parsed = parseJson(raw, "run request body");
+  const canonical = canonicalizeRunRequest(parsed);
+  const canonicalRaw = toCanonicalJson(canonical as unknown as CanonicalJsonValue, "run request");
+  if (canonicalRaw !== raw) {
+    invalid("run request body", "is not canonical JSON");
+  }
+  return canonical;
+};
+
+const RAW_EVENT_FIELDS = [
+  "run_id",
+  "scenario_id",
+  "script_version",
+  "compatibility_date",
+  "runtime_period",
+  "colo",
+  "thermal_class",
+  "outcome",
+  "cpu_ms",
+  "observed_at",
+] as const;
+
+const OBSERVED_AT_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+
+function canonicalizeRawEvent(value: unknown): WorkloadCeilingRawEvent {
+  assertExactFields(value, RAW_EVENT_FIELDS, "raw event");
+  assertNonEmptyString(value["run_id"], "run_id");
+  assertNonEmptyString(value["scenario_id"], "scenario_id");
+  assertNonEmptyString(value["script_version"], "script_version");
+  assertNonEmptyString(value["compatibility_date"], "compatibility_date");
+  assertNonEmptyString(value["runtime_period"], "runtime_period");
+  assertNonEmptyString(value["colo"], "colo");
+  const thermalClass = value["thermal_class"];
+  if (!(WORKLOAD_CEILING_THERMAL_CLASSES as readonly unknown[]).includes(thermalClass)) {
+    invalid(
+      "thermal_class",
+      `must be one of ${WORKLOAD_CEILING_THERMAL_CLASSES.join(", ")}; got ${String(thermalClass)}`,
+    );
+  }
+  assertNonEmptyString(value["outcome"], "outcome");
+  const outcome = value["outcome"];
+  const cpuMs = value["cpu_ms"];
+  if (cpuMs !== null && (typeof cpuMs !== "number" || !Number.isFinite(cpuMs) || cpuMs < 0)) {
+    invalid("cpu_ms", "must be null or a finite non-negative number");
+  }
+  // No synthesized CPU: an "ok" invocation always carries the platform's own
+  // telemetry number, never a null this module would otherwise have to fill
+  // in; a "missing-terminal-event" record can never carry a number, because
+  // nothing genuine produced one — a non-null value there would be exactly
+  // the fabricated evidence this codec exists to refuse.
+  if (outcome === "ok" && cpuMs === null) {
+    invalid("cpu_ms", 'must be a finite number when outcome is "ok"');
+  }
+  if (outcome === "missing-terminal-event" && cpuMs !== null) {
+    invalid("cpu_ms", 'must be null when outcome is "missing-terminal-event"');
+  }
+  assertNonEmptyString(value["observed_at"], "observed_at");
+  const observedAt = value["observed_at"];
+  if (!OBSERVED_AT_PATTERN.test(observedAt)) {
+    invalid("observed_at", "must be an RFC 3339 UTC timestamp (YYYY-MM-DDTHH:mm:ss[.sss]Z)");
+  }
+  return {
+    run_id: value["run_id"],
+    scenario_id: value["scenario_id"],
+    script_version: value["script_version"],
+    compatibility_date: value["compatibility_date"],
+    runtime_period: value["runtime_period"],
+    colo: value["colo"],
+    thermal_class: thermalClass as WorkloadCeilingThermalClass,
+    outcome,
+    cpu_ms: cpuMs,
+    observed_at: observedAt,
+  };
+}
+
+/** Canonical-JSON-serializes a validated raw event. Rejects a field outside the exact set. */
+export const encodeWorkloadCeilingRawEvent = (event: WorkloadCeilingRawEvent): string => {
+  const canonical = canonicalizeRawEvent(event);
+  return toCanonicalJson(canonical as unknown as CanonicalJsonValue, "raw event");
+};
+
+/**
+ * Decodes and validates a `WorkloadCeilingRawEvent` from an unmodified
+ * platform response that `workload-ceiling-collect.ts` has already reduced
+ * to one candidate JSON record. Preserves `exceededCpu` and
+ * `missing-terminal-event` as explicit outcomes rather than collapsing them,
+ * and never derives `cpu_ms` — it is required on the wire and passed
+ * through unchanged.
+ */
+export const decodeWorkloadCeilingRawEvent = (raw: string): WorkloadCeilingRawEvent => {
+  const parsed = parseJson(raw, "raw event body");
+  const canonical = canonicalizeRawEvent(parsed);
+  const canonicalRaw = toCanonicalJson(canonical as unknown as CanonicalJsonValue, "raw event");
+  if (canonicalRaw !== raw) {
+    invalid("raw event body", "is not canonical JSON");
+  }
+  return canonical;
+};
+
+/** Builds the strict raw-event record for an invocation the collection window never resolved. */
+export const missingTerminalWorkloadCeilingRawEvent = (input: {
+  readonly run_id: string;
+  readonly scenario_id: string;
+  readonly script_version: string;
+  readonly compatibility_date: string;
+  readonly runtime_period: string;
+  readonly colo: string;
+  readonly thermal_class: WorkloadCeilingThermalClass;
+  readonly observed_at: string;
+}): WorkloadCeilingRawEvent =>
+  canonicalizeRawEvent({
+    ...input,
+    outcome: "missing-terminal-event",
+    cpu_ms: null,
+  });

--- a/bench/measurement/workload-ceiling-harness.ts
+++ b/bench/measurement/workload-ceiling-harness.ts
@@ -2,12 +2,19 @@
  * Strict wire codecs for the deployed workload-ceiling evidence harness
  * (parent plan Task 8).
  *
- * Two shapes cross the trust boundary between the local measurement tooling
+ * Three shapes cross the trust boundary between the local measurement tooling
  * and the deployed study Worker:
  *
  *  - `WorkloadCeilingRunRequest` — what `workload-ceiling-provision.ts` /
  *    a future orchestrator sends to invoke one authenticated run against one
  *    exact fixture.
+ *  - `WorkloadCeilingFixtureDescriptor` — the `fixture.json`
+ *    `workload-ceiling-provision.ts` writes into the bucket and the Worker
+ *    reads back to locate both representations of one fixture. It crosses the
+ *    boundary through R2 rather than over HTTP, which makes a single codec
+ *    here MORE load-bearing, not less: the two ends deploy independently, so
+ *    a field renamed on the provisioning side would otherwise pass its own
+ *    build and only surface as a runtime 502 from the deployed Worker.
  *  - `WorkloadCeilingRawEvent` — the strict normalized shape
  *    `workload-ceiling-collect.ts` derives from the official platform
  *    telemetry source. The Worker never emits this itself and never
@@ -25,6 +32,22 @@
 import { canonicalJson, type CanonicalJsonValue } from "./canonical-json.ts";
 
 export const WORKLOAD_CEILING_CONTRACT_ID = "baerly.workload-ceiling/chunked-snapshot/v1" as const;
+
+/**
+ * The ONE R2 bucket both ends of the study must agree on.
+ *
+ * `bench/workload-ceiling-worker/wrangler.jsonc` binds `env.BUCKET` to this
+ * name, and `workload-ceiling-provision.ts` writes fixtures to whatever
+ * `credentials/cloudflare.json` names. Those are configured independently, and
+ * a mismatch is silent at provisioning time and unrecognizable at run time —
+ * every `POST /run` returns a 502 `fixture descriptor is missing`, which reads
+ * as a provisioning bug rather than a bucket-name mismatch. This constant is
+ * what `workload-ceiling-provision.ts` preflights the credentials file
+ * against, so the mismatch fails loudly before anything is written. Wrangler
+ * config is JSONC and cannot import it — the name is repeated there under a
+ * comment pointing back here.
+ */
+export const WORKLOAD_CEILING_BUCKET_NAME = "baerly-storage-eval" as const;
 
 export const WORKLOAD_CEILING_IMPLEMENTATIONS = [
   "monolithic-control",
@@ -217,6 +240,83 @@ export const decodeWorkloadCeilingRunRequest = (raw: string): WorkloadCeilingRun
   }
   return canonical;
 };
+
+/**
+ * The `fixture.json` descriptor `workload-ceiling-provision.ts` writes at
+ * `<fixture_prefix>/fixture.json`, and the only thing the deployed Worker
+ * reads to find the two representations of one provisioned fixture.
+ */
+export interface WorkloadCeilingFixtureDescriptor {
+  readonly contract_id: typeof WORKLOAD_CEILING_CONTRACT_ID;
+  readonly collection: string;
+  /** Key of the single-blob control representation. */
+  readonly monolithic_key: string;
+  /** Key of the manifest heading the candidate chunk layout. */
+  readonly manifest_key: string;
+  readonly log_seq_start: number;
+}
+
+const FIXTURE_DESCRIPTOR_FIELDS = [
+  "contract_id",
+  "collection",
+  "monolithic_key",
+  "manifest_key",
+  "log_seq_start",
+] as const;
+
+function canonicalizeFixtureDescriptor(value: unknown): WorkloadCeilingFixtureDescriptor {
+  assertExactFields(value, FIXTURE_DESCRIPTOR_FIELDS, "fixture descriptor");
+  if (value["contract_id"] !== WORKLOAD_CEILING_CONTRACT_ID) {
+    invalid("contract_id", `must be ${WORKLOAD_CEILING_CONTRACT_ID}`);
+  }
+  assertNonEmptyString(value["collection"], "collection");
+  assertNonEmptyString(value["monolithic_key"], "monolithic_key");
+  assertNonEmptyString(value["manifest_key"], "manifest_key");
+  const logSeqStart = value["log_seq_start"];
+  if (typeof logSeqStart !== "number" || !Number.isSafeInteger(logSeqStart) || logSeqStart < 0) {
+    invalid("log_seq_start", "must be a non-negative safe integer");
+  }
+  return {
+    contract_id: WORKLOAD_CEILING_CONTRACT_ID,
+    collection: value["collection"],
+    monolithic_key: value["monolithic_key"],
+    manifest_key: value["manifest_key"],
+    log_seq_start: logSeqStart,
+  };
+}
+
+/** Canonical-JSON-serializes a validated fixture descriptor. Rejects a field outside the exact set. */
+export const encodeWorkloadCeilingFixtureDescriptor = (
+  descriptor: WorkloadCeilingFixtureDescriptor,
+): string => {
+  const canonical = canonicalizeFixtureDescriptor(descriptor);
+  return toCanonicalJson(canonical as unknown as CanonicalJsonValue, "fixture descriptor");
+};
+
+/**
+ * Decodes and validates a `WorkloadCeilingFixtureDescriptor` read back out of
+ * the bucket. Enforces canonical bytes, which is what makes the
+ * `descriptor_canonical_hash` the provisioning report persists meaningful
+ * end-to-end: the Worker will only accept the exact bytes that hash covers.
+ */
+export const decodeWorkloadCeilingFixtureDescriptor = (
+  raw: string,
+): WorkloadCeilingFixtureDescriptor => {
+  const parsed = parseJson(raw, "fixture descriptor body");
+  const canonical = canonicalizeFixtureDescriptor(parsed);
+  const canonicalRaw = toCanonicalJson(
+    canonical as unknown as CanonicalJsonValue,
+    "fixture descriptor",
+  );
+  if (canonicalRaw !== raw) {
+    invalid("fixture descriptor body", "is not canonical JSON");
+  }
+  return canonical;
+};
+
+/** The key `workload-ceiling-provision.ts` writes the descriptor to and the Worker reads it from. */
+export const workloadCeilingFixtureDescriptorKey = (fixturePrefix: string): string =>
+  `${fixturePrefix}/fixture.json`;
 
 const RAW_EVENT_FIELDS = [
   "run_id",

--- a/bench/measurement/workload-ceiling-provision.test.ts
+++ b/bench/measurement/workload-ceiling-provision.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "vitest";
+import { snapshotHash } from "@baerly/protocol";
+import { decodeSnapshotChunk, decodeSnapshotManifest } from "@baerly/server/_internal/testing";
+import {
+  buildWorkloadCeilingFixture,
+  WorkloadCeilingProvisionError,
+  type WorkloadCeilingFixtureSpec,
+} from "./workload-ceiling-provision.ts";
+
+const incarnation = "ab".repeat(16);
+const spec: WorkloadCeilingFixtureSpec = {
+  scenario_id: "scen-1",
+  collection: "coll-1",
+  row_count: 7,
+  document_bytes: 64,
+  manifest_descriptors: 3,
+};
+
+describe("buildWorkloadCeilingFixture", () => {
+  test("groups rows into contiguous near-even chunks (7 rows / 3 groups → 3/2/2)", async () => {
+    const fixture = await buildWorkloadCeilingFixture(spec, "fixtures/x", incarnation);
+    const manifestBytes = fixture.writes.find((w) => w.key === fixture.manifest_key)!.body;
+    const manifest = await decodeSnapshotManifest(manifestBytes, fixture.manifest_key, "coll-1", 0);
+    expect(manifest.chunks.map((c) => c.row_count)).toEqual([3, 2, 2]);
+    // Pad width is derived from the max index — one digit for a 7-row set.
+    expect(manifest.chunks[0]!.first_id).toBe("row-0");
+    expect(manifest.chunks.at(-1)!.last_id).toBe("row-6");
+  });
+
+  test("every chunk round-trips through the strict decoder", async () => {
+    const fixture = await buildWorkloadCeilingFixture(spec, "fixtures/x", incarnation);
+    const manifestBytes = fixture.writes.find((w) => w.key === fixture.manifest_key)!.body;
+    const manifest = await decodeSnapshotManifest(manifestBytes, fixture.manifest_key, "coll-1", 0);
+    for (const descriptor of manifest.chunks) {
+      const chunkBytes = fixture.writes.find((w) => w.key === descriptor.key)!.body;
+      const chunk = await decodeSnapshotChunk(chunkBytes, descriptor.key, "coll-1", descriptor);
+      expect(descriptor.byte_length).toBe(chunkBytes.byteLength);
+      expect(chunk.docs).toHaveLength(descriptor.row_count);
+    }
+  });
+
+  test("is deterministic for the same incarnation, and keys carry its digest", async () => {
+    const a = await buildWorkloadCeilingFixture(spec, "fixtures/x", incarnation);
+    const b = await buildWorkloadCeilingFixture(spec, "fixtures/x", incarnation);
+    expect(a.writes).toEqual(b.writes);
+    const manifestBytes = a.writes.find((w) => w.key === a.manifest_key)!.body;
+    const manifestDigest = await snapshotHash(manifestBytes);
+    expect(a.manifest_key).toContain(manifestDigest.slice(0, 16));
+  });
+
+  test("pads every row to the declared document size and numbers ids stably", async () => {
+    const fixture = await buildWorkloadCeilingFixture(spec, "fixtures/x", incarnation);
+    const monolithic = fixture.writes.find((w) => w.key === fixture.monolithic_key)!.body;
+    const parsed = JSON.parse(new TextDecoder().decode(monolithic)) as {
+      rows: { _id: string; body: { payload: string } }[];
+    };
+    expect(parsed.rows.map((r) => r._id)).toEqual([
+      "row-0",
+      "row-1",
+      "row-2",
+      "row-3",
+      "row-4",
+      "row-5",
+      "row-6",
+    ]);
+    for (const row of parsed.rows) {
+      expect(row.body.payload.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("writes monolithic + one chunk per group + manifest + descriptor", async () => {
+    const fixture = await buildWorkloadCeilingFixture(spec, "fixtures/x", incarnation);
+    expect(fixture.writes).toHaveLength(1 + 3 + 1 + 1);
+    expect(fixture.writes.map((w) => w.key)).toContain(fixture.descriptor_key);
+  });
+});
+
+describe("spec and argument validation", () => {
+  const cases = [
+    [{ ...spec, scenario_id: "  " }, "scenario_id"],
+    [{ ...spec, collection: "" }, "collection"],
+    [{ ...spec, row_count: 0 }, "row_count"],
+    [{ ...spec, document_bytes: 31 }, "document_bytes"],
+    [{ ...spec, manifest_descriptors: 0 }, "manifest_descriptors"],
+    [{ ...spec, manifest_descriptors: 8 }, "manifest_descriptors"], // exceeds row_count
+  ] as const;
+
+  test.each(cases)("rejects %j on %s", async (bad, field) => {
+    await expect(
+      buildWorkloadCeilingFixture(bad as WorkloadCeilingFixtureSpec, "fixtures/x", incarnation),
+    ).rejects.toSatisfy(
+      (error: unknown) => error instanceof WorkloadCeilingProvisionError && error.field === field,
+    );
+  });
+
+  test("rejects an unclean fixture prefix and a non-hex incarnation", async () => {
+    await expect(buildWorkloadCeilingFixture(spec, "/abs", incarnation)).rejects.toSatisfy(
+      (e: unknown) => e instanceof WorkloadCeilingProvisionError && e.field === "fixturePrefix",
+    );
+    await expect(
+      buildWorkloadCeilingFixture(spec, "fixtures/x", "AB".repeat(16)),
+    ).rejects.toSatisfy(
+      (e: unknown) => e instanceof WorkloadCeilingProvisionError && e.field === "incarnation",
+    );
+  });
+});

--- a/bench/measurement/workload-ceiling-provision.ts
+++ b/bench/measurement/workload-ceiling-provision.ts
@@ -23,8 +23,7 @@
  */
 import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { runAsCliEntrypoint } from "./cli-entrypoint.ts";
 import { AwsClient } from "aws4fetch";
 import { encodeJsonBytes, snapshotHash, type DocumentData, type Storage } from "@baerly/protocol";
 import { S3HttpStorage } from "@baerly/adapter-node";
@@ -363,8 +362,4 @@ async function main(): Promise<number> {
 // CLI entrypoint guard: `main()` runs only when this module is executed
 // directly, never when a test imports it — with a credentials file present
 // in the working tree, an import must never provision a real R2 fixture.
-const isCli =
-  process.argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(process.argv[1]!);
-if (isCli) {
-  process.exitCode = await main();
-}
+await runAsCliEntrypoint(import.meta.url, main);

--- a/bench/measurement/workload-ceiling-provision.ts
+++ b/bench/measurement/workload-ceiling-provision.ts
@@ -39,7 +39,13 @@ import {
 import { canonicalJson, hashCanonicalJson, type CanonicalJsonValue } from "./canonical-json.ts";
 import { createExactKeyCleanup, type ExactKeyCleanup } from "./storage-factory.ts";
 import { loadEndpointCreds } from "../../tests/fixtures/endpoint-creds.ts";
-import { WORKLOAD_CEILING_CONTRACT_ID } from "./workload-ceiling-harness.ts";
+import {
+  encodeWorkloadCeilingFixtureDescriptor,
+  WORKLOAD_CEILING_BUCKET_NAME,
+  WORKLOAD_CEILING_CONTRACT_ID,
+  workloadCeilingFixtureDescriptorKey,
+  type WorkloadCeilingFixtureDescriptor,
+} from "./workload-ceiling-harness.ts";
 import { WORKLOAD_CEILING_STUDY } from "./workload-ceiling-contract.ts";
 
 const INCARNATION_PATTERN = /^[0-9a-f]{32}$/;
@@ -209,15 +215,18 @@ export const buildWorkloadCeilingFixture = async (
   const manifestKey = snapshotManifestKey(fixturePrefix, incarnation, manifestDigest);
   writes.push({ key: manifestKey, body: manifestEncoded });
 
-  const descriptorValue = {
+  // One codec, shared with the deployed Worker that reads these bytes back
+  // (`workload-ceiling-harness.ts`) — the field set has a single source of
+  // truth, so a rename here fails this build rather than the Worker's runtime.
+  const descriptorValue: WorkloadCeilingFixtureDescriptor = {
     contract_id: WORKLOAD_CEILING_CONTRACT_ID,
     collection: spec.collection,
     monolithic_key: monolithicKey,
     manifest_key: manifestKey,
     log_seq_start: 0,
   };
-  const descriptorCanonical = canonicalJson(descriptorValue as unknown as CanonicalJsonValue);
-  const descriptorKey = `${fixturePrefix}/fixture.json`;
+  const descriptorCanonical = encodeWorkloadCeilingFixtureDescriptor(descriptorValue);
+  const descriptorKey = workloadCeilingFixtureDescriptorKey(fixturePrefix);
   writes.push({ key: descriptorKey, body: new TextEncoder().encode(descriptorCanonical) });
 
   return {
@@ -293,6 +302,21 @@ async function main(): Promise<number> {
         "(tests/fixtures/endpoint-creds.ts). This script provisions fixtures " +
         "against a real R2 bucket for the deployed workload-ceiling study; " +
         "there is nothing to do without credentials.",
+    );
+    return 1;
+  }
+
+  // Preflight the one coupling nothing else enforces: the deployed Worker's
+  // `env.BUCKET` binding is a literal in wrangler.jsonc, so fixtures written
+  // to any other bucket are invisible to it. Refuse before writing anything.
+  if (creds.bucket !== WORKLOAD_CEILING_BUCKET_NAME) {
+    console.error(
+      `workload-ceiling-provision: credentials/cloudflare.json names bucket ` +
+        `"${creds.bucket}", but the study Worker's wrangler.jsonc binds ` +
+        `env.BUCKET to "${WORKLOAD_CEILING_BUCKET_NAME}". Provisioning into a ` +
+        `different bucket would make every POST /run fail with a 502 ` +
+        `"fixture descriptor is missing". Point the credentials file at ` +
+        `"${WORKLOAD_CEILING_BUCKET_NAME}", or change both together.`,
     );
     return 1;
   }

--- a/bench/measurement/workload-ceiling-provision.ts
+++ b/bench/measurement/workload-ceiling-provision.ts
@@ -1,0 +1,370 @@
+/**
+ * Exact fixture provisioning for the deployed workload-ceiling study (parent
+ * plan Task 8 Step 4).
+ *
+ * Builds fixtures out of band from `WORKLOAD_CEILING_STUDY`
+ * (`workload-ceiling-contract.ts`) — the Worker never provisions anything
+ * itself (`bench/workload-ceiling-worker/src/index.ts`). One
+ * `WorkloadCeilingFixtureSpec` produces ONE logical row set, materialized
+ * into BOTH storage shapes the study compares side by side under a single
+ * `fixture_prefix`:
+ *
+ *  - a monolithic JSON blob (`monolithic.json`), the shape of today's
+ *    shipped single-snapshot format;
+ *  - the proposed manifest + chunk layout (`snapshot-manifest.ts` /
+ *    `snapshot-chunk.ts`), so `monolithic-control` and `chunked-candidate`
+ *    runs measure the identical data through two different storage shapes.
+ *
+ * `buildWorkloadCeilingFixture` is pure — no I/O, easy to unit-test and to
+ * hash independently of any backend. `provisionWorkloadCeilingFixture` is
+ * the one function that touches `Storage`, and it returns an
+ * `ExactKeyCleanup` (`storage-factory.ts`) over precisely the keys it wrote —
+ * never a bucket, never an unresolved prefix.
+ */
+import { randomUUID } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { AwsClient } from "aws4fetch";
+import { encodeJsonBytes, snapshotHash, type DocumentData, type Storage } from "@baerly/protocol";
+import { S3HttpStorage } from "@baerly/adapter-node";
+import {
+  encodeSnapshotChunk,
+  snapshotChunkKey,
+  type SnapshotChunk,
+  type SnapshotChunkDescriptor,
+  encodeSnapshotManifest,
+  snapshotManifestKey,
+  type SnapshotManifest,
+} from "@baerly/server/_internal/testing";
+import { canonicalJson, hashCanonicalJson, type CanonicalJsonValue } from "./canonical-json.ts";
+import { createExactKeyCleanup, type ExactKeyCleanup } from "./storage-factory.ts";
+import { loadEndpointCreds } from "../../tests/fixtures/endpoint-creds.ts";
+import { WORKLOAD_CEILING_CONTRACT_ID } from "./workload-ceiling-harness.ts";
+import { WORKLOAD_CEILING_STUDY } from "./workload-ceiling-contract.ts";
+
+const INCARNATION_PATTERN = /^[0-9a-f]{32}$/;
+
+export interface WorkloadCeilingFixtureSpec {
+  readonly scenario_id: string;
+  readonly collection: string;
+  readonly row_count: number;
+  readonly document_bytes: number;
+  readonly manifest_descriptors: number;
+}
+
+export class WorkloadCeilingProvisionError extends Error {
+  readonly code = "WorkloadCeilingProvisionInvalid" as const;
+  readonly field: string;
+  constructor(field: string, detail: string) {
+    super(`bench/measurement/workload-ceiling-provision: invalid ${field} — ${detail}`);
+    this.name = "WorkloadCeilingProvisionError";
+    this.field = field;
+  }
+}
+
+function assertSpec(spec: WorkloadCeilingFixtureSpec): void {
+  if (spec.scenario_id.trim() === "") {
+    throw new WorkloadCeilingProvisionError("scenario_id", "must be a nonempty string");
+  }
+  if (spec.collection.trim() === "") {
+    throw new WorkloadCeilingProvisionError("collection", "must be a nonempty string");
+  }
+  if (!Number.isInteger(spec.row_count) || spec.row_count < 1) {
+    throw new WorkloadCeilingProvisionError("row_count", "must be a positive integer");
+  }
+  if (!Number.isInteger(spec.document_bytes) || spec.document_bytes < 32) {
+    throw new WorkloadCeilingProvisionError("document_bytes", "must be an integer >= 32");
+  }
+  if (!Number.isInteger(spec.manifest_descriptors) || spec.manifest_descriptors < 1) {
+    throw new WorkloadCeilingProvisionError("manifest_descriptors", "must be a positive integer");
+  }
+  if (spec.manifest_descriptors > spec.row_count) {
+    throw new WorkloadCeilingProvisionError(
+      "manifest_descriptors",
+      "must not exceed row_count (every chunk must carry at least one row)",
+    );
+  }
+}
+
+interface FixtureRow {
+  readonly _id: string;
+  readonly body: DocumentData;
+}
+
+/** Deterministic scalar-ordered rows: `row-000`, `row-001`, ... — same input, same bytes, every run. */
+function buildRows(spec: WorkloadCeilingFixtureSpec): readonly FixtureRow[] {
+  const width = String(spec.row_count - 1).length;
+  const rows: FixtureRow[] = [];
+  for (let index = 0; index < spec.row_count; index++) {
+    const id = `row-${String(index).padStart(width, "0")}`;
+    const bare = encodeJsonBytes({ _id: id, payload: "" }).byteLength;
+    const padLength = Math.max(0, spec.document_bytes - bare);
+    rows.push({ _id: id, body: { _id: id, payload: "x".repeat(padLength) } });
+  }
+  return rows;
+}
+
+/** Contiguous, near-even groups over the already-sorted rows — `manifest_descriptors` chunks, never zero rows each. */
+function groupRows(
+  rows: readonly FixtureRow[],
+  groupCount: number,
+): readonly (readonly FixtureRow[])[] {
+  const groups: FixtureRow[][] = [];
+  const base = Math.floor(rows.length / groupCount);
+  const extra = rows.length % groupCount;
+  let offset = 0;
+  for (let g = 0; g < groupCount; g++) {
+    const size = base + (g < extra ? 1 : 0);
+    groups.push(rows.slice(offset, offset + size));
+    offset += size;
+  }
+  return groups;
+}
+
+export interface WorkloadCeilingFixtureWrite {
+  readonly key: string;
+  readonly body: Uint8Array;
+}
+
+export interface WorkloadCeilingFixture {
+  readonly spec: WorkloadCeilingFixtureSpec;
+  readonly fixture_prefix: string;
+  readonly incarnation: string;
+  readonly descriptor_key: string;
+  /** SHA-256 over the descriptor's canonical JSON bytes — persisted before the Worker is ever invoked. */
+  readonly descriptor_canonical_hash: string;
+  readonly manifest_key: string;
+  readonly monolithic_key: string;
+  readonly writes: readonly WorkloadCeilingFixtureWrite[];
+}
+
+/**
+ * Pure. Builds the monolithic blob, the manifest + chunk set, and the
+ * fixture descriptor the Worker reads to find both — all as an in-memory
+ * write plan. No `Storage` touched here.
+ */
+export const buildWorkloadCeilingFixture = async (
+  spec: WorkloadCeilingFixtureSpec,
+  fixturePrefix: string,
+  incarnation: string,
+): Promise<WorkloadCeilingFixture> => {
+  assertSpec(spec);
+  if (fixturePrefix.length === 0 || fixturePrefix.startsWith("/") || fixturePrefix.endsWith("/")) {
+    throw new WorkloadCeilingProvisionError(
+      "fixturePrefix",
+      "must be a nonempty clean relative prefix",
+    );
+  }
+  if (!INCARNATION_PATTERN.test(incarnation)) {
+    throw new WorkloadCeilingProvisionError("incarnation", "must be 32 lowercase hex characters");
+  }
+
+  const rows = buildRows(spec);
+  const writes: WorkloadCeilingFixtureWrite[] = [];
+
+  const monolithicKey = `${fixturePrefix}/monolithic.json`;
+  const monolithicValue = {
+    collection: spec.collection,
+    rows: rows.map((row) => ({ _id: row._id, body: row.body as CanonicalJsonValue })),
+  };
+  writes.push({
+    key: monolithicKey,
+    body: new TextEncoder().encode(canonicalJson(monolithicValue as unknown as CanonicalJsonValue)),
+  });
+
+  const groups = groupRows(rows, spec.manifest_descriptors);
+  const chunkDescriptors: SnapshotChunkDescriptor[] = [];
+  for (const group of groups) {
+    const chunk: SnapshotChunk = {
+      schema_version: 2,
+      collection: spec.collection,
+      incarnation,
+      first_id: group[0]!._id,
+      last_id: group.at(-1)!._id,
+      docs: group.map((row) => row.body),
+    };
+    const encoded = encodeSnapshotChunk(chunk);
+    const digest = await snapshotHash(encoded);
+    const key = snapshotChunkKey(fixturePrefix, incarnation, digest);
+    writes.push({ key, body: encoded });
+    chunkDescriptors.push({
+      first_id: chunk.first_id,
+      last_id: chunk.last_id,
+      key,
+      byte_length: encoded.byteLength,
+      row_count: group.length,
+    });
+  }
+
+  const manifest: SnapshotManifest = {
+    schema_version: 2,
+    collection: spec.collection,
+    log_seq_start: 0,
+    incarnation,
+    collation: "utf8-scalar-v1",
+    chunks: chunkDescriptors,
+  };
+  const manifestEncoded = encodeSnapshotManifest(manifest);
+  const manifestDigest = await snapshotHash(manifestEncoded);
+  const manifestKey = snapshotManifestKey(fixturePrefix, incarnation, manifestDigest);
+  writes.push({ key: manifestKey, body: manifestEncoded });
+
+  const descriptorValue = {
+    contract_id: WORKLOAD_CEILING_CONTRACT_ID,
+    collection: spec.collection,
+    monolithic_key: monolithicKey,
+    manifest_key: manifestKey,
+    log_seq_start: 0,
+  };
+  const descriptorCanonical = canonicalJson(descriptorValue as unknown as CanonicalJsonValue);
+  const descriptorKey = `${fixturePrefix}/fixture.json`;
+  writes.push({ key: descriptorKey, body: new TextEncoder().encode(descriptorCanonical) });
+
+  return {
+    spec,
+    fixture_prefix: fixturePrefix,
+    incarnation,
+    descriptor_key: descriptorKey,
+    descriptor_canonical_hash: await hashCanonicalJson(
+      descriptorValue as unknown as CanonicalJsonValue,
+    ),
+    manifest_key: manifestKey,
+    monolithic_key: monolithicKey,
+    writes,
+  };
+};
+
+export interface WorkloadCeilingProvisionResult {
+  readonly fixture: WorkloadCeilingFixture;
+  readonly cleanup: ExactKeyCleanup;
+}
+
+/**
+ * Writes every artifact `buildWorkloadCeilingFixture` planned, then returns
+ * an `ExactKeyCleanup` over exactly those keys. Persists the descriptor +
+ * manifest before returning — this function's return is the earliest point
+ * a caller can invoke the Worker, and by then both are already durable.
+ */
+export const provisionWorkloadCeilingFixture = async (input: {
+  readonly storage: Storage;
+  readonly spec: WorkloadCeilingFixtureSpec;
+  readonly fixturePrefix: string;
+  readonly incarnation: string;
+}): Promise<WorkloadCeilingProvisionResult> => {
+  const fixture = await buildWorkloadCeilingFixture(
+    input.spec,
+    input.fixturePrefix,
+    input.incarnation,
+  );
+  for (const write of fixture.writes) {
+    await input.storage.put(write.key, write.body);
+  }
+  return {
+    fixture,
+    cleanup: createExactKeyCleanup({
+      storage: input.storage,
+      keys: fixture.writes.map((write) => write.key),
+    }),
+  };
+};
+
+/** A fresh 32-lowercase-hex incarnation, matching `packages/server/src/snapshot-manifest.ts`'s grammar. */
+export const randomIncarnation = (): string => randomUUID().replaceAll("-", "");
+
+/**
+ * CLI entrypoint (`pnpm bench:workload-ceiling:provision`). Real R2
+ * provisioning, so it requires `credentials/cloudflare.json` (the
+ * `loadEndpointCreds` convention, `tests/fixtures/endpoint-creds.ts`) — the
+ * same file shape and skip-honestly posture the credential-gated test
+ * suites use, except here absence is a script failure rather than a skip:
+ * there is nothing useful this script can do without a real bucket.
+ *
+ * Deliberately does NOT invoke the Worker or clean up after itself — a
+ * provisioned fixture must outlive this process so
+ * `workload-ceiling-collect.ts` and a manual Worker invocation can use it.
+ * The returned `ExactKeyCleanup`'s authority is written into the report file
+ * so a later cleanup step can reconstruct exactly which keys to remove.
+ */
+async function main(): Promise<number> {
+  const creds = await loadEndpointCreds("cloudflare.json");
+  if (creds === null) {
+    console.error(
+      "workload-ceiling-provision: no credentials/cloudflare.json found " +
+        "(tests/fixtures/endpoint-creds.ts). This script provisions fixtures " +
+        "against a real R2 bucket for the deployed workload-ceiling study; " +
+        "there is nothing to do without credentials.",
+    );
+    return 1;
+  }
+
+  const signer = new AwsClient({
+    accessKeyId: creds.credentials.accessKeyId,
+    secretAccessKey: creds.credentials.secretAccessKey,
+    region: creds.region,
+    service: "s3",
+  });
+  const storage = new S3HttpStorage({
+    endpoint: creds.endpoint,
+    bucket: creds.bucket,
+    sign: (req) => signer.sign(req),
+  });
+
+  const runId = process.env["WORKLOAD_CEILING_RUN_ID"] ?? randomUUID();
+  const scenarioId = process.env["WORKLOAD_CEILING_SCENARIO_ID"] ?? "byte-axis/default/hot-key";
+  const documentBytes = Number(
+    process.env["WORKLOAD_CEILING_DOCUMENT_BYTES"] ??
+      WORKLOAD_CEILING_STUDY.axis_sweeps.byte_axis.document_bytes,
+  );
+  const collectionBytesTarget = Number(
+    process.env["WORKLOAD_CEILING_COLLECTION_BYTES"] ??
+      WORKLOAD_CEILING_STUDY.minimum_useful_targets.byte_axis.collection_bytes,
+  );
+  const manifestDescriptors = Number(process.env["WORKLOAD_CEILING_MANIFEST_DESCRIPTORS"] ?? 8);
+  const spec: WorkloadCeilingFixtureSpec = {
+    scenario_id: scenarioId,
+    collection: "items",
+    row_count: Math.max(1, Math.round(collectionBytesTarget / documentBytes)),
+    document_bytes: documentBytes,
+    manifest_descriptors: manifestDescriptors,
+  };
+  const fixturePrefix = `tenants/workload-ceiling-study/collections/${runId}`;
+  const incarnation = randomIncarnation();
+
+  const result = await provisionWorkloadCeilingFixture({
+    storage,
+    spec,
+    fixturePrefix,
+    incarnation,
+  });
+
+  const report = {
+    run_id: runId,
+    spec,
+    fixture_prefix: fixturePrefix,
+    incarnation,
+    descriptor_key: result.fixture.descriptor_key,
+    descriptor_canonical_hash: result.fixture.descriptor_canonical_hash,
+    manifest_key: result.fixture.manifest_key,
+    monolithic_key: result.fixture.monolithic_key,
+    written_keys: result.fixture.writes.map((write) => write.key),
+    cleanup_authority: result.cleanup.authority,
+  };
+  const outDir = "bench/results/workload-ceiling";
+  await mkdir(outDir, { recursive: true });
+  const outPath = `${outDir}/fixture-${runId}.json`;
+  await writeFile(outPath, JSON.stringify(report, null, 2));
+  console.log(`provisioned fixture ${fixturePrefix} (incarnation ${incarnation})`);
+  console.log(`descriptor canonical hash: ${result.fixture.descriptor_canonical_hash}`);
+  console.log(`wrote ${outPath}`);
+  return 0;
+}
+
+// CLI entrypoint guard: `main()` runs only when this module is executed
+// directly, never when a test imports it — with a credentials file present
+// in the working tree, an import must never provision a real R2 fixture.
+const isCli =
+  process.argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(process.argv[1]!);
+if (isCli) {
+  process.exitCode = await main();
+}

--- a/bench/workload-ceiling-worker/README.md
+++ b/bench/workload-ceiling-worker/README.md
@@ -1,0 +1,173 @@
+# Workload-ceiling study Worker
+
+Deployed evidence harness for the workload-ceiling study (parent plan Task 8,
+`docs/superpowers/programs/increase-workload-ceiling/`). This Worker is
+measurement-only: it is not part of any published `@gusto/baerly-storage`
+entry point, it is not reachable from a user's application, and it changes no
+production behavior.
+
+## What it does
+
+One authenticated `POST /run` per invocation:
+
+1. Validates the request body as a `WorkloadCeilingRunRequest`
+   (`../measurement/workload-ceiling-harness.ts`) — strict field set,
+   canonical JSON, no unknown fields.
+2. Opens the exact fixture `workload-ceiling-provision.ts` already wrote
+   under `fixture_prefix`. It never provisions a fixture itself.
+3. Awaits one controlled fold subject —
+   `foldChunkedSnapshotReference(rows, [])` from
+   `packages/server/src/chunked-snapshot-reference.ts`, the same independent
+   logical oracle the chunk-native view is checked against — over whichever
+   representation `implementation` selects:
+   - `monolithic-control` — a single JSON blob, the shape of today's shipped
+     single-snapshot format.
+   - `chunked-candidate` — the proposed manifest + chunk layout, read through
+     `openSnapshotView` (`packages/server/src/snapshot-view.ts`).
+4. Emits the run's join identifiers exactly once as a single structured
+   Workers Logs line, and returns the kernel result (row count).
+
+It does **not** provision fixtures, aggregate results across runs, loop or
+retry, schedule cron, or self-report CPU time — `Date.now()` /
+`performance.now()` do not appear in `src/index.ts`. The only source of
+truth for CPU is the platform's own invocation telemetry, retrieved
+out-of-band by `../measurement/workload-ceiling-collect.ts`.
+
+## Why CPU is never self-reported
+
+A Worker cannot observe its own CPU-limit enforcement from inside the
+isolate — the limit is enforced by the runtime around the isolate, and an
+in-process timer measures wall time, not the runtime's own CPU accounting.
+Reporting a self-timed number here would be exactly the kind of synthesized
+evidence `workload-ceiling-harness.ts`'s codec exists to refuse. The study
+instead retrieves the platform's own number through the GraphQL Analytics
+API's `workersInvocationsAdaptive` dataset, which reports per-invocation
+`status` (the outcome, e.g. success, or an exceeded-resources / exception /
+disconnect classification) and CPU time.
+
+## Join mechanism
+
+Workers Analytics does not carry a caller-supplied correlation ID per row.
+The plan's Step 10 language ("deploy a uniquely named study Worker") assumes
+a fresh per-run deployment, whose `scriptName` alone would disambiguate
+invocations. This harness instead reuses one already-deployed, fixed-name
+Worker (`baerly-storage`, overwritten in place by `deploy.mjs` for each
+smoke run — see §"Token scope" for why), so disambiguation for Task 8's one
+authorized smoke run rests on `workload-ceiling-collect.ts` querying
+`workersInvocationsAdaptive` filtered by that fixed `scriptName` plus a
+narrow `datetime` window bounding the single invocation, rather than on the
+name itself. The Workers Logs line emitted in step 4 above (`run_id` /
+`scenario_id` / `implementation`) is the independent check that the
+telemetry row collected in that window is in fact this run. A later,
+bulk multi-run study (out of this plan's scope) would need per-run
+uniqueness back, since a shared name plus overlapping windows could no
+longer disambiguate concurrent invocations.
+
+## Platform documentation this rests on
+
+Retrieved via this repo's `cloudflare`, `workers-best-practices`, and
+`wrangler` Claude Code skills at implementation time (Task 8 Step 1); linked
+directly here per that step's requirement.
+
+- Module Worker shape / `fetch` handler:
+  <https://developers.cloudflare.com/workers/runtime-apis/handlers/fetch/>
+- `wrangler.jsonc` configuration reference:
+  <https://developers.cloudflare.com/workers/wrangler/configuration/>
+- Compatibility dates:
+  <https://developers.cloudflare.com/workers/configuration/compatibility-dates/>
+- R2 bucket binding (`r2_buckets`, `env.BUCKET`):
+  <https://developers.cloudflare.com/r2/api/workers/workers-api-reference/>
+- GraphQL Analytics API — query shape, `*Adaptive` raw-row datasets,
+  `workersInvocationsAdaptive` dimensions/metrics (`cpuTime`, `status`,
+  `scriptName`, `coloCode`, `scriptVersion`):
+  <https://developers.cloudflare.com/analytics/graphql-api/>,
+  <https://developers.cloudflare.com/analytics/graphql-api/tutorials/querying-workers-metrics/>
+- Workers observability / metrics and invocation status classification:
+  <https://developers.cloudflare.com/workers/observability/metrics-and-analytics/>
+- Workers Logs (the join-identifier emission path):
+  <https://developers.cloudflare.com/workers/observability/logs/workers-logs/>
+- Non-interactive Wrangler auth (`CLOUDFLARE_API_TOKEN` /
+  `CLOUDFLARE_ACCOUNT_ID`, sourced here from `CF_API_TOKEN` / `CF_ACCOUNT_ID`
+  per `tests/integration/day-one-handshake.test.ts`'s existing convention):
+  <https://developers.cloudflare.com/workers/wrangler/ci-cd/>
+
+## Deploying (not performed by this task)
+
+Step 10 of Task 8 — one authorized deployed smoke run — is deliberately
+**not** performed by this repository's automated gates (`pnpm verify`,
+`pnpm test`), and requires `CF_API_TOKEN` / `CF_ACCOUNT_ID` or
+`credentials/cloudflare-deploy.json` to be provisioned first (see below).
+
+`deploy.mjs` wraps `wrangler` so auth never has to live in shell env or a
+global dotfile — never `wrangler login`. It resolves `CLOUDFLARE_API_TOKEN` /
+`CLOUDFLARE_ACCOUNT_ID` the same way `../measurement/workload-ceiling-collect.ts`
+does: `CF_API_TOKEN` + `CF_ACCOUNT_ID` env vars if both are set, otherwise a
+repo-scoped `credentials/cloudflare-deploy.json` (gitignored —
+`{ "api_token": "...", "account_id": "..." }`, read by
+`loadCloudflareDeployCreds` in `tests/fixtures/endpoint-creds.ts`). Either
+way the resolved credentials are injected only into the spawned `wrangler`
+child's environment, never printed or written elsewhere. Once one of those
+two sources is available:
+
+```sh
+node bench/workload-ceiling-worker/deploy.mjs deploy --name baerly-storage
+
+node bench/workload-ceiling-worker/deploy.mjs secret put WORKLOAD_CEILING_SHARED_SECRET \
+  --name baerly-storage
+```
+
+### Token scope
+
+Cloudflare's API token permission model has no per-script resource type —
+`Workers Scripts: Edit` grants edit access to every Worker in whichever
+account you scope the token to under **Account Resources**, not just this
+study's. `deploy.mjs` narrows that in code instead: it refuses to run any
+`wrangler` subcommand whose `--name` isn't exactly `baerly-storage` (the
+same `WORKLOAD_CEILING_WORKER_NAME` constant
+`../measurement/workload-ceiling-collect.ts` uses to filter telemetry), so a
+typo'd or copy-pasted `--name` can never reach an unrelated script even
+though the credential technically could. Treat the token itself
+as disposable regardless — create it right before a Step 10 run and revoke
+it from the Cloudflare dashboard once cleanup is confirmed, rather than
+leaving a standing account-wide-Workers credential around.
+
+Provision the fixture first (`pnpm bench:workload-ceiling:provision`),
+invoke once, collect (`pnpm bench:workload-ceiling:collect`), verify the
+join, then delete the fixed-name study Worker
+(`node bench/workload-ceiling-worker/deploy.mjs delete --name
+baerly-storage`) — only once the study as a whole concludes — along with
+its exact leased keys. The Worker is deliberately not run-unique: it is
+fixed-name and overwritten in place by each smoke run (see §"Join
+mechanism"), so there is no per-run deployment to clean up between runs.
+Never delete the bucket or an unresolved prefix.
+
+## Runbook — one smoke run
+
+`workersInvocationsAdaptive` rows are minute-bucketed aggregates. Two
+invocations inside the same minute collapse into one row with summed CPU —
+the collector's request-count assertion treats such a row as unresolved, so
+space the two invocations at least one minute apart and give each its own
+explicit collection window:
+
+1. `deploy.mjs deploy --name baerly-storage` (once), then set the shared
+   secret.
+2. Provision the fixture (`pnpm bench:workload-ceiling:provision`).
+3. Invoke `POST /run` for `monolithic-control`; note the time.
+4. Collect with explicit `WORKLOAD_CEILING_WINDOW_START`/`_END` bounding
+   only that invocation, routed to the control side's own directory:
+   `WORKLOAD_CEILING_OUT_DIR=bench/results/workload-ceiling/control pnpm
+   bench:workload-ceiling:collect`.
+5. Wait ≥ 1 minute. Repeat 3–4 for `chunked-candidate` with
+   `WORKLOAD_CEILING_OUT_DIR=bench/results/workload-ceiling/candidate`.
+6. `WORKLOAD_CEILING_CONTROL_DIR=bench/results/workload-ceiling/control
+   WORKLOAD_CEILING_CANDIDATE_DIR=bench/results/workload-ceiling/candidate
+   pnpm bench:workload-ceiling:compare`.
+
+The per-implementation directories in steps 4–5 are mandatory, not
+housekeeping: `workload-ceiling-compare.ts` joins two event directories,
+one per side, and both implementations reuse the same `scenario_id`s —
+collected into one shared directory, every scenario arrives twice there
+and is evicted as a duplicate, leaving zero pairs and an exit 1.
+
+Never rely on the default 10-minute window — it will span both invocations
+and both sides will record `missing-terminal-event`.

--- a/bench/workload-ceiling-worker/README.md
+++ b/bench/workload-ceiling-worker/README.md
@@ -149,6 +149,15 @@ the collector's request-count assertion treats such a row as unresolved, so
 space the two invocations at least one minute apart and give each its own
 explicit collection window:
 
+0. Confirm `credentials/cloudflare.json` names the bucket
+   `baerly-storage-eval`. Provisioning writes fixtures to whatever bucket that
+   file names, while `wrangler.jsonc` binds the Worker's `env.BUCKET` to
+   `baerly-storage-eval` as a literal — the two are configured independently,
+   and a mismatch means every `POST /run` returns a 502
+   `fixture descriptor is missing` that reads as a provisioning bug.
+   `pnpm bench:workload-ceiling:provision` preflights this and refuses to
+   write on a mismatch; the constant both sides answer to is
+   `WORKLOAD_CEILING_BUCKET_NAME` in `../measurement/workload-ceiling-harness.ts`.
 1. `deploy.mjs deploy --name baerly-storage` (once), then set the shared
    secret.
 2. Provision the fixture (`pnpm bench:workload-ceiling:provision`).

--- a/bench/workload-ceiling-worker/deploy.mjs
+++ b/bench/workload-ceiling-worker/deploy.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Thin wrangler wrapper for the workload-ceiling study Worker (Task 8 Step
+// 10 — not run by `pnpm verify`/`pnpm test`, never wired into a release
+// script). Resolves Cloudflare auth the same way
+// `../measurement/workload-ceiling-collect.ts` does: `CF_API_TOKEN` +
+// `CF_ACCOUNT_ID` env vars if both are set, otherwise a repo-scoped
+// `credentials/cloudflare-deploy.json` (gitignored — see
+// `tests/fixtures/endpoint-creds.ts`'s `loadCloudflareDeployCreds`). Either
+// way, the resolved token/account id are injected only into the spawned
+// `wrangler` child's environment — never printed, never written to disk,
+// never exported into the calling shell.
+//
+// Usage: node bench/workload-ceiling-worker/deploy.mjs <wrangler subcommand and args...>
+//   node bench/workload-ceiling-worker/deploy.mjs deploy --name baerly-storage
+//   node bench/workload-ceiling-worker/deploy.mjs secret put WORKLOAD_CEILING_SHARED_SECRET --name baerly-storage
+//   node bench/workload-ceiling-worker/deploy.mjs delete --name baerly-storage
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "..", "..");
+const WRANGLER_CONFIG = join(HERE, "wrangler.jsonc");
+
+async function loadDeployCreds() {
+  try {
+    const raw = await readFile(join(REPO_ROOT, "credentials", "cloudflare-deploy.json"), "utf8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+// A defined-but-blank env var must not count as "set" — it would pass the
+// undefined-only checks in resolveAuth and surface later as a confusing
+// wrangler auth failure instead of this script's clear usage error.
+const present = (v) => v !== undefined && v.trim() !== "";
+
+async function resolveAuth() {
+  const envToken = process.env["CF_API_TOKEN"];
+  const envAccount = process.env["CF_ACCOUNT_ID"];
+  if (present(envToken) && present(envAccount)) {
+    return { apiToken: envToken, accountId: envAccount };
+  }
+  const fileCreds = await loadDeployCreds();
+  const apiToken = present(envToken) ? envToken : fileCreds?.api_token;
+  const accountId = present(envAccount) ? envAccount : fileCreds?.account_id;
+  if (!present(apiToken) || !present(accountId)) {
+    console.error(
+      "workload-ceiling-worker/deploy.mjs: requires CF_API_TOKEN + CF_ACCOUNT_ID " +
+        "(env vars) or credentials/cloudflare-deploy.json ({ api_token, account_id }).",
+    );
+    return null;
+  }
+  return { apiToken, accountId };
+}
+
+// The token behind this script has account-wide `Workers Scripts:Edit` —
+// Cloudflare's API token permission model has no per-script resource scope
+// to narrow that with (see bench/workload-ceiling-worker/README.md
+// §"Token scope"). This exact-name check is the code-level substitute: it
+// must match `WORKLOAD_CEILING_WORKER_NAME` in
+// `../measurement/workload-ceiling-collect.ts` (the study's one
+// already-deployed, reused Worker — see that constant's doc comment for why
+// this plan doesn't mint a uniquely-named deployment per run), and every
+// wrangler invocation below is refused unless its `--name` matches exactly,
+// so a typo'd or copy-pasted `--name` can never reach an unrelated script
+// even though the credential technically could.
+const STUDY_WORKER_NAME = "baerly-storage";
+
+function extractName(args) {
+  const eqForm = args.find((arg) => arg.startsWith("--name="));
+  if (eqForm !== undefined) {
+    return eqForm.slice("--name=".length);
+  }
+  const flagIndex = args.indexOf("--name");
+  return flagIndex === -1 ? undefined : args[flagIndex + 1];
+}
+
+const wranglerArgs = process.argv.slice(2);
+if (wranglerArgs.length === 0) {
+  console.error("usage: node bench/workload-ceiling-worker/deploy.mjs <wrangler subcommand...>");
+  process.exit(1);
+}
+
+const targetName = extractName(wranglerArgs);
+if (targetName !== STUDY_WORKER_NAME) {
+  console.error(
+    `workload-ceiling-worker/deploy.mjs: refusing to run — every invocation must pass ` +
+      `--name "${STUDY_WORKER_NAME}" exactly (got ${
+        targetName === undefined ? "no --name" : JSON.stringify(targetName)
+      }). This account-wide-scoped token is restricted in code to this study's ` +
+      `one reused Worker only.`,
+  );
+  process.exit(1);
+}
+
+const auth = await resolveAuth();
+if (auth === null) {
+  process.exit(1);
+}
+
+const child = spawn("pnpm", ["exec", "wrangler", ...wranglerArgs, "--config", WRANGLER_CONFIG], {
+  stdio: "inherit",
+  cwd: REPO_ROOT,
+  env: {
+    ...process.env,
+    CLOUDFLARE_API_TOKEN: auth.apiToken,
+    CLOUDFLARE_ACCOUNT_ID: auth.accountId,
+  },
+});
+child.on("exit", (code) => {
+  process.exit(code ?? 1);
+});

--- a/bench/workload-ceiling-worker/src/constant-time-equal.test.ts
+++ b/bench/workload-ceiling-worker/src/constant-time-equal.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { constantTimeEqual } from "./constant-time-equal.ts";
+
+describe("constantTimeEqual", () => {
+  test("equal strings compare true", () => {
+    expect(constantTimeEqual("secret-value", "secret-value")).toBe(true);
+  });
+  test("a one-byte difference compares false", () => {
+    expect(constantTimeEqual("secret-value", "secret-valuf")).toBe(false);
+  });
+  test("a length difference compares false", () => {
+    expect(constantTimeEqual("secret", "secret-value")).toBe(false);
+  });
+  test("a length difference compares false (a strict prefix is the short case)", () => {
+    expect(constantTimeEqual("secret-value", "secret")).toBe(false);
+  });
+  test("empty versus nonempty compares false, empty versus empty true", () => {
+    expect(constantTimeEqual("", "x")).toBe(false);
+    expect(constantTimeEqual("", "")).toBe(true);
+  });
+  test("non-ASCII secrets compare on UTF-8 bytes, not code units", () => {
+    // Precomposed U+00E9 vs 'e' + combining U+0301: same visual, different bytes.
+    // Write both as escapes so the source can't silently normalize them.
+    expect(constantTimeEqual("s\u00e9cret", "s\u00e9cret")).toBe(true);
+    expect(constantTimeEqual("s\u00e9cret", "se\u0301cret")).toBe(false);
+  });
+});

--- a/bench/workload-ceiling-worker/src/constant-time-equal.ts
+++ b/bench/workload-ceiling-worker/src/constant-time-equal.ts
@@ -1,0 +1,20 @@
+/**
+ * Constant-time-ISH byte comparison for the bearer secret. No early return on
+ * mismatch, and both operands are compared over the LONGER of the two
+ * lengths so an attacker cannot use response timing to learn the secret's
+ * length either. Not a cryptographic primitive — a deliberately small,
+ * dependency-free substitute for `node:crypto`'s `timingSafeEqual`, which
+ * would otherwise be this Worker's only reason to declare `nodejs_compat`.
+ */
+export function constantTimeEqual(a: string, b: string): boolean {
+  const left = UTF8_ENCODER.encode(a);
+  const right = UTF8_ENCODER.encode(b);
+  const length = Math.max(left.length, right.length);
+  let diff = left.length ^ right.length;
+  for (let i = 0; i < length; i++) {
+    diff |= (left[i] ?? 0) ^ (right[i] ?? 0);
+  }
+  return diff === 0;
+}
+
+const UTF8_ENCODER = new TextEncoder();

--- a/bench/workload-ceiling-worker/src/index.test.ts
+++ b/bench/workload-ceiling-worker/src/index.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+import worker, { type WorkloadCeilingWorkerEnv } from "./index.ts";
+
+// The env cast is safe on every path under test: the 401 guard returns
+// before `env.BUCKET` is ever read, and the 400 path (decode failure)
+// returns before it too — no real R2 binding is needed.
+const env = (sharedSecret: string | undefined): WorkloadCeilingWorkerEnv =>
+  ({ WORKLOAD_CEILING_SHARED_SECRET: sharedSecret }) as unknown as WorkloadCeilingWorkerEnv;
+
+// Node's `Request` normalizes trailing HTTP whitespace off header values, so
+// a literal `Authorization: Bearer ` (empty token) cannot be constructed
+// through the real constructor — it collapses to `Bearer` (token `null`).
+// The fail-open bug under test is specifically the RAW empty-token header
+// reaching `constantTimeEqual("", <unset secret>)` as equal-empty-bytes, so
+// these requests carry a hand-rolled headers view that preserves the exact
+// bytes. Everything else the handler touches (`method`, `url`, `text`) is a
+// plain value on the duck-typed object.
+const postRun = (authorization: string, body = "not-json"): Request =>
+  ({
+    method: "POST",
+    url: "https://study.example/run",
+    headers: {
+      get: (name: string): string | null => (name === "authorization" ? authorization : null),
+    },
+    text: () => Promise.resolve(body),
+  }) as unknown as Request;
+
+describe("POST /run authentication fails closed", () => {
+  test("a missing secret rejects an empty bearer token", async () => {
+    // The operator forgot `wrangler secret put`: the binding is absent, and
+    // `constantTimeEqual("", undefined)` compares zero bytes to zero bytes —
+    // equal. The handler must reject before that compare is reached.
+    const response = await worker.fetch(postRun("Bearer "), env(undefined));
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "unauthorized" });
+  });
+
+  test("a missing secret rejects a real-looking token", async () => {
+    const response = await worker.fetch(postRun("Bearer real-looking-token"), env(undefined));
+    expect(response.status).toBe(401);
+  });
+
+  test("a blank secret rejects even a matching blank token", async () => {
+    const response = await worker.fetch(postRun("Bearer  "), env("  "));
+    expect(response.status).toBe(401);
+  });
+
+  test("a set secret with the correct token still reaches request decoding", async () => {
+    // Pins that the fail-closed guard did not overfire: correct secret +
+    // token gets PAST auth and dies on the garbage body with 400, not 401.
+    const response = await worker.fetch(
+      postRun("Bearer real-secret", "garbage"),
+      env("real-secret"),
+    );
+    expect(response.status).toBe(400);
+  });
+});

--- a/bench/workload-ceiling-worker/src/index.test.ts
+++ b/bench/workload-ceiling-worker/src/index.test.ts
@@ -34,8 +34,9 @@ const postRun = (authorization: string, body = "not-json"): Request =>
     text: () => Promise.resolve(body),
   }) as unknown as Request;
 
-// Simple mock storage implementation
-function createMockStorage(files: Record<string, string>): Storage {
+// Simple mock storage implementation. Accepts raw bytes as well as strings so
+// a test can load the exact write plan `buildWorkloadCeilingFixture` produces.
+function createMockStorage(files: Record<string, string | Uint8Array>): Storage {
   const get = async (
     key: string,
     _options?: { signal?: AbortSignal },
@@ -45,7 +46,7 @@ function createMockStorage(files: Record<string, string>): Storage {
       return null;
     }
     return {
-      body: new TextEncoder().encode(content),
+      body: typeof content === "string" ? new TextEncoder().encode(content) : content,
       metadata: undefined,
     };
   };
@@ -76,7 +77,23 @@ const validRequest = {
 };
 
 // Import encoding functions for proper canonical JSON
-import { encodeWorkloadCeilingRunRequest } from "../../measurement/workload-ceiling-harness.ts";
+import {
+  encodeWorkloadCeilingFixtureDescriptor,
+  encodeWorkloadCeilingRunRequest,
+} from "../../measurement/workload-ceiling-harness.ts";
+import { buildWorkloadCeilingFixture } from "../../measurement/workload-ceiling-provision.ts";
+
+/** An authenticated `POST /run` carrying an already-encoded request body. */
+const authedPostRun = (body: string): Request =>
+  ({
+    method: "POST",
+    url: "https://example.com/run",
+    headers: {
+      get: (name: string): string | null => (name === "authorization" ? "Bearer secret" : null),
+    },
+    text: () => Promise.resolve(body),
+    signal: new AbortController().signal,
+  }) as unknown as Request;
 
 describe("POST /run authentication fails closed", () => {
   test("a missing secret rejects an empty bearer token", async () => {
@@ -138,10 +155,18 @@ describe("Wrong method/path returns 404", () => {
   });
 });
 
+interface RunResult {
+  readonly row_count: number;
+  readonly contract_id: string;
+  readonly run_id: string;
+  readonly scenario_id: string;
+  readonly implementation: string;
+}
+
 describe("Success path with mocked storage", () => {
   test("succeeds on monolithic-control implementation", async () => {
     const mockStorage = createMockStorage({
-      [`${fixturePrefix}/fixture.json`]: JSON.stringify({
+      [`${fixturePrefix}/fixture.json`]: encodeWorkloadCeilingFixtureDescriptor({
         contract_id: "baerly.workload-ceiling/chunked-snapshot/v1",
         collection: "test-collection",
         monolithic_key: `${fixturePrefix}/monolithic.json`,
@@ -155,29 +180,152 @@ describe("Success path with mocked storage", () => {
 
     mockR2BindingStorage.mockReturnValue(mockStorage);
 
-    const body = encodeWorkloadCeilingRunRequest(validRequest);
-    const request = {
-      method: "POST",
-      url: "https://example.com/run",
-      headers: {
-        get: (name: string): string | null => (name === "authorization" ? "Bearer secret" : null),
-      },
-      text: () => Promise.resolve(body),
-    } as unknown as Request;
-
-    const response = await worker.fetch(request, env("secret"));
+    const response = await worker.fetch(
+      authedPostRun(encodeWorkloadCeilingRunRequest(validRequest)),
+      env("secret"),
+    );
     expect(response.status).toBe(200);
-    const result = (await response.json()) as {
-      row_count: number;
-      contract_id: string;
-      run_id: string;
-      scenario_id: string;
-      implementation: string;
-    };
+    const result = (await response.json()) as RunResult;
     expect(result.row_count).toBe(1);
     expect(result.contract_id).toBe("baerly.workload-ceiling/chunked-snapshot/v1");
     expect(result.run_id).toBe("test-run-id");
     expect(result.scenario_id).toBe("test-scenario");
     expect(result.implementation).toBe("monolithic-control");
+  });
+
+  // The candidate representation is the study's whole subject, and it is the
+  // more complex of the two read paths (manifest open → chunk fetch → view
+  // materialize). Driving it off `buildWorkloadCeilingFixture`'s real write
+  // plan means this test exercises the SAME bytes a provisioned run reads —
+  // the manifest/chunk codecs and their key derivation included — rather than
+  // a hand-written approximation of them.
+  describe("chunked-candidate reads the provisioned manifest + chunk layout", () => {
+    const spec = {
+      scenario_id: "test-scenario",
+      collection: "items",
+      row_count: 6,
+      document_bytes: 64,
+      // > 1, so a single-chunk manifest cannot pass this by accident.
+      manifest_descriptors: 3,
+    };
+
+    const provisioned = async () => {
+      const fixture = await buildWorkloadCeilingFixture(
+        spec,
+        fixturePrefix,
+        "0123456789abcdef0123456789abcdef",
+      );
+      const files: Record<string, string | Uint8Array> = {};
+      for (const write of fixture.writes) {
+        files[write.key] = write.body;
+      }
+      return { fixture, files };
+    };
+
+    test("folds every provisioned row", async () => {
+      const { files } = await provisioned();
+      mockR2BindingStorage.mockReturnValue(createMockStorage(files));
+
+      const response = await worker.fetch(
+        authedPostRun(
+          encodeWorkloadCeilingRunRequest({ ...validRequest, implementation: "chunked-candidate" }),
+        ),
+        env("secret"),
+      );
+      expect(response.status).toBe(200);
+      const result = (await response.json()) as RunResult;
+      expect(result.implementation).toBe("chunked-candidate");
+      expect(result.row_count).toBe(spec.row_count);
+    });
+
+    test("both implementations fold the identical row count off one fixture", async () => {
+      // The comparison only isolates storage-shape cost if the two branches
+      // agree on what they computed. A candidate path that silently dropped a
+      // chunk would otherwise read as a cheaper implementation.
+      const { files } = await provisioned();
+      mockR2BindingStorage.mockReturnValue(createMockStorage(files));
+
+      const counts: number[] = [];
+      for (const implementation of ["monolithic-control", "chunked-candidate"] as const) {
+        const response = await worker.fetch(
+          authedPostRun(encodeWorkloadCeilingRunRequest({ ...validRequest, implementation })),
+          env("secret"),
+        );
+        expect(response.status).toBe(200);
+        counts.push(((await response.json()) as RunResult).row_count);
+      }
+      expect(counts).toEqual([spec.row_count, spec.row_count]);
+    });
+
+    test("a chunk missing from the bucket fails as a 502, never a short fold", async () => {
+      // A truncated read must not look like a smaller collection — that would
+      // silently understate the candidate's cost.
+      const { fixture, files } = await provisioned();
+      const chunkKey = fixture.writes.find((write) => write.key.includes("/chunk"))?.key;
+      expect(chunkKey).toBeDefined();
+      delete files[chunkKey!];
+      mockR2BindingStorage.mockReturnValue(createMockStorage(files));
+
+      const response = await worker.fetch(
+        authedPostRun(
+          encodeWorkloadCeilingRunRequest({ ...validRequest, implementation: "chunked-candidate" }),
+        ),
+        env("secret"),
+      );
+      expect(response.status).toBe(502);
+      await expect(response.json()).resolves.toMatchObject({
+        error: expect.stringContaining("chunked fixture is unreadable"),
+      });
+    });
+  });
+});
+
+describe("Fixture descriptor rejection", () => {
+  test("a descriptor with an unknown field is a 502, not a 400", async () => {
+    // The caller's own body decoded cleanly; a broken upstream fixture is not
+    // the caller's bad request.
+    mockR2BindingStorage.mockReturnValue(
+      createMockStorage({
+        [`${fixturePrefix}/fixture.json`]: JSON.stringify({
+          collection: "items",
+          contract_id: "baerly.workload-ceiling/chunked-snapshot/v1",
+          log_seq_start: 0,
+          manifest_key: "m",
+          monolithic_key: "n",
+          unexpected: true,
+        }),
+      }),
+    );
+
+    const response = await worker.fetch(
+      authedPostRun(encodeWorkloadCeilingRunRequest(validRequest)),
+      env("secret"),
+    );
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toMatchObject({
+      error: expect.stringContaining("fixture descriptor is unusable"),
+    });
+  });
+
+  test("a non-canonical descriptor is rejected, pinning the persisted hash's meaning", async () => {
+    // Same fields, unsorted keys — the bytes the provisioning report's
+    // descriptor_canonical_hash covers are the only bytes the Worker accepts.
+    mockR2BindingStorage.mockReturnValue(
+      createMockStorage({
+        [`${fixturePrefix}/fixture.json`]: JSON.stringify({
+          contract_id: "baerly.workload-ceiling/chunked-snapshot/v1",
+          collection: "items",
+          monolithic_key: "n",
+          manifest_key: "m",
+          log_seq_start: 0,
+        }),
+      }),
+    );
+
+    const response = await worker.fetch(
+      authedPostRun(encodeWorkloadCeilingRunRequest(validRequest)),
+      env("secret"),
+    );
+    expect(response.status).toBe(502);
   });
 });

--- a/bench/workload-ceiling-worker/src/index.test.ts
+++ b/bench/workload-ceiling-worker/src/index.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
+import type { Storage } from "@baerly/protocol";
 import worker, { type WorkloadCeilingWorkerEnv } from "./index.ts";
+
+vi.mock("@baerly/adapter-cloudflare", () => ({
+  // eslint-disable-next-line vitest/require-mock-type-parameters
+  r2BindingStorage: vi.fn(),
+}));
+
+const { r2BindingStorage } = await import("@baerly/adapter-cloudflare");
+const mockR2BindingStorage = vi.mocked(r2BindingStorage);
 
 // The env cast is safe on every path under test: the 401 guard returns
 // before `env.BUCKET` is ever read, and the 400 path (decode failure)
@@ -24,6 +33,50 @@ const postRun = (authorization: string, body = "not-json"): Request =>
     },
     text: () => Promise.resolve(body),
   }) as unknown as Request;
+
+// Simple mock storage implementation
+function createMockStorage(files: Record<string, string>): Storage {
+  const get = async (
+    key: string,
+    _options?: { signal?: AbortSignal },
+  ): Promise<{ body: Uint8Array; metadata?: Record<string, string> } | null> => {
+    const content = files[key];
+    if (content === undefined) {
+      return null;
+    }
+    return {
+      body: new TextEncoder().encode(content),
+      metadata: undefined,
+    };
+  };
+
+  return {
+    get,
+    // vitest-ignore: mock storage implementation, type parameters not required
+    // eslint-disable-next-line vitest/require-mock-type-parameters
+    delete: vi.fn(),
+    // eslint-disable-next-line vitest/require-mock-type-parameters
+    deleteMany: vi.fn(),
+    // eslint-disable-next-line vitest/require-mock-type-parameters
+    put: vi.fn(),
+    // eslint-disable-next-line vitest/require-mock-type-parameters
+    list: vi.fn(),
+    // eslint-disable-next-line vitest/require-mock-type-parameters
+    close: vi.fn(),
+  } as unknown as Storage;
+}
+
+const fixturePrefix = "test-fixture";
+const validRequest = {
+  contract_id: "baerly.workload-ceiling/chunked-snapshot/v1" as const,
+  run_id: "test-run-id",
+  scenario_id: "test-scenario",
+  implementation: "monolithic-control" as const,
+  fixture_prefix: fixturePrefix,
+};
+
+// Import encoding functions for proper canonical JSON
+import { encodeWorkloadCeilingRunRequest } from "../../measurement/workload-ceiling-harness.ts";
 
 describe("POST /run authentication fails closed", () => {
   test("a missing secret rejects an empty bearer token", async () => {
@@ -53,5 +106,78 @@ describe("POST /run authentication fails closed", () => {
       env("real-secret"),
     );
     expect(response.status).toBe(400);
+  });
+});
+
+describe("Wrong method/path returns 404", () => {
+  test("returns 404 for GET request", async () => {
+    const request = {
+      method: "GET",
+      url: "https://example.com/run",
+      headers: {
+        get: (name: string): string | null => (name === "authorization" ? "Bearer token" : null),
+      },
+    } as unknown as Request;
+    const response = await worker.fetch(request, env("secret"));
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "not found: POST /run only",
+    });
+  });
+
+  test("returns 404 for wrong path", async () => {
+    const request = {
+      method: "POST",
+      url: "https://example.com/other",
+      headers: {
+        get: (name: string): string | null => (name === "authorization" ? "Bearer token" : null),
+      },
+    } as unknown as Request;
+    const response = await worker.fetch(request, env("secret"));
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("Success path with mocked storage", () => {
+  test("succeeds on monolithic-control implementation", async () => {
+    const mockStorage = createMockStorage({
+      [`${fixturePrefix}/fixture.json`]: JSON.stringify({
+        contract_id: "baerly.workload-ceiling/chunked-snapshot/v1",
+        collection: "test-collection",
+        monolithic_key: `${fixturePrefix}/monolithic.json`,
+        manifest_key: `${fixturePrefix}/manifest.json`,
+        log_seq_start: 0,
+      }),
+      [`${fixturePrefix}/monolithic.json`]: JSON.stringify({
+        rows: [{ _id: "doc1" as const, body: { _id: "doc1" as const, data: "value" } }],
+      }),
+    });
+
+    mockR2BindingStorage.mockReturnValue(mockStorage);
+
+    const body = encodeWorkloadCeilingRunRequest(validRequest);
+    const request = {
+      method: "POST",
+      url: "https://example.com/run",
+      headers: {
+        get: (name: string): string | null => (name === "authorization" ? "Bearer secret" : null),
+      },
+      text: () => Promise.resolve(body),
+    } as unknown as Request;
+
+    const response = await worker.fetch(request, env("secret"));
+    expect(response.status).toBe(200);
+    const result = (await response.json()) as {
+      row_count: number;
+      contract_id: string;
+      run_id: string;
+      scenario_id: string;
+      implementation: string;
+    };
+    expect(result.row_count).toBe(1);
+    expect(result.contract_id).toBe("baerly.workload-ceiling/chunked-snapshot/v1");
+    expect(result.run_id).toBe("test-run-id");
+    expect(result.scenario_id).toBe("test-scenario");
+    expect(result.implementation).toBe("monolithic-control");
   });
 });

--- a/bench/workload-ceiling-worker/src/index.ts
+++ b/bench/workload-ceiling-worker/src/index.ts
@@ -42,9 +42,9 @@ import type { DocumentData, Storage } from "@baerly/protocol";
 import { r2BindingStorage } from "@baerly/adapter-cloudflare";
 import {
   foldChunkedSnapshotReference,
+  openSnapshotView,
   type ReferenceRow,
-} from "../../../packages/server/src/chunked-snapshot-reference.ts";
-import { openSnapshotView } from "../../../packages/server/src/snapshot-view.ts";
+} from "@baerly/server/_internal/testing";
 import {
   decodeWorkloadCeilingRunRequest,
   WORKLOAD_CEILING_CONTRACT_ID,

--- a/bench/workload-ceiling-worker/src/index.ts
+++ b/bench/workload-ceiling-worker/src/index.ts
@@ -1,0 +1,322 @@
+/**
+ * Deployed evidence Worker for the workload-ceiling study (parent plan
+ * Task 8). This module is measurement-only: it is not part of any published
+ * `@gusto/baerly-storage` entry point, it does not run in a user's
+ * application, and importing it changes no production behavior.
+ *
+ * What it does, exactly:
+ *
+ *  1. Accepts one authenticated `POST /run` carrying a
+ *     `WorkloadCeilingRunRequest` (`../../measurement/workload-ceiling-harness.ts`).
+ *  2. Opens the EXACT fixture `workload-ceiling-provision.ts` already wrote
+ *     under `fixture_prefix` — it never provisions one itself.
+ *  3. Awaits ONE controlled fold subject —
+ *     `foldChunkedSnapshotReference(rows, [])`, the same independent logical
+ *     oracle `packages/server/src/chunked-snapshot-reference.test.ts` checks
+ *     the chunk-native view against — over whichever representation
+ *     `implementation` selects.
+ *  4. Emits the run's join identifiers exactly once, as a single structured
+ *     Workers Logs line, and returns the kernel result.
+ *
+ * What it deliberately does NOT do: provision fixtures, aggregate results
+ * across runs, loop or retry, schedule cron, or self-report CPU time. CPU
+ * time is never computed in this module — `Date.now()` / `performance.now()`
+ * do not appear here. The only source of truth for CPU is the platform's own
+ * `workersInvocationsAdaptive` telemetry, retrieved out-of-band by
+ * `../../measurement/workload-ceiling-collect.ts`. See README.md for the
+ * platform documentation this rests on.
+ *
+ * The two `implementation` values read the SAME logical row set through two
+ * different storage shapes that `workload-ceiling-provision.ts` writes side
+ * by side under one `fixture_prefix`:
+ *
+ *  - `monolithic-control` — a single JSON blob (`fixture.json`'s
+ *    `monolithic_key`), the shape of today's shipped single-snapshot format.
+ *  - `chunked-candidate` — the proposed manifest + chunk layout, read
+ *    through `openSnapshotView` (`packages/server/src/snapshot-view.ts`).
+ *
+ * Both feed the identical fold subject, so the comparison isolates the
+ * storage-shape cost, not a difference in what gets computed.
+ */
+import type { DocumentData, Storage } from "@baerly/protocol";
+import { r2BindingStorage } from "@baerly/adapter-cloudflare";
+import {
+  foldChunkedSnapshotReference,
+  type ReferenceRow,
+} from "../../../packages/server/src/chunked-snapshot-reference.ts";
+import { openSnapshotView } from "../../../packages/server/src/snapshot-view.ts";
+import {
+  decodeWorkloadCeilingRunRequest,
+  WORKLOAD_CEILING_CONTRACT_ID,
+  type WorkloadCeilingRunRequest,
+} from "../../measurement/workload-ceiling-harness.ts";
+import { constantTimeEqual } from "./constant-time-equal.ts";
+
+export interface WorkloadCeilingWorkerEnv {
+  readonly BUCKET: R2Bucket;
+  /**
+   * Set via `wrangler secret put WORKLOAD_CEILING_SHARED_SECRET` — a
+   * separate manual step that can be forgotten, so the binding is ABSENT at
+   * runtime in exactly that failure mode. Never a `vars` literal. The fetch
+   * handler fails closed on that absence (and on a blank value) rather than
+   * letting an empty bearer token compare equal against an unset secret.
+   */
+  readonly WORKLOAD_CEILING_SHARED_SECRET: string | undefined;
+}
+
+interface WorkloadCeilingFixtureDescriptor {
+  readonly contract_id: typeof WORKLOAD_CEILING_CONTRACT_ID;
+  readonly collection: string;
+  readonly monolithic_key: string;
+  readonly manifest_key: string;
+  readonly log_seq_start: number;
+}
+
+const FIXTURE_DESCRIPTOR_FIELDS = [
+  "contract_id",
+  "collection",
+  "monolithic_key",
+  "manifest_key",
+  "log_seq_start",
+] as const;
+
+class WorkloadCeilingWorkerError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "WorkloadCeilingWorkerError";
+    this.status = status;
+  }
+}
+
+function parseFixtureDescriptor(bytes: Uint8Array): WorkloadCeilingFixtureDescriptor {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(bytes));
+  } catch (error) {
+    throw new WorkloadCeilingWorkerError(
+      502,
+      `fixture descriptor is not valid JSON: ${String(error)}`,
+    );
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new WorkloadCeilingWorkerError(502, "fixture descriptor must be an object");
+  }
+  const keys = Object.keys(parsed);
+  const expected = new Set<string>(FIXTURE_DESCRIPTOR_FIELDS);
+  if (keys.length !== FIXTURE_DESCRIPTOR_FIELDS.length || !keys.every((key) => expected.has(key))) {
+    throw new WorkloadCeilingWorkerError(
+      502,
+      "fixture descriptor must contain exactly the expected fields",
+    );
+  }
+  const value = parsed as Record<string, unknown>;
+  if (value["contract_id"] !== WORKLOAD_CEILING_CONTRACT_ID) {
+    throw new WorkloadCeilingWorkerError(502, "fixture descriptor contract_id mismatch");
+  }
+  if (typeof value["collection"] !== "string" || value["collection"].trim() === "") {
+    throw new WorkloadCeilingWorkerError(
+      502,
+      "fixture descriptor collection must be a nonempty string",
+    );
+  }
+  if (typeof value["monolithic_key"] !== "string" || value["monolithic_key"].trim() === "") {
+    throw new WorkloadCeilingWorkerError(
+      502,
+      "fixture descriptor monolithic_key must be a nonempty string",
+    );
+  }
+  if (typeof value["manifest_key"] !== "string" || value["manifest_key"].trim() === "") {
+    throw new WorkloadCeilingWorkerError(
+      502,
+      "fixture descriptor manifest_key must be a nonempty string",
+    );
+  }
+  if (!Number.isSafeInteger(value["log_seq_start"]) || (value["log_seq_start"] as number) < 0) {
+    throw new WorkloadCeilingWorkerError(
+      502,
+      "fixture descriptor log_seq_start must be a non-negative safe integer",
+    );
+  }
+  return {
+    contract_id: WORKLOAD_CEILING_CONTRACT_ID,
+    collection: value["collection"],
+    monolithic_key: value["monolithic_key"],
+    manifest_key: value["manifest_key"],
+    log_seq_start: value["log_seq_start"] as number,
+  };
+}
+
+function fixtureDescriptorKey(fixturePrefix: string): string {
+  return `${fixturePrefix}/fixture.json`;
+}
+
+async function loadMonolithicRows(
+  storage: Storage,
+  key: string,
+  signal: AbortSignal,
+): Promise<readonly ReferenceRow[]> {
+  const stored = await storage.get(key, { signal });
+  if (stored === null) {
+    throw new WorkloadCeilingWorkerError(502, `monolithic fixture body is missing: ${key}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(stored.body));
+  } catch (error) {
+    throw new WorkloadCeilingWorkerError(
+      502,
+      `monolithic fixture body is not valid JSON: ${String(error)}`,
+    );
+  }
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    Array.isArray(parsed) ||
+    !("rows" in parsed) ||
+    !Array.isArray((parsed as { rows: unknown }).rows)
+  ) {
+    throw new WorkloadCeilingWorkerError(
+      502,
+      "monolithic fixture body must be an object with a rows array",
+    );
+  }
+  return (parsed as { rows: readonly ReferenceRow[] }).rows;
+}
+
+async function loadChunkedRows(
+  storage: Storage,
+  descriptor: WorkloadCeilingFixtureDescriptor,
+  signal: AbortSignal,
+): Promise<readonly ReferenceRow[]> {
+  const view = await openSnapshotView({
+    storage,
+    manifestKey: descriptor.manifest_key,
+    collection: descriptor.collection,
+    expectedLogSeqStart: descriptor.log_seq_start,
+    signal,
+  });
+  const materialized: Map<string, DocumentData> = await view.materialize(signal);
+  return [...materialized].map(([_id, body]) => ({ _id, body }));
+}
+
+async function runControlledFold(
+  storage: Storage,
+  request: WorkloadCeilingRunRequest,
+  signal: AbortSignal,
+): Promise<{ readonly row_count: number }> {
+  const descriptorStored = await storage.get(fixtureDescriptorKey(request.fixture_prefix), {
+    signal,
+  });
+  if (descriptorStored === null) {
+    throw new WorkloadCeilingWorkerError(
+      502,
+      `fixture descriptor is missing: ${fixtureDescriptorKey(request.fixture_prefix)}`,
+    );
+  }
+  const descriptor = parseFixtureDescriptor(descriptorStored.body);
+  let rows: readonly ReferenceRow[];
+  switch (request.implementation) {
+    case "monolithic-control": {
+      rows = await loadMonolithicRows(storage, descriptor.monolithic_key, signal);
+      break;
+    }
+    case "chunked-candidate": {
+      rows = await loadChunkedRows(storage, descriptor, signal);
+      break;
+    }
+    default: {
+      const exhaustive: never = request.implementation;
+      throw new WorkloadCeilingWorkerError(400, `unknown implementation: ${String(exhaustive)}`);
+    }
+  }
+  const folded = foldChunkedSnapshotReference(rows, []);
+  return { row_count: folded.length };
+}
+
+function bearerToken(request: Request): string | null {
+  const header = request.headers.get("authorization");
+  if (header === null || !header.startsWith("Bearer ")) {
+    return null;
+  }
+  return header.slice("Bearer ".length);
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export default {
+  async fetch(request: Request, env: WorkloadCeilingWorkerEnv): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method !== "POST" || url.pathname !== "/run") {
+      return jsonResponse(404, { error: "not found: POST /run only" });
+    }
+
+    // Fail CLOSED, at the handler — auth policy lives here, not in the
+    // comparator (`constant-time-equal.ts` deliberately pins empty-vs-empty
+    // → true as comparator semantics). Without the secret-side checks an
+    // unset binding makes `constantTimeEqual("", undefined)` compare zero
+    // bytes to zero bytes and authenticate an empty bearer, and a blank
+    // secret would accept a blank token the same way.
+    const token = bearerToken(request);
+    const secret = env.WORKLOAD_CEILING_SHARED_SECRET;
+    if (
+      token === null ||
+      secret === undefined ||
+      secret.trim() === "" ||
+      !constantTimeEqual(token, secret)
+    ) {
+      return jsonResponse(401, { error: "unauthorized" });
+    }
+
+    let runRequest: WorkloadCeilingRunRequest;
+    try {
+      runRequest = decodeWorkloadCeilingRunRequest(await request.text());
+    } catch (error) {
+      return jsonResponse(400, { error: describeError(error) });
+    }
+
+    // Join identifiers, emitted EXACTLY ONCE. `workload-ceiling-collect.ts`
+    // joins the platform's `workersInvocationsAdaptive` telemetry row to
+    // this run by the fixed study Worker's `scriptName` plus a narrow time
+    // window (see README.md); this Workers Logs line is what lets a study
+    // reader independently confirm which run produced which telemetry row.
+    console.log(
+      JSON.stringify({
+        workload_ceiling_run_id: runRequest.run_id,
+        workload_ceiling_scenario_id: runRequest.scenario_id,
+        workload_ceiling_implementation: runRequest.implementation,
+      }),
+    );
+
+    const storage = r2BindingStorage(env.BUCKET);
+    try {
+      // `request.signal` — not a hand-rolled controller that is never
+      // aborted — so an aborted client connection actually cancels the
+      // in-flight storage reads behind the fold.
+      const result = await runControlledFold(storage, runRequest, request.signal);
+      return jsonResponse(200, {
+        contract_id: WORKLOAD_CEILING_CONTRACT_ID,
+        run_id: runRequest.run_id,
+        scenario_id: runRequest.scenario_id,
+        implementation: runRequest.implementation,
+        row_count: result.row_count,
+      });
+    } catch (error) {
+      const status = error instanceof WorkloadCeilingWorkerError ? error.status : 500;
+      return jsonResponse(status, {
+        error: describeError(error),
+        run_id: runRequest.run_id,
+        scenario_id: runRequest.scenario_id,
+      });
+    }
+  },
+} satisfies ExportedHandler<WorkloadCeilingWorkerEnv>;

--- a/bench/workload-ceiling-worker/src/index.ts
+++ b/bench/workload-ceiling-worker/src/index.ts
@@ -46,8 +46,11 @@ import {
   type ReferenceRow,
 } from "@baerly/server/_internal/testing";
 import {
+  decodeWorkloadCeilingFixtureDescriptor,
   decodeWorkloadCeilingRunRequest,
   WORKLOAD_CEILING_CONTRACT_ID,
+  workloadCeilingFixtureDescriptorKey,
+  type WorkloadCeilingFixtureDescriptor,
   type WorkloadCeilingRunRequest,
 } from "../../measurement/workload-ceiling-harness.ts";
 import { constantTimeEqual } from "./constant-time-equal.ts";
@@ -64,22 +67,6 @@ export interface WorkloadCeilingWorkerEnv {
   readonly WORKLOAD_CEILING_SHARED_SECRET: string | undefined;
 }
 
-interface WorkloadCeilingFixtureDescriptor {
-  readonly contract_id: typeof WORKLOAD_CEILING_CONTRACT_ID;
-  readonly collection: string;
-  readonly monolithic_key: string;
-  readonly manifest_key: string;
-  readonly log_seq_start: number;
-}
-
-const FIXTURE_DESCRIPTOR_FIELDS = [
-  "contract_id",
-  "collection",
-  "monolithic_key",
-  "manifest_key",
-  "log_seq_start",
-] as const;
-
 class WorkloadCeilingWorkerError extends Error {
   readonly status: number;
   constructor(status: number, message: string) {
@@ -89,66 +76,21 @@ class WorkloadCeilingWorkerError extends Error {
   }
 }
 
+/**
+ * Runs the descriptor through the SHARED harness codec, then restates any
+ * rejection as a 502. The status matters: a malformed descriptor is a broken
+ * upstream fixture, not a bad request from the caller (whose own body already
+ * decoded cleanly), so it must never be reported as the caller's 400.
+ */
 function parseFixtureDescriptor(bytes: Uint8Array): WorkloadCeilingFixtureDescriptor {
-  let parsed: unknown;
   try {
-    parsed = JSON.parse(new TextDecoder().decode(bytes));
+    return decodeWorkloadCeilingFixtureDescriptor(new TextDecoder().decode(bytes));
   } catch (error) {
     throw new WorkloadCeilingWorkerError(
       502,
-      `fixture descriptor is not valid JSON: ${String(error)}`,
+      `fixture descriptor is unusable: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
-  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new WorkloadCeilingWorkerError(502, "fixture descriptor must be an object");
-  }
-  const keys = Object.keys(parsed);
-  const expected = new Set<string>(FIXTURE_DESCRIPTOR_FIELDS);
-  if (keys.length !== FIXTURE_DESCRIPTOR_FIELDS.length || !keys.every((key) => expected.has(key))) {
-    throw new WorkloadCeilingWorkerError(
-      502,
-      "fixture descriptor must contain exactly the expected fields",
-    );
-  }
-  const value = parsed as Record<string, unknown>;
-  if (value["contract_id"] !== WORKLOAD_CEILING_CONTRACT_ID) {
-    throw new WorkloadCeilingWorkerError(502, "fixture descriptor contract_id mismatch");
-  }
-  if (typeof value["collection"] !== "string" || value["collection"].trim() === "") {
-    throw new WorkloadCeilingWorkerError(
-      502,
-      "fixture descriptor collection must be a nonempty string",
-    );
-  }
-  if (typeof value["monolithic_key"] !== "string" || value["monolithic_key"].trim() === "") {
-    throw new WorkloadCeilingWorkerError(
-      502,
-      "fixture descriptor monolithic_key must be a nonempty string",
-    );
-  }
-  if (typeof value["manifest_key"] !== "string" || value["manifest_key"].trim() === "") {
-    throw new WorkloadCeilingWorkerError(
-      502,
-      "fixture descriptor manifest_key must be a nonempty string",
-    );
-  }
-  if (!Number.isSafeInteger(value["log_seq_start"]) || (value["log_seq_start"] as number) < 0) {
-    throw new WorkloadCeilingWorkerError(
-      502,
-      "fixture descriptor log_seq_start must be a non-negative safe integer",
-    );
-  }
-  return {
-    contract_id: WORKLOAD_CEILING_CONTRACT_ID,
-    collection: value["collection"],
-    monolithic_key: value["monolithic_key"],
-    manifest_key: value["manifest_key"],
-    log_seq_start: value["log_seq_start"] as number,
-  };
-}
-
-function fixtureDescriptorKey(fixturePrefix: string): string {
-  return `${fixturePrefix}/fixture.json`;
 }
 
 async function loadMonolithicRows(
@@ -189,15 +131,30 @@ async function loadChunkedRows(
   descriptor: WorkloadCeilingFixtureDescriptor,
   signal: AbortSignal,
 ): Promise<readonly ReferenceRow[]> {
-  const view = await openSnapshotView({
-    storage,
-    manifestKey: descriptor.manifest_key,
-    collection: descriptor.collection,
-    expectedLogSeqStart: descriptor.log_seq_start,
-    signal,
-  });
-  const materialized: Map<string, DocumentData> = await view.materialize(signal);
-  return [...materialized].map(([_id, body]) => ({ _id, body }));
+  // A manifest or chunk the descriptor references but the bucket does not hold
+  // is a broken upstream fixture — the same 502 the monolithic branch reports
+  // for its missing body, so an operator reads one status class for "your
+  // fixture is incomplete" regardless of which representation was requested.
+  // Kernel errors are restated, never swallowed: `materialize` must not be
+  // allowed to return a short row set, which would understate the candidate's
+  // cost as a cheaper implementation.
+  try {
+    const view = await openSnapshotView({
+      storage,
+      manifestKey: descriptor.manifest_key,
+      collection: descriptor.collection,
+      expectedLogSeqStart: descriptor.log_seq_start,
+      signal,
+    });
+    const materialized: Map<string, DocumentData> = await view.materialize(signal);
+    return [...materialized].map(([_id, body]) => ({ _id, body }));
+  } catch (error) {
+    signal.throwIfAborted();
+    throw new WorkloadCeilingWorkerError(
+      502,
+      `chunked fixture is unreadable: ${describeError(error)}`,
+    );
+  }
 }
 
 async function runControlledFold(
@@ -205,14 +162,10 @@ async function runControlledFold(
   request: WorkloadCeilingRunRequest,
   signal: AbortSignal,
 ): Promise<{ readonly row_count: number }> {
-  const descriptorStored = await storage.get(fixtureDescriptorKey(request.fixture_prefix), {
-    signal,
-  });
+  const descriptorKey = workloadCeilingFixtureDescriptorKey(request.fixture_prefix);
+  const descriptorStored = await storage.get(descriptorKey, { signal });
   if (descriptorStored === null) {
-    throw new WorkloadCeilingWorkerError(
-      502,
-      `fixture descriptor is missing: ${fixtureDescriptorKey(request.fixture_prefix)}`,
-    );
+    throw new WorkloadCeilingWorkerError(502, `fixture descriptor is missing: ${descriptorKey}`);
   }
   const descriptor = parseFixtureDescriptor(descriptorStored.body);
   let rows: readonly ReferenceRow[];

--- a/bench/workload-ceiling-worker/wrangler.jsonc
+++ b/bench/workload-ceiling-worker/wrangler.jsonc
@@ -15,7 +15,7 @@
   "name": "baerly-storage",
   "main": "./src/index.ts",
   "compatibility_date": "2026-08-15",
-  "compatibility_flags": ["nodejs_compat"],
+  "compatibility_flags": [],
 
   "r2_buckets": [
     {

--- a/bench/workload-ceiling-worker/wrangler.jsonc
+++ b/bench/workload-ceiling-worker/wrangler.jsonc
@@ -1,0 +1,31 @@
+{
+  // Deployed evidence Worker for the workload-ceiling study (parent plan
+  // Task 8). See README.md for what this Worker does, what it deliberately
+  // does not do, and the platform documentation this config rests on.
+  //
+  // Reuses "baerly-storage" — one already-deployed Worker overwritten in
+  // place for each Step 10 smoke run, rather than a uniquely-named
+  // per-run deployment. See README.md §"Join mechanism" and §"Token scope"
+  // for why, and `WORKLOAD_CEILING_WORKER_NAME` in
+  // ../measurement/workload-ceiling-collect.ts, which this name must match.
+  // Not deployed by `pnpm verify`/`pnpm test` — only via deploy.mjs, and
+  // only with CF_API_TOKEN/CF_ACCOUNT_ID or credentials/cloudflare-deploy.json
+  // provisioned first.
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "baerly-storage",
+  "main": "./src/index.ts",
+  "compatibility_date": "2026-08-15",
+  "compatibility_flags": ["nodejs_compat"],
+
+  "r2_buckets": [
+    {
+      "binding": "BUCKET",
+      "bucket_name": "baerly-storage-eval",
+    },
+  ],
+
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+  },
+}

--- a/bench/workload-ceiling-worker/wrangler.jsonc
+++ b/bench/workload-ceiling-worker/wrangler.jsonc
@@ -17,6 +17,14 @@
   "compatibility_date": "2026-08-15",
   "compatibility_flags": [],
 
+  // `bucket_name` MUST match `WORKLOAD_CEILING_BUCKET_NAME` in
+  // ../measurement/workload-ceiling-harness.ts, which is also the bucket
+  // `credentials/cloudflare.json` must name — provisioning writes fixtures
+  // there, and this binding is the only place the Worker looks for them.
+  // JSONC cannot import the constant, so the name is repeated here;
+  // `pnpm bench:workload-ceiling:provision` preflights the credentials file
+  // against it and refuses to write on a mismatch, which would otherwise
+  // surface only as a 502 "fixture descriptor is missing" per run.
   "r2_buckets": [
     {
       "binding": "BUCKET",

--- a/package.json
+++ b/package.json
@@ -227,7 +227,10 @@
     "bench:maintenance-backlog": "node --import ./bench/register-hooks.mjs bench/maintenance-backlog.ts",
     "bench:amortized-write-cost": "node --import ./bench/register-hooks.mjs bench/amortized-write-cost.ts",
     "bench:write-amp-stress": "node --import ./bench/register-hooks.mjs bench/write-amp-stress.ts",
-    "bench:collection-fanout": "node --import ./bench/register-hooks.mjs bench/collection-fanout.ts"
+    "bench:collection-fanout": "node --import ./bench/register-hooks.mjs bench/collection-fanout.ts",
+    "bench:workload-ceiling:provision": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-provision.ts",
+    "bench:workload-ceiling:collect": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-collect.ts",
+    "bench:workload-ceiling:compare": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-compare.ts"
   },
   "dependencies": {
     "@logtape/logtape": "2.2.4"

--- a/packages/server/src/_internal/testing.ts
+++ b/packages/server/src/_internal/testing.ts
@@ -34,3 +34,15 @@ export {
   type SnapshotChunkDescriptor,
   type SnapshotManifest,
 } from "../snapshot-manifest.ts";
+export {
+  foldChunkedSnapshotReference,
+  type ReferenceFold,
+  type ReferenceMutation,
+  type ReferenceRow,
+} from "../chunked-snapshot-reference.ts";
+export {
+  openSnapshotView,
+  type OpenSnapshotViewInput,
+  type SnapshotRow,
+  type SnapshotView,
+} from "../snapshot-view.ts";

--- a/packages/server/src/_internal/testing.ts
+++ b/packages/server/src/_internal/testing.ts
@@ -21,3 +21,16 @@ export {
   tryAdoptOwnSessionLogEntry,
 } from "../log-conflict-adoption.ts";
 export { InMemoryMetricsRecorder } from "./in-memory-metrics.ts";
+export {
+  decodeSnapshotChunk,
+  encodeSnapshotChunk,
+  snapshotChunkKey,
+  type SnapshotChunk,
+} from "../snapshot-chunk.ts";
+export {
+  decodeSnapshotManifest,
+  encodeSnapshotManifest,
+  snapshotManifestKey,
+  type SnapshotChunkDescriptor,
+  type SnapshotManifest,
+} from "../snapshot-manifest.ts";

--- a/tests/fixtures/endpoint-creds.ts
+++ b/tests/fixtures/endpoint-creds.ts
@@ -33,3 +33,32 @@ export async function loadEndpointCreds(file: string): Promise<EndpointCreds | n
     return null;
   }
 }
+
+/**
+ * Shape of `credentials/cloudflare-deploy.json` (gitignored) — a Cloudflare
+ * API token (`Workers Scripts:Edit`, `R2:Edit`, `Account:Read` scopes, per
+ * `docs/contributing/day-one-gate.md`) plus account id, repo-scoped so
+ * neither has to live in shell env or a global dotfile. Deliberately a
+ * separate file from `cloudflare.json`: that one holds R2's S3-family
+ * `EndpointCreds` shape, this one holds wrangler/GraphQL-Analytics-API auth,
+ * and the two are read by different tools for different purposes.
+ */
+export interface CloudflareDeployCreds {
+  api_token: string;
+  account_id: string;
+}
+
+/**
+ * Read `credentials/cloudflare-deploy.json` and parse it as
+ * {@link CloudflareDeployCreds}, or return `null` when the file is
+ * absent/unreadable — the same credential-gated skip signal as
+ * {@link loadEndpointCreds}.
+ */
+export async function loadCloudflareDeployCreds(): Promise<CloudflareDeployCreds | null> {
+  try {
+    const raw = await readFile(join("credentials", "cloudflare-deploy.json"), "utf8");
+    return JSON.parse(raw) as CloudflareDeployCreds;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What & why

Adds the local half of the Task 8 evidence harness for the workload-ceiling study preregistered in #146: strict wire codecs for the run request/raw telemetry event, exact fixture provisioning that materializes one row set into both the monolithic and chunked storage shapes, a minimal deployed study Worker that runs one controlled fold and never self-reports CPU, telemetry collection via Cloudflare's GraphQL Analytics API, and control/candidate comparison built on `statistics.ts`. The second commit switches the Worker from a unique-per-run deployment to reusing one fixed-name Worker, moving disambiguation from `scriptName` alone to `scriptName` plus a narrow datetime window.

The live Cloudflare smoke run is deferred — no `CF_API_TOKEN`/`CF_ACCOUNT_ID` or `credentials/cloudflare.json` in this environment.

## Key points

- CPU time is never self-reported: a Worker can't observe the runtime's own CPU-limit enforcement from inside the isolate, so the only source of truth is the platform's own `workersInvocationsAdaptive` telemetry, retrieved out-of-band.
- Token scope is narrowed in code, not just by policy: `deploy.mjs` refuses any `wrangler` subcommand whose `--name` isn't exactly `baerly-storage`, since Cloudflare's API token model has no per-script resource type.
- The `chunked-candidate` fold path opens `SnapshotView` from #147 (merged), which this branch builds on directly.

## Verification

Not independently re-run for this PR; author validated locally, CI runs the full gate on the PR.

## Notes for reviewers

Builds on #146 (workload-ceiling contract preregistration, merged) and #147 (chunk-native view, merged). The actual deployed smoke run isn't performed by this PR or by `pnpm verify`/`pnpm test` — see `bench/workload-ceiling-worker/README.md`'s "Deploying" section.