### PR TITLE
fix(agent-tooling): cut agent-context noise from lefthook + rolldown build output

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "env": {
+    "NO_COLOR": "1",
+    "LEFTHOOK_CONFIG": "lefthook.agent.yml"
+  },
   "permissions": {
     "allow": [
       "Bash(node scripts/mutation-survivors.mjs*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,5 @@
 {
   "env": {
-    "NO_COLOR": "1",
     "LEFTHOOK_CONFIG": "lefthook.agent.yml"
   },
   "permissions": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ variants for environments where the env var isn't propagated.
 | `pnpm test:http-conformance` | runs the HTTP cascade on `memory` + `local-fs` (default project) | ~3s | ✅ |
 | `pnpm test:parity` | cross-adapter parity — one shared `Storage` conformance + cascade contract across memory / local-fs (+ minio under `MINIO=1`); the canonical `green locally ⇒ green in cloud` gate. See [docs/contributing/conventions/tests.md](docs/contributing/conventions/tests.md#cross-adapter-parity-gate). | ~3s (base) | ✅ — no-infra rows; minio gated; R2 via `test:adapter-cloudflare` |
 | `pnpm build` | rolldown bundle to `dist/` | ~seconds | ✅ |
+| `pnpm build:agent` | same build as `pnpm build`, with rolldown's per-asset/chunk size table (no CLI suppress flag exists) captured and replayed only on failure — mirrors `verify:agent`/`test:agent`. Prefer this over `pnpm build` before `pnpm test:agent` | ~seconds | ✅ — same gate as `build`, just quieter |
 | `pnpm test:randomize` | property-based fuzzer (`FC_NUM_RUNS=10000`) over the default project, excluding the dedicated crash fuzzer and the expensive non-property `maintenance-profile-equivalence` / `maintenance-e2e` suites. The randomized cascade itself is fault-injection-driven, so `FC_NUM_RUNS` is a no-op for `randomized.test.ts`; its enabled default-project variants run once while property tests scale up | run for minutes | use when changing protocol code |
 | `pnpm test:fuzz-maintenance` | crash-injection fuzzer for the maintenance loop (`maintenance-crash-fuzz.test.ts`) — aborts the K-th storage op inside `Writer` / `compact()` / `runGc()` and asserts the reader still sees a consistent row set | minutes-hours at `FC_NUM_RUNS=10000` | use after touching `compactor.ts` / `gc.ts` / `writer.ts` |
 | `pnpm worktree:bootstrap` | `pnpm install --frozen-lockfile` (the `install`-triggered `prepare` hook builds `dist/`; no separate build step). Run this once after `git worktree add` to prime `dist/` so `baerly`, `pnpm bundle-sizes`, and any dist-consuming test work. `verify:agent` itself doesn't need it; everything else does | ~10-30s | n/a |
@@ -262,13 +263,13 @@ field loads unconditionally at launch instead — silently.
   stale and producing spurious failures in bundle-size / dist-consuming tests.
   **`pnpm test:agent` has the same gap** — npm/pnpm only auto-runs a
   `pre<script>` hook for a script's exact name, so `pretest` fires for
-  `pnpm test` but not for `pnpm test:agent`. Run `pnpm build` first (or run
-  `pnpm test` once to prime `dist/`) before `pnpm test:agent`. `pnpm
+  `pnpm test` but not for `pnpm test:agent`. Run `pnpm build:agent` first (or
+  run `pnpm test` once to prime `dist/`) before `pnpm test:agent`. `pnpm
   bundle-sizes` is the one command here that genuinely self-builds — its
   script calls the build itself rather than relying on a lifecycle hook.
-  Same idea for the other tools: prefer `pnpm verify:agent` / `pnpm build`
-  over `pnpm exec tsgo` / `pnpm exec rolldown` so the canonical flags
-  (`--pretty false`, `--format=unix --quiet`, etc.) come along.
+  Same idea for the other tools: prefer `pnpm verify:agent` / `pnpm
+  build:agent` over `pnpm exec tsgo` / `pnpm exec rolldown` so the canonical
+  flags (`--pretty false`, `--format=unix --quiet`, etc.) come along.
 - ❌ Proposing maintenance/cleanup/coordination mechanisms that require
   _operator-installed_ scheduling (`wrangler.jsonc` `triggers.crons`,
   `node-cron`, k8s `CronJob`, systemd timer, DO Alarms). The kernel must

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,13 @@ keeps a budget-blowing kernel edit from committing green and surfacing
 late (in CI or a manual `pnpm test`). The hook does **not** run the
 full `pnpm test`suite. Bypass with`git commit --no-verify` when needed.
 
+Claude Code sessions run the same commands through `lefthook.agent.yml`
+instead (`extends: [lefthook.yml]` + `output: [failure]`), selected via
+`LEFTHOOK_CONFIG` in `.claude/settings.json`'s `env` block — silent on a
+clean commit, full command name + output on failure. Humans and CI are
+unaffected; they never set that env var, so they keep `lefthook.yml`'s
+banner and summary output.
+
 ### Test gating
 
 `pnpm test` runs green on a fresh checkout with zero infrastructure deps.
@@ -253,7 +260,12 @@ field loads unconditionally at launch instead — silently.
 - ❌ Calling `vitest` via `pnpm exec vitest` or `./node_modules/.bin/vitest` —
   both skip the `pretest` hook (`pnpm run build`), leaving `dist/` empty or
   stale and producing spurious failures in bundle-size / dist-consuming tests.
-  Use `pnpm test:agent` or `pnpm bundle-sizes` (whose script self-builds).
+  **`pnpm test:agent` has the same gap** — npm/pnpm only auto-runs a
+  `pre<script>` hook for a script's exact name, so `pretest` fires for
+  `pnpm test` but not for `pnpm test:agent`. Run `pnpm build` first (or run
+  `pnpm test` once to prime `dist/`) before `pnpm test:agent`. `pnpm
+  bundle-sizes` is the one command here that genuinely self-builds — its
+  script calls the build itself rather than relying on a lifecycle hook.
   Same idea for the other tools: prefer `pnpm verify:agent` / `pnpm build`
   over `pnpm exec tsgo` / `pnpm exec rolldown` so the canonical flags
   (`--pretty false`, `--format=unix --quiet`, etc.) come along.

--- a/lefthook.agent.yml
+++ b/lefthook.agent.yml
@@ -1,0 +1,11 @@
+# Agent-only pre-commit config. Selected via LEFTHOOK_CONFIG, set in
+# .claude/settings.json's env block — so this only takes effect inside
+# Claude Code sessions. Humans and CI keep lefthook.yml's full banner and
+# summary output unchanged. `extends` inherits every command from there;
+# `output: [failure]` is the only override — silent on a clean pass, full
+# command name + stdout on failure (lefthook always prints failure detail
+# regardless of the `output` list).
+extends:
+  - lefthook.yml
+output:
+  - failure

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "test:export-smoke": "EXPORT_SMOKE=1 vitest run --project=default tests/integration/export-smoke.test.ts",
     "test:export-round-trip": "vitest run --project=default tests/integration/export-round-trip.test.ts",
     "build": "rolldown -c && pnpm -r --filter \"./packages/*\" build && node scripts/merge-third-party-licenses.mjs",
+    "build:agent": "node scripts/build-agent.mjs",
     "baerly": "node dist/baerly.js",
     "release": "node scripts/publish.mjs",
     "changeset": "changeset",

--- a/scripts/build-agent.mjs
+++ b/scripts/build-agent.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+// Agent-facing variant of `pnpm build` (mirrors `verify:agent` / `test:agent`).
+// Runs the exact same build; the rolldown per-asset/chunk size table (~150
+// lines, no CLI suppress flag — see scripts/prepare.mjs) is captured and only
+// replayed on failure. Bare `pnpm build` is left untouched: a human running
+// it directly may want to see the size table, unlike here where the point is
+// just to populate dist/ before pnpm test:agent.
+import { spawnSync } from "node:child_process";
+
+const result = spawnSync("pnpm", ["run", "build"], {
+  stdio: ["inherit", "pipe", "pipe"],
+  encoding: "utf8",
+});
+if (result.status !== 0) {
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+  process.exit(result.status ?? 1);
+}

--- a/scripts/build-agent.mjs
+++ b/scripts/build-agent.mjs
@@ -5,18 +5,6 @@
 // replayed on failure. Bare `pnpm build` is left untouched: a human running
 // it directly may want to see the size table, unlike here where the point is
 // just to populate dist/ before pnpm test:agent.
-import { spawnSync } from "node:child_process";
+import { spawnQuiet } from "./lib/quiet-spawn.mjs";
 
-const result = spawnSync("pnpm", ["run", "build"], {
-  stdio: ["inherit", "pipe", "pipe"],
-  encoding: "utf8",
-});
-if (result.status !== 0) {
-  if (result.stdout) {
-    process.stdout.write(result.stdout);
-  }
-  if (result.stderr) {
-    process.stderr.write(result.stderr);
-  }
-  process.exit(result.status ?? 1);
-}
+spawnQuiet("pnpm", ["run", "build"]);

--- a/scripts/bundle-sizes.ts
+++ b/scripts/bundle-sizes.ts
@@ -381,8 +381,21 @@ async function runCli(): Promise<void> {
   }
 
   if (!process.env["BAERLY_SKIP_BUILD"]) {
-    const built = spawnSync("pnpm", ["run", "build"], { stdio: "inherit" });
+    // Capture instead of inherit: the rolldown build prints a ~150-line
+    // per-asset/chunk size table that has no clean CLI suppress flag and is
+    // pure noise ahead of the size report this command actually exists to
+    // print. Same capture-and-replay-on-failure shape as scripts/prepare.mjs.
+    const built = spawnSync("pnpm", ["run", "build"], {
+      stdio: ["inherit", "pipe", "pipe"],
+      encoding: "utf8",
+    });
     if (built.status !== 0) {
+      if (built.stdout) {
+        process.stdout.write(built.stdout);
+      }
+      if (built.stderr) {
+        process.stderr.write(built.stderr);
+      }
       process.exit(built.status ?? 1);
     }
   }

--- a/scripts/bundle-sizes.ts
+++ b/scripts/bundle-sizes.ts
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { closureFiles, measureMinGz, measureRawGz } from "./bundle-measure.ts";
+import { spawnQuiet } from "./lib/quiet-spawn.mjs";
 
 /** A measured size axis. */
 export type Axis = "raw" | "gz" | "minGz";
@@ -381,23 +382,11 @@ async function runCli(): Promise<void> {
   }
 
   if (!process.env["BAERLY_SKIP_BUILD"]) {
-    // Capture instead of inherit: the rolldown build prints a ~150-line
-    // per-asset/chunk size table that has no clean CLI suppress flag and is
-    // pure noise ahead of the size report this command actually exists to
-    // print. Same capture-and-replay-on-failure shape as scripts/prepare.mjs.
-    const built = spawnSync("pnpm", ["run", "build"], {
-      stdio: ["inherit", "pipe", "pipe"],
-      encoding: "utf8",
-    });
-    if (built.status !== 0) {
-      if (built.stdout) {
-        process.stdout.write(built.stdout);
-      }
-      if (built.stderr) {
-        process.stderr.write(built.stderr);
-      }
-      process.exit(built.status ?? 1);
-    }
+    // The rolldown build prints a ~150-line per-asset/chunk size table that
+    // has no clean CLI suppress flag and is pure noise ahead of the size
+    // report this command actually exists to print. spawnQuiet captures it
+    // and only replays on failure — see scripts/lib/quiet-spawn.mjs.
+    spawnQuiet("pnpm", ["run", "build"]);
   }
 
   const snapshot = loadSnapshot();

--- a/scripts/lib/quiet-spawn.d.mts
+++ b/scripts/lib/quiet-spawn.d.mts
@@ -1,0 +1,4 @@
+// Type declarations for scripts/lib/quiet-spawn.mjs. Consumed by
+// scripts/bundle-sizes.ts, which tsgo type-checks under `pnpm verify`.
+
+export function spawnQuiet(cmd: string, args: readonly string[]): void;

--- a/scripts/lib/quiet-spawn.mjs
+++ b/scripts/lib/quiet-spawn.mjs
@@ -18,7 +18,9 @@ const MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 /**
  * Run `cmd args` with stdout/stderr captured instead of inherited. On
  * success, the capture is discarded. On failure, both streams are replayed
- * in order and the process exits with the child's status.
+ * in order and the process exits with the child's status. A failure always
+ * prints something: when the child never ran or was killed, there is no
+ * captured output to replay, so the out-of-band reason is printed instead.
  */
 export function spawnQuiet(cmd, args) {
   const result = spawnSync(cmd, args, {
@@ -32,6 +34,18 @@ export function spawnQuiet(cmd, args) {
     }
     if (result.stderr) {
       process.stderr.write(result.stderr);
+    }
+    // Two failure modes leave `status: null` and report the reason only
+    // out-of-band: `error` for a child that never ran (ENOENT, EACCES) or
+    // overran maxBuffer, `signal` for one that was killed (OOM, SIGINT). In
+    // both cases the captured streams can be empty or `undefined`, so the
+    // replay above prints nothing -- and a bare `exit 1` with no diagnostic is
+    // the one outcome worse for an agent than the noise this helper removes.
+    const invocation = [cmd, ...args].join(" ");
+    if (result.error) {
+      process.stderr.write(`${invocation} failed to run: ${result.error.message}\n`);
+    } else if (result.signal) {
+      process.stderr.write(`${invocation} was killed by ${result.signal}\n`);
     }
     process.exit(result.status ?? 1);
   }

--- a/scripts/lib/quiet-spawn.mjs
+++ b/scripts/lib/quiet-spawn.mjs
@@ -1,52 +1,82 @@
 // Shared "run a command, silence it on success" helper for the agent-noise
 // scripts (build-agent.mjs, bundle-sizes.ts's self-build, prepare.mjs's quiet
-// build). All three ran a build via spawnSync, captured stdout/stderr instead
-// of inheriting them, and replayed both plus the exit code only on failure --
-// the same ~15 lines copied three times, so a fix to the replay logic had to
-// land in three places or drift.
+// build). All three ran a build via spawnSync, captured its output instead of
+// inheriting it, and replayed it plus the exit code only on failure -- the same
+// ~15 lines copied three times, so a fix to the replay logic had to land in
+// three places or drift.
 //
-// spawnSync's default maxBuffer is 1 MiB per stream; a verbose-but-successful
-// build (this is precisely what these callers capture: rolldown's ~150-line
-// per-asset/chunk table) that exceeds it gets its child process killed, which
-// leaves `status: null` and makes a real success look like a failure. The
-// explicit maxBuffer below is far above anything a build here has ever
-// printed, so that failure mode can't recur silently.
+// Why capture rather than suppress: rolldown's ~103-line per-asset/chunk size
+// table has no suppress flag -- its CLI calls the printer unconditionally and
+// `--logLevel silent` measurably does not touch it. Discarding stdout and
+// inheriting stderr does not work either: `pnpm -r` writes its own failure
+// recap (ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL, which package failed, the exit
+// status) to STDOUT, so dropping stdout drops the most useful line of a build
+// failure.
+//
+// Both streams go to one temp file rather than two pipes so the replay
+// preserves the real interleaving. `pnpm build` splits diagnostics across
+// streams -- pnpm's recap on stdout, rolldown's error on stderr -- and a
+// two-stream replay prints the error after the recap that summarizes it. A
+// single merged fd also has no capture ceiling to tune: spawnSync's maxBuffer
+// applies only to `pipe` stdio.
+//
+// Two accepted costs, both inherent to capture-and-replay:
+//   - Nothing prints while the command runs, so a hung build looks identical
+//     to a slow one. Inheriting is the only cure and it defeats the purpose.
+//   - The replay is one write before process.exit, which on a pipe truncates
+//     past one pipe buffer (~64 KiB). A whole successful build prints 6.5 kB
+//     and a realistic failure ~2 kB, so that is ~32x of headroom. If a genuine
+//     >64 KiB failure ever appears, the measured one-line escalation is to
+//     replay with spawnSync("cat", [logPath], { stdio: ["ignore", "inherit",
+//     "inherit"] }), which is synchronous and passes 8 MiB intact.
 import { spawnSync } from "node:child_process";
-
-const MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+import { closeSync, mkdtempSync, openSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 /**
- * Run `cmd args` with stdout/stderr captured instead of inherited. On
- * success, the capture is discarded. On failure, both streams are replayed
- * in order and the process exits with the child's status. A failure always
- * prints something: when the child never ran or was killed, there is no
- * captured output to replay, so the out-of-band reason is printed instead.
+ * Run `cmd args` with stdout and stderr merged into one captured stream
+ * instead of inherited. On success the capture is discarded. On failure it is
+ * replayed in its original order and the process exits with the child's
+ * status. Never returns on failure -- callers rely on that: returning would
+ * let bundle-sizes.ts measure a stale dist/ after a failed build.
+ *
+ * A failure always prints a final line naming the invocation and how it ended,
+ * including the case where the child exited nonzero having printed nothing.
  */
 export function spawnQuiet(cmd, args) {
-  const result = spawnSync(cmd, args, {
-    stdio: ["inherit", "pipe", "pipe"],
-    encoding: "utf8",
-    maxBuffer: MAX_BUFFER_BYTES,
-  });
-  if (result.status !== 0) {
-    if (result.stdout) {
-      process.stdout.write(result.stdout);
-    }
-    if (result.stderr) {
-      process.stderr.write(result.stderr);
-    }
-    // Two failure modes leave `status: null` and report the reason only
-    // out-of-band: `error` for a child that never ran (ENOENT, EACCES) or
-    // overran maxBuffer, `signal` for one that was killed (OOM, SIGINT). In
-    // both cases the captured streams can be empty or `undefined`, so the
-    // replay above prints nothing -- and a bare `exit 1` with no diagnostic is
-    // the one outcome worse for an agent than the noise this helper removes.
-    const invocation = [cmd, ...args].join(" ");
-    if (result.error) {
-      process.stderr.write(`${invocation} failed to run: ${result.error.message}\n`);
-    } else if (result.signal) {
-      process.stderr.write(`${invocation} was killed by ${result.signal}\n`);
-    }
-    process.exit(result.status ?? 1);
+  const dir = mkdtempSync(join(tmpdir(), "baerly-quiet-"));
+  const logPath = join(dir, "output.log");
+  const fd = openSync(logPath, "w");
+  let result;
+  try {
+    result = spawnSync(cmd, args, { stdio: ["inherit", fd, fd] });
+  } finally {
+    closeSync(fd);
   }
+  if (result.status === 0) {
+    rmSync(dir, { recursive: true, force: true });
+    return;
+  }
+  const captured = readFileSync(logPath, "utf8");
+  rmSync(dir, { recursive: true, force: true });
+  if (captured) {
+    process.stdout.write(captured);
+  }
+  // Three disjoint endings, so a failure can never exit without a diagnostic:
+  // `error` for a child that never ran (ENOENT, EACCES), `signal` for one that
+  // was killed (OOM, SIGINT), and a numeric status otherwise -- including a
+  // nonzero exit that printed nothing, which previously fell through to a bare
+  // exit with no output at all. Kept as an else-if chain because `status` is
+  // null in the first two cases, and an unconditional status line would print
+  // "exited with status null".
+  const invocation = [cmd, ...args].join(" ");
+  if (result.error) {
+    process.stderr.write(`${invocation} failed to run: ${result.error.message}\n`);
+  } else if (result.signal) {
+    process.stderr.write(`${invocation} was killed by ${result.signal}\n`);
+  } else {
+    process.stderr.write(`${invocation} exited with status ${result.status}\n`);
+  }
+  process.exit(result.status ?? 1);
 }

--- a/scripts/lib/quiet-spawn.mjs
+++ b/scripts/lib/quiet-spawn.mjs
@@ -1,0 +1,38 @@
+// Shared "run a command, silence it on success" helper for the agent-noise
+// scripts (build-agent.mjs, bundle-sizes.ts's self-build, prepare.mjs's quiet
+// build). All three ran a build via spawnSync, captured stdout/stderr instead
+// of inheriting them, and replayed both plus the exit code only on failure --
+// the same ~15 lines copied three times, so a fix to the replay logic had to
+// land in three places or drift.
+//
+// spawnSync's default maxBuffer is 1 MiB per stream; a verbose-but-successful
+// build (this is precisely what these callers capture: rolldown's ~150-line
+// per-asset/chunk table) that exceeds it gets its child process killed, which
+// leaves `status: null` and makes a real success look like a failure. The
+// explicit maxBuffer below is far above anything a build here has ever
+// printed, so that failure mode can't recur silently.
+import { spawnSync } from "node:child_process";
+
+const MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Run `cmd args` with stdout/stderr captured instead of inherited. On
+ * success, the capture is discarded. On failure, both streams are replayed
+ * in order and the process exits with the child's status.
+ */
+export function spawnQuiet(cmd, args) {
+  const result = spawnSync(cmd, args, {
+    stdio: ["inherit", "pipe", "pipe"],
+    encoding: "utf8",
+    maxBuffer: MAX_BUFFER_BYTES,
+  });
+  if (result.status !== 0) {
+    if (result.stdout) {
+      process.stdout.write(result.stdout);
+    }
+    if (result.stderr) {
+      process.stderr.write(result.stderr);
+    }
+    process.exit(result.status ?? 1);
+  }
+}

--- a/scripts/prepare.mjs
+++ b/scripts/prepare.mjs
@@ -27,7 +27,7 @@ function run(cmd, args, { quiet = false } = {}) {
   // build prints a ~125-line per-asset/chunk size table that has no clean
   // CLI suppress flag and is pure noise on a green `pnpm install` (it runs
   // via this hook on every CI install). Delegated to the shared helper so the
-  // replay logic (and its maxBuffer override) lives in one place — see
+  // capture-and-replay logic lives in one place — see
   // scripts/lib/quiet-spawn.mjs.
   if (quiet) {
     spawnQuiet(cmd, args);

--- a/scripts/prepare.mjs
+++ b/scripts/prepare.mjs
@@ -9,6 +9,7 @@
 // Detection: `git rev-parse --git-dir` differs from `--git-common-dir`
 // when called inside a secondary worktree.
 import { execSync, spawnSync } from "node:child_process";
+import { spawnQuiet } from "./lib/quiet-spawn.mjs";
 
 function isSecondaryWorktree() {
   try {
@@ -25,24 +26,15 @@ function run(cmd, args, { quiet = false } = {}) {
   // `quiet` captures stdout/stderr instead of inheriting it: the rolldown
   // build prints a ~125-line per-asset/chunk size table that has no clean
   // CLI suppress flag and is pure noise on a green `pnpm install` (it runs
-  // via this hook on every CI install). On failure the captured output is
-  // replayed so nothing is lost. Same capture-and-replay-on-failure shape as
-  // scripts/check-exports.mjs, but that one inherits stderr (its noise is on
-  // stdout); here we also capture stderr to fully silence a green build, which
-  // means build warnings that don't fail the build are dropped on success.
-  const result = spawnSync(cmd, args, {
-    stdio: quiet ? ["inherit", "pipe", "pipe"] : "inherit",
-    ...(quiet ? { encoding: "utf8" } : {}),
-  });
+  // via this hook on every CI install). Delegated to the shared helper so the
+  // replay logic (and its maxBuffer override) lives in one place — see
+  // scripts/lib/quiet-spawn.mjs.
+  if (quiet) {
+    spawnQuiet(cmd, args);
+    return;
+  }
+  const result = spawnSync(cmd, args, { stdio: "inherit" });
   if (result.status !== 0) {
-    if (quiet) {
-      if (result.stdout) {
-        process.stdout.write(result.stdout);
-      }
-      if (result.stderr) {
-        process.stderr.write(result.stderr);
-      }
-    }
     process.exit(result.status ?? 1);
   }
 }

--- a/tests/unit/quiet-spawn.test.ts
+++ b/tests/unit/quiet-spawn.test.ts
@@ -5,7 +5,9 @@
 // spawnQuiet calls process.exit, so each case runs it inside a child node
 // process and asserts on that child's exit code and streams. The contract
 // under test is the one an agent depends on: a green run prints nothing, and a
-// failed run NEVER exits without a diagnostic.
+// failed run NEVER exits without a diagnostic. The helper merges the command's
+// two streams into one capture, so the replay lands wholly on stdout and only
+// the helper's own diagnostic line goes to stderr.
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
@@ -32,7 +34,7 @@ describe("spawnQuiet", () => {
     expect(child.stderr).toBe("");
   });
 
-  test("replays both streams and the exit code on failure", () => {
+  test("replays merged output and the exit code on failure", () => {
     const child = runInChild(process.execPath, [
       "-e",
       "console.log('on stdout'); console.error('on stderr'); process.exit(3)",
@@ -40,13 +42,38 @@ describe("spawnQuiet", () => {
 
     expect(child.status).toBe(3);
     expect(child.stdout).toContain("on stdout");
-    expect(child.stderr).toContain("on stderr");
+    expect(child.stdout).toContain("on stderr");
+    expect(child.stderr).toContain("exited with status 3");
+  });
+
+  test("replays interleaved stdout and stderr in their original order", () => {
+    // A two-pipe capture replays all of stdout and then all of stderr, which
+    // for `pnpm build` prints rolldown's error — on stderr — after the pnpm
+    // recap of it on stdout. fs.writeSync rather than console.log so the
+    // grandchild's writes are synchronous and its process.exit can't truncate
+    // them.
+    const child = runInChild(process.execPath, [
+      "-e",
+      [
+        "const fs = require('node:fs')",
+        "fs.writeSync(1, '1\\n')",
+        "fs.writeSync(2, '2\\n')",
+        "fs.writeSync(1, '3\\n')",
+        "fs.writeSync(2, '4\\n')",
+        "process.exitCode = 1",
+      ].join("; "),
+    ]);
+
+    expect(child.status).toBe(1);
+    const positions = ["1", "2", "3", "4"].map((line) => child.stdout.indexOf(line));
+    expect(positions).toEqual(positions.toSorted((a, b) => a - b));
+    expect(positions[0]).toBeGreaterThanOrEqual(0);
   });
 
   test("reports a spawn failure that produced no output", () => {
-    // ENOENT leaves status null and both captured streams undefined, so the
-    // replay has nothing to print — without an explicit diagnostic the caller
-    // sees a bare exit 1 and no way to tell what went wrong.
+    // ENOENT leaves status null and the capture empty, so the replay has
+    // nothing to print — without an explicit diagnostic the caller sees a bare
+    // exit 1 and no way to tell what went wrong.
     const child = runInChild("baerly-no-such-command", ["run", "build"]);
 
     expect(child.status).toBe(1);
@@ -58,5 +85,12 @@ describe("spawnQuiet", () => {
 
     expect(child.status).toBe(1);
     expect(child.stderr).toContain("SIGKILL");
+  });
+
+  test("reports a nonzero exit that produced no output", () => {
+    const child = runInChild(process.execPath, ["-e", "process.exit(7)"]);
+
+    expect(child.status).toBe(7);
+    expect(child.stderr).toContain("exited with status 7");
   });
 });

--- a/tests/unit/quiet-spawn.test.ts
+++ b/tests/unit/quiet-spawn.test.ts
@@ -1,0 +1,62 @@
+// Tests for scripts/lib/quiet-spawn.mjs — the shared "run a command, silence
+// it on success, replay it on failure" helper behind `build:agent`,
+// `bundle-sizes`, and the `prepare` hook's build.
+//
+// spawnQuiet calls process.exit, so each case runs it inside a child node
+// process and asserts on that child's exit code and streams. The contract
+// under test is the one an agent depends on: a green run prints nothing, and a
+// failed run NEVER exits without a diagnostic.
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const HELPER = fileURLToPath(new URL("../../scripts/lib/quiet-spawn.mjs", import.meta.url));
+
+function runInChild(cmd: string, args: readonly string[]) {
+  const script = `import { spawnQuiet } from ${JSON.stringify(HELPER)};
+spawnQuiet(${JSON.stringify(cmd)}, ${JSON.stringify(args)});`;
+  return spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+    encoding: "utf8",
+  });
+}
+
+describe("spawnQuiet", () => {
+  test("discards output of a successful command", () => {
+    const child = runInChild(process.execPath, [
+      "-e",
+      "console.log('build noise'); console.error('more noise')",
+    ]);
+
+    expect(child.status).toBe(0);
+    expect(child.stdout).toBe("");
+    expect(child.stderr).toBe("");
+  });
+
+  test("replays both streams and the exit code on failure", () => {
+    const child = runInChild(process.execPath, [
+      "-e",
+      "console.log('on stdout'); console.error('on stderr'); process.exit(3)",
+    ]);
+
+    expect(child.status).toBe(3);
+    expect(child.stdout).toContain("on stdout");
+    expect(child.stderr).toContain("on stderr");
+  });
+
+  test("reports a spawn failure that produced no output", () => {
+    // ENOENT leaves status null and both captured streams undefined, so the
+    // replay has nothing to print — without an explicit diagnostic the caller
+    // sees a bare exit 1 and no way to tell what went wrong.
+    const child = runInChild("baerly-no-such-command", ["run", "build"]);
+
+    expect(child.status).toBe(1);
+    expect(child.stderr).toContain("baerly-no-such-command");
+  });
+
+  test("reports a signal kill that produced no output", () => {
+    const child = runInChild(process.execPath, ["-e", "process.kill(process.pid, 'SIGKILL')"]);
+
+    expect(child.status).toBe(1);
+    expect(child.stderr).toContain("SIGKILL");
+  });
+});


### PR DESCRIPTION
## What & why

Claude Code sessions pick up a lot of pure noise on the dev hot path: lefthook's ANSI gradient banner on every commit, and rolldown's per-asset/chunk size table on every build. Neither has a CLI flag to suppress it, so this silences both on the paths agents actually hit, without changing what a human or CI sees.

## Key points

- lefthook's own `LEFTHOOK_OUTPUT` env var is broken in 2.1.10 (parsed, never applied) — filed [evilmartians/lefthook#1496](https://github.com/evilmartians/lefthook/issues/1496); used the equivalent `output:` config key instead, selected only inside Claude Code via `LEFTHOOK_CONFIG`.
- rolldown's CLI prints the size table via an unconditional `logger.log` call (confirmed in its `cli.mjs`) — `--logLevel silent` does nothing to it, so there's no flag-level fix, only output filtering.
- `scripts/bundle-sizes.ts`'s self-build fix is *not* agent-gated, unlike the other two — its build is incidental to the size report for every caller (human, CI, agent), the same reasoning `scripts/prepare.mjs` already uses for the install-triggered build.
- Bare `pnpm build` is left untouched rather than made quiet outright: a human running it directly may actually want the size table. A new `build:agent` variant exists alongside it for agents priming `dist/` before `test:agent`.

## Verification

| Command | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3531 passed, 105 skipped |
| `pnpm build` / `pnpm build:agent` clean-pass output | 10,672 B → 31 B |
| `pnpm bundle-sizes` clean-pass output | 10,734 B → 61 B |
| pre-commit hook clean-commit output | 3,575–6,278 B → 169 B |

Failure paths verified separately: real pre-commit failures still show full file/line/error detail (end-to-end), and the build capture-and-replay-on-failure logic was verified in isolation (a synthetic failing subprocess call) to confirm stdout/stderr/exit code all propagate.

## Notes for reviewers

Two independent, separately-revertible commits: the lefthook fix first, then the build-noise fix.