### PR TITLE
docs: restate the free CPU ceiling as economic, not a wall

### DIFF
--- a/docs/about/graduation.md
+++ b/docs/about/graduation.md
@@ -2,7 +2,7 @@
 title: Graduation thresholds
 audience: operator
 summary: Operator runbook for a collection at or past a limit — map the symptom, pick the graduation path, and set the env var or move hosts.
-last-reviewed: 2026-08-09
+last-reviewed: 2026-08-26
 tags: [operations, cost, capacity, graduation]
 related: [cost-model.md, workload-fit.md, thesis.md, "../spec/scale-ceilings.md", "../adr/002-ephemeral-coordination.md"]
 ---
@@ -216,7 +216,7 @@ trips first —
 CPU vs. free's ~10 ms), then set `BAERLY_MAINTENANCE_PROFILE=cf-paid`.
 That alone moves `C` to 8 MiB and `E` to 32,768 and compaction resumes;
 there is no env override to set for the common case. On paid, CPU stops
-being the practical wall and Worker memory (~128 MB) becomes the limit —
+being the binding cost and Worker memory (~128 MB) becomes the limit —
 which is why the paid ceiling is 8 MiB rather than "tens of MB"
 ([why that number](../spec/scale-ceilings.md#per-tier-bounds)). If you
 override `C` past the profile value, size it to memory, not CPU; see
@@ -246,11 +246,11 @@ new snapshot, and log tail resident at once. CPU is still fine.
 
 **What to do:** move the collection to a long-lived Node host, which
 selects the node profile automatically (`C = 32 MiB`, `E = 65,536`),
-then raise the env cap as above if the host has the heap for it, or wait
-for chunked snapshots. The current
-snapshot format is single-level (one L9 snapshot replaces the prior) and
-is forward-compatible with a future multi-level L0..L9 scheme that folds
-incrementally without a wire change.
+then raise the env cap as above if the host has the heap for it. The
+current snapshot format is single-level: one L9 snapshot replaces the
+prior. A chunked replacement is in development, but plan around the Node
+host rather than around it — it lands as a pre-1.0 format cut rather than
+a compatible extension, so it arrives as a migration, not an upgrade.
 
 ### Tail churn is not a graduation signal
 
@@ -313,18 +313,24 @@ larger profile is the supported way to raise `E`.
 **Cloudflare caveat: size the cap to the isolate.** Raising
 `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` above what a CF isolate can rebuild
 can create a killed-rebuild loop: the gate passes, the rebuild runs in
-`ctx.waitUntil`, the isolate is killed by CPU or memory, no in-band
-backoff fires, and the next write tries again.
+`ctx.waitUntil`, the isolate dies, no in-band backoff fires, and the next
+write tries again. The demonstrated cause is **memory** — an isolate over
+~128 MB is terminated. A CPU-driven kill has not been observed: a
+deployed Worker with a configured 10 ms limit ran 4 MiB folds at
+41.7–67.8 ms of measured CPU and reported success every time
+([why](../spec/scale-ceilings.md#is-the-free-cpu-limit-a-wall)).
+Cloudflare terminates a Worker that overruns *consistently*, so treat a
+CPU-driven loop as possible but unmeasured, and a memory-driven one as
+real.
 
 On the free profile, the CF adapter `console.warn`s once at handler init
 when `BAERLY_MAINTENANCE_MAX_FOLD_BYTES > CF_FREE_MAX_SAFE_FOLD_BYTES`
-(1 MiB), the largest snapshot a free isolate can one-shot rebuild under
-the ~10 ms budget. It stays silent on `cf-paid`, whose own ceiling is
-already 8x that bound and whose wall is memory rather than CPU. There is
-still no runtime metric for the kill itself.
-Watch the snapshot key and object count from `baerly inspect`; a
-snapshot key that never advances while `live_log_tail` grows is a
-rebuild that keeps not landing.
+(1 MiB) — the point past which one fold stops fitting the free tier's CPU
+budget. It stays silent on `cf-paid`, whose own ceiling is already 8x
+that bound and whose binding cost is memory rather than CPU. Either way
+there is no runtime metric: watch the snapshot key and object count from
+`baerly inspect`; a snapshot key that never advances while
+`live_log_tail` grows is a rebuild that keeps not landing.
 
 Safe remedies, in order:
 
@@ -334,8 +340,11 @@ Safe remedies, in order:
 - **Serverful Node:** no per-request CPU/subrequest cap; bounded by host
   RAM, and the node profile is selected automatically. Raise the env cap
   above 32 MiB only with heap to spare.
-- **Chunked snapshots:** future multi-level L0..L9 rebuilds would avoid
-  holding the whole snapshot resident. Not shipped.
+- **Chunked snapshots:** a chunked replacement for the single-level
+  snapshot would avoid holding the whole snapshot resident. Not shipped;
+  it lands as a pre-1.0 format cut rather than an in-place upgrade, and
+  its fold-side benefit depends on document IDs being append-ordered, as
+  the auto-generated ones are.
 
 ## How to raise a limit
 
@@ -343,7 +352,7 @@ Safe remedies, in order:
 | --- | --- | --- |
 | Static fold-byte ceiling `C` (512 KB cf-free / 8 MiB cf-paid / 32 MiB node) | `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` env var | Set out-of-band in the deploy environment; takes effect on the next write tick. Size to what the host can rebuild — `C ≈ heap / 10`. |
 | Static fold-row ceiling `E` (2,048 cf-free / 32,768 cf-paid / 65,536 node) | Move to a larger host profile: `BAERLY_MAINTENANCE_PROFILE=cf-paid` on Cloudflare, or a Node host (automatic) | No env var sets `E` directly. Node's 65,536 is the largest shipped value; past it, split or graduate the collection. |
-| Cloudflare free CPU / subrequest wall (~10 ms CPU, 50 subrequests) | Cloudflare plan upgrade (free → paid), then `BAERLY_MAINTENANCE_PROFILE=cf-paid` | Paid raises CPU to 30 s default (up to 5 min); subrequest limit lifts to 10,000/request by default, raisable to 10M, changed 2026-02-11. The profile switch also moves `C`/`E` to the paid ceilings, so `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` is only needed to go past 8 MiB. A finer-grained per-platform `cpuLimit` declaration was evaluated and measured unnecessary: the in-band write tick keeps up to ~3x the rate envelope under stress on free, so it is not built. |
+| Cloudflare free CPU budget and subrequest wall (~10 ms CPU, economic; 50 subrequests, hard) | Cloudflare plan upgrade (free → paid), then `BAERLY_MAINTENANCE_PROFILE=cf-paid` | Paid raises CPU to 30 s default (up to 5 min); subrequest limit lifts to 10,000/request by default, raisable to 10M, changed 2026-02-11. The profile switch also moves `C`/`E` to the paid ceilings, so `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` is only needed to go past 8 MiB. A finer-grained per-platform `cpuLimit` declaration was evaluated and measured unnecessary: the in-band write tick keeps up to ~3x the rate envelope under stress on free, so it is not built. |
 | Per-collection commit scope (one ordered log per collection; no cross-collection atomicity) | Cannot be increased; protocol invariant | The write hotspot is the next numbered `log/<seq>` create for one collection. Cross-collection atomicity is not offered. |
 | Snapshot and legacy-content hash addressing | Cannot be increased; protocol invariant | Snapshot filenames embed full SHA-256, and current readers recompute the body hash before accepting a snapshot. Legacy content filenames use 128-bit truncated SHA-256 and collisions were never runtime-verified; the objects are now inert and nothing reads or reclaims them, so the truncation carries no remaining safety obligation. |
 

--- a/docs/about/graduation.md
+++ b/docs/about/graduation.md
@@ -2,7 +2,7 @@
 title: Graduation thresholds
 audience: operator
 summary: Operator runbook for a collection at or past a limit — map the symptom, pick the graduation path, and set the env var or move hosts.
-last-reviewed: 2026-08-26
+last-reviewed: 2026-08-27
 tags: [operations, cost, capacity, graduation]
 related: [cost-model.md, workload-fit.md, thesis.md, "../spec/scale-ceilings.md", "../adr/002-ephemeral-coordination.md"]
 ---
@@ -352,7 +352,7 @@ Safe remedies, in order:
 | --- | --- | --- |
 | Static fold-byte ceiling `C` (512 KB cf-free / 8 MiB cf-paid / 32 MiB node) | `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` env var | Set out-of-band in the deploy environment; takes effect on the next write tick. Size to what the host can rebuild — `C ≈ heap / 10`. |
 | Static fold-row ceiling `E` (2,048 cf-free / 32,768 cf-paid / 65,536 node) | Move to a larger host profile: `BAERLY_MAINTENANCE_PROFILE=cf-paid` on Cloudflare, or a Node host (automatic) | No env var sets `E` directly. Node's 65,536 is the largest shipped value; past it, split or graduate the collection. |
-| Cloudflare free CPU budget and subrequest wall (~10 ms CPU, economic; 50 subrequests, hard) | Cloudflare plan upgrade (free → paid), then `BAERLY_MAINTENANCE_PROFILE=cf-paid` | Paid raises CPU to 30 s default (up to 5 min); subrequest limit lifts to 10,000/request by default, raisable to 10M, changed 2026-02-11. The profile switch also moves `C`/`E` to the paid ceilings, so `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` is only needed to go past 8 MiB. A finer-grained per-platform `cpuLimit` declaration was evaluated and measured unnecessary: the in-band write tick keeps up to ~3x the rate envelope under stress on free, so it is not built. |
+| Cloudflare free CPU budget and subrequest wall (~10 ms CPU, economic; 50 subrequests, hard) | Cloudflare plan upgrade (free → paid), then `BAERLY_MAINTENANCE_PROFILE=cf-paid` | Paid raises CPU to 30 s default (up to 5 min); subrequest limit lifts to 10,000/request by default, raisable to 10M, changed 2026-02-11. The profile switch also moves `C`/`E` to the paid ceilings, so `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` is only needed to go past 8 MiB. A finer-grained per-platform `cpuLimit` declaration was evaluated and judged unnecessary — as a design assertion, not a measurement: `C` and `E` already sit well inside the free CPU budget, so a separate knob would add operator surface without changing which folds pass the gate. |
 | Per-collection commit scope (one ordered log per collection; no cross-collection atomicity) | Cannot be increased; protocol invariant | The write hotspot is the next numbered `log/<seq>` create for one collection. Cross-collection atomicity is not offered. |
 | Snapshot and legacy-content hash addressing | Cannot be increased; protocol invariant | Snapshot filenames embed full SHA-256, and current readers recompute the body hash before accepting a snapshot. Legacy content filenames use 128-bit truncated SHA-256 and collisions were never runtime-verified; the objects are now inert and nothing reads or reclaims them, so the truncation carries no remaining safety obligation. |
 

--- a/docs/adr/007-chunked-snapshot-layout.md
+++ b/docs/adr/007-chunked-snapshot-layout.md
@@ -3,7 +3,7 @@ title: Incarnation-scoped chunked snapshot layout
 audience: adr
 doc_type: adr
 summary: ADR 007 — the next snapshot layout is one strict manifest over immutable, incarnation-scoped, content-authenticated chunks, activated through one pre-1.0 atomic format cut.
-last-reviewed: 2026-08-17
+last-reviewed: 2026-08-26
 tags: [decision, adr, snapshot, storage-layout, versioning]
 related:
   [
@@ -28,9 +28,12 @@ The current snapshot is one content-addressed JSON object containing every
 document. A fold must load, sort, and encode the complete collection even when
 its selected log prefix changes one narrow ID range. That whole-collection work
 sets the present maintenance ceiling on request-bounded runtimes. Splitting the
-body can make work local, but only if ordering, publication, reuse, integrity,
-and garbage collection compose without a coordinator, a second reader, or an
-orphan key that can later become live again.
+body can make work local, but only if two conditions hold. First, the workload's
+document IDs must be ordered enough that a bounded log prefix touches a bounded
+run of chunks — measurement puts this condition in the Consequences below.
+Second, ordering, publication, reuse, integrity, and garbage collection must
+compose without a coordinator, a second reader, or an orphan key that can later
+become live again.
 
 The change is also a real bucket-layout break under
 [ADR-003](003-layout-versioning-cordon.md), not an additive field on the old
@@ -459,6 +462,19 @@ the complete collection, while the numbered-log commit point and request-
 bounded coordination model remain unchanged. Point and bounded-range reads can
 avoid unrelated chunk bodies; complete reads pay one manifest plus a statically
 bounded chunk fan-out.
+
+**The fold-work consequence is conditional on document-ID locality.** Measured
+in encode bytes per mutation folded, append-ordered IDs — the product's UUIDv7
+auto-ID — range from break-even (0.94x) to a 40x win, monotone in descriptor
+count. Uniformly distributed
+caller-supplied IDs cost 1.8x–25x *more* than the monolithic rebuild at every
+collection size and every boundary policy, and never reach parity: a bounded
+log prefix over uniform IDs touches chunks all across the manifest, so the
+selected prefix truncates and the fold rewrites more bytes per mutation than
+one whole-collection rebuild would. A collection durably in that regime is a
+graduation signal, not a supported cell, and this ADR does not admit a format
+selector, a second layout, or an ID-rewriting mode to rescue it. The read-side
+consequences above are unconditional; only the fold-work one is not.
 
 The cost is a breaking stored layout and three removed public construction
 exports. Activation requires coordinated snapshot/current schema changes, a

--- a/docs/spec/scale-ceilings.md
+++ b/docs/spec/scale-ceilings.md
@@ -3,7 +3,7 @@ title: Scale ceilings
 audience: spec
 doc_type: verification
 summary: Where every published scale limit comes from — the fold cost model, the measured per-host snapshot ceilings C and E, and the storage-side throughput walls.
-last-reviewed: 2026-08-26
+last-reviewed: 2026-08-27
 tags: [capacity, verification, fold, ceilings]
 related: ["../about/graduation.md", "../about/workload-fit.md", "../about/cost-model.md"]
 ---
@@ -109,6 +109,14 @@ interrupted before the body is complete, readers reject the hash
 mismatch. If the snapshot body lands but the `current.json` CAS does
 not, the snapshot is a correct but unreferenced orphan for GC. The
 pointer does not advance, but data is not corrupted.
+
+What an interrupted fold costs is liveness, not integrity. Because
+`current.json` never advances, `log_seq_start` stays where it was: the
+tail keeps growing and the next write tick retries the same rebuild. One
+interruption is a retried tick. A rebuild the host can never finish is a
+loop, and the cost of the loop is the unbounded tail — which is why the
+ceiling has to be sized to what the host can actually rebuild
+([Cloudflare caveat](../about/graduation.md#operations-plane-env-vars)).
 
 ## Fold cost model
 

--- a/docs/spec/scale-ceilings.md
+++ b/docs/spec/scale-ceilings.md
@@ -3,7 +3,7 @@ title: Scale ceilings
 audience: spec
 doc_type: verification
 summary: Where every published scale limit comes from — the fold cost model, the measured per-host snapshot ceilings C and E, and the storage-side throughput walls.
-last-reviewed: 2026-08-09
+last-reviewed: 2026-08-26
 tags: [capacity, verification, fold, ceilings]
 related: ["../about/graduation.md", "../about/workload-fit.md", "../about/cost-model.md"]
 ---
@@ -61,12 +61,12 @@ at 8 MiB — 8 MiB peaks at ~19.5 MB and 19.5 × 4 = 78 MB fits under the
 149 MB) does not. Where a per-tier cell below cites "the 4x margin",
 this is the rule it means.
 
-cf-free is the exception, because its wall is CPU rather than memory:
-2048 rows measures ~1.5 ms and the row axis does not reach ~10 ms until
-~16,384 rows, but that margin was measured off workerd and so does not
-transfer. The value stays deliberately far inside it, because a
-free-isolate overrun is CPU-killed mid-rebuild and strands the
-`current.json` CAS.
+cf-free is the exception, because its binding cost is CPU rather than
+memory: 2048 rows measures ~1.5 ms and the row axis does not reach ~10 ms
+until ~16,384 rows, but that margin was measured off workerd and so does
+not transfer. The value stays deliberately far inside it;
+[Is the free CPU limit a wall?](#is-the-free-cpu-limit-a-wall) records
+what that conservatism rests on.
 
 **Still estimated:** the CPU column below and anything derived from it.
 CPU was measured on Node v24 / darwin-arm64, which is not workerd, and
@@ -205,10 +205,10 @@ The row ceiling catches tiny-doc snapshots that bytes can miss, and like
 `C` it is now per host: `E = 2048` on cf-free
 (`MAINTENANCE_MAX_FOLD_ROWS`), `32,768` on cf-paid, `65,536` on node.
 cf-free stays at 2048 even though the row axis does not reach the ~10 ms
-free budget until ~16,384 rows, because a free-isolate overrun is
-CPU-killed mid-rebuild and strands the `current.json` CAS; the larger
-hosts fail by running slow, not by stranding, so they are sized to
-memory.
+free budget until ~16,384 rows, because that margin was measured off
+workerd and the free CPU line is a cost budget rather than a guarded wall
+([details](#is-the-free-cpu-limit-a-wall)); the larger hosts are sized to
+memory, which on those hosts is a real limit.
 
 ### When a fold fires, and when it defers
 
@@ -233,9 +233,12 @@ pure and never trigger maintenance. For folding, three gates matter:
   `snapshot_rows + maxFoldEntriesPerPass > E`. `E` is likewise per host
   profile: 2048 on cf-free, 32,768 on cf-paid, 65,536 on node.
 
-`C` is conservative *on cf-free* because there is no adaptive backoff for
-a killed rebuild. Cloudflare free's ~10 ms CPU budget can rebuild roughly
-a 1 MB snapshot; `C = 512 KB` leaves margin. On CF free, setting
+`C` is conservative *on cf-free* because a fold that overruns cannot back
+off in-band — there is no adaptive retry, and the fold runs on a user's
+write. Cloudflare free's ~10 ms CPU budget can rebuild roughly a 1 MB
+snapshot; `C = 512 KB` leaves margin. That budget is economic rather than
+enforced at any measured duty cycle
+([details](#is-the-free-cpu-limit-a-wall)). On CF free, setting
 `BAERLY_MAINTENANCE_MAX_FOLD_BYTES` above
 `CF_FREE_MAX_SAFE_FOLD_BYTES = 1 MiB` emits an init-time
 `console.warn`.
@@ -310,25 +313,60 @@ measured wall rather than inherited from cf-free, so the shipped ceiling
 is already near the hardware wall on every tier; raising `C` further is
 an override, not the normal path.
 
-Cloudflare free has two binding walls:
+Cloudflare free has one hard per-invocation wall and one economic
+ceiling. Isolate memory (~128 MB) is a third hard limit, but at
+`C = 512 KB` it is nowhere near binding; it is what binds cf-paid and
+Node.
 
-- **CPU:** ~10 ms/request, defended by `C` and `E`.
-- **Subrequests:** 50/request, defended by the
+- **Subrequests: 50/request — hard.** Defended by the
   `maxFoldEntriesPerPass ≈ 20` tail slice. A fold pass is about
   `slice + 3` subrequests. GC's mark cap bounds LIST classification and
   ledger growth, while its sweep cap bounds DELETEs; one phase per tick
   stays under 50. Exact GC accounting is maintained in the
   `CLOUDFLARE_FREE_TIER` JSDoc and
   `packages/server/src/maintenance-budget.test.ts`.
+- **CPU: ~10 ms/request — economic.** `C` and `E` are sized against it as
+  a cost and latency budget line, not as a guard against termination.
+
+#### Is the free CPU limit a wall?
+
+Not at any duty cycle that has been measured. On a deployed Worker with a
+*configured* `limits.cpu_ms: 10`, 4 MiB folds consumed 41.7–67.8 ms of
+platform-measured CPU and every invocation reported `outcome: success` —
+the budget exceeded up to ~6.8x with enforcement never engaging, at ~3 s
+and 70 s spacing alike. An earlier probe on a confirmed Workers Free
+account, with no `limits` block at all, ran ten consecutive 4 MiB folds
+at 23–66 ms with zero `exceededCpu`.
+
+Cloudflare documents the limit as elastic: an isolate has "built-in
+flexibility" for infrequent overruns, and a Worker that "starts hitting
+the limit consistently" is terminated according to the configured limit.
+A kill is therefore not excluded. What is unmeasured is the region where
+it would appear: sustained rates *faster* than one fold every ~3 s, and
+runs longer than the ten consecutive invocations tested. No numeric
+threshold, window, or duty cycle is published.
+
+Two consequences:
+
+- **The cost model is unaffected.** The measured ~10–16 ms/MB at 4 MiB
+  corroborates the [fold cost model](#fold-cost-model) above. What the
+  measurement removes is the kill, not the number.
+- **On cf-free, `C` and `E` are budget lines rather than guards.** They
+  bound real costs — the free daily allowance, billed CPU-ms on the
+  Standard usage model, and user-visible write latency, since the fold
+  runs on the write path — but not a termination risk that has been
+  observed. This applies to the free tier only: on cf-paid and Node, `C`
+  guards the ~128 MB memory wall, which does terminate an isolate, and
+  those values stay sized to it at a 4x margin.
 
 | Tier | Hardware walls | Binds on | What can actually fold |
 | --- | --- | --- | --- |
-| **Cloudflare free** | ~10 ms CPU/request and 50 subrequests/request | CPU + subrequests | profile `C = 512 KB` ⇒ ~512 KB snapshot (`S_max = C`), `E = 2048` rows; tail drains ≈ 20 entries/tick; raising `C` past ~1 MB (`CF_FREE_MAX_SAFE_FOLD_BYTES`) hits the CPU wall and `console.warn`s |
+| **Cloudflare free** | ~10 ms CPU/request (economic) and 50 subrequests/request (hard) | CPU cost + subrequests | profile `C = 512 KB` ⇒ ~512 KB snapshot (`S_max = C`), `E = 2048` rows; tail drains ≈ 20 entries/tick; raising `C` past ~1 MB (`CF_FREE_MAX_SAFE_FOLD_BYTES`) takes the fold past the ~10 ms CPU budget and `console.warn`s |
 | **Cloudflare paid** | 30 s CPU default (up to 5 min); ~128 MB Worker memory; 10,000 subrequests/request default, raisable to 10M, changed 2026-02-11; free wall stays 50 | memory | `C = 8 MiB` (`CF_PAID_MAINTENANCE_MAX_FOLD_BYTES`), `E = 32,768` rows (`CF_PAID_MAINTENANCE_MAX_FOLD_ROWS`), selected by `BAERLY_MAINTENANCE_PROFILE=cf-paid` — no `C` override needed to get there. CPU is not the wall; memory is: 8 MiB peaks at ~19.5 MB, which fits the 4x margin under ~128 MB; the next grid cell (16 MiB ⇒ 37.3 MB) does not. That margin is why the ceiling is not "tens of MB" |
 | **Serverful Node** | no per-request cap; process RAM; a fold blocks the event loop | host memory | `C = 32 MiB` (`NODE_MAINTENANCE_MAX_FOLD_BYTES`), `E = 65,536` rows (`NODE_MAINTENANCE_MAX_FOLD_ROWS`), selected automatically by the Node adapter. 32 MiB is the top of the measured grid, **not** the measured wall — the probe reports `grid-exhausted` for this profile at every margin and every heap from 704 MB up. Past the grid, scale by `C ≈ heap / 10`. Per-pass caps are `NODE_MAINTENANCE_*` (moderate, latency-budgeted) |
 
 Implications: on Cloudflare free, a ~1 MB snapshot is near the ~10 ms
-CPU wall, and the 50-subrequest wall makes a large tail drain over many
+CPU budget, and the 50-subrequest wall makes a large tail drain over many
 write ticks. On Cloudflare paid, CPU could rebuild a multi-GB snapshot,
 but Worker memory (~128 MB) is the wall because a fold holds the old
 snapshot, new snapshot, and log tail at once — measured at ~2.4x the

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -75,6 +75,12 @@
     "tests/integration/conformance.test.ts",
     "tests/fixtures/check-acceptance",
 
+    // Gitignored scratch space for bench artifacts and disposable measurement
+    // drivers. Nothing in here ships or is imported by tracked code, and a
+    // driver written against another branch's `bench/measurement` surface must
+    // not be able to turn `pnpm verify` red on a base that never had it.
+    "bench/results",
+
     "packages/adapter-cloudflare/src",
     "tests/fixtures/mock-execution-context.ts",
     "tests/integration/public-surface.test.ts",


### PR DESCRIPTION
## What & why

`docs/spec/scale-ceilings.md` derived the cf-free ceilings `C = 512 KB` and `E = 2048` from an assumed hard ~10 ms per-invocation CPU wall on Cloudflare, and described an overrun as "CPU-killed mid-rebuild". Measurement does not support the kill. A deployed Worker with a *configured* `limits.cpu_ms: 10` ran 4 MiB folds at 41.7–67.8 ms of platform-measured CPU and reported `outcome: success` on every invocation, at ~3 s and 70 s spacing alike; an earlier probe on a confirmed Workers Free account with no `limits` block ran ten consecutive 4 MiB folds at 23–66 ms with zero `exceededCpu`. This PR restates cf-free's CPU line as an economic budget rather than a guarded wall, in one section everything else points at, and fixes three adjacent claims that were wrong for related reasons.

`C` and `E` do not move. The measured ~10–16 ms/MB at 4 MiB corroborates the fold cost model already in the doc — what the measurement removes is the kill, not the curve.

## Key points

- Cloudflare free now has exactly one hard per-invocation wall (50 subrequests) and one economic ceiling (CPU). Isolate memory is a third hard limit, noted as nowhere near binding at `C = 512 KB`.
- A kill is not excluded, and the doc says where it would live: Cloudflare documents the limit as elastic, and the unmeasured region is sustained rates faster than one fold every ~3 s, and runs longer than the ten consecutive invocations tested.
- `graduation.md`'s killed-rebuild-loop guidance now names memory as the demonstrated cause — an isolate over ~128 MB really is terminated — and CPU as possible but unmeasured.
- `graduation.md` drops the claim that the current snapshot format is forward-compatible with a future multi-level scheme "without a wire change". The chunked replacement is a pre-1.0 format cut, so an operator should plan around the Node host rather than around it.
- ADR-007's fold-work consequence becomes conditional on document-ID locality: append-ordered IDs (the UUIDv7 auto-ID) range from break-even to a 40x win in encode bytes per mutation folded, while uniformly distributed caller-supplied IDs cost 1.8x–25x *more* than the monolithic rebuild at every collection size and boundary policy and never reach parity. The read-side consequences are unconditional and unchanged.
- `scale-ceilings.md`'s interrupted-fold passage gains the liveness consequence it omitted: the CAS never advances, so `log_seq_start` stays put, the tail grows, and the next write tick retries the same rebuild.
- `graduation.md`'s "a finer-grained per-platform `cpuLimit` was **measured** unnecessary" is downgraded to a design assertion — the cited ~3x rate envelope has no artifact in `docs`, `bench`, or `plans`. The conclusion stands; the reason the row now gives is checkable.
- `tsconfig.json` excludes the gitignored `bench/results/` scratch space. The root program was compiling it, so a one-off driver written against another branch's `bench/measurement` surface could turn `pnpm verify` red on a base that never had that surface.
- Not here: two operator-facing `console.warn` strings and six `constants.ts` JSDoc blocks still assert the CPU kill. JSDoc ships un-stripped, so that change needs a `pnpm bundle-sizes` rebaseline and lands separately.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3706 passed, 105 skipped |

No changeset — nothing user-facing changes. `pnpm bundle-sizes` was not run and does not apply; no `packages/*/src/**` or `rolldown.config.ts` file is touched.

`scripts/verify-docs.mjs` validates cross-link paths but strips the `#` fragment, so the anchors this PR adds or retargets were checked by hand against their headings.

## Notes for reviewers

Start at the new "Is the free CPU limit a wall?" section in `scale-ceilings.md` — everything else either links it or follows from it. The claim most worth pushing on is the ADR-007 locality conditional, since it constrains what the chunked layout is allowed to promise.

The measurement provenance — both probe runs, the per-cell outcome tables, and the two minted `script_version`s — lives in the Lane B capture runbook, which is not tracked in this repo. Ask and I'll paste the relevant tables into a comment.
