### PR TITLE
refactor(snapshot): consolidate chunked-snapshot codec helpers

### DIFF
--- a/bench/measurement/workload-ceiling-contract.ts
+++ b/bench/measurement/workload-ceiling-contract.ts
@@ -120,7 +120,10 @@ export const WORKLOAD_CEILING_STUDY = {
 /**
  * The study's deliberately small admission predicate. It evaluates only
  * preregistered evidence fields; provision, collection, and telemetry details
- * remain the concern of the later measurement harness.
+ * remain the concern of the later measurement harness. The `admission`
+ * `requires_*` flags are the declarative record of these requirements — each
+ * is pinned to `true` by the contract type, so the predicate asserts the
+ * requirements directly rather than guarding on flags that can never flip.
  */
 export const satisfiesWorkloadCeilingAdmission = (
   evidence: WorkloadCeilingStudyEvidence,
@@ -130,10 +133,10 @@ export const satisfiesWorkloadCeilingAdmission = (
     admission.accepted_evidence_sources;
 
   return (
-    (!admission.requires_deployed_workers || acceptedSources.includes(evidence.source)) &&
+    acceptedSources.includes(evidence.source) &&
     evidence.profile === admission.primary_profile &&
-    (!admission.requires_zero_failures_upper_bound || evidence.has_zero_failures_upper_bound) &&
+    evidence.has_zero_failures_upper_bound &&
     admission.required_statistics.every((statistic) => evidence.statistics.includes(statistic)) &&
-    (!admission.requires_repeated_tail_drain || evidence.has_repeated_tail_drain)
+    evidence.has_repeated_tail_drain
   );
 };

--- a/packages/server/src/chunked-snapshot-reference.test.ts
+++ b/packages/server/src/chunked-snapshot-reference.test.ts
@@ -173,6 +173,26 @@ describe("chunked snapshot reference fold", () => {
       ),
     );
   });
+
+  test("normalizes pathological row and mutation nesting as BaerlyError", () => {
+    const depth = 100_000;
+    let nested: unknown = true;
+    for (let level = 0; level < depth; level++) {
+      nested = [nested];
+    }
+    expectInvalidResponse(() =>
+      foldChunkedSnapshotReference(
+        [{ _id: "a", body: { _id: "a", value: nested } as unknown as DocumentData }],
+        [],
+      ),
+    );
+    expectInvalidResponse(() =>
+      foldChunkedSnapshotReference(
+        [],
+        [{ op: "I", doc_id: "a", after: { _id: "a", value: nested } as unknown as DocumentData }],
+      ),
+    );
+  });
 });
 
 const idArb = fc.oneof(

--- a/packages/server/src/chunked-snapshot-reference.ts
+++ b/packages/server/src/chunked-snapshot-reference.ts
@@ -1,5 +1,10 @@
-import { BaerlyError, type DocumentData, type DocumentValue } from "@baerly/protocol";
-import { assertCodecDocId, normalizeCodecFailure } from "./snapshot-codec.ts";
+import type { DocumentData, DocumentValue } from "@baerly/protocol";
+import {
+  assertCodecDocId,
+  type CodecCode,
+  makeCodecFail,
+  normalizeCodecFailure,
+} from "./snapshot-codec.ts";
 import { compareDocIds } from "./snapshot-doc-id.ts";
 
 export interface ReferenceRow {
@@ -20,12 +25,9 @@ export type ReferenceFold = (
   mutations: readonly ReferenceMutation[],
 ) => readonly ReferenceRow[];
 
-function invalid(
-  code: "InvalidConfig" | "InvalidResponse",
-  message: string,
-  cause?: unknown,
-): never {
-  throw new BaerlyError(code, `chunked snapshot reference: ${message}`, cause);
+const failReference = makeCodecFail("chunked snapshot reference");
+function invalid(code: CodecCode, message: string, cause?: unknown): never {
+  return failReference(code, message, cause);
 }
 
 function assertDocumentValue(value: unknown, where: string, ancestors: Set<object>): void {

--- a/packages/server/src/chunked-snapshot-reference.ts
+++ b/packages/server/src/chunked-snapshot-reference.ts
@@ -1,5 +1,6 @@
 import { BaerlyError, type DocumentData, type DocumentValue } from "@baerly/protocol";
-import { assertSnapshotDocId, compareDocIds } from "./snapshot-doc-id.ts";
+import { assertCodecDocId, normalizeCodecFailure } from "./snapshot-codec.ts";
+import { compareDocIds } from "./snapshot-doc-id.ts";
 
 export interface ReferenceRow {
   readonly _id: string;
@@ -19,19 +20,12 @@ export type ReferenceFold = (
   mutations: readonly ReferenceMutation[],
 ) => readonly ReferenceRow[];
 
-function invalid(message: string, cause?: unknown): never {
-  throw new BaerlyError("InvalidResponse", `chunked snapshot reference: ${message}`, cause);
-}
-
-function assertStoredDocId(value: unknown, where: string): asserts value is string {
-  if (typeof value !== "string") {
-    invalid(`${where} must be a string`);
-  }
-  try {
-    assertSnapshotDocId(value);
-  } catch (error) {
-    invalid(`${where} is invalid`, error);
-  }
+function invalid(
+  code: "InvalidConfig" | "InvalidResponse",
+  message: string,
+  cause?: unknown,
+): never {
+  throw new BaerlyError(code, `chunked snapshot reference: ${message}`, cause);
 }
 
 function assertDocumentValue(value: unknown, where: string, ancestors: Set<object>): void {
@@ -40,36 +34,36 @@ function assertDocumentValue(value: unknown, where: string, ancestors: Set<objec
   }
   if (typeof value === "number") {
     if (!Number.isFinite(value)) {
-      invalid(`${where} must contain only finite numbers`);
+      invalid("InvalidResponse", `${where} must contain only finite numbers`);
     }
     return;
   }
   if (value === null || typeof value !== "object") {
-    invalid(`${where} contains a value outside DocumentData`);
+    invalid("InvalidResponse", `${where} contains a value outside DocumentData`);
   }
   if (ancestors.has(value)) {
-    invalid(`${where} contains a cycle`);
+    invalid("InvalidResponse", `${where} contains a cycle`);
   }
   ancestors.add(value);
   if (Array.isArray(value)) {
     for (let index = 0; index < value.length; index++) {
       if (!Object.hasOwn(value, index)) {
-        invalid(`${where} contains a sparse array`);
+        invalid("InvalidResponse", `${where} contains a sparse array`);
       }
       assertDocumentValue(value[index], `${where}[${index}]`, ancestors);
     }
   } else {
     const prototype = Object.getPrototypeOf(value);
     if (prototype !== Object.prototype && prototype !== null) {
-      invalid(`${where} must contain only plain objects`);
+      invalid("InvalidResponse", `${where} must contain only plain objects`);
     }
     if (Object.getOwnPropertySymbols(value).length !== 0) {
-      invalid(`${where} must not contain symbol keys`);
+      invalid("InvalidResponse", `${where} must not contain symbol keys`);
     }
     const descriptors = Object.getOwnPropertyDescriptors(value);
     for (const [key, descriptor] of Object.entries(descriptors)) {
       if (!descriptor.enumerable || !("value" in descriptor)) {
-        invalid(`${where}.${key} must be an enumerable data property`);
+        invalid("InvalidResponse", `${where}.${key} must be an enumerable data property`);
       }
       assertDocumentValue(descriptor.value, `${where}.${key}`, ancestors);
     }
@@ -79,19 +73,22 @@ function assertDocumentValue(value: unknown, where: string, ancestors: Set<objec
 
 function assertDocument(value: unknown, id: string, where: string): asserts value is DocumentData {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    invalid(`${where} must be a document object`);
+    invalid("InvalidResponse", `${where} must be a document object`);
   }
   assertDocumentValue(value, where, new Set<object>());
   const storedId = Object.getOwnPropertyDescriptor(value, "_id")?.value;
-  assertStoredDocId(storedId, `${where}._id`);
+  assertCodecDocId(storedId, `${where}._id`, "InvalidResponse", invalid);
   if (storedId !== id) {
-    invalid(`${where}._id must equal ${where === "row.body" ? "row._id" : "mutation.doc_id"}`);
+    invalid(
+      "InvalidResponse",
+      `${where}._id must equal ${where === "row.body" ? "row._id" : "mutation.doc_id"}`,
+    );
   }
 }
 
 function assertObject(value: unknown, where: string): asserts value is Record<string, unknown> {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    invalid(`${where} must be an object`);
+    invalid("InvalidResponse", `${where} must be an object`);
   }
 }
 
@@ -117,45 +114,51 @@ function cloneAndFreezeValue(value: DocumentValue): DocumentValue {
 const cloneAndFreezeDocument = (document: DocumentData): DocumentData =>
   cloneAndFreezeValue(document) as DocumentData;
 
-export const foldChunkedSnapshotReference: ReferenceFold = (rows, mutations) => {
-  if (!Array.isArray(rows)) {
-    invalid("rows must be an array");
-  }
-  if (!Array.isArray(mutations)) {
-    invalid("mutations must be an array");
-  }
+export const foldChunkedSnapshotReference: ReferenceFold = (rows, mutations) =>
+  normalizeCodecFailure(
+    invalid,
+    "InvalidResponse",
+    "rows or mutations exceed supported validation depth",
+    () => {
+      if (!Array.isArray(rows)) {
+        invalid("InvalidResponse", "rows must be an array");
+      }
+      if (!Array.isArray(mutations)) {
+        invalid("InvalidResponse", "mutations must be an array");
+      }
 
-  const documents = new Map<string, DocumentData>();
-  for (const candidate of rows as readonly unknown[]) {
-    assertObject(candidate, "row");
-    assertStoredDocId(candidate["_id"], "row._id");
-    const id = candidate["_id"];
-    assertDocument(candidate["body"], id, "row.body");
-    if (documents.has(id)) {
-      invalid("rows contain a duplicate _id");
-    }
-    documents.set(id, cloneAndFreezeDocument(candidate["body"]));
-  }
+      const documents = new Map<string, DocumentData>();
+      for (const candidate of rows as readonly unknown[]) {
+        assertObject(candidate, "row");
+        assertCodecDocId(candidate["_id"], "row._id", "InvalidResponse", invalid);
+        const id = candidate["_id"];
+        assertDocument(candidate["body"], id, "row.body");
+        if (documents.has(id)) {
+          invalid("InvalidResponse", "rows contain a duplicate _id");
+        }
+        documents.set(id, cloneAndFreezeDocument(candidate["body"]));
+      }
 
-  for (const candidate of mutations as readonly unknown[]) {
-    assertObject(candidate, "mutation");
-    const op = candidate["op"];
-    if (op !== "I" && op !== "U" && op !== "D") {
-      invalid("mutation.op must be I, U, or D");
-    }
-    assertStoredDocId(candidate["doc_id"], "mutation.doc_id");
-    const id = candidate["doc_id"];
-    if (op === "D") {
-      documents.delete(id);
-    } else {
-      assertDocument(candidate["after"], id, "mutation.after");
-      documents.set(id, cloneAndFreezeDocument(candidate["after"]));
-    }
-  }
+      for (const candidate of mutations as readonly unknown[]) {
+        assertObject(candidate, "mutation");
+        const op = candidate["op"];
+        if (op !== "I" && op !== "U" && op !== "D") {
+          invalid("InvalidResponse", "mutation.op must be I, U, or D");
+        }
+        assertCodecDocId(candidate["doc_id"], "mutation.doc_id", "InvalidResponse", invalid);
+        const id = candidate["doc_id"];
+        if (op === "D") {
+          documents.delete(id);
+        } else {
+          assertDocument(candidate["after"], id, "mutation.after");
+          documents.set(id, cloneAndFreezeDocument(candidate["after"]));
+        }
+      }
 
-  return Object.freeze(
-    [...documents]
-      .map(([_id, body]) => Object.freeze({ _id, body }))
-      .toSorted((left, right) => compareDocIds(left._id, right._id)),
+      return Object.freeze(
+        [...documents]
+          .map(([_id, body]) => Object.freeze({ _id, body }))
+          .toSorted((left, right) => compareDocIds(left._id, right._id)),
+      );
+    },
   );
-};

--- a/packages/server/src/log-retirement-aba.test.ts
+++ b/packages/server/src/log-retirement-aba.test.ts
@@ -165,7 +165,10 @@ describe("log retirement vs. the numbered-log create", () => {
     await advanceFloorAndRetire(inner);
     gate.release();
 
-    await expect(pausedCommit).rejects.toMatchObject({ code: "AmbiguousCommit" });
+    await expect(pausedCommit).rejects.toMatchObject({
+      code: "AmbiguousCommit",
+      retriable: false,
+    });
     const visible = await Db.create({ storage: inner, app: "a", tenant: "t" })
       .collection("c")
       .get(DOC_ID);
@@ -195,35 +198,14 @@ describe("log retirement vs. the numbered-log create", () => {
     await advanceFloorAndRetire(inner);
     gate.release();
 
-    await expect(pausedCommit).rejects.toMatchObject({ code: "AmbiguousCommit" });
-    const visible = await Db.create({ storage: inner, app: "a", tenant: "t" })
-      .collection("c")
-      .get(DOC_ID);
-    expect(visible).toBeUndefined();
-  });
-
-  test("the ambiguous failure is not retriable", async () => {
-    const inner = new MemoryStorage();
-    await seedManifest(inner);
-    const gate = gatedPutStorage(inner, logObjectKey(PREFIX, 0), "delay");
-
-    const pausedCommit = runWithContext(MAINTENANCE_OFF, () =>
-      new Writer({ storage: gate.storage, currentJsonKey: CURRENT_KEY }).commit({
-        op: "I",
-        collection: "c",
-        docId: DOC_ID,
-        body: { ...DOC_BODY },
-      }),
-    );
-    await gate.reached;
-    await seedLogEntry(inner, PREFIX, 0, { doc_id: "peer-doc", after: { _id: "peer-doc" } });
-    await advanceFloorAndRetire(inner);
-    gate.release();
-
     await expect(pausedCommit).rejects.toMatchObject({
       code: "AmbiguousCommit",
       retriable: false,
     });
+    const visible = await Db.create({ storage: inner, app: "a", tenant: "t" })
+      .collection("c")
+      .get(DOC_ID);
+    expect(visible).toBeUndefined();
   });
 
   test('a rejected commit records db.write.ambiguous_commit_total with cleanup="deleted"', async () => {

--- a/packages/server/src/snapshot-chunk.ts
+++ b/packages/server/src/snapshot-chunk.ts
@@ -4,36 +4,33 @@ import {
   type DocumentData,
   type DocumentValue,
   encodeJsonBytes,
-  MAX_KEY_BYTES,
   snapshotHash,
 } from "@baerly/protocol";
 import { assertKeyWithinLimit } from "./key-limit.ts";
 import { assertPathSegment } from "./path-segment.ts";
-import { assertSnapshotDocId, compareDocIds } from "./snapshot-doc-id.ts";
+import {
+  assertCodecDocId,
+  assertExactFields,
+  DIGEST_PATTERN,
+  equalBytes,
+  INCARNATION_PATTERN,
+  MAX_CHUNK_BYTES,
+  MAX_CHUNK_ROWS,
+  normalizeCodecFailure,
+  parseArtifactKey,
+} from "./snapshot-codec.ts";
+import { compareDocIds } from "./snapshot-doc-id.ts";
 import type { SnapshotChunkDescriptor } from "./snapshot-manifest.ts";
 
 const SNAPSHOT_CHUNK_SCHEMA_VERSION = 2;
-const MAX_CHUNK_BYTES = 1024 * 1024;
-const MAX_CHUNK_ROWS = 4096;
-const INCARNATION_PATTERN = /^[0-9a-f]{32}$/;
-const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
-const CHUNK_KEY_PATTERN =
-  /^(.+)\/_v2\/snapshot\/chunks\/([0-9a-f]{32})\/sha256\/([0-9a-f]{64})\.json$/;
-const utf8 = new TextEncoder();
 
 export interface SnapshotChunk {
-  readonly schema_version: number;
+  readonly schema_version: typeof SNAPSHOT_CHUNK_SCHEMA_VERSION;
   readonly collection: string;
   readonly incarnation: string;
   readonly first_id: string;
   readonly last_id: string;
   readonly docs: readonly DocumentData[];
-}
-
-interface ParsedChunkKey {
-  readonly prefix: string;
-  readonly incarnation: string;
-  readonly digest: string;
 }
 
 function invalid(
@@ -44,45 +41,6 @@ function invalid(
   throw new BaerlyError(code, `snapshot chunk: ${message}`, cause);
 }
 
-function normalizeCodecFailure<T>(
-  code: "InvalidConfig" | "InvalidResponse",
-  operation: () => T,
-): T {
-  try {
-    return operation();
-  } catch (error) {
-    if (error instanceof BaerlyError) {
-      throw error;
-    }
-    invalid(code, "body exceeds supported JSON validation depth", error);
-  }
-}
-
-function assertExactFields(
-  value: unknown,
-  expected: readonly string[],
-  where: string,
-  code: "InvalidConfig" | "InvalidResponse",
-): asserts value is Record<string, unknown> {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    invalid(code, `${where} must be an object`);
-  }
-  const prototype = Object.getPrototypeOf(value);
-  const descriptors = Object.getOwnPropertyDescriptors(value);
-  const keys = Object.keys(descriptors);
-  if (
-    (prototype !== Object.prototype && prototype !== null) ||
-    Object.getOwnPropertySymbols(value).length !== 0 ||
-    keys.length !== expected.length ||
-    expected.some((key) => {
-      const descriptor = descriptors[key];
-      return descriptor === undefined || !descriptor.enumerable || !("value" in descriptor);
-    })
-  ) {
-    invalid(code, `${where} must contain exactly the required fields`);
-  }
-}
-
 function assertCallerSegment(value: unknown, role: string): asserts value is string {
   if (typeof value !== "string") {
     invalid("InvalidConfig", `${role} must be a string`);
@@ -91,17 +49,6 @@ function assertCallerSegment(value: unknown, role: string): asserts value is str
     assertPathSegment(value, role);
   } catch (error) {
     invalid("InvalidConfig", `${role} is invalid`, error);
-  }
-}
-
-function assertStoredDocId(value: unknown, where: string): asserts value is string {
-  if (typeof value !== "string") {
-    invalid("InvalidResponse", `${where} must be a string`);
-  }
-  try {
-    assertSnapshotDocId(value);
-  } catch (error) {
-    invalid("InvalidResponse", `${where} is invalid`, error);
   }
 }
 
@@ -215,16 +162,7 @@ function canonicalizeDocument(
     new Set<object>(),
   ) as DocumentData;
   const id = Object.getOwnPropertyDescriptor(canonical, "_id")?.value;
-  if (code === "InvalidConfig") {
-    assertCallerSegment(id, `${where}._id`);
-    try {
-      assertSnapshotDocId(id);
-    } catch (error) {
-      invalid(code, `${where}._id is invalid`, error);
-    }
-  } else {
-    assertStoredDocId(id, `${where}._id`);
-  }
+  assertCodecDocId(id, `${where}._id`, code, invalid);
   return canonical;
 }
 
@@ -237,6 +175,7 @@ function canonicalizeChunk(
     ["schema_version", "collection", "incarnation", "first_id", "last_id", "docs"],
     "body",
     code,
+    invalid,
   );
   if (value["schema_version"] !== SNAPSHOT_CHUNK_SCHEMA_VERSION) {
     invalid(code, "unsupported schema_version");
@@ -281,33 +220,20 @@ function canonicalizeChunk(
   };
 }
 
-function parseChunkKey(key: string, code: "InvalidConfig" | "InvalidResponse"): ParsedChunkKey {
-  if (utf8.encode(key).byteLength > MAX_KEY_BYTES) {
-    invalid(code, `key exceeds ${MAX_KEY_BYTES} bytes`);
-  }
-  const match = CHUNK_KEY_PATTERN.exec(key);
-  if (match === null) {
-    invalid(code, "key does not match the schema-v2 chunk grammar");
-  }
-  if (match[1]!.endsWith("/")) {
-    invalid(code, "key collection prefix contains an empty trailing segment");
-  }
-  return { prefix: match[1]!, incarnation: match[2]!, digest: match[3]! };
-}
-
-function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
-  return left.byteLength === right.byteLength && left.every((byte, index) => byte === right[index]);
-}
-
 export const encodeSnapshotChunk = (chunk: SnapshotChunk): Uint8Array => {
-  return normalizeCodecFailure("InvalidConfig", () => {
-    const canonical = canonicalizeChunk(chunk, "InvalidConfig");
-    const bytes = encodeJsonBytes(canonical);
-    if (bytes.byteLength > MAX_CHUNK_BYTES) {
-      invalid("InvalidConfig", `canonical body exceeds ${MAX_CHUNK_BYTES} bytes`);
-    }
-    return bytes;
-  });
+  return normalizeCodecFailure(
+    invalid,
+    "InvalidConfig",
+    "body exceeds supported JSON validation depth",
+    () => {
+      const canonical = canonicalizeChunk(chunk, "InvalidConfig");
+      const bytes = encodeJsonBytes(canonical);
+      if (bytes.byteLength > MAX_CHUNK_BYTES) {
+        invalid("InvalidConfig", `canonical body exceeds ${MAX_CHUNK_BYTES} bytes`);
+      }
+      return bytes;
+    },
+  );
 };
 
 export const snapshotChunkKey = (
@@ -339,7 +265,7 @@ export const decodeSnapshotChunk = async (
     invalid("InvalidResponse", "body length is outside the chunk ceiling");
   }
   const bodyBytes = bytes.slice();
-  const parsedKey = parseChunkKey(key, "InvalidResponse");
+  const parsedKey = parseArtifactKey(key, "chunk", "InvalidResponse", invalid);
   if (descriptor.key !== key || descriptor.byte_length !== bodyBytes.byteLength) {
     invalid("InvalidResponse", "body does not match its descriptor key or byte length");
   }
@@ -354,14 +280,19 @@ export const decodeSnapshotChunk = async (
   } catch (error) {
     invalid("InvalidResponse", "body is not valid JSON", error);
   }
-  const canonical = normalizeCodecFailure("InvalidResponse", () => {
-    const value = canonicalizeChunk(parsed, "InvalidResponse");
-    const canonicalBytes = encodeJsonBytes(value);
-    if (!equalBytes(bodyBytes, canonicalBytes)) {
-      invalid("InvalidResponse", "body is not canonical JSON");
-    }
-    return value;
-  });
+  const canonical = normalizeCodecFailure(
+    invalid,
+    "InvalidResponse",
+    "body exceeds supported JSON validation depth",
+    () => {
+      const value = canonicalizeChunk(parsed, "InvalidResponse");
+      const canonicalBytes = encodeJsonBytes(value);
+      if (!equalBytes(bodyBytes, canonicalBytes)) {
+        invalid("InvalidResponse", "body is not canonical JSON");
+      }
+      return value;
+    },
+  );
   if (canonical.collection !== expectedCollection) {
     invalid("InvalidResponse", "body collection does not match the expected collection");
   }

--- a/packages/server/src/snapshot-chunk.ts
+++ b/packages/server/src/snapshot-chunk.ts
@@ -1,5 +1,4 @@
 import {
-  BaerlyError,
   decodeJsonBytes,
   type DocumentData,
   type DocumentValue,
@@ -11,9 +10,11 @@ import { assertPathSegment } from "./path-segment.ts";
 import {
   assertCodecDocId,
   assertExactFields,
+  type CodecCode,
   DIGEST_PATTERN,
   equalBytes,
   INCARNATION_PATTERN,
+  makeCodecFail,
   MAX_CHUNK_BYTES,
   MAX_CHUNK_ROWS,
   normalizeCodecFailure,
@@ -33,12 +34,9 @@ export interface SnapshotChunk {
   readonly docs: readonly DocumentData[];
 }
 
-function invalid(
-  code: "InvalidConfig" | "InvalidResponse",
-  message: string,
-  cause?: unknown,
-): never {
-  throw new BaerlyError(code, `snapshot chunk: ${message}`, cause);
+const failChunk = makeCodecFail("snapshot chunk");
+function invalid(code: CodecCode, message: string, cause?: unknown): never {
+  return failChunk(code, message, cause);
 }
 
 function assertCallerSegment(value: unknown, role: string): asserts value is string {

--- a/packages/server/src/snapshot-codec.ts
+++ b/packages/server/src/snapshot-codec.ts
@@ -1,0 +1,137 @@
+import { BaerlyError, MAX_KEY_BYTES } from "@baerly/protocol";
+import { assertSnapshotDocId } from "./snapshot-doc-id.ts";
+
+/**
+ * Machinery shared by the strict chunked-snapshot artifact codecs
+ * (`snapshot-chunk.ts`, `snapshot-manifest.ts`) and the reference fold
+ * (`chunked-snapshot-reference.ts`).
+ *
+ * Every helper reports failures through the caller's `fail` function so each
+ * codec keeps its own artifact-scoped message prefix (`snapshot chunk: …`,
+ * `snapshot manifest: …`, `chunked snapshot reference: …`) and error code,
+ * while the validation logic itself exists exactly once. Layout invariants
+ * come from ADR-007 (docs/adr/007-chunked-snapshot-layout.md).
+ */
+
+/** Failure polarity of a codec check: caller ingress vs. stored data. */
+export type CodecCode = "InvalidConfig" | "InvalidResponse";
+
+/** Artifact-scoped failure constructor bound by each codec. */
+export type CodecFail = (code: CodecCode, message: string, cause?: unknown) => never;
+
+/** Chunk bodies encode to at most 1 MiB of canonical bytes (ADR-007). */
+export const MAX_CHUNK_BYTES = 1024 * 1024;
+
+/** A chunk is never empty and carries at most 4,096 rows (ADR-007). */
+export const MAX_CHUNK_ROWS = 4096;
+
+/** `incarnation` is 32 lowercase hex characters (ADR-007). */
+export const INCARNATION_PATTERN = /^[0-9a-f]{32}$/;
+
+/** Artifact digests are 64 lowercase hex characters (ADR-007). */
+export const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
+
+/** The only chunk key grammar under a collection prefix (ADR-007). */
+export const CHUNK_KEY_PATTERN =
+  /^(.+)\/_v2\/snapshot\/chunks\/([0-9a-f]{32})\/sha256\/([0-9a-f]{64})\.json$/;
+
+/** The only manifest key grammar under a collection prefix (ADR-007). */
+export const MANIFEST_KEY_PATTERN =
+  /^(.+)\/_v2\/snapshot\/manifests\/([0-9a-f]{32})\/sha256\/([0-9a-f]{64})\.json$/;
+
+const utf8 = new TextEncoder();
+
+/**
+ * Convert a non-`BaerlyError` escape from a validation closure — in practice
+ * the `RangeError` from recursing over pathologically nested data — into the
+ * codec's typed failure.
+ */
+export function normalizeCodecFailure<T>(
+  fail: CodecFail,
+  code: CodecCode,
+  message: string,
+  operation: () => T,
+): T {
+  try {
+    return operation();
+  } catch (error) {
+    if (error instanceof BaerlyError) {
+      throw error;
+    }
+    fail(code, message, error);
+  }
+}
+
+/** Require an object with exactly `expected` enumerable data fields. */
+export function assertExactFields(
+  value: unknown,
+  expected: readonly string[],
+  where: string,
+  code: CodecCode,
+  fail: CodecFail,
+): asserts value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(code, `${where} must be an object`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  const keys = Object.keys(descriptors);
+  if (
+    (prototype !== Object.prototype && prototype !== null) ||
+    Object.getOwnPropertySymbols(value).length !== 0 ||
+    keys.length !== expected.length ||
+    expected.some((key) => {
+      const descriptor = descriptors[key];
+      return descriptor === undefined || !descriptor.enumerable || !("value" in descriptor);
+    })
+  ) {
+    fail(code, `${where} must contain exactly the required fields`);
+  }
+}
+
+/** Validate a document ID and report rejection through the codec's `fail`. */
+export function assertCodecDocId(
+  value: unknown,
+  where: string,
+  code: CodecCode,
+  fail: CodecFail,
+): asserts value is string {
+  if (typeof value !== "string") {
+    fail(code, `${where} must be a string`);
+  }
+  try {
+    assertSnapshotDocId(value);
+  } catch (error) {
+    fail(code, `${where} is invalid`, error);
+  }
+}
+
+export interface ParsedArtifactKey {
+  readonly prefix: string;
+  readonly incarnation: string;
+  readonly digest: string;
+}
+
+/** Parse and validate an artifact key under its schema-v2 grammar. */
+export function parseArtifactKey(
+  key: unknown,
+  kind: "manifest" | "chunk",
+  code: CodecCode,
+  fail: CodecFail,
+): ParsedArtifactKey {
+  if (typeof key !== "string" || utf8.encode(key).byteLength > MAX_KEY_BYTES) {
+    fail(code, `${kind} key is invalid or exceeds ${MAX_KEY_BYTES} bytes`);
+  }
+  const match = (kind === "manifest" ? MANIFEST_KEY_PATTERN : CHUNK_KEY_PATTERN).exec(key);
+  if (match === null) {
+    fail(code, `${kind} key does not match the schema-v2 grammar`);
+  }
+  if (match[1]!.endsWith("/")) {
+    fail(code, `${kind} key collection prefix contains an empty trailing segment`);
+  }
+  return { prefix: match[1]!, incarnation: match[2]!, digest: match[3]! };
+}
+
+export function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  return left.byteLength === right.byteLength && left.every((byte, index) => byte === right[index]);
+}

--- a/packages/server/src/snapshot-codec.ts
+++ b/packages/server/src/snapshot-codec.ts
@@ -19,6 +19,20 @@ export type CodecCode = "InvalidConfig" | "InvalidResponse";
 /** Artifact-scoped failure constructor bound by each codec. */
 export type CodecFail = (code: CodecCode, message: string, cause?: unknown) => never;
 
+/**
+ * Build a `CodecFail` that prefixes every message with the codec's artifact
+ * name. Callers must wrap this in a `function` declaration annotated
+ * `: never` (`function invalid(...): never { return makeCodecFail(...)(...); }`)
+ * rather than binding it directly to a `const` — TS control-flow narrowing
+ * after an `invalid(...)` call only recognizes a `function` declaration's own
+ * annotated `never` return, not a variable holding a `never`-returning value.
+ */
+export function makeCodecFail(prefix: string): CodecFail {
+  return (code, message, cause) => {
+    throw new BaerlyError(code, `${prefix}: ${message}`, cause);
+  };
+}
+
 /** Chunk bodies encode to at most 1 MiB of canonical bytes (ADR-007). */
 export const MAX_CHUNK_BYTES = 1024 * 1024;
 
@@ -32,11 +46,11 @@ export const INCARNATION_PATTERN = /^[0-9a-f]{32}$/;
 export const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
 
 /** The only chunk key grammar under a collection prefix (ADR-007). */
-export const CHUNK_KEY_PATTERN =
+const CHUNK_KEY_PATTERN =
   /^(.+)\/_v2\/snapshot\/chunks\/([0-9a-f]{32})\/sha256\/([0-9a-f]{64})\.json$/;
 
 /** The only manifest key grammar under a collection prefix (ADR-007). */
-export const MANIFEST_KEY_PATTERN =
+const MANIFEST_KEY_PATTERN =
   /^(.+)\/_v2\/snapshot\/manifests\/([0-9a-f]{32})\/sha256\/([0-9a-f]{64})\.json$/;
 
 const utf8 = new TextEncoder();

--- a/packages/server/src/snapshot-manifest.test.ts
+++ b/packages/server/src/snapshot-manifest.test.ts
@@ -118,6 +118,20 @@ describe("snapshot manifest codec", () => {
       },
     ],
     [
+      "mismatched descriptor prefixes",
+      {
+        ...manifest(),
+        chunks: [
+          descriptor({ first_id: "a", last_id: "b" }),
+          descriptor({
+            first_id: "c",
+            last_id: "d",
+            key: fixedChunkKey.replace(prefix, "app/other"),
+          }),
+        ],
+      },
+    ],
+    [
       "overlapping ranges",
       {
         ...manifest(),
@@ -296,6 +310,21 @@ describe("snapshot manifest codec", () => {
     expect(() => encodeSnapshotManifest(symbolField)).toThrowError(
       expect.objectContaining({ code: "InvalidConfig" }),
     );
+
+    expect(() =>
+      encodeSnapshotManifest(
+        manifest({
+          chunks: [
+            descriptor({ first_id: "a", last_id: "b" }),
+            descriptor({
+              first_id: "c",
+              last_id: "d",
+              key: fixedChunkKey.replace(prefix, "app/other"),
+            }),
+          ],
+        }),
+      ),
+    ).toThrowError(expect.objectContaining({ code: "InvalidConfig" }));
   });
 });
 

--- a/packages/server/src/snapshot-manifest.ts
+++ b/packages/server/src/snapshot-manifest.ts
@@ -1,12 +1,14 @@
-import { BaerlyError, decodeJsonBytes, encodeJsonBytes, snapshotHash } from "@baerly/protocol";
+import { decodeJsonBytes, encodeJsonBytes, snapshotHash } from "@baerly/protocol";
 import { assertKeyWithinLimit } from "./key-limit.ts";
 import { assertPathSegment } from "./path-segment.ts";
 import {
   assertCodecDocId,
   assertExactFields,
+  type CodecCode,
   DIGEST_PATTERN,
   equalBytes,
   INCARNATION_PATTERN,
+  makeCodecFail,
   MAX_CHUNK_BYTES,
   MAX_CHUNK_ROWS,
   normalizeCodecFailure,
@@ -35,12 +37,9 @@ export interface SnapshotManifest {
   readonly chunks: readonly SnapshotChunkDescriptor[];
 }
 
-function invalid(
-  code: "InvalidConfig" | "InvalidResponse",
-  message: string,
-  cause?: unknown,
-): never {
-  throw new BaerlyError(code, `snapshot manifest: ${message}`, cause);
+const failManifest = makeCodecFail("snapshot manifest");
+function invalid(code: CodecCode, message: string, cause?: unknown): never {
+  return failManifest(code, message, cause);
 }
 
 function positiveSafeInteger(

--- a/packages/server/src/snapshot-manifest.ts
+++ b/packages/server/src/snapshot-manifest.ts
@@ -1,26 +1,22 @@
-import {
-  BaerlyError,
-  decodeJsonBytes,
-  encodeJsonBytes,
-  MAX_KEY_BYTES,
-  snapshotHash,
-} from "@baerly/protocol";
+import { BaerlyError, decodeJsonBytes, encodeJsonBytes, snapshotHash } from "@baerly/protocol";
 import { assertKeyWithinLimit } from "./key-limit.ts";
 import { assertPathSegment } from "./path-segment.ts";
-import { assertSnapshotDocId, compareDocIds } from "./snapshot-doc-id.ts";
+import {
+  assertCodecDocId,
+  assertExactFields,
+  DIGEST_PATTERN,
+  equalBytes,
+  INCARNATION_PATTERN,
+  MAX_CHUNK_BYTES,
+  MAX_CHUNK_ROWS,
+  normalizeCodecFailure,
+  parseArtifactKey,
+} from "./snapshot-codec.ts";
+import { compareDocIds } from "./snapshot-doc-id.ts";
 
 const SNAPSHOT_MANIFEST_SCHEMA_VERSION = 2;
 const MAX_MANIFEST_BYTES = 64 * 1024;
 const MAX_MANIFEST_CHUNKS = 32;
-const MAX_CHUNK_BYTES = 1024 * 1024;
-const MAX_CHUNK_ROWS = 4096;
-const INCARNATION_PATTERN = /^[0-9a-f]{32}$/;
-const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
-const MANIFEST_KEY_PATTERN =
-  /^(.+)\/_v2\/snapshot\/manifests\/([0-9a-f]{32})\/sha256\/([0-9a-f]{64})\.json$/;
-const CHUNK_KEY_PATTERN =
-  /^(.+)\/_v2\/snapshot\/chunks\/([0-9a-f]{32})\/sha256\/([0-9a-f]{64})\.json$/;
-const utf8 = new TextEncoder();
 
 export interface SnapshotChunkDescriptor {
   readonly first_id: string;
@@ -31,18 +27,12 @@ export interface SnapshotChunkDescriptor {
 }
 
 export interface SnapshotManifest {
-  readonly schema_version: number;
+  readonly schema_version: typeof SNAPSHOT_MANIFEST_SCHEMA_VERSION;
   readonly collection: string;
   readonly log_seq_start: number;
   readonly incarnation: string;
   readonly collation: "utf8-scalar-v1";
   readonly chunks: readonly SnapshotChunkDescriptor[];
-}
-
-interface ParsedArtifactKey {
-  readonly prefix: string;
-  readonly incarnation: string;
-  readonly digest: string;
 }
 
 function invalid(
@@ -51,85 +41,6 @@ function invalid(
   cause?: unknown,
 ): never {
   throw new BaerlyError(code, `snapshot manifest: ${message}`, cause);
-}
-
-function normalizeCodecFailure<T>(
-  code: "InvalidConfig" | "InvalidResponse",
-  operation: () => T,
-): T {
-  try {
-    return operation();
-  } catch (error) {
-    if (error instanceof BaerlyError) {
-      throw error;
-    }
-    invalid(code, "body exceeds supported JSON validation depth", error);
-  }
-}
-
-function assertExactFields(
-  value: unknown,
-  expected: readonly string[],
-  where: string,
-  code: "InvalidConfig" | "InvalidResponse",
-): asserts value is Record<string, unknown> {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    invalid(code, `${where} must be an object`);
-  }
-  const prototype = Object.getPrototypeOf(value);
-  const descriptors = Object.getOwnPropertyDescriptors(value);
-  const keys = Object.keys(descriptors);
-  if (
-    (prototype !== Object.prototype && prototype !== null) ||
-    Object.getOwnPropertySymbols(value).length !== 0 ||
-    keys.length !== expected.length ||
-    expected.some((key) => {
-      const descriptor = descriptors[key];
-      return descriptor === undefined || !descriptor.enumerable || !("value" in descriptor);
-    })
-  ) {
-    invalid(code, `${where} must contain exactly the required fields`);
-  }
-}
-
-function assertStoredDocId(value: unknown, where: string): asserts value is string {
-  if (typeof value !== "string") {
-    invalid("InvalidResponse", `${where} must be a string`);
-  }
-  try {
-    assertSnapshotDocId(value);
-  } catch (error) {
-    invalid("InvalidResponse", `${where} is invalid`, error);
-  }
-}
-
-function assertCallerDocId(value: unknown, where: string): asserts value is string {
-  if (typeof value !== "string") {
-    invalid("InvalidConfig", `${where} must be a string`);
-  }
-  try {
-    assertSnapshotDocId(value);
-  } catch (error) {
-    invalid("InvalidConfig", `${where} is invalid`, error);
-  }
-}
-
-function parseArtifactKey(
-  key: unknown,
-  kind: "manifest" | "chunk",
-  code: "InvalidConfig" | "InvalidResponse",
-): ParsedArtifactKey {
-  if (typeof key !== "string" || utf8.encode(key).byteLength > MAX_KEY_BYTES) {
-    invalid(code, `${kind} key is invalid or exceeds ${MAX_KEY_BYTES} bytes`);
-  }
-  const match = (kind === "manifest" ? MANIFEST_KEY_PATTERN : CHUNK_KEY_PATTERN).exec(key);
-  if (match === null) {
-    invalid(code, `${kind} key does not match the schema-v2 grammar`);
-  }
-  if (match[1]!.endsWith("/")) {
-    invalid(code, `${kind} key collection prefix contains an empty trailing segment`);
-  }
-  return { prefix: match[1]!, incarnation: match[2]!, digest: match[3]! };
 }
 
 function positiveSafeInteger(
@@ -153,6 +64,7 @@ function canonicalizeManifest(
     ["schema_version", "collection", "log_seq_start", "incarnation", "collation", "chunks"],
     "body",
     code,
+    invalid,
   );
   if (value["schema_version"] !== SNAPSHOT_MANIFEST_SCHEMA_VERSION) {
     invalid(code, "unsupported schema_version");
@@ -181,6 +93,7 @@ function canonicalizeManifest(
   }
 
   const seenKeys = new Set<string>();
+  let chunkPrefix: string | undefined;
   const chunks = value["chunks"].map((candidate, index): SnapshotChunkDescriptor => {
     const where = `chunks[${index}]`;
     assertExactFields(
@@ -188,14 +101,10 @@ function canonicalizeManifest(
       ["first_id", "last_id", "key", "byte_length", "row_count"],
       where,
       code,
+      invalid,
     );
-    if (code === "InvalidConfig") {
-      assertCallerDocId(candidate["first_id"], `${where}.first_id`);
-      assertCallerDocId(candidate["last_id"], `${where}.last_id`);
-    } else {
-      assertStoredDocId(candidate["first_id"], `${where}.first_id`);
-      assertStoredDocId(candidate["last_id"], `${where}.last_id`);
-    }
+    assertCodecDocId(candidate["first_id"], `${where}.first_id`, code, invalid);
+    assertCodecDocId(candidate["last_id"], `${where}.last_id`, code, invalid);
     if (compareDocIds(candidate["first_id"], candidate["last_id"]) > 0) {
       invalid(code, `${where} range is reversed`);
     }
@@ -203,7 +112,16 @@ function canonicalizeManifest(
     if (typeof descriptorKey !== "string") {
       invalid(code, `${where}.key must be a string`);
     }
-    const parsedKey = parseArtifactKey(descriptorKey, "chunk", code);
+    const parsedKey = parseArtifactKey(descriptorKey, "chunk", code, invalid);
+    // Internal consistency: every descriptor key must share one collection
+    // prefix, so an encodable manifest is always decodable under a manifest
+    // key built from that same prefix. `expectedPrefix` (decode only) then
+    // pins the shared prefix to the manifest key's own prefix.
+    if (chunkPrefix === undefined) {
+      chunkPrefix = parsedKey.prefix;
+    } else if (parsedKey.prefix !== chunkPrefix) {
+      invalid(code, "chunk descriptor keys must share one collection prefix");
+    }
     if (expectedPrefix !== undefined && parsedKey.prefix !== expectedPrefix) {
       invalid(code, `${where}.key belongs to another collection prefix`);
     }
@@ -243,19 +161,20 @@ function canonicalizeManifest(
   };
 }
 
-function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
-  return left.byteLength === right.byteLength && left.every((byte, index) => byte === right[index]);
-}
-
 export const encodeSnapshotManifest = (manifest: SnapshotManifest): Uint8Array => {
-  return normalizeCodecFailure("InvalidConfig", () => {
-    const canonical = canonicalizeManifest(manifest, "InvalidConfig");
-    const bytes = encodeJsonBytes(canonical);
-    if (bytes.byteLength > MAX_MANIFEST_BYTES) {
-      invalid("InvalidConfig", `canonical body exceeds ${MAX_MANIFEST_BYTES} bytes`);
-    }
-    return bytes;
-  });
+  return normalizeCodecFailure(
+    invalid,
+    "InvalidConfig",
+    "body exceeds supported JSON validation depth",
+    () => {
+      const canonical = canonicalizeManifest(manifest, "InvalidConfig");
+      const bytes = encodeJsonBytes(canonical);
+      if (bytes.byteLength > MAX_MANIFEST_BYTES) {
+        invalid("InvalidConfig", `canonical body exceeds ${MAX_MANIFEST_BYTES} bytes`);
+      }
+      return bytes;
+    },
+  );
 };
 
 export const snapshotManifestKey = (
@@ -287,7 +206,7 @@ export const decodeSnapshotManifest = async (
     invalid("InvalidResponse", "body length is outside the manifest ceiling");
   }
   const bodyBytes = bytes.slice();
-  const parsedKey = parseArtifactKey(key, "manifest", "InvalidResponse");
+  const parsedKey = parseArtifactKey(key, "manifest", "InvalidResponse", invalid);
   const digest = await snapshotHash(bodyBytes);
   if (digest !== parsedKey.digest) {
     invalid("InvalidResponse", "body digest does not match its key");
@@ -299,14 +218,19 @@ export const decodeSnapshotManifest = async (
   } catch (error) {
     invalid("InvalidResponse", "body is not valid JSON", error);
   }
-  const canonical = normalizeCodecFailure("InvalidResponse", () => {
-    const value = canonicalizeManifest(parsed, "InvalidResponse", parsedKey.prefix);
-    const canonicalBytes = encodeJsonBytes(value);
-    if (!equalBytes(bodyBytes, canonicalBytes)) {
-      invalid("InvalidResponse", "body is not canonical JSON");
-    }
-    return value;
-  });
+  const canonical = normalizeCodecFailure(
+    invalid,
+    "InvalidResponse",
+    "body exceeds supported JSON validation depth",
+    () => {
+      const value = canonicalizeManifest(parsed, "InvalidResponse", parsedKey.prefix);
+      const canonicalBytes = encodeJsonBytes(value);
+      if (!equalBytes(bodyBytes, canonicalBytes)) {
+        invalid("InvalidResponse", "body is not canonical JSON");
+      }
+      return value;
+    },
+  );
   if (canonical.collection !== expectedCollection) {
     invalid("InvalidResponse", "body collection does not match the expected collection");
   }


### PR DESCRIPTION
## What & why

`snapshot-chunk.ts` and `snapshot-manifest.ts` each carried their own copies of `assertExactFields`, `normalizeCodecFailure`, `parseArtifactKey`, document-ID assertion, `equalBytes`, and the key-grammar patterns. This extracts them into a shared `snapshot-codec.ts`, parameterized on each caller's failure constructor so artifact-scoped error messages and codes are preserved, and has `chunked-snapshot-reference.ts` reuse the document-ID and depth-normalization helpers too.

## Key points

- While consolidating, closes a gap: manifest chunk descriptor keys must now share one collection prefix, so an encodable manifest is always decodable under a manifest key built from that same prefix.
- Second commit is an unrelated small cleanup found along the way: merges a duplicate `AmbiguousCommit` "not retriable" test into the main below-floor test, and simplifies the workload-ceiling admission predicate since its `requires_*` flags are pinned to `true` by the contract type.

## Verification

| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3529 passed, 105 skipped |