### PR TITLE
docs: capture gotchas and decisions from recent kernel/build work

### DIFF
--- a/.claude/rules/change-discipline.md
+++ b/.claude/rules/change-discipline.md
@@ -14,3 +14,14 @@ related: ["../../docs/contributing/conventions/change-discipline.md"]
 Canonical content lives at [`docs/contributing/conventions/change-discipline.md`](../../docs/contributing/conventions/change-discipline.md).
 Read that file before making non-trivial code changes — especially
 before introducing compatibility shims or removing existing behavior.
+
+## Cutting a field from a public function-arg type
+
+Typecheck will not find every caller. The excess-property check fires
+on object *literals* but not on spreads, so
+`...(cond && { droppedKey: x })` compiles clean and carries the removed
+key into the runtime call, where the narrowed API silently ignores it.
+
+After any field cut, grep for both the direct form and
+`\.\.\.[^)]*<droppedKey>:`. The spread variant is the one a green
+`verify:agent` doesn't rule out.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,18 @@ variants for environments where the env var isn't propagated.
 
 > **Agents: don't pipe `verify:agent` / `test:agent` through `| tail -N` or `| head -N`.** Both scripts are already compact — one finding per line, with full detail preserved on failures. Piping to `tail`/`head` removes the lines you need; if the first run prints nothing useful, the _output is empty because the gate passed_, not because the tail was wrong. Same applies to `pnpm bundle-sizes`.
 
+> **Two `test:agent` invocation traps.** `pnpm test:agent -- <path>` silently
+> runs the whole default-project suite — the `--` becomes a positional that
+> neutralizes vitest's path filter; write `pnpm test:agent <path>` instead.
+> `pnpm test:agent --project=<name>` also fails silently: the script already
+> hard-codes `--project=default`, so a second `--project=` supplies two
+> conflicting filters rather than overriding the first. There's no way to
+> retarget `test:agent` at another vitest project — use the project's own
+> script (e.g. `pnpm test:adapter-cloudflare <paths>`). And `FC_NUM_RUNS` in
+> front of `pnpm test:fuzz-maintenance` is a no-op — the script hardcodes
+> `FC_NUM_RUNS=10000` — so read the effective value off the `$ ...` command
+> vitest echoes rather than assuming your override took.
+
 | Command | What it catches | Runtime | Clean on `main`? |
 | --- | --- | --- | --- |
 | `pnpm verify` | typecheck (`tsgo --noEmit`, run twice — the Node-only root program, then the Workers program via `-p tsconfig.cloudflare.json`) + `verify:examples` + lint (`oxlint`) + `format:check` (`oxfmt --check .`, whole-repo) + `lint-format-coverage` (ownership guard) + `verify:docs` (markdown validation) + `check-spec-drift` + `check-version-matrix` | ~seconds | ✅ — non-zero exit _is_ your regression |
@@ -212,7 +224,10 @@ field loads unconditionally at launch instead — silently.
   Don't add jest, mocha, or `bun:test`.
 - **Public API docs live as JSDoc on `packages/server/src/db.ts` and
   `packages/server/src/table.ts`.** IDE hover and tsgo consume them
-  directly — no rendered markdown ref to maintain.
+  directly — no rendered markdown ref to maintain. Navigation pointers
+  ("this file does X, dispatched from Z") go in the package's
+  `AGENTS.md` instead; a source header holds only why-non-obvious
+  context.
 - **Per-collection linearizability is a hard invariant.** The
   `log/<seq>` `If-None-Match: "*"` create linearizes each collection;
   cross-collection writes are unordered and non-atomic.
@@ -303,7 +318,10 @@ field loads unconditionally at launch instead — silently.
 ## Scope guidance
 
 - **Bugfix?** Reproduce with a failing test first. Pick the right test file
-  by topic (`json.test.ts`, `time.test.ts`, etc.).
+  by topic (`json.test.ts`, `time.test.ts`, etc.). Before shipping, re-inject
+  the original implementation and confirm the new test goes red — a test
+  that only passes against the fix is unproven; the fixture (not the
+  assertion) is what has to discriminate the two implementations.
 - **New public API method on `Db` / `Collection`?** See [docs/contributing/extending.md](docs/contributing/extending.md).
   Add JSDoc with `@example` — IDEs and tsgo consume it directly.
 - **Touching the sync protocol?** Read `docs/spec/sync-protocol.md` and
@@ -319,17 +337,23 @@ field loads unconditionally at launch instead — silently.
   exist. ~10 minutes of verification up front beats hours of work
   stuck on phantom references.
 
-## Pull request bodies
+## Pull request bodies, code comments, and planning docs
 
-Follow [`.github/pull_request_template.md`](.github/pull_request_template.md).
-It applies whether or not the template was rendered into your editor —
-`gh pr create --body` bypasses it, so read the file.
+Follow [`.github/pull_request_template.md`](.github/pull_request_template.md)
+for PRs. It applies whether or not the template was rendered into your
+editor — `gh pr create --body` bypasses it, so read the file.
 
-The body is a maintainer's reference, not a record of how the branch was
-built. Default to short and lead with the conclusion. State what the code
-does now; don't narrate how you arrived at it. A tried-and-abandoned
-approach or a changed plan gets **one line under "Key points"** and
-appears nowhere else. Deferred work is an issue link, not an inventory.
+All three are references for whoever reads them next, not a record of
+how you got there. Default to short and lead with the conclusion. State
+what the code or decision does/is *now*; don't narrate how you arrived
+at it — no session dates, no PR-number-as-evidence, no "the reviewer
+said" attribution inside prose that's just describing current behavior.
+A tried-and-abandoned approach or a changed plan gets **one line**
+(under a PR's "Key points", or as a decision sentence in the doc/comment
+it constrains) and appears nowhere else — never a "Revision history"
+section. Deferred work is an issue link, not an inventory. The full
+version of this rule, with concrete before/after examples, lives in
+[change-discipline.md](docs/contributing/conventions/change-discipline.md#comments-pr-bodies-and-planning-docs-describe-now-not-how-you-got-there).
 
 Most of what wants to sprawl into a PR body belongs somewhere durable
 instead — a changeset for user-facing behavior, `docs/spec` or `docs/adr`

--- a/docs/contributing/conventions/bundle-budgets.md
+++ b/docs/contributing/conventions/bundle-budgets.md
@@ -107,6 +107,27 @@ A new subpath in `publishConfig.exports` must be added to
 `bundle-sizes.json` with a `tier` and a `note`. A test enforces this, so a new
 export cannot silently escape gating.
 
+## Regenerating a baseline
+
+Never copy `bundle-sizes.json` from another branch or carry an earlier
+rebaseline forward through a history rewrite — a committed baseline can
+carry the writing machine's toolchain/lockfile drift on entries your
+branch never touched, which quietly raises the ceiling on those entries
+so a genuine regression there lands green. Run `pnpm bundle-sizes
+--write` fresh on each branch tip, then read the diff and confirm every
+moved entry is one whose closure you actually changed. An entry moving
+that you can't explain by your own diff means stale `dist/` or a
+lockfile difference — fix that first.
+
+The other direction: `main`'s own committed baseline can itself be
+stale, not just a branch's. If the gate fails by far more than your diff
+explains, `git stash` (or WIP-commit) your work, `git reset --hard
+origin/main`, and run `pnpm bundle-sizes --report` on pure `main` — if
+main doesn't measure zero against its own committed baseline, that drift
+predates your branch. Land the refresh as its own `chore` commit with
+the measured table, then your feature commit on top, so the feature's
+numbers are attributable to it alone.
+
 ## The common regression
 
 A helper co-located with heavy runtime drags that whole module into every

--- a/docs/contributing/conventions/change-discipline.md
+++ b/docs/contributing/conventions/change-discipline.md
@@ -98,6 +98,15 @@ narrowing" to "demonstrated harm in keeping it."
 - **Redundant config knobs.** `metrics` / `schemas` / `indexes` overrides
   on `Db.create` duplicated `config.collections[*]`; the final shape is
   `Db.create({ storage, app, tenant, config? })` — no parallel knobs.
+- **Flattened `baerly.config.ts`.** Collection names stay namespaced under
+  `collections`; they never move to the top level alongside `auth` /
+  `target` / `observability`. Flattening needs a discriminator telling a
+  user-chosen name apart from a reserved key, and the namespace is what
+  makes a new top-level config key additive rather than a collision. The
+  rejected discriminators are recorded in the `BaerlyConfig` JSDoc
+  (`packages/protocol/src/app-config.ts`). Reopening this needs a
+  user-facing bug attributable to the nesting — "one less indent level" is
+  not enough.
 - **Cross-collection atomic write path.** Prohibited — it breaks the
   no-2PC invariant. There is no atomic write path spanning collections;
   every write appends to exactly one collection log (see
@@ -183,7 +192,9 @@ route it by its commitment level; commitment is signaled by an affirmative act
   Keep the decision; drop the speculative *mechanism* — record that an axis is
   deferred, not the shape it might one day take.
 - **Concrete, would-probably-accept-a-PR** → a GitHub Issue, `backlog` label, no
-  milestone. An open issue means "intent," not "scheduled."
+  milestone. An open issue means "intent," not "scheduled." The label _is_ that
+  signal — don't restate it as a disclaimer in the issue body; the affirmative
+  act of labeling already carries the meaning.
 - **Fuzzy / strategic / "wouldn't it be nice"** → GitHub Discussions, off the
   tree. Keep it out of the repo so a written note is never mistaken for a
   commitment the project has made.
@@ -272,3 +283,56 @@ authoring goal by keeping deployment friction out of the builder path. A
 mechanism that adds an operator chore breaks the deployment path builders
 depend on, so it harms the authoring audience too. That is what these
 three checks protect.
+
+## Comments, PR bodies, and planning docs describe now, not how you got there
+
+A source comment, PR body, commit message, or planning doc is a
+reference for whoever reads it next, not a transcript of the session
+that produced it. State what the code or decision *is*; don't narrate
+how an agent, reviewer, or subagent arrived at it. This generalizes
+[CLAUDE.md → Pull request bodies, code comments, and planning
+docs](../../../CLAUDE.md#pull-request-bodies-code-comments-and-planning-docs)
+to every place prose ships into the tree.
+
+**Why this needs saying explicitly:** this repo is worked by many
+coding-agent sessions, each carrying its own working memory of the
+debate that produced a decision — who proposed what, which claim turned
+out wrong, which PR number a fact traces to, what date something was
+"surfaced." That narrative is legitimate and belongs in the agent's own
+cross-session memory. It never belongs in a file this repo ships — if a
+fact is memory-shaped, it does not also belong in a comment, docstring,
+commit body, or planning doc.
+
+Signatures that the narrative leaked into the tree — check for these
+before landing a comment or doc edit:
+
+- A date, session ID, or PR-number citation inside prose describing
+  *current* behavior ("Surfaced 2026-05-24…", "as of PR #107…", "the
+  T03 subagent reported this as pre-existing"). If the fact is still
+  true, state it in present tense with no date and no attribution. A
+  version boundary that genuinely matters belongs in `CHANGELOG.md` or
+  a versioned migration note, not a source comment.
+- A planning doc with an appended "Revision history" or "Update
+  2026-…" section instead of an edited, current plan. Replace the
+  outdated section; don't narrate the disagreement that produced the
+  replacement.
+- JSDoc or a module header that reads like an incident report — several
+  paragraphs of "why the naive fix doesn't work" investigation — rather
+  than the conclusion. Keep the one non-obvious invariant or
+  counter-intuitive tradeoff; cut the investigation trail that led
+  there.
+
+What's fine to keep is a rejected approach *stated as a decision*, with
+no date, no attribution, no blow-by-blow — e.g. "flattening was
+evaluated and rejected: every discriminator considered fails" next to
+the code it constrains. That is worth defending against a future
+re-proposal. The test is whether the passage reads like a decision or
+like a transcript:
+
+- ❌ "Surfaced during review: a reviewer claimed the uncaught
+  `storage.get` here is a defect... it was deferred, not fixed... the PR
+  merged with it open."
+- ✅ "Every storage call in `runGc` is uncaught; a throw aborts the
+  whole pass. That's a deliberate fail-safe — sweep DELETEs are
+  idempotent and nothing has been CAS-written yet when an earlier step
+  throws — fuzz-tested by `maintenance-crash-fuzz.test.ts`."

--- a/docs/contributing/conventions/docs.md
+++ b/docs/contributing/conventions/docs.md
@@ -104,6 +104,18 @@ copies are not identical today (e.g. some are bold and standalone,
 others are embedded in a longer sentence or soft-wrapped). Keep the
 phrasing aligned; don't claim they're byte-identical.
 
+## Link and anchor checking
+
+`pnpm verify:docs` **does** fail on a broken cross-file anchor
+(`other.md#some-heading`) — don't plan a doc restructure on the
+assumption anchors are unchecked. Two tools run in that script and only
+one checks anchors: `scripts/verify-docs.mjs` validates only that the
+target *file* exists (anchor-blind); `remark --frail` runs
+`remark-validate-links`, which resolves the fragment against the target
+file's actual headings and turns a `missing-heading-in-file` warning
+into a hard failure. What's genuinely unchecked is **figure drift** — a
+quoted number going stale against the doc that owns it.
+
 ## Don't
 
 - ❌ Duplicate content between `CLAUDE.md` and `docs/*.md`. CLAUDE.md

--- a/docs/contributing/conventions/tests.md
+++ b/docs/contributing/conventions/tests.md
@@ -79,6 +79,18 @@ a file mixes both kinds of test. Prefer the object-form
 - Don't string-match on `error.message` — the wording isn't stable.
 - Rationale: JSDoc on `BaerlyError` in [`packages/protocol/src/errors.ts`](../../../packages/protocol/src/errors.ts).
 
+## Runtime-boundary refactors
+
+A commit claiming "public signatures unchanged" or "byte-identical" is
+making a runtime claim, not a type claim — typecheck and lint can't
+verify it. When a refactor crosses a runtime boundary between two
+ecosystems (Web Streams ↔ Node Streams, sync ↔ async, fire-and-forget ↔
+awaited), demand a test that exercises the failure mode the old code
+tolerated — usually disconnect, abort, partial-read, or a rejected
+promise the old idiom silently swallowed. If the new idiom is stricter
+(often why it was chosen), that strictness is the behavior change, and
+only a runtime test surfaces it.
+
 ## Network-dependent tests
 - Tests that hit the network live in `tests/integration/` and expect
   Minio at `http://127.0.0.1:9102`. Bring it up with `pnpm dev:storage`

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -230,6 +230,46 @@ whole-repo) is part of `pnpm verify`, and the lefthook pre-commit hook
 also runs `oxfmt` on staged code/markup. Markdown is outside oxfmt;
 `verify:docs` validates Markdown instead of reformatting it.
 
+### Lefthook's typecheck fails on an import you didn't touch
+
+`tsgo --noEmit` resolves `baerly-storage/<subpath>` specifiers via the
+root `package.json` `exports` map, which points at `./dist/*.d.ts` — not
+at `packages/*/src/`. `pnpm install` rebuilds `dist/` via `prepare`, but
+`dist/` can drift from source between installs during ordinary edits. If
+the failure is `Module "baerly-storage/<sub>" has no exported member
+"X"` and `X` is present in the matching package's `src/index.ts`, run
+`pnpm build` before assuming the source is wrong. A fresh `git worktree`
+starts with no `dist/` at all — run `pnpm worktree:bootstrap` once after
+`git worktree add`, and again after rebasing onto a `main` that touched
+the kernel, so dist-consuming tests and byte-budget assertions measure
+the current tree.
+
+### `tsgo --noEmit` reports a `Cannot find module` that disappears on retry
+
+In a fresh `git worktree` especially, `tsgo --noEmit` (the typecheck gate
+in `verify`/`verify:agent`/the lefthook hook) is occasionally
+non-deterministic: successive runs on the same unchanged tree report 0
+errors, then several, then a different set, then 0 again. The spurious
+errors are always `TS2307 Cannot find module` against workspace packages
+or special specifiers (`@baerly/server`, `cloudflare:test`, …). If you
+see that shape, re-run once before editing the flagged files. A
+reproducing error is real — fix it. A green retry does not clear a red
+run: treat the red one as authoritative and find the cause.
+
+### `pnpm build` breaks after editing a tsconfig's `include`/`exclude`
+
+Adding or removing a `packages/*/src` path from the root `tsconfig.json`
+breaks declaration emit: `rolldown-plugin-dts` (`rolldown.config.ts`)
+runs `tsgo` against the tsconfig it's told to use, so an excluded package
+has no program to emit from and `pnpm build` dies with `tsgo did not
+generate dts file for .../src/index.ts`. No fast gate catches this —
+`verify:agent` never builds, and `test:agent`'s `pretest` skips the build
+whenever `dist/` already exists — so run `pnpm build` explicitly after
+touching a tsconfig's `include`/`exclude` or `rolldown.config.ts`; don't
+infer build health from a green `verify:agent`/`test:agent`. The repo has
+three tsconfigs by design: root (Node-only), `tsconfig.cloudflare.json`
+(Workers surface), and `tsconfig.build.json` (both, dts emit only).
+
 ### The pre-commit hook didn't fire
 
 `pnpm install` installs the lefthook pre-commit hook in the primary

--- a/docs/contributing/extending.md
+++ b/docs/contributing/extending.md
@@ -233,6 +233,17 @@ always carries `_id` (the server mints a UUIDv7 for inserts that omit
 it), so the schema must assert it — author `_id: z.string()`, not
 `.optional()`.
 
+For any field that may be **absent**, reach for `.optional()`, not
+`.nullable()`. `DocumentValue` has no `null` member — RFC 7396
+merge-patch (which `merge()` in `packages/protocol/src/json.ts`
+implements) treats `null` in an update patch as a deletion sentinel, not
+a stored value. A schema declaring `assignee: z.string().nullable()`
+type-checks but diverges from runtime: the type says `string | null`,
+but a `find()` call returns the field as `undefined` (absent), never
+`null`. If you need to teach the merge-patch semantics, frame it as
+"passing `tags: null` in an update deletes the field," not "the field
+can hold null."
+
 A multi-row `update()` is **not** transactional across rows. Validation
 runs per row on the merged post-image, and each row commits
 independently: if row N fails, rows 0..N-1 are already committed and stay
@@ -646,6 +657,26 @@ Other utilities (e.g. `compact`, `runGc`, `rebuildIndex`) are
 end-to-end orchestrators rather than helpers; their entry points are
 documented in [architecture.md](../architecture.md) under "Where
 invariants live."
+
+### Keeping an `Internal*` type off the published `.d.ts`
+
+An `Internal*` widening stays unpublished only if no published entry
+point reaches it — including *structurally*, through another exported
+type's field types, even when the internal type is never name-exported
+itself. Exporting it from a module that happens to be a published entry
+is enough to land it in that entry's `.d.ts`, and TypeScript won't stop
+the caller: the excess-property check only fires on fresh object
+literals, so a named variable of the internal type passes clean.
+
+Declare the type in the module that owns it and re-export it from
+`packages/server/src/_internal/testing.ts`, which is deliberately absent
+from `publishConfig.exports` — `export type { InternalRunGcOptions } from
+"../gc.ts"`. Fixtures and the CLI reach it through
+`@baerly/server/_internal/testing`; published entries never do.
+
+`tests/integration/internal-types-unpublished.test.ts` is the gate. Its
+name scan keys off the `Internal` prefix, so a widening named otherwise
+slips past layer 2 — follow the convention.
 
 ---
 

--- a/docs/contributing/publishing.md
+++ b/docs/contributing/publishing.md
@@ -34,6 +34,16 @@ automatically; `pnpm release` refuses to publish a stale one.
    the `fixed` group). Write the body for an LLM reader; breaking changes
    MUST include an old→new migration block (see `.changeset/README.md`).
 
+   Two gotchas invisible until a dry run: `changeset version` bumps and
+   writes a `CHANGELOG.md` for **every** non-ignored workspace package
+   that depends on the bumped one, including `private: true` ones — the
+   `examples/*` apps depend on `baerly-storage: workspace:*`, so a leaf
+   dependent needs to sit in the Changesets `ignore` list or it gets a
+   spurious changelog. And `changeset version` prepends new versions
+   immediately under the `CHANGELOG.md` H1, displacing any preamble
+   between the H1 and the first `## <version>` — put meta-notes as a
+   footer at EOF instead, since prepends never touch the bottom.
+
 2. **At release time** — consume the changesets:
 
    ```sh
@@ -94,6 +104,14 @@ automatically; `pnpm release` refuses to publish a stale one.
 
 Workspace `@baerly/*` packages are marked `"private": true` and are
 never published — they bundle into the published `@gusto/baerly-storage`.
+
+The published subpaths (`./cloudflare`, `./auth`, `./http`, `./node`,
+`./config`, `./client`, `./client/react`, `./dev`, `./dev/vite`,
+`./maintenance`, `./observability`, …) are defined in the **root**
+`package.json`'s `exports`, not in any `packages/*/package.json`. The
+workspace packages have their own internal `exports` (e.g.
+`./_internal/testing`) that are not part of the published surface —
+grepping `packages/*/package.json` for a subpath is a false negative.
 
 ## One-time setup
 

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -33,6 +33,13 @@ module's transitive imports are evaluated lazily.
 Exit-code contract (per `src/deploy.ts:10-16` and friends): 0 success,
 1 user error, 2 storage/external error, 3 protocol invariant.
 
+Two citty (`^0.2.2`) quirks this package works around — the camelCase
+alias it auto-injects for kebab-case flags, and `runCommand` not
+intercepting `--help`/`--version` the way `runMain` does — are
+documented next to their fixes in `src/subcommand.ts` and
+`src/bin-runner.ts` respectively; read those before touching flag
+parsing or the bin entry.
+
 ## Shared with create-baerly-storage
 
 `@baerly/cli` surfaces exactly one subpath export:

--- a/packages/create-baerly-storage/AGENTS.md
+++ b/packages/create-baerly-storage/AGENTS.md
@@ -107,6 +107,13 @@ readable list), `snippet` (the worker-entry snippet text), `snippetTarget`
 
 ## When editing templates
 
+- **`examples/*/tsconfig*.json` must inline every `compilerOption` — no
+  `"extends"`, to a monorepo-root path or to a sibling within the same
+  template.** These are scaffold templates copied verbatim into a user's
+  repo; the user has no monorepo root, so a parent-relative `extends`
+  breaks after scaffolding. The duplication across the 4 templates × 2
+  leaf tsconfigs is intentional — don't dedup it with a shared base, even
+  a sibling one that would mechanically resolve today.
 - Use sentinels (e.g. `appName`, not the literal value) so the
   substituter doesn't double-rewrite. See
   `packages/create-baerly-storage/src/scaffold.test.ts` for examples.

--- a/packages/protocol/src/app-config.ts
+++ b/packages/protocol/src/app-config.ts
@@ -90,6 +90,19 @@ export interface CollectionDefinition {
  * The full `baerly.config.ts` runtime shape. Re-exported from
  * `baerly-storage` and consumed by the day-1 `npm create baerly`
  * scaffold + the `baerly admin rebuild-index` CLI.
+ *
+ * The two-tier shape — collections namespaced under `collections`,
+ * reserved keys at the top level — is deliberate. Flattening collection
+ * names to the top level was evaluated and rejected: it needs a
+ * discriminator separating a user-chosen collection name from a reserved
+ * key, and both candidates fail. A reserved-key allowlist
+ * (`Exclude<keyof C, ReservedKeys>`) breaks every time a config key is
+ * added — that set has already grown twice — turning each future
+ * addition into a breaking change or a forced rename for whoever named a
+ * collection after it. A structural sentinel keyed on `schema:` presence
+ * fails because {@link CollectionDefinition.schema} is optional, and
+ * `{ notes: {} }` is the hello-world shape the `examples/minimal-*`
+ * scaffolds ship. The namespace is what keeps config growth additive.
  */
 export interface BaerlyConfig {
   /**

--- a/packages/server/src/gc.ts
+++ b/packages/server/src/gc.ts
@@ -56,6 +56,18 @@
  * CAS-lost on `gc/pending.json` is non-fatal: the DELETEs already
  * issued are durable, so we return a successful result and the next
  * pass will pick up any work this pass lost.
+ *
+ * **Not fault-isolated, by design.** Every storage call in Steps 1-5 —
+ * the `current.json`/`gc/pending.json` reads, the mark-phase `LIST`s,
+ * the sweep DELETEs — is uncaught within `runGc` itself; a throw from
+ * any of them aborts the whole pass. That's a deliberate fail-safe, not
+ * a gap to close with a `try`/`catch` around one call: Steps 3-4 re-LIST
+ * from scratch every pass rather than trusting partial progress, sweep
+ * DELETEs are idempotent, and the pending-ledger CAS in Step 5 hasn't
+ * happened yet when an earlier step throws — so an abort mid-pass loses
+ * no durable state and deletes nothing it shouldn't. This is fuzz-tested
+ * directly: `maintenance-crash-fuzz.test.ts` aborts the K-th storage op
+ * inside `runGc` and asserts the reader still returns every live row.
  */
 
 import {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,10 @@
+# Under pnpm 11 (pinned via `packageManager`) every resolution setting —
+# `overrides`, `packageExtensions`, `allowBuilds`, `linkWorkspacePackages` —
+# belongs in this file, not in a `"pnpm"` field in `package.json`. That
+# field is silently inert there: no error, no effect. The tell is `pnpm
+# install` printing `Lockfile is up to date, resolution step is skipped`
+# when you expected a re-resolve.
+
 packages:
   - .
   - packages/*


### PR DESCRIPTION
## What & why

Captures gotchas and decisions surfaced by recent kernel/build work before they're lost: adds ADR-008 for the two-tier `baerly.config.ts` shape, and writes up tsgo/dist drift in fresh worktrees, bundle-baseline rebaselining pitfalls, doc anchor checking scope, runtime-boundary refactor test gaps, field-cut spread blind spots, citty flag-parsing quirks, scaffold tsconfig extends restrictions, changesets version/changelog gotchas, and the comments/PR-bodies/planning-docs "describe now, not how you got there" rule.

## Verification

Docs-only change. There's a pre-existing TS failure unrelated to this branch, currently being tracked in CI.

## Notes for reviewers

Mostly additive documentation across CLAUDE.md, contributing conventions, package AGENTS.md files, and JSDoc on `gc.ts`/`app-config.ts`.