### PR TITLE
fix(server): shrink only genuinely oversize chunk candidates

### DIFF
--- a/packages/server/src/snapshot-chunk-builder.test.ts
+++ b/packages/server/src/snapshot-chunk-builder.test.ts
@@ -7,6 +7,7 @@ import {
   type ReferenceRow,
 } from "./chunked-snapshot-reference.ts";
 import { decodeSnapshotChunk } from "./snapshot-chunk.ts";
+import { MAX_CHUNK_BYTES } from "./snapshot-codec.ts";
 import { compareDocIds } from "./snapshot-doc-id.ts";
 import {
   buildSnapshotChunks,
@@ -307,6 +308,39 @@ describe("snapshot chunk builder", () => {
         selectedNeighborIndex: null,
       }),
     ).rejects.toMatchObject({ code: "InvalidResponse" });
+  });
+
+  test("shrinks a first candidate that starts above the 1 MiB hard ceiling instead of throwing", async () => {
+    // 20 docs x ~60,000 bytes = ~1.2 MiB: the initial greedy candidate (all 20
+    // rows, before any backoff) already exceeds MAX_CHUNK_BYTES on its own.
+    const customPolicy: SnapshotChunkBoundaryPolicy = {
+      target_chunk_bytes: 128 * 1024,
+      target_rows: 20,
+    };
+    const mutations: ReferenceMutation[] = Array.from({ length: 20 }, (_, index) => {
+      const id = String(index).padStart(2, "0");
+      return { op: "I", doc_id: id, after: doc(id, "x".repeat(60_000)) };
+    });
+
+    const result = await buildSnapshotChunks({
+      collection,
+      collectionPrefix,
+      descriptors: [],
+      loadedChunks: new Map(),
+      mutations: mutationMap(mutations),
+      incarnation,
+      policy: customPolicy,
+      lockedDirectOwnerIndex: null,
+      selectedNeighborIndex: null,
+    });
+
+    expect(result.chunks.reduce((sum, chunk) => sum + chunk.row_count, 0)).toBe(20);
+    for (const chunk of result.chunks) {
+      expect(chunk.byte_length).toBeLessThanOrEqual(MAX_CHUNK_BYTES);
+      if (chunk.row_count >= 2) {
+        expect(chunk.byte_length).toBeLessThanOrEqual(customPolicy.target_chunk_bytes);
+      }
+    }
   });
 
   test("merges underfull facing output with immediate right neighbor", async () => {

--- a/packages/server/src/snapshot-chunk-builder.test.ts
+++ b/packages/server/src/snapshot-chunk-builder.test.ts
@@ -343,6 +343,37 @@ describe("snapshot chunk builder", () => {
     }
   });
 
+  test("propagates a non-size encoding failure as InvalidConfig instead of shrinking", async () => {
+    // A pathologically nested document fails encoding for a reason that has
+    // nothing to do with candidate size, so shrinking the candidate can never
+    // fix it. It must surface immediately as the codec's own InvalidConfig,
+    // not get treated as an oversize condition and reduced to a singleton
+    // (which would also relabel it InvalidResponse along the way).
+    let nested: unknown = true;
+    for (let level = 0; level < 15_000; level++) {
+      nested = [nested];
+    }
+    const mutations: ReferenceMutation[] = [
+      { op: "I", doc_id: "a", after: doc("a", 1) },
+      { op: "I", doc_id: "b", after: { _id: "b", value: nested } as unknown as DocumentData },
+      { op: "I", doc_id: "c", after: doc("c", 3) },
+    ];
+
+    await expect(
+      buildSnapshotChunks({
+        collection,
+        collectionPrefix,
+        descriptors: [],
+        loadedChunks: new Map(),
+        mutations: mutationMap(mutations),
+        incarnation,
+        policy: CHUNK_BOUNDARY_POLICIES["c128-r512"],
+        lockedDirectOwnerIndex: null,
+        selectedNeighborIndex: null,
+      }),
+    ).rejects.toMatchObject({ code: "InvalidConfig" });
+  });
+
   test("rewrites an at-target c1024-r4096 chunk after one insert instead of throwing", async () => {
     // c1024-r4096's target_chunk_bytes equals MAX_CHUNK_BYTES, so a chunk
     // packed up to that target sits exactly at the hard ceiling: rewriting it

--- a/packages/server/src/snapshot-chunk-builder.test.ts
+++ b/packages/server/src/snapshot-chunk-builder.test.ts
@@ -30,7 +30,7 @@ const mutationMap = (
 ): ReadonlyMap<string, ReferenceMutation> =>
   new Map(mutations.map((mutation) => [mutation.doc_id, mutation]));
 
-const { createDescriptor } = makeSnapshotChunkFixtures({
+const { createChunkBytes, createDescriptor } = makeSnapshotChunkFixtures({
   collection,
   collectionPrefix,
   incarnation,
@@ -339,6 +339,59 @@ describe("snapshot chunk builder", () => {
       expect(chunk.byte_length).toBeLessThanOrEqual(MAX_CHUNK_BYTES);
       if (chunk.row_count >= 2) {
         expect(chunk.byte_length).toBeLessThanOrEqual(customPolicy.target_chunk_bytes);
+      }
+    }
+  });
+
+  test("rewrites an at-target c1024-r4096 chunk after one insert instead of throwing", async () => {
+    // c1024-r4096's target_chunk_bytes equals MAX_CHUNK_BYTES, so a chunk
+    // packed up to that target sits exactly at the hard ceiling: rewriting it
+    // with one more row is the scenario the greedy backoff must shrink out
+    // of, not merely a synthetic customPolicy.
+    const policy = CHUNK_BOUNDARY_POLICIES["c1024-r4096"];
+    const docs: DocumentData[] = [];
+    for (let i = 0; docs.length < policy.target_rows; i++) {
+      const id = `row-${String(i).padStart(4, "0")}`;
+      const candidate = [...docs, doc(id, "x".repeat(2000))];
+      let candidateBytes: number;
+      try {
+        candidateBytes = createChunkBytes(candidate).byteLength;
+      } catch {
+        break;
+      }
+      if (candidateBytes > policy.target_chunk_bytes) {
+        break;
+      }
+      docs.push(candidate.at(-1)!);
+    }
+    expect(docs.length).toBeGreaterThan(1);
+
+    const descriptor = await createDescriptor(docs);
+    expect(descriptor.byte_length).toBeLessThanOrEqual(policy.target_chunk_bytes);
+
+    const extraId = `row-${String(docs.length).padStart(4, "0")}`;
+    const mutations: ReferenceMutation[] = [
+      { op: "I", doc_id: extraId, after: doc(extraId, "x".repeat(2000)) },
+    ];
+
+    const result = await buildSnapshotChunks({
+      collection,
+      collectionPrefix,
+      descriptors: [descriptor],
+      loadedChunks: new Map([[descriptor.key, docs]]),
+      mutations: mutationMap(mutations),
+      incarnation,
+      policy,
+      lockedDirectOwnerIndex: 0,
+      selectedNeighborIndex: null,
+    });
+
+    expect(result.chunks.reduce((sum, chunk) => sum + chunk.row_count, 0)).toBe(docs.length + 1);
+    expect(result.split_increments).toBe(1);
+    for (const chunk of result.chunks) {
+      expect(chunk.byte_length).toBeLessThanOrEqual(MAX_CHUNK_BYTES);
+      if (chunk.row_count >= 2) {
+        expect(chunk.byte_length).toBeLessThanOrEqual(policy.target_chunk_bytes);
       }
     }
   });

--- a/packages/server/src/snapshot-chunk-builder.ts
+++ b/packages/server/src/snapshot-chunk-builder.ts
@@ -1,11 +1,6 @@
 import { BaerlyError, type DocumentData, encodeJsonBytes, snapshotHash } from "@baerly/protocol";
 import { type ReferenceMutation } from "./chunked-snapshot-reference.ts";
-import {
-  type CodecCode,
-  INCARNATION_PATTERN,
-  makeCodecFail,
-  MAX_CHUNK_BYTES,
-} from "./snapshot-codec.ts";
+import { type CodecCode, INCARNATION_PATTERN, makeCodecFail } from "./snapshot-codec.ts";
 import { encodeSnapshotChunk, snapshotChunkKey, type SnapshotChunk } from "./snapshot-chunk.ts";
 import { assertSnapshotDocId, compareDocIds } from "./snapshot-doc-id.ts";
 import {
@@ -534,12 +529,24 @@ function splitGroupDocsGreedily(
         last_id: candidateDocs.at(-1)!["_id"] as string,
         docs: candidateDocs,
       };
-      const candidateBytes = encodeBuilderChunk(candidateChunk);
+      const isSingleton = end === start + 1;
 
-      if (candidateBytes.byteLength <= policy.target_chunk_bytes || end === start + 1) {
-        if (candidateBytes.byteLength > MAX_CHUNK_BYTES) {
-          invalid("InvalidResponse", "document exceeds hard chunk byte maximum");
+      let candidateBytes: Uint8Array;
+      try {
+        candidateBytes = encodeBuilderChunk(candidateChunk);
+      } catch (error) {
+        // A candidate that exceeds MAX_CHUNK_BYTES throws instead of
+        // returning a size, so a too-big multi-document candidate is
+        // indistinguishable here from an over-target one: shrink and retry.
+        // A singleton can't shrink further, so its failure is terminal.
+        if (isSingleton) {
+          throw error;
         }
+        end--;
+        continue;
+      }
+
+      if (candidateBytes.byteLength <= policy.target_chunk_bytes || isSingleton) {
         result.push({ docs: candidateDocs, bytes: candidateBytes });
         start = end;
         break;

--- a/packages/server/src/snapshot-chunk-builder.ts
+++ b/packages/server/src/snapshot-chunk-builder.ts
@@ -1,7 +1,12 @@
 import { BaerlyError, type DocumentData, encodeJsonBytes, snapshotHash } from "@baerly/protocol";
 import { type ReferenceMutation } from "./chunked-snapshot-reference.ts";
 import { type CodecCode, INCARNATION_PATTERN, makeCodecFail } from "./snapshot-codec.ts";
-import { encodeSnapshotChunk, snapshotChunkKey, type SnapshotChunk } from "./snapshot-chunk.ts";
+import {
+  encodeSnapshotChunk,
+  isChunkOversizeError,
+  snapshotChunkKey,
+  type SnapshotChunk,
+} from "./snapshot-chunk.ts";
 import { assertSnapshotDocId, compareDocIds } from "./snapshot-doc-id.ts";
 import {
   firstDescriptorEndingAtOrAfter,
@@ -52,8 +57,11 @@ function encodeBuilderChunk(chunk: SnapshotChunk): Uint8Array {
   try {
     return encodeSnapshotChunk(chunk);
   } catch (error) {
-    if (error instanceof BaerlyError) {
+    if (isChunkOversizeError(error)) {
       invalid("InvalidResponse", error.message, error.cause);
+    }
+    if (error instanceof BaerlyError) {
+      throw error;
     }
     invalid("InvalidResponse", "failed to encode snapshot chunk", error);
   }
@@ -538,8 +546,11 @@ function splitGroupDocsGreedily(
         // A candidate that exceeds MAX_CHUNK_BYTES throws instead of
         // returning a size, so a too-big multi-document candidate is
         // indistinguishable here from an over-target one: shrink and retry.
-        // A singleton can't shrink further, so its failure is terminal.
-        if (isSingleton) {
+        // Any other failure (bad doc-id ordering, excessive JSON depth, …)
+        // is a real bug that shrinking can't fix, so it must surface
+        // immediately even for a non-singleton candidate. A singleton can't
+        // shrink further either way, so its failure is always terminal.
+        if (!isChunkOversizeError(error) || isSingleton) {
           throw error;
         }
         end--;

--- a/packages/server/src/snapshot-chunk.ts
+++ b/packages/server/src/snapshot-chunk.ts
@@ -1,4 +1,5 @@
 import {
+  BaerlyError,
   decodeJsonBytes,
   type DocumentData,
   type DocumentValue,
@@ -218,6 +219,8 @@ function canonicalizeChunk(
   };
 }
 
+const CHUNK_OVERSIZE_MESSAGE = `canonical body exceeds ${MAX_CHUNK_BYTES} bytes`;
+
 export const encodeSnapshotChunk = (chunk: SnapshotChunk): Uint8Array => {
   return normalizeCodecFailure(
     invalid,
@@ -227,12 +230,22 @@ export const encodeSnapshotChunk = (chunk: SnapshotChunk): Uint8Array => {
       const canonical = canonicalizeChunk(chunk, "InvalidConfig");
       const bytes = encodeJsonBytes(canonical);
       if (bytes.byteLength > MAX_CHUNK_BYTES) {
-        invalid("InvalidConfig", `canonical body exceeds ${MAX_CHUNK_BYTES} bytes`);
+        invalid("InvalidConfig", CHUNK_OVERSIZE_MESSAGE);
       }
       return bytes;
     },
   );
 };
+
+/**
+ * True when `error` is the specific failure `encodeSnapshotChunk` throws for
+ * a canonical body over `MAX_CHUNK_BYTES` — as opposed to any other encoding
+ * or validation failure (bad doc-id ordering, excessive JSON depth, etc.),
+ * which callers must not treat as a shrink-and-retry signal.
+ */
+export function isChunkOversizeError(error: unknown): error is BaerlyError {
+  return error instanceof BaerlyError && error.message.endsWith(CHUNK_OVERSIZE_MESSAGE);
+}
 
 export const snapshotChunkKey = (
   collectionPrefix: string,


### PR DESCRIPTION
## What & why

`splitGroupDocsGreedily` (chunked-format builder, unwired research code for the increase-workload-ceiling candidate) builds a chunk candidate and, on any encode failure, shrinks it and retries — the loop's backoff for a candidate that starts above the target size. `encodeSnapshotChunk` throws instead of returning a size once the canonical body exceeds `MAX_CHUNK_BYTES`, but it also throws for failures that have nothing to do with size (bad doc-id ordering, excessive JSON nesting depth). The backoff now only retries on the actual oversize condition and rethrows everything else immediately, so a real data-shape bug surfaces as its own `InvalidConfig` instead of being silently shrunk toward a singleton and relabeled `InvalidResponse`.

## Key points

- `isChunkOversizeError` in `snapshot-chunk.ts` is the single source of truth for the oversize message; `splitGroupDocsGreedily` gates its shrink-and-retry on that predicate instead of "any thrown error."
- A singleton candidate has nothing left to shrink, so its failure was already terminal either way; the fix is scoped to non-singleton candidates, which previously masked non-size errors behind repeated shrink attempts before finally surfacing them mislabeled.
- Removes the old post-encode `byteLength > MAX_CHUNK_BYTES` guard — it was dead code, since `encodeBuilderChunk` already throws before ever returning bytes that large.
- No changeset: this code path (`chunked-fold-planner.ts` / `snapshot-chunk-builder.ts`) isn't wired into the maintenance/compactor pipeline or exported publicly yet, so there's no user-facing behavior change.

## Verification

| `pnpm test:agent` | 3709 passed |
| `pnpm verify:agent` | clean |
| `pnpm bundle-sizes` | 14/14, no growth |
| manual replay of the ticket's repro table (256/512/1024/2048 docs × all three chunk policies) | all previously-throwing cases now build successfully |

## Notes for reviewers

The classification fix (only treat the actual `MAX_CHUNK_BYTES` overflow as retry-worthy) was flagged by Fresh Eyes review against the first commit.

Refs docs/superpowers/programs/increase-workload-ceiling/plans/tickets/defect-builder-greedy-split.md