### PR TITLE
build(tsconfig): add workload-ceiling-worker to both tsgo programs

### DIFF
--- a/tsconfig.cloudflare.json
+++ b/tsconfig.cloudflare.json
@@ -28,7 +28,9 @@
     "tests/integration/public-surface.test.ts",
     "tests/integration/s3-worker-e2e.test.ts",
     "tests/setup/http-conformance-worker.ts",
-    "tests/setup/r2-binding.ts"
+    "tests/setup/r2-binding.ts",
+    "bench/workload-ceiling-worker/src/index.ts",
+    "bench/workload-ceiling-worker/src/index.test.ts"
   ],
   // `extends` would otherwise inherit the root program's exclusions, which are
   // exactly this program's includes.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -80,6 +80,8 @@
     "tests/integration/public-surface.test.ts",
     "tests/integration/s3-worker-e2e.test.ts",
     "tests/setup/http-conformance-worker.ts",
-    "tests/setup/r2-binding.ts"
+    "tests/setup/r2-binding.ts",
+    "bench/workload-ceiling-worker/src/index.ts",
+    "bench/workload-ceiling-worker/src/index.test.ts"
   ]
 }


### PR DESCRIPTION
## What & why

`bench/workload-ceiling-worker/src/index.ts` and `index.test.ts` were missing from both the root and Cloudflare tsgo `include` lists, leaving them untypechecked by `pnpm verify`.

## Verification

| `pnpm verify:agent` | clean |
| `pnpm build:agent` + `pnpm test:agent` | 3647 passed, 105 skipped |