### PR TITLE
fix(bench): nearest-rank percentiles, plus teardown docs and a rule-glob fix

### DIFF
--- a/.claude/rules/bundle-budgets.md
+++ b/.claude/rules/bundle-budgets.md
@@ -1,7 +1,14 @@
 ---
 description: Bundle-size policy for bundle-affecting edits (delta gate, do-not-golf-comments rule)
 paths:
-  ["packages/*/src/**/*.ts", "packages/*/src/**/*.tsx", "rolldown.config.ts", "bundle-sizes.json"]
+  [
+    "packages/*/src/**/*.ts",
+    "packages/*/src/**/*.tsx",
+    "rolldown.config.ts",
+    "bundle-sizes.json",
+    "!packages/**/*.test.ts",
+    "!packages/**/*.test.tsx",
+  ]
 title: "Auto-load: bundle budget policy"
 audience: agent
 summary: Triggers on bundle-affecting source — packages/*/src, rolldown.config.ts, and the bundle-sizes.json snapshot itself — and routes the agent to docs/contributing/conventions/bundle-budgets.md before it writes.

--- a/.claude/rules/bundle-budgets.md
+++ b/.claude/rules/bundle-budgets.md
@@ -8,6 +8,7 @@ paths:
     "bundle-sizes.json",
     "!packages/**/*.test.ts",
     "!packages/**/*.test.tsx",
+    "!packages/**/*.test-d.ts",
   ]
 title: "Auto-load: bundle budget policy"
 audience: agent

--- a/bench/README.md
+++ b/bench/README.md
@@ -84,7 +84,7 @@ storage layout or manifest cache policy.
 ### Result JSON
 
 One file per run; the canonical shape is `type RunResult` in
-`bench/load-harness/cli.ts`. Every field is non-optional except
+`bench/load-harness/assemble-result.ts`. Every field is non-optional except
 `run.backend_details`. File names follow the pattern:
 
 ```

--- a/bench/load-harness/assemble-result.ts
+++ b/bench/load-harness/assemble-result.ts
@@ -7,6 +7,7 @@
  * test. Everything here is I/O-free and clock-free.
  */
 
+import { quantileNearestRank } from "../measurement/statistics.ts";
 import type { StorageSnapshot } from "../types.ts";
 import type { ManifestCacheMode } from "./stores/manifest-cache.ts";
 import type { Preset } from "./presets.ts";
@@ -81,13 +82,18 @@ export interface AssembleOpts {
   readonly tenants: number;
 }
 
+/**
+ * `quantile-nearest-rank-v1` over `arr`, or 0 for an empty sample.
+ *
+ * The zero is the load-bearing part: an op that recorded no latency still
+ * gets a percentile block in the run JSON, and `quantileNearestRank` throws
+ * on an empty sample rather than inventing a number for one.
+ */
 function pct(arr: number[], q: number): number {
   if (arr.length === 0) {
     return 0;
   }
-  const sorted = [...arr].toSorted((a, b) => a - b);
-  const idx = Math.min(sorted.length - 1, Math.floor(sorted.length * q));
-  return sorted[idx]!;
+  return quantileNearestRank(arr, q);
 }
 
 export function assembleResult(o: AssembleOpts): RunResult {

--- a/bench/load-harness/assemble-result.ts
+++ b/bench/load-harness/assemble-result.ts
@@ -1,0 +1,180 @@
+/**
+ * The canonical load-harness `RunResult` shape, and the pure function that
+ * assembles one from the five phase snapshots.
+ *
+ * Lives outside `cli.ts` because that module reads `process.argv` and calls
+ * `main()` at import time, so nothing declared there is reachable from a
+ * test. Everything here is I/O-free and clock-free.
+ */
+
+import type { StorageSnapshot } from "../types.ts";
+import type { ManifestCacheMode } from "./stores/manifest-cache.ts";
+import type { Preset } from "./presets.ts";
+
+export type Variant = "memory" | "local-fs" | "node-minio" | "cloudflare-r2" | "node-gcs";
+
+export type RunResult = {
+  run: {
+    preset: string;
+    variant: Variant;
+    cache_mode: "cold" | "metadata-warm" | "data-warm" | "tiny-cache";
+    records: number;
+    ops: number;
+    seed: number;
+    timestamp: string;
+    backend_details?: Record<string, string>;
+  };
+  latency_ms: {
+    logical_op: { p50: number; p95: number; p99: number };
+    by_op: Record<string, { p50: number; p95: number; p99: number }>;
+  };
+  object_store: {
+    get: number;
+    put: number;
+    head: number;
+    list: number;
+    delete: number;
+    bytes_read: number;
+    bytes_written: number;
+    retries: number;
+    conflict_412: number;
+    rate_limit_429: number;
+  };
+  derived: {
+    get_per_op: number;
+    put_per_op: number;
+    bytes_read_per_op: number;
+    bytes_written_per_op: number;
+    class_a_per_tenant_per_hour: number;
+  };
+  cache: { manifest_hit_rate: number; snapshot_hit_rate: number };
+  compaction: {
+    bytes_read: number;
+    bytes_written: number;
+    objects_read: number;
+    objects_written: number;
+    bytes_ratio: number;
+  };
+};
+
+export interface PhaseResult {
+  readonly metrics: StorageSnapshot;
+  readonly wallclockMs: number;
+}
+
+export interface AssembleOpts {
+  readonly preset: Preset;
+  readonly variant: Variant;
+  readonly cacheMode: ManifestCacheMode;
+  readonly records: number;
+  readonly totalOps: number;
+  readonly seed: number;
+  readonly startedIso: string;
+  readonly backendDetails: Record<string, string>;
+  readonly seedRes: PhaseResult;
+  readonly ingestRes: PhaseResult;
+  readonly queryPreRes: PhaseResult;
+  readonly compactRes: PhaseResult;
+  readonly queryPostRes: PhaseResult;
+  readonly cacheStats: { manifestHitRate: number; snapshotHitRate: number };
+  readonly latencyByOp: Map<string, number[]>;
+  readonly tenants: number;
+}
+
+function pct(arr: number[], q: number): number {
+  if (arr.length === 0) {
+    return 0;
+  }
+  const sorted = [...arr].toSorted((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.floor(sorted.length * q));
+  return sorted[idx]!;
+}
+
+export function assembleResult(o: AssembleOpts): RunResult {
+  const phases = [o.seedRes, o.ingestRes, o.queryPreRes, o.compactRes, o.queryPostRes];
+  const sum = (pick: (s: StorageSnapshot) => number): number =>
+    phases.reduce((acc, p) => acc + pick(p.metrics), 0);
+
+  const get = sum((s) => s.object_store.get);
+  const put = sum((s) => s.object_store.put);
+  const head = sum((s) => s.object_store.head);
+  const list = sum((s) => s.object_store.list);
+  const del = sum((s) => s.object_store.delete);
+  const bytesRead = sum((s) => s.object_store.bytes_read);
+  const bytesWritten = sum((s) => s.object_store.bytes_written);
+  const retries = sum((s) => s.object_store.retries);
+  const conflict412 = sum((s) => s.object_store.conflict_412);
+  const rateLimit429 = sum((s) => s.object_store.rate_limit_429);
+
+  // Class A idle bound: measured during query-post phase only.
+  // Billing-correct — DeleteObject is $0 on R2/S3, so it is excluded
+  // (see docs/about/cost-model.md). The idle reader path issues neither
+  // PUT nor LIST, so this is 0 on a healthy idle workload.
+  const classAInQueryPost =
+    o.queryPostRes.metrics.object_store.put + o.queryPostRes.metrics.object_store.list;
+  const queryPostHours = Math.max(1e-6, o.queryPostRes.wallclockMs / 3_600_000);
+  const classAPerTenantPerHour = classAInQueryPost / Math.max(1, o.tenants) / queryPostHours;
+
+  // Compaction phase isolation.
+  const compactObjectsRead = o.compactRes.metrics.object_store.get;
+  const compactObjectsWritten = o.compactRes.metrics.object_store.put;
+  const compactBytesRead = o.compactRes.metrics.object_store.bytes_read;
+  const compactBytesWritten = o.compactRes.metrics.object_store.bytes_written;
+
+  // Per-op latency percentiles.
+  const allLatencies: number[] = [];
+  const byOp: Record<string, { p50: number; p95: number; p99: number }> = {};
+  for (const [kind, arr] of o.latencyByOp) {
+    byOp[kind] = { p50: pct(arr, 0.5), p95: pct(arr, 0.95), p99: pct(arr, 0.99) };
+    allLatencies.push(...arr);
+  }
+  const logicalOp = {
+    p50: pct(allLatencies, 0.5),
+    p95: pct(allLatencies, 0.95),
+    p99: pct(allLatencies, 0.99),
+  };
+
+  return {
+    run: {
+      preset: o.preset.name,
+      variant: o.variant,
+      cache_mode: o.cacheMode,
+      records: o.records,
+      ops: o.totalOps,
+      seed: o.seed,
+      timestamp: o.startedIso,
+      backend_details: o.backendDetails,
+    },
+    latency_ms: { logical_op: logicalOp, by_op: byOp },
+    object_store: {
+      get,
+      put,
+      head,
+      list,
+      delete: del,
+      bytes_read: bytesRead,
+      bytes_written: bytesWritten,
+      retries,
+      conflict_412: conflict412,
+      rate_limit_429: rateLimit429,
+    },
+    derived: {
+      get_per_op: get / Math.max(1, o.totalOps),
+      put_per_op: put / Math.max(1, o.totalOps),
+      bytes_read_per_op: bytesRead / Math.max(1, o.totalOps),
+      bytes_written_per_op: bytesWritten / Math.max(1, o.totalOps),
+      class_a_per_tenant_per_hour: classAPerTenantPerHour,
+    },
+    cache: {
+      manifest_hit_rate: o.cacheStats.manifestHitRate,
+      snapshot_hit_rate: o.cacheStats.snapshotHitRate,
+    },
+    compaction: {
+      bytes_read: compactBytesRead,
+      bytes_written: compactBytesWritten,
+      objects_read: compactObjectsRead,
+      objects_written: compactObjectsWritten,
+      bytes_ratio: compactBytesWritten / Math.max(1, compactBytesRead),
+    },
+  };
+}

--- a/bench/load-harness/cli.ts
+++ b/bench/load-harness/cli.ts
@@ -4,7 +4,7 @@
  * Wires the ticket-50 CountingStorage + ticket-51 preset framework
  * + ticket-53 runner + manifest cache into one invocation. Writes
  * a canonical `RunResult` JSON to `bench/results/load/` per the
- * shape locked in this file's `type RunResult` declaration.
+ * shape locked in `assemble-result.ts`.
  *
  * Backend gating mirrors `pnpm test:minio` — `--variant=node-minio`
  * requires `MINIO=1` and `pnpm dev:storage` running. `--variant=node-gcs`
@@ -51,7 +51,7 @@ import type { EndpointCreds } from "../../tests/fixtures/endpoint-creds.ts";
 import type { BaerlyConfig } from "@baerly/server";
 import { LocalFsStorage } from "@baerly/dev";
 import { CountingStorage } from "../storage.ts";
-import type { StorageSnapshot } from "../types.ts";
+import { assembleResult, type Variant } from "./assemble-result.ts";
 import { ManifestCachedStorage, type ManifestCacheMode } from "./stores/manifest-cache.ts";
 import { runSeed } from "./runner/seed.ts";
 import { runReplay } from "./runner/replay.ts";
@@ -76,56 +76,6 @@ import "./presets/many-tiny-apps.ts";
 import "./presets/rag-document-store.ts";
 // eslint-disable-next-line import/no-unassigned-import
 import "./presets/chat-conversation-store.ts";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-type Variant = "memory" | "local-fs" | "node-minio" | "cloudflare-r2" | "node-gcs";
-
-export type RunResult = {
-  run: {
-    preset: string;
-    variant: "memory" | "local-fs" | "node-minio" | "cloudflare-r2" | "node-gcs";
-    cache_mode: "cold" | "metadata-warm" | "data-warm" | "tiny-cache";
-    records: number;
-    ops: number;
-    seed: number;
-    timestamp: string;
-    backend_details?: Record<string, string>;
-  };
-  latency_ms: {
-    logical_op: { p50: number; p95: number; p99: number };
-    by_op: Record<string, { p50: number; p95: number; p99: number }>;
-  };
-  object_store: {
-    get: number;
-    put: number;
-    head: number;
-    list: number;
-    delete: number;
-    bytes_read: number;
-    bytes_written: number;
-    retries: number;
-    conflict_412: number;
-    rate_limit_429: number;
-  };
-  derived: {
-    get_per_op: number;
-    put_per_op: number;
-    bytes_read_per_op: number;
-    bytes_written_per_op: number;
-    class_a_per_tenant_per_hour: number;
-  };
-  cache: { manifest_hit_rate: number; snapshot_hit_rate: number };
-  compaction: {
-    bytes_read: number;
-    bytes_written: number;
-    objects_read: number;
-    objects_written: number;
-    bytes_ratio: number;
-  };
-};
 
 // ---------------------------------------------------------------------------
 // Argv parser
@@ -326,132 +276,6 @@ function currentJsonKeysFor(
   return dataset.tenants.map(
     (t) => `app/${appName}/tenant/${t.tenantId}/manifests/${collection}/current.json`,
   );
-}
-
-// ---------------------------------------------------------------------------
-// assembleResult
-// ---------------------------------------------------------------------------
-
-interface PhaseResult {
-  readonly metrics: StorageSnapshot;
-  readonly wallclockMs: number;
-}
-
-interface AssembleOpts {
-  readonly preset: Preset;
-  readonly variant: Variant;
-  readonly cacheMode: ManifestCacheMode;
-  readonly records: number;
-  readonly totalOps: number;
-  readonly seed: number;
-  readonly startedIso: string;
-  readonly backendDetails: Record<string, string>;
-  readonly seedRes: PhaseResult;
-  readonly ingestRes: PhaseResult;
-  readonly queryPreRes: PhaseResult;
-  readonly compactRes: PhaseResult;
-  readonly queryPostRes: PhaseResult;
-  readonly cacheStats: { manifestHitRate: number; snapshotHitRate: number };
-  readonly latencyByOp: Map<string, number[]>;
-  readonly tenants: number;
-}
-
-function pct(arr: number[], q: number): number {
-  if (arr.length === 0) {
-    return 0;
-  }
-  const sorted = [...arr].toSorted((a, b) => a - b);
-  const idx = Math.min(sorted.length - 1, Math.floor(sorted.length * q));
-  return sorted[idx]!;
-}
-
-function assembleResult(o: AssembleOpts): RunResult {
-  const phases = [o.seedRes, o.ingestRes, o.queryPreRes, o.compactRes, o.queryPostRes];
-  const sum = (pick: (s: StorageSnapshot) => number): number =>
-    phases.reduce((acc, p) => acc + pick(p.metrics), 0);
-
-  const get = sum((s) => s.object_store.get);
-  const put = sum((s) => s.object_store.put);
-  const head = sum((s) => s.object_store.head);
-  const list = sum((s) => s.object_store.list);
-  const del = sum((s) => s.object_store.delete);
-  const bytesRead = sum((s) => s.object_store.bytes_read);
-  const bytesWritten = sum((s) => s.object_store.bytes_written);
-  const retries = sum((s) => s.object_store.retries);
-  const conflict412 = sum((s) => s.object_store.conflict_412);
-  const rateLimit429 = sum((s) => s.object_store.rate_limit_429);
-
-  // Class A idle bound: measured during query-post phase only.
-  // Billing-correct — DeleteObject is $0 on R2/S3, so it is excluded
-  // (see docs/about/cost-model.md). The idle reader path issues neither
-  // PUT nor LIST, so this is 0 on a healthy idle workload.
-  const classAInQueryPost =
-    o.queryPostRes.metrics.object_store.put + o.queryPostRes.metrics.object_store.list;
-  const queryPostHours = Math.max(1e-6, o.queryPostRes.wallclockMs / 3_600_000);
-  const classAPerTenantPerHour = classAInQueryPost / Math.max(1, o.tenants) / queryPostHours;
-
-  // Compaction phase isolation.
-  const compactObjectsRead = o.compactRes.metrics.object_store.get;
-  const compactObjectsWritten = o.compactRes.metrics.object_store.put;
-  const compactBytesRead = o.compactRes.metrics.object_store.bytes_read;
-  const compactBytesWritten = o.compactRes.metrics.object_store.bytes_written;
-
-  // Per-op latency percentiles.
-  const allLatencies: number[] = [];
-  const byOp: Record<string, { p50: number; p95: number; p99: number }> = {};
-  for (const [kind, arr] of o.latencyByOp) {
-    byOp[kind] = { p50: pct(arr, 0.5), p95: pct(arr, 0.95), p99: pct(arr, 0.99) };
-    allLatencies.push(...arr);
-  }
-  const logicalOp = {
-    p50: pct(allLatencies, 0.5),
-    p95: pct(allLatencies, 0.95),
-    p99: pct(allLatencies, 0.99),
-  };
-
-  return {
-    run: {
-      preset: o.preset.name,
-      variant: o.variant,
-      cache_mode: o.cacheMode,
-      records: o.records,
-      ops: o.totalOps,
-      seed: o.seed,
-      timestamp: o.startedIso,
-      backend_details: o.backendDetails,
-    },
-    latency_ms: { logical_op: logicalOp, by_op: byOp },
-    object_store: {
-      get,
-      put,
-      head,
-      list,
-      delete: del,
-      bytes_read: bytesRead,
-      bytes_written: bytesWritten,
-      retries,
-      conflict_412: conflict412,
-      rate_limit_429: rateLimit429,
-    },
-    derived: {
-      get_per_op: get / Math.max(1, o.totalOps),
-      put_per_op: put / Math.max(1, o.totalOps),
-      bytes_read_per_op: bytesRead / Math.max(1, o.totalOps),
-      bytes_written_per_op: bytesWritten / Math.max(1, o.totalOps),
-      class_a_per_tenant_per_hour: classAPerTenantPerHour,
-    },
-    cache: {
-      manifest_hit_rate: o.cacheStats.manifestHitRate,
-      snapshot_hit_rate: o.cacheStats.snapshotHitRate,
-    },
-    compaction: {
-      bytes_read: compactBytesRead,
-      bytes_written: compactBytesWritten,
-      objects_read: compactObjectsRead,
-      objects_written: compactObjectsWritten,
-      bytes_ratio: compactBytesWritten / Math.max(1, compactBytesRead),
-    },
-  };
 }
 
 // ---------------------------------------------------------------------------

--- a/bench/load-harness/tests/assemble-result.test.ts
+++ b/bench/load-harness/tests/assemble-result.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, expect } from "vitest";
+import { assembleResult, type PhaseResult } from "../assemble-result.ts";
+import { getPreset } from "../presets.ts";
+// Side-effect import: registers the preset `getPreset` below resolves.
+// eslint-disable-next-line import/no-unassigned-import
+import "../presets/recent-first-crud.ts";
+import type { StorageSnapshot } from "../../types.ts";
+
+const zeroPhase: PhaseResult = {
+  metrics: {
+    object_store: {
+      get: 0,
+      put: 0,
+      head: 0,
+      list: 0,
+      delete: 0,
+      bytes_read: 0,
+      bytes_written: 0,
+      retries: 0,
+      conflict_412: 0,
+      rate_limit_429: 0,
+    },
+    latency_ms: { by_op: {} },
+    ops_by_prefix: {},
+  } satisfies StorageSnapshot,
+  wallclockMs: 1,
+};
+
+/** Descending, so the assertion also pins that the sample gets sorted. */
+const descending = (from: number, to: number): number[] => {
+  const out: number[] = [];
+  for (let v = from; v >= to; v--) {
+    out.push(v);
+  }
+  return out;
+};
+
+const assemble = (latencyByOp: Map<string, number[]>): ReturnType<typeof assembleResult> =>
+  assembleResult({
+    preset: getPreset("recent-first-crud"),
+    variant: "memory",
+    cacheMode: "metadata-warm",
+    records: 10,
+    totalOps: 10,
+    seed: 42,
+    startedIso: "2026-01-01T00:00:00.000Z",
+    backendDetails: {},
+    seedRes: zeroPhase,
+    ingestRes: zeroPhase,
+    queryPreRes: zeroPhase,
+    compactRes: zeroPhase,
+    queryPostRes: zeroPhase,
+    cacheStats: { manifestHitRate: 0, snapshotHitRate: 0 },
+    latencyByOp,
+    tenants: 1,
+  });
+
+describe("assembleResult latency percentiles", () => {
+  test("maps p50/p95/p99 per op and over the pooled sample", () => {
+    // At n=100 (and n=200 pooled) all three ranks discriminate the
+    // one-indexed `ceil(q*n)` from a zero-indexed `floor(n*q)` — 50 vs 51,
+    // 95 vs 96, 99 vs 100 — so a reverted or swapped quantile fails here
+    // rather than coinciding.
+    const result = assemble(
+      new Map([
+        ["list-recent", descending(100, 1)],
+        ["insert", descending(200, 101)],
+      ]),
+    );
+    expect(result.latency_ms.by_op["list-recent"]).toEqual({ p50: 50, p95: 95, p99: 99 });
+    expect(result.latency_ms.by_op["insert"]).toEqual({ p50: 150, p95: 195, p99: 199 });
+    // Pooled across both ops: 1..200.
+    expect(result.latency_ms.logical_op).toEqual({ p50: 100, p95: 190, p99: 198 });
+  });
+
+  test("reports zeros for an op with no samples and for an empty pooled sample", () => {
+    // `quantileNearestRank` throws on an empty sample; the harness reports
+    // a zeroed block instead, so this branch must never reach it.
+    const result = assemble(new Map([["head", []]]));
+    expect(result.latency_ms.by_op["head"]).toEqual({ p50: 0, p95: 0, p99: 0 });
+    expect(result.latency_ms.logical_op).toEqual({ p50: 0, p95: 0, p99: 0 });
+  });
+});

--- a/bench/measurement/storage-factory.ts
+++ b/bench/measurement/storage-factory.ts
@@ -275,6 +275,9 @@ export const createMemoryStorageFactory = (): StorageFactory => {
             storage: instance,
             authority: { kind: "memory-instance", lease_id: leaseId },
             runCleanup: async () => {
+              // Supported teardown contract: the factory owns the instance and
+              // must clear it. MemoryStorage._clear() is @internal but is the
+              // intended cleanup path for measurement infrastructure.
               instance._clear();
               return { attempted: [leaseId], cleaned: [leaseId], failures: [] };
             },

--- a/bench/metrics.test.ts
+++ b/bench/metrics.test.ts
@@ -8,10 +8,9 @@ describe("Metrics.snapshot() percentiles", () => {
       m.recordCommit(latency, 0);
     }
     const snap = m.snapshot();
-    // sorted = [1..10], n=10. rank = ceil(q*n), value = sorted[rank-1].
-    expect(snap.latency_p50_ms).toBe(5); // rank ceil(0.5*10)=5 -> sorted[4]=5
-    expect(snap.latency_p99_ms).toBe(10); // rank ceil(0.99*10)=10 -> sorted[9]=10
-    expect(snap.latency_p999_ms).toBe(10); // rank ceil(0.999*10)=10 -> sorted[9]=10
+    expect(snap.latency_p50_ms).toBe(5); // ceil(0.5*10)=5 -> sorted[4]=5
+    expect(snap.latency_p99_ms).toBe(10); // ceil(0.99*10)=10 -> sorted[9]=10
+    expect(snap.latency_p999_ms).toBe(10); // ceil(0.999*10)=10 -> sorted[9]=10
   });
 
   test("computes nearest-rank percentiles over 1..1000 where every rank lands on an exact integer", () => {
@@ -20,31 +19,12 @@ describe("Metrics.snapshot() percentiles", () => {
       m.recordCommit(latency, 0);
     }
     const snap = m.snapshot();
-    // sorted = [1..1000], n=1000. Values equal their own rank, so
-    // rank = ceil(q*n) reads off the expected value directly.
+    // Load-bearing at this n: `latency_p999_ms` only discriminates a
+    // correctly wired q=0.999 at large n — at n=10 every candidate rank
+    // lands on the max, so 1..10 cannot catch a mis-wired p999.
     expect(snap.latency_p50_ms).toBe(500); // ceil(0.5*1000)=500
     expect(snap.latency_p99_ms).toBe(990); // ceil(0.99*1000)=990
     expect(snap.latency_p999_ms).toBe(999); // ceil(0.999*1000)=999
-  });
-
-  test("clamps rank into [1,n] for a single-sample snapshot", () => {
-    const m = new Metrics();
-    m.recordCommit(42, 0);
-    const snap = m.snapshot();
-    expect(snap.latency_p50_ms).toBe(42);
-    expect(snap.latency_p99_ms).toBe(42);
-    expect(snap.latency_p999_ms).toBe(42);
-  });
-
-  test("clamps rank into [1,n] for a two-sample snapshot", () => {
-    const m = new Metrics();
-    m.recordCommit(10, 0);
-    m.recordCommit(20, 0);
-    const snap = m.snapshot();
-    // n=2. p50: ceil(1)=1 -> sorted[0]=10. p99/p999: ceil(1.98 or 1.998)=2 -> sorted[1]=20.
-    expect(snap.latency_p50_ms).toBe(10);
-    expect(snap.latency_p99_ms).toBe(20);
-    expect(snap.latency_p999_ms).toBe(20);
   });
 
   test("returns zeroed percentiles when no commits were recorded", () => {

--- a/bench/metrics.test.ts
+++ b/bench/metrics.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from "vitest";
+import { Metrics } from "./metrics.ts";
+
+describe("Metrics.snapshot() percentiles", () => {
+  test("computes nearest-rank percentiles for a shuffled 1..10 sample", () => {
+    const m = new Metrics();
+    for (const latency of [7, 1, 9, 3, 5, 2, 8, 4, 6, 10]) {
+      m.recordCommit(latency, 0);
+    }
+    const snap = m.snapshot();
+    // sorted = [1..10], n=10. rank = ceil(q*n), value = sorted[rank-1].
+    expect(snap.latency_p50_ms).toBe(5); // rank ceil(0.5*10)=5 -> sorted[4]=5
+    expect(snap.latency_p99_ms).toBe(10); // rank ceil(0.99*10)=10 -> sorted[9]=10
+    expect(snap.latency_p999_ms).toBe(10); // rank ceil(0.999*10)=10 -> sorted[9]=10
+  });
+
+  test("computes nearest-rank percentiles over 1..1000 where every rank lands on an exact integer", () => {
+    const m = new Metrics();
+    for (let latency = 1000; latency >= 1; latency--) {
+      m.recordCommit(latency, 0);
+    }
+    const snap = m.snapshot();
+    // sorted = [1..1000], n=1000. Values equal their own rank, so
+    // rank = ceil(q*n) reads off the expected value directly.
+    expect(snap.latency_p50_ms).toBe(500); // ceil(0.5*1000)=500
+    expect(snap.latency_p99_ms).toBe(990); // ceil(0.99*1000)=990
+    expect(snap.latency_p999_ms).toBe(999); // ceil(0.999*1000)=999
+  });
+
+  test("clamps rank into [1,n] for a single-sample snapshot", () => {
+    const m = new Metrics();
+    m.recordCommit(42, 0);
+    const snap = m.snapshot();
+    expect(snap.latency_p50_ms).toBe(42);
+    expect(snap.latency_p99_ms).toBe(42);
+    expect(snap.latency_p999_ms).toBe(42);
+  });
+
+  test("clamps rank into [1,n] for a two-sample snapshot", () => {
+    const m = new Metrics();
+    m.recordCommit(10, 0);
+    m.recordCommit(20, 0);
+    const snap = m.snapshot();
+    // n=2. p50: ceil(1)=1 -> sorted[0]=10. p99/p999: ceil(1.98 or 1.998)=2 -> sorted[1]=20.
+    expect(snap.latency_p50_ms).toBe(10);
+    expect(snap.latency_p99_ms).toBe(20);
+    expect(snap.latency_p999_ms).toBe(20);
+  });
+
+  test("returns zeroed percentiles when no commits were recorded", () => {
+    const m = new Metrics();
+    const snap = m.snapshot();
+    expect(snap.latency_p50_ms).toBe(0);
+    expect(snap.latency_p99_ms).toBe(0);
+    expect(snap.latency_p999_ms).toBe(0);
+  });
+
+  test("tracks commit_count, conflict/rate-limit counters, and the retry tail alongside percentiles", () => {
+    const m = new Metrics();
+    m.recordCommit(5, 2);
+    m.recordCommit(9, 7);
+    m.recordConflict412();
+    m.recordConflict412();
+    m.recordRateLimit429();
+    const snap = m.snapshot();
+    expect(snap.commit_count).toBe(2);
+    expect(snap.conflict_412_count).toBe(2);
+    expect(snap.rate_limit_429_count).toBe(1);
+    expect(snap.retry_tail_max).toBe(7);
+  });
+});

--- a/bench/metrics.ts
+++ b/bench/metrics.ts
@@ -36,7 +36,8 @@ export class Metrics {
       if (sorted.length === 0) {
         return 0;
       }
-      const idx = Math.min(sorted.length - 1, Math.floor(sorted.length * q));
+      // Nearest-rank: one-indexed ceil(q*n) over the ascending sort, clamped to [0,n-1]
+      const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil(q * sorted.length) - 1));
       return sorted[idx]!;
     };
     return {

--- a/bench/metrics.ts
+++ b/bench/metrics.ts
@@ -5,6 +5,7 @@
  * S1 c=32 × 60s × ~50 ops/sec ≈ 96 000.
  */
 
+import { quantileNearestRank } from "./measurement/statistics.ts";
 import type { MetricsSnapshot } from "./types.ts";
 
 export class Metrics {
@@ -31,14 +32,11 @@ export class Metrics {
   }
 
   snapshot(): MetricsSnapshot {
-    const sorted = [...this.latencies].toSorted((a, b) => a - b);
     const pick = (q: number): number => {
-      if (sorted.length === 0) {
+      if (this.latencies.length === 0) {
         return 0;
       }
-      // Nearest-rank: one-indexed ceil(q*n) over the ascending sort, clamped to [0,n-1]
-      const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil(q * sorted.length) - 1));
-      return sorted[idx]!;
+      return quantileNearestRank(this.latencies, q);
     };
     return {
       commit_count: this.commits,

--- a/bench/storage.test.ts
+++ b/bench/storage.test.ts
@@ -59,6 +59,20 @@ describe("CountingStorage per-op counters", () => {
     expect(snap.latency_ms.by_op.head).toBeUndefined();
   });
 
+  test("snapshot maps p50/p95/p99 onto q=0.5/0.95/0.99 of the retained samples", () => {
+    const c = new CountingStorage(new MemoryStorage());
+    // Descending 100..1 — nearest-rank sorts, and at n=100 all three ranks
+    // discriminate the one-indexed `ceil(q*n)` from a zero-indexed
+    // `floor(n*q)`: 50 vs 51, 95 vs 96, 99 vs 100. Pushed directly because
+    // real `performance.now()` deltas can't pin an expected value.
+    for (let ms = 100; ms >= 1; ms--) {
+      c.latenciesByOp.put.push(ms);
+    }
+    const snap = c.snapshot();
+    expect(snap.latency_ms.by_op.put).toEqual({ p50: 50, p95: 95, p99: 99 });
+    expect(snap.latency_ms.by_op.get).toBeUndefined();
+  });
+
   test("reset() clears every counter in lock-step", async () => {
     const c = new CountingStorage(new MemoryStorage());
     await c.put("a/b/c", new Uint8Array([1, 2, 3]));

--- a/bench/storage.ts
+++ b/bench/storage.ts
@@ -22,6 +22,7 @@ import {
   BaerlyError,
 } from "@baerly/protocol";
 import { S3HttpStorage } from "@baerly/adapter-node";
+import { quantileNearestRank } from "./measurement/statistics.ts";
 import type { StorageSnapshot, OpLatencyTail } from "./types.ts";
 
 export interface BenchStorageOpts {
@@ -86,13 +87,11 @@ function tailOrUndefined(samples: number[]): OpLatencyTail | undefined {
   if (samples.length === 0) {
     return undefined;
   }
-  const sorted = [...samples].toSorted((a, b) => a - b);
-  const pick = (q: number): number => {
-    // Nearest-rank: one-indexed ceil(q*n) over the ascending sort, clamped to [0,n-1]
-    const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil(q * sorted.length) - 1));
-    return sorted[idx]!;
+  return {
+    p50: quantileNearestRank(samples, 0.5),
+    p95: quantileNearestRank(samples, 0.95),
+    p99: quantileNearestRank(samples, 0.99),
   };
-  return { p50: pick(0.5), p95: pick(0.95), p99: pick(0.99) };
 }
 
 /**

--- a/bench/storage.ts
+++ b/bench/storage.ts
@@ -88,7 +88,8 @@ function tailOrUndefined(samples: number[]): OpLatencyTail | undefined {
   }
   const sorted = [...samples].toSorted((a, b) => a - b);
   const pick = (q: number): number => {
-    const idx = Math.min(sorted.length - 1, Math.floor(sorted.length * q));
+    // Nearest-rank: one-indexed ceil(q*n) over the ascending sort, clamped to [0,n-1]
+    const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil(q * sorted.length) - 1));
     return sorted[idx]!;
   };
   return { p50: pick(0.5), p95: pick(0.95), p99: pick(0.99) };

--- a/packages/dev/src/local-fs.ts
+++ b/packages/dev/src/local-fs.ts
@@ -109,6 +109,22 @@ const compareKeysUtf8 = (a: string, b: string): number => {
  * Node-only — imports `node:fs`, `node:path`, `node:crypto`. Lives in
  * `@baerly/dev` because the protocol kernel is pure-modules / no I/O
  * and must remain Worker-bundleable.
+ *
+ * ⚠️ **Hard termination and temp files.**
+ *
+ * Writes stage a sibling `.baerly-tmp-*` file before atomic rename/link.
+ * Normal failures clean up the temp in `finally`, but hard termination
+ * (`SIGKILL`, OOM, power loss) can strand a temp inside the root directory.
+ *
+ * These files are hidden from `list`, `gc`, `fsck`, and usage reporting
+ * by design—the temp filter applies at every depth.
+ *
+ * **Manual cleanup procedure:**
+ * 1. Stop all writers using the root
+ * 2. Run: `find <root> -name '.baerly-tmp-*' -delete`
+ *
+ * Do not clean while writes are in progress—races with in-flight PUTs
+ * can delete a file that a concurrent operation is about to rename.
  */
 export class LocalFsStorage implements Storage {
   readonly #root: string;


### PR DESCRIPTION
## What & why

Every bench percentile site computed the tail rank as `Math.floor(n * q)`, a zero-indexed rank that under-reports latency tails: at n=20, q=0.95 it returns the maximum sample instead of the 19th of 20; at n=10 it only lands in range because of the clamp; and for q=0.5 on even n it returns the lower median rather than the upper, biasing p50 low. All three sites — `bench/metrics.ts`, `bench/storage.ts`, and the load-harness result assembler — now delegate to `quantileNearestRank`, the standard one-indexed `ceil(q*n)` clamped into `[1, n]`. Reported percentiles therefore shift one rank lower than before; that shift is the fix.

Also here: two comment clarifications and one agent-rule glob fix, all unrelated to the above and to each other. The branch is a small grab-bag rather than one theme.

## Key points

- No new formula: the change dedups onto the existing hash-pinned `quantile-nearest-rank-v1` contract (`bench/README.md:216`, `STATISTICS_TEST_VECTORS` in `bench/measurement/statistics.ts`), whose vectors already pin ceil over round at q=0.3. Nothing in `bench/` computes a quantile inline anymore.
- The percentile change is the only behavior change in the branch, and it is confined to `bench/` — no shipped package computes percentiles this way.
- `assembleResult` moved out of `bench/load-harness/cli.ts` into `bench/load-harness/assemble-result.ts`. `cli.ts` reads `process.argv` and calls `main()` at import time, so nothing declared there was reachable from a test; the load-harness percentile wiring was untestable rather than untested.
- `pct()`'s empty-sample guard survives the migration: an op that recorded no latency still gets a zeroed block, where `quantileNearestRank` throws. Non-finite input is left to throw — every sample is a `performance.now()` delta, and a NaN-derived percentile reported as a number is worse than a loud failure.
- Tests are wiring-scoped, with the algorithm itself left to `bench/measurement/statistics.test.ts`: `bench/storage.test.ts` and `bench/load-harness/tests/assemble-result.test.ts` pin which q each of p50/p95/p99 reads, and `bench/metrics.test.ts` drops its two clamp cases (statistics.test.ts already covers the `[1, n]` clamp). Every new fixture discriminates ceil from floor at its n — n=100/200 for the storage and load-harness tails, 1..1000 for p999 — so each fails red against the old formula instead of coinciding with it.
- Closes the deferred follow-up that tracked `cli.ts`'s `pct()` as the last floor-based site.
- No changeset: `bench/` and `.claude/` aren't published, and the `@baerly/dev` edit is comments-only.
- `.claude/rules/bundle-budgets.md`'s `paths:` glob matched `*.test.ts` alongside shipping source, so editing a unit test auto-loaded bundle-budget policy for a file that cannot affect a bundle. Negated globs now exclude test files.

## Verification

| Command | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3654 passed, 105 skipped |
| `pnpm bundle-sizes` | ok (14 entries) |
| `pnpm build:agent` | clean |

Not run: the Minio / credentialed / Workerd-gated suites, and `pnpm test:randomize`. No protocol code changed.

## Notes for reviewers

The `LocalFsStorage` class JSDoc deliberately overlaps the existing `tempPathFor` JSDoc, which already documents in-bucket staging, the every-depth temp filter, and that nothing reclaims a stranded temp. `tempPathFor` is a private module-level const, so an IDE consumer hovering the exported class never sees any of it. The class block restates the consequence and adds the one thing not documented anywhere: cleanup requires stopping writers first, because deleting a temp while a PUT is in flight races the rename. If you'd rather not carry the restatement, the alternative is a one-line pointer plus the race warning.
