### PR TITLE
feat(bench): land the workload-ceiling capture tooling

### DIFF
--- a/bench/measurement/workload-ceiling-aggregate.test.ts
+++ b/bench/measurement/workload-ceiling-aggregate.test.ts
@@ -1,0 +1,711 @@
+/**
+ * Tests for workload-ceiling-aggregate.ts — per-cell aggregation under
+ * evidence-contract v2: execution outcome, evidence completeness, and CPU
+ * sample completeness as three separate gates.
+ */
+import { test, expect } from "vitest";
+import {
+  assessWorkloadCeilingCellEvidence,
+  buildWorkloadCeilingAxisReport,
+} from "./workload-ceiling-aggregate.ts";
+import { WORKLOAD_CEILING_STUDY } from "./workload-ceiling-contract.ts";
+import {
+  WORKLOAD_CEILING_EVIDENCE_CONTRACT_ID,
+  type WorkloadCeilingImplementation,
+  WorkloadCeilingHarnessError,
+  type WorkloadCeilingInvocationRecord,
+  type WorkloadCeilingRawEvent,
+  type WorkloadCeilingSweepCell,
+} from "./workload-ceiling-harness.ts";
+
+/** Helper: build a raw event with defaults. */
+const rawEvent = (overrides: Partial<WorkloadCeilingRawEvent>): WorkloadCeilingRawEvent => ({
+  evidence_contract_id: WORKLOAD_CEILING_EVIDENCE_CONTRACT_ID,
+  run_id: "run-1",
+  scenario_id: "byte-axis/1MiB",
+  script_version: "v1",
+  compatibility_date: "2024-01-01",
+  runtime_period: "2024-01-01",
+  colo: "dfw",
+  thermal_class: "cold",
+  outcome: "success",
+  cpu_ms: 10,
+  observed_at: "2024-01-01T00:00:00Z",
+  evidence: {
+    status: "resolved",
+    detail: null,
+    authority: "workers-observability",
+    authoritative_outcome: "ok",
+    authoritative_cpu_ms: 10,
+    authoritative_response_status: 200,
+    cpu_source: "workers-invocations-adaptive",
+    cpu_outcome_verbatim: "success",
+  },
+  ...overrides,
+});
+
+/** A successful invocation whose adaptive CPU row never landed. */
+const cpuMissingSuccess = (overrides: Partial<WorkloadCeilingRawEvent>): WorkloadCeilingRawEvent =>
+  rawEvent({
+    cpu_ms: null,
+    evidence: {
+      status: "resolved",
+      detail: null,
+      authority: "workers-observability",
+      authoritative_outcome: "ok",
+      authoritative_cpu_ms: 7,
+      authoritative_response_status: 200,
+      cpu_source: "none",
+      cpu_outcome_verbatim: null,
+    },
+    ...overrides,
+  });
+
+/** An invocation whose authoritative record never arrived. */
+const evidenceMissing = (overrides: Partial<WorkloadCeilingRawEvent>): WorkloadCeilingRawEvent =>
+  rawEvent({
+    script_version: "unresolved",
+    colo: "unknown",
+    outcome: null,
+    cpu_ms: null,
+    evidence: {
+      status: "missing",
+      detail: "no workers-observability join line for run_id in window",
+      authority: "workers-observability",
+      authoritative_outcome: null,
+      authoritative_cpu_ms: null,
+      authoritative_response_status: null,
+      cpu_source: "none",
+      cpu_outcome_verbatim: null,
+    },
+    ...overrides,
+  });
+
+/** Helper: build a sweep cell with all required fields for tests. */
+const testCell = (overrides: {
+  readonly scenario_id: string;
+  readonly target_bytes: number;
+  readonly achieved_bytes: number;
+  readonly row_count: number;
+}): WorkloadCeilingSweepCell => ({
+  scenario_id: overrides.scenario_id,
+  axis: "byte",
+  target_bytes: overrides.target_bytes,
+  achieved_bytes: overrides.achieved_bytes,
+  row_count: overrides.row_count,
+  document_bytes: 100,
+  manifest_descriptors: 10,
+  fixture_prefix: "test-fixture",
+  incarnation: "test-incarnation",
+  monolithic_key: "test-monolithic-key",
+  manifest_key: "test-manifest-key",
+  descriptor_canonical_hash: "test-hash",
+});
+
+/** Helper: journal (planned-invocation) records for one cell/arm. */
+const plannedRecords = (
+  count: number,
+  scenarioId = "byte-axis/1MiB",
+  implementation = "monolithic-control",
+): WorkloadCeilingInvocationRecord[] =>
+  Array.from({ length: count }, (_, i) => ({
+    contract_id: "baerly.workload-ceiling/chunked-snapshot/v1",
+    sweep_id: "test-sweep",
+    run_id: `planned-${i}`,
+    scenario_id: scenarioId,
+    implementation: implementation as WorkloadCeilingInvocationRecord["implementation"],
+    fixture_prefix: "test-fixture",
+    warmup: false,
+    invoked_at: "2026-08-24T17:30:00.000Z",
+    window_gte: "2026-08-24T17:30:00.000Z",
+    window_lt: "2026-08-24T17:31:00.000Z",
+    http_status: 200,
+    row_count: 491,
+    thermal_class: "warm",
+  }));
+
+/** Helper: build multiple events sharing one scenario_id. */
+const withEvents = (
+  count: number,
+  base: Partial<WorkloadCeilingRawEvent> = {},
+): WorkloadCeilingRawEvent[] =>
+  Array.from({ length: count }, (_, i) => rawEvent({ ...base, run_id: `run-${i}` }));
+
+const oneCellReport = (
+  events: readonly WorkloadCeilingRawEvent[],
+  planned: readonly WorkloadCeilingInvocationRecord[],
+  implementation: WorkloadCeilingImplementation = "monolithic-control",
+) =>
+  buildWorkloadCeilingAxisReport({
+    sweepId: "test-sweep",
+    axis: "byte",
+    cells: [
+      testCell({
+        scenario_id: "byte-axis/1MiB",
+        target_bytes: 1_048_576,
+        achieved_bytes: 1_048_576,
+        row_count: 1000,
+      }),
+    ],
+    plannedInvocations: planned,
+    eventsByArm: new Map([[implementation, events]]),
+  });
+
+const expectRefusal = (fn: () => unknown): { field: string; message: string } => {
+  try {
+    fn();
+  } catch (error) {
+    expect(error).toBeInstanceOf(WorkloadCeilingHarnessError);
+    const harnessError = error as WorkloadCeilingHarnessError;
+    return { field: harnessError.field, message: harnessError.message };
+  }
+  expect.unreachable();
+  return { field: "unreachable", message: "unreachable" };
+};
+
+test("groups repetitions of one scenario into one cell, rather than evicting them", () => {
+  const report = oneCellReport(withEvents(30), plannedRecords(30));
+  expect(report.cells).toHaveLength(1);
+  expect(report.cells[0]!.evidence.collected_event_count).toBe(30);
+  expect(report.cells[0]!.cpu_ms!.p50.sample_size).toBe(30);
+});
+
+test("the report carries the evidence-contract revision, so old and new reports cannot be confused", () => {
+  const report = oneCellReport(withEvents(30), plannedRecords(30));
+  expect(report.evidence_contract_id).toBe("baerly.workload-ceiling/evidence/v2");
+});
+
+test("every emitted statistic carries its algorithm tag", () => {
+  const cell = oneCellReport(withEvents(30), plannedRecords(30)).cells[0]!;
+  expect(cell.cpu_ms!.p50.algorithm).toBe("quantile-r7-v1");
+  expect(cell.cpu_ms!.dispersion.algorithm).toBe("mad-from-median-v1");
+  expect(cell.failure_upper_bound.algorithm).toBe("wilson-one-sided-upper-v1");
+});
+
+test("a complete cell reports the full evidence assessment", () => {
+  const cell = oneCellReport(withEvents(30), plannedRecords(30)).cells[0]!;
+  expect(cell.evidence).toMatchObject({
+    planned_count: 30,
+    collected_event_count: 30,
+    authoritative_event_count: 30,
+    execution_failure_count: 0,
+    evidence_missing_count: 0,
+    evidence_ambiguous_count: 0,
+    finite_cpu_sample_count: 30,
+    cpu_sample_floor: WORKLOAD_CEILING_STUDY.capture.cpu_sample_floor_per_cell,
+    complete: true,
+    cpu_complete: true,
+  });
+  expect(cell.zero_failure_upper_bound).toMatchObject({
+    algorithm: "clopper-pearson-zero-failure-upper-v1",
+    failures: 0,
+    attempts: 30,
+  });
+});
+
+test("missing adaptive rows with successful observability do not become execution failures", () => {
+  // The rehearsal's exact shape: 40 planned, all 40 authoritative successes,
+  // 2 CPU rows dropped. Admission-worthy on every v2 gate.
+  const events = [
+    ...withEvents(38, { scenario_id: "byte-axis/1MiB", cpu_ms: 5 }),
+    ...Array.from({ length: 2 }, (_, i) =>
+      cpuMissingSuccess({ run_id: `dropped-${i}`, scenario_id: "byte-axis/1MiB" }),
+    ),
+  ];
+  const cell = oneCellReport(events, plannedRecords(40)).cells[0]!;
+  expect(cell.evidence.complete).toBe(true);
+  expect(cell.evidence.execution_failure_count).toBe(0);
+  expect(cell.evidence.finite_cpu_sample_count).toBe(38);
+  expect(cell.evidence.cpu_complete).toBe(true);
+  expect(cell.zero_failure_upper_bound).toMatchObject({ failures: 0, attempts: 40 });
+  expect(cell.cpu_provenance).toEqual({ workers_invocations_adaptive: 38, none: 2 });
+  // The two CPU-missing successes contribute no quantile sample.
+  expect(cell.cpu_ms!.p50.sample_size).toBe(38);
+});
+
+test("a successful authoritative event without CPU fails CPU completeness, not the execution outcome", () => {
+  // 29 finite CPU samples of 40 planned: below the floor. The cell reports a
+  // clean execution outcome (0 failures, valid zero-failure bound) while its
+  // CPU-completeness verdict is false.
+  const events = [
+    ...withEvents(29, { scenario_id: "byte-axis/1MiB", cpu_ms: 5 }),
+    ...Array.from({ length: 11 }, (_, i) =>
+      cpuMissingSuccess({ run_id: `dropped-${i}`, scenario_id: "byte-axis/1MiB" }),
+    ),
+  ];
+  const cell = oneCellReport(events, plannedRecords(40)).cells[0]!;
+  expect(cell.evidence.execution_failure_count).toBe(0);
+  expect(cell.evidence.evidence_missing_count).toBe(0);
+  expect(cell.evidence.complete).toBe(true);
+  expect(cell.evidence.finite_cpu_sample_count).toBe(29);
+  expect(cell.evidence.cpu_complete).toBe(false);
+  expect(cell.zero_failure_upper_bound).toMatchObject({ failures: 0 });
+});
+
+test("a missing authoritative observability event blocks evidence completeness", () => {
+  const events = [
+    ...withEvents(39, { scenario_id: "byte-axis/1MiB" }),
+    evidenceMissing({ run_id: "gone", scenario_id: "byte-axis/1MiB" }),
+  ];
+  const refusal = expectRefusal(() => oneCellReport(events, plannedRecords(40)));
+  expect(refusal.field).toBe("evidence_completeness");
+  expect(refusal.message).toMatch(/1 missing/);
+});
+
+test("an uncollected planned invocation (no event file at all) blocks evidence completeness", () => {
+  const refusal = expectRefusal(() => oneCellReport(withEvents(39), plannedRecords(40)));
+  expect(refusal.field).toBe("evidence_completeness");
+  expect(refusal.message).toMatch(/1 uncollected/);
+});
+
+test("an ambiguous authoritative event blocks evidence completeness", () => {
+  const events = [
+    ...withEvents(39, { scenario_id: "byte-axis/1MiB" }),
+    rawEvent({
+      run_id: "dup",
+      scenario_id: "byte-axis/1MiB",
+      script_version: "unresolved",
+      colo: "unknown",
+      outcome: null,
+      cpu_ms: null,
+      evidence: {
+        status: "ambiguous",
+        detail: "2 join lines carry this run_id in one window",
+        authority: "workers-observability",
+        authoritative_outcome: null,
+        authoritative_cpu_ms: null,
+        authoritative_response_status: null,
+        cpu_source: "none",
+        cpu_outcome_verbatim: null,
+      },
+    }),
+  ];
+  const refusal = expectRefusal(() => oneCellReport(events, plannedRecords(40)));
+  expect(refusal.field).toBe("evidence_completeness");
+  expect(refusal.message).toMatch(/1 ambiguous/);
+});
+
+test("a top-up cannot restore completeness: extra successes never erase a missing record", () => {
+  // 39 resolved successes plus one missing record, planned 40. Collecting
+  // MORE successful events cannot change the missing count — the only honest
+  // reading is refusal.
+  const events = [
+    ...withEvents(39, { scenario_id: "byte-axis/1MiB" }),
+    evidenceMissing({ run_id: "gone", scenario_id: "byte-axis/1MiB" }),
+  ];
+  const moreEvents = [
+    ...withEvents(99, { scenario_id: "byte-axis/1MiB" }),
+    evidenceMissing({ run_id: "gone", scenario_id: "byte-axis/1MiB" }),
+  ];
+  expectRefusal(() => oneCellReport(events, plannedRecords(40)));
+  const refusal = expectRefusal(() => oneCellReport(moreEvents, plannedRecords(100)));
+  expect(refusal.field).toBe("evidence_completeness");
+});
+
+test("refuses a capture planned below the preregistered CPU sample floor", () => {
+  // The rehearsal's passing condition: a deliberately short run refuses with
+  // `field: sample_count` rather than producing an admissible-looking report.
+  const refusal = expectRefusal(() => oneCellReport(withEvents(1), plannedRecords(1)));
+  expect(refusal.field).toBe("sample_count");
+});
+
+test("an exceededCpu sample is an execution failure even with a partial CPU value", () => {
+  const events = [
+    ...withEvents(39, { scenario_id: "byte-axis/1MiB", cpu_ms: 5 }),
+    rawEvent({
+      run_id: "killed",
+      scenario_id: "byte-axis/1MiB",
+      outcome: "exceededCpu",
+      cpu_ms: 99,
+      evidence: {
+        status: "resolved",
+        detail: null,
+        authority: "workers-observability",
+        authoritative_outcome: "exceededCpu",
+        authoritative_cpu_ms: 99,
+        authoritative_response_status: null,
+        cpu_source: "workers-invocations-adaptive",
+        cpu_outcome_verbatim: "exceededCpu",
+      },
+    }),
+  ];
+  const cell = oneCellReport(events, plannedRecords(40)).cells[0]!;
+  expect(cell.evidence.execution_failure_count).toBe(1);
+  expect(cell.evidence.complete).toBe(true);
+  expect(cell.zero_failure_upper_bound).toMatchObject({
+    invalid: "failures-present",
+    failure_count: 1,
+  });
+  expect(cell.failure_upper_bound.failures).toBe(1);
+  expect(cell.failure_upper_bound.upper).toBeGreaterThan(0);
+  // The censored value never enters the resolved quantiles.
+  expect(cell.cpu_ms!.p50.value).toBe(5);
+  expect(cell.cpu_ms!.p50.sample_size).toBe(39);
+  expect(cell.exceeded_cpu_ms!.p50.value).toBe(99);
+});
+
+test("a cell where every invocation exceeded CPU reports outcomes, not quantiles", () => {
+  const events = Array.from({ length: 30 }, (_, i) =>
+    rawEvent({
+      run_id: `run-${i}`,
+      scenario_id: "byte-axis/1MiB",
+      outcome: "exceededCpu",
+      cpu_ms: 15,
+      evidence: {
+        status: "resolved",
+        detail: null,
+        authority: "workers-observability",
+        authoritative_outcome: "exceededCpu",
+        authoritative_cpu_ms: 15,
+        authoritative_response_status: null,
+        cpu_source: "workers-invocations-adaptive",
+        cpu_outcome_verbatim: "exceededCpu",
+      },
+    }),
+  );
+  const cell = oneCellReport(events, plannedRecords(30)).cells[0]!;
+  expect(cell.cpu_ms).toBeNull();
+  expect(cell.outcomes["exceededCpu"]).toBe(30);
+  expect(cell.exceeded_cpu_ms).not.toBeNull();
+  expect(cell.exceeded_cpu_ms!.p50.value).toBe(15);
+  // Past-the-wall is an expected state, not a refusal: evidence is complete,
+  // the CPU floor simply cannot be met by dead invocations.
+  expect(cell.evidence.complete).toBe(true);
+  expect(cell.evidence.cpu_complete).toBe(false);
+});
+
+test("refuses a cell whose RESOLVED events disagree on script_version", () => {
+  const events = [
+    rawEvent({ run_id: "run-0", scenario_id: "byte-axis/1MiB", script_version: "v2" }),
+    ...withEvents(30, { scenario_id: "byte-axis/1MiB", script_version: "v1" }),
+  ];
+  const refusal = expectRefusal(() => oneCellReport(events, plannedRecords(31)));
+  expect(refusal.field).toBe("script_version");
+});
+
+test("an evidence-missing sample is not mistaken for a mid-run redeploy", () => {
+  // Regression, 2026-08-24 rehearsal: the sentinel script_version of an
+  // unresolved record must never masquerade as the cell's deployment
+  // metadata — but under v2 the refusal that follows is
+  // `evidence_completeness`, not `script_version`.
+  const events = [
+    evidenceMissing({ run_id: "gone", scenario_id: "byte-axis/1MiB" }),
+    ...withEvents(30, { scenario_id: "byte-axis/1MiB", script_version: "v1" }),
+  ];
+  const refusal = expectRefusal(() => oneCellReport(events, plannedRecords(31)));
+  expect(refusal.field).toBe("evidence_completeness");
+});
+
+test("assessWorkloadCeilingCellEvidence reports counts without refusing", () => {
+  // The assessment behind the refusal is independently observable, so a
+  // blocked capture's counts can be read without producing a report.
+  const assessment = assessWorkloadCeilingCellEvidence(
+    [...withEvents(2), cpuMissingSuccess({ run_id: "d1" }), evidenceMissing({ run_id: "gone" })],
+    4,
+    WORKLOAD_CEILING_STUDY.capture.cpu_sample_floor_per_cell,
+  );
+  expect(assessment).toMatchObject({
+    planned_count: 4,
+    collected_event_count: 4,
+    authoritative_event_count: 3,
+    execution_failure_count: 0,
+    evidence_missing_count: 1,
+    evidence_ambiguous_count: 0,
+    finite_cpu_sample_count: 2,
+    complete: false,
+    cpu_complete: false,
+  });
+});
+
+test("source and field provenance survive aggregation", () => {
+  // Verbatim authoritative outcome literals and per-source CPU counts roll
+  // up into the cell summary next to the canonical histogram.
+  const events = [
+    ...withEvents(29, {
+      scenario_id: "byte-axis/1MiB",
+      cpu_ms: 5,
+      evidence: {
+        status: "resolved",
+        detail: null,
+        authority: "workers-observability",
+        authoritative_outcome: "ok",
+        authoritative_cpu_ms: 5,
+        authoritative_response_status: 200,
+        cpu_source: "workers-invocations-adaptive",
+        cpu_outcome_verbatim: "success",
+      },
+    }),
+    rawEvent({
+      run_id: "killed",
+      scenario_id: "byte-axis/1MiB",
+      outcome: "exceededCpu",
+      cpu_ms: 99,
+      evidence: {
+        status: "resolved",
+        detail: null,
+        authority: "workers-observability",
+        authoritative_outcome: "exceededCpu",
+        authoritative_cpu_ms: 99,
+        authoritative_response_status: null,
+        cpu_source: "none",
+        cpu_outcome_verbatim: null,
+      },
+    }),
+  ];
+  const cell = oneCellReport(events, plannedRecords(30)).cells[0]!;
+  expect(cell.outcomes).toEqual({ success: 29, exceededCpu: 1 });
+  expect(cell.outcome_verbatim).toEqual({ ok: 29, exceededCpu: 1 });
+  expect(cell.cpu_provenance).toEqual({ workers_invocations_adaptive: 29, none: 1 });
+});
+
+test("hash cost is hashed minus unhashed, stratified by cell", () => {
+  const controlEvents = withEvents(30, {
+    scenario_id: "byte-axis/1MiB",
+    cpu_ms: 12,
+  });
+  const unhashedEvents = withEvents(30, {
+    scenario_id: "byte-axis/1MiB",
+    cpu_ms: 10,
+  });
+
+  const report = buildWorkloadCeilingAxisReport({
+    sweepId: "test-sweep",
+    axis: "byte",
+    cells: [
+      testCell({
+        scenario_id: "byte-axis/1MiB",
+        target_bytes: 1_048_576,
+        achieved_bytes: 1_048_576,
+        row_count: 1000,
+      }),
+    ],
+    plannedInvocations: [
+      ...plannedRecords(30, "byte-axis/1MiB", "monolithic-control"),
+      ...plannedRecords(30, "byte-axis/1MiB", "monolithic-control-unhashed"),
+    ],
+    eventsByArm: new Map([
+      ["monolithic-control", controlEvents],
+      ["monolithic-control-unhashed", unhashedEvents],
+    ]),
+  });
+
+  expect(report.hash_cost).toHaveLength(1);
+  expect(report.hash_cost[0]!.scenario_id).toBe("byte-axis/1MiB");
+  expect(report.hash_cost[0]!.difference_ms).toHaveLength(30);
+  // Hashed (12) - Unhashed (10) = 2
+  expect(report.hash_cost[0]!.difference_ms[0]!.candidate).toBe(12);
+  expect(report.hash_cost[0]!.difference_ms[0]!.baseline).toBe(10);
+});
+
+test("a dropped CPU row removes its own ordinal instead of shifting every later pair", () => {
+  // The contract preregisters ~15% adaptive-row drops. Filtering each arm to
+  // usable samples and THEN zipping by index makes the 3rd unhashed drop pair
+  // control#3 against unhashed#4, control#4 against unhashed#5, and so on —
+  // every later difference computed across invocations from different passes,
+  // silently.
+  const period = (i: number) =>
+    `2024-01-01T00:${String(i).padStart(2, "0")}:00Z/2024-01-01T00:${String(i + 1).padStart(2, "0")}:00Z`;
+  const controlEvents = Array.from({ length: 30 }, (_, i) =>
+    rawEvent({ run_id: `c-${i}`, runtime_period: period(i), cpu_ms: 100 + i }),
+  );
+  const unhashedEvents = Array.from({ length: 30 }, (_, i) =>
+    i === 2
+      ? cpuMissingSuccess({ run_id: `u-${i}`, runtime_period: period(i) })
+      : rawEvent({ run_id: `u-${i}`, runtime_period: period(i), cpu_ms: i }),
+  );
+
+  const report = buildWorkloadCeilingAxisReport({
+    sweepId: "test-sweep",
+    axis: "byte",
+    cells: [
+      testCell({
+        scenario_id: "byte-axis/1MiB",
+        target_bytes: 1_048_576,
+        achieved_bytes: 1_048_576,
+        row_count: 1000,
+      }),
+    ],
+    plannedInvocations: [
+      ...plannedRecords(30, "byte-axis/1MiB", "monolithic-control"),
+      ...plannedRecords(30, "byte-axis/1MiB", "monolithic-control-unhashed"),
+    ],
+    eventsByArm: new Map([
+      ["monolithic-control", controlEvents],
+      ["monolithic-control-unhashed", unhashedEvents],
+    ]),
+  });
+
+  const pairs = report.hash_cost[0]!.difference_ms;
+  expect(pairs).toHaveLength(29);
+  // Ordinal 2 is absent, and every surviving pair still holds one ordinal:
+  // control 100 + k against unhashed k.
+  expect(pairs.map((p) => p.pair_id)).not.toContain("byte-axis/1MiB#2");
+  expect(pairs.map((p) => p.pair_id)).toEqual(
+    [...Array(30).keys()].filter((k) => k !== 2).map((k) => `byte-axis/1MiB#${String(k)}`),
+  );
+  for (const pair of pairs) {
+    expect(pair.candidate - pair.baseline).toBe(100);
+  }
+});
+
+test("hash cost pairs by telemetry minute, not by the order events were read", () => {
+  // `readEventsFromDirectory` returns readdir order and `observed_at` is the
+  // collector's clock, so neither orders the invocations. Shuffling one arm's
+  // files must not change which repetitions are paired.
+  const period = (i: number) =>
+    `2024-01-01T00:${String(i).padStart(2, "0")}:00Z/2024-01-01T00:${String(i + 1).padStart(2, "0")}:00Z`;
+  const controlEvents = Array.from({ length: 30 }, (_, i) =>
+    rawEvent({ run_id: `c-${i}`, runtime_period: period(i), cpu_ms: 100 + i }),
+  );
+  const unhashedEvents = Array.from({ length: 30 }, (_, i) =>
+    rawEvent({ run_id: `u-${i}`, runtime_period: period(i), cpu_ms: i }),
+  );
+
+  const build = (unhashed: readonly WorkloadCeilingRawEvent[]) =>
+    buildWorkloadCeilingAxisReport({
+      sweepId: "test-sweep",
+      axis: "byte",
+      cells: [
+        testCell({
+          scenario_id: "byte-axis/1MiB",
+          target_bytes: 1_048_576,
+          achieved_bytes: 1_048_576,
+          row_count: 1000,
+        }),
+      ],
+      plannedInvocations: [
+        ...plannedRecords(30, "byte-axis/1MiB", "monolithic-control"),
+        ...plannedRecords(30, "byte-axis/1MiB", "monolithic-control-unhashed"),
+      ],
+      eventsByArm: new Map([
+        ["monolithic-control", controlEvents],
+        ["monolithic-control-unhashed", unhashed],
+      ]),
+    }).hash_cost[0]!.difference_ms;
+
+  expect(build(unhashedEvents.toReversed())).toEqual(build(unhashedEvents));
+});
+
+test("an arm the journal planned but nothing collected refuses, rather than being skipped", () => {
+  // The loop used to iterate the collected arms only, so an arm whose event
+  // directory never appeared — collect-batch crashed, or the CLI ENOENT'd it —
+  // was never visited and its wholly-uncollected cells never reached the
+  // completeness refusal. A sweep missing an entire captured arm produced a
+  // clean-looking report over the arms that survived.
+  const refusal = expectRefusal(() =>
+    buildWorkloadCeilingAxisReport({
+      sweepId: "test-sweep",
+      axis: "byte",
+      cells: [
+        testCell({
+          scenario_id: "byte-axis/1MiB",
+          target_bytes: 1_048_576,
+          achieved_bytes: 1_048_576,
+          row_count: 1000,
+        }),
+      ],
+      plannedInvocations: [
+        ...plannedRecords(30, "byte-axis/1MiB", "monolithic-control"),
+        ...plannedRecords(30, "byte-axis/1MiB", "chunked-candidate"),
+      ],
+      eventsByArm: new Map([["monolithic-control", withEvents(30)]]),
+    }),
+  );
+  expect(refusal.field).toBe("evidence_completeness");
+  expect(refusal.message).toContain("chunked-candidate");
+});
+
+test("hash cost is omitted for a cell missing an arm, never imputed", () => {
+  const report = oneCellReport(withEvents(30), plannedRecords(30));
+  expect(report.hash_cost).toHaveLength(0);
+});
+
+test("the slope fit reports its condition estimate and needs two resolved cells", () => {
+  // One resolved cell → unavailable
+  const oneCellReportResult = oneCellReport(withEvents(30), plannedRecords(30));
+  expect(oneCellReportResult.cpu_per_mib).toMatchObject({
+    unavailable: expect.any(String),
+  });
+
+  // Four resolved cells → fit with condition estimate
+  const fourCellReport = buildWorkloadCeilingAxisReport({
+    sweepId: "test-sweep",
+    axis: "byte",
+    cells: [
+      testCell({
+        scenario_id: "byte-axis/512KiB",
+        target_bytes: 524_288,
+        achieved_bytes: 524_288,
+        row_count: 500,
+      }),
+      testCell({
+        scenario_id: "byte-axis/1MiB",
+        target_bytes: 1_048_576,
+        achieved_bytes: 1_048_576,
+        row_count: 1000,
+      }),
+      testCell({
+        scenario_id: "byte-axis/2MiB",
+        target_bytes: 2_097_152,
+        achieved_bytes: 2_097_152,
+        row_count: 2000,
+      }),
+      testCell({
+        scenario_id: "byte-axis/4MiB",
+        target_bytes: 4_194_304,
+        achieved_bytes: 4_194_304,
+        row_count: 4000,
+      }),
+    ],
+    plannedInvocations: [
+      ...plannedRecords(30, "byte-axis/512KiB"),
+      ...plannedRecords(30, "byte-axis/1MiB"),
+      ...plannedRecords(30, "byte-axis/2MiB"),
+      ...plannedRecords(30, "byte-axis/4MiB"),
+    ],
+    eventsByArm: new Map([
+      [
+        "monolithic-control",
+        [
+          ...withEvents(30, { scenario_id: "byte-axis/512KiB", cpu_ms: 5 }),
+          ...withEvents(30, { scenario_id: "byte-axis/1MiB", cpu_ms: 10 }),
+          ...withEvents(30, { scenario_id: "byte-axis/2MiB", cpu_ms: 20 }),
+          ...withEvents(30, { scenario_id: "byte-axis/4MiB", cpu_ms: 40 }),
+        ],
+      ],
+    ]),
+  });
+
+  const fit = fourCellReport.cpu_per_mib;
+  if (!("unavailable" in fit)) {
+    expect(fit.algorithm).toBe("ols-qr-v1");
+    expect(fit.intercept_present).toBe(true);
+    expect(fit.condition_estimate).toBeLessThan(100);
+  }
+});
+
+test("quantiles are additionally reported per thermal class", () => {
+  const events = [
+    ...withEvents(10, { scenario_id: "byte-axis/1MiB", thermal_class: "cold", cpu_ms: 5 }),
+    ...withEvents(10, { scenario_id: "byte-axis/1MiB", thermal_class: "warm", cpu_ms: 15 }),
+    ...withEvents(10, { scenario_id: "byte-axis/1MiB", thermal_class: "unknown", cpu_ms: 10 }),
+  ];
+  const cell = oneCellReport(events, plannedRecords(30)).cells[0]!;
+  expect(cell.cpu_ms_by_thermal.cold).toBeDefined();
+  expect(cell.cpu_ms_by_thermal.warm).toBeDefined();
+  expect(cell.cpu_ms_by_thermal.unknown).toBeDefined();
+  expect(cell.cpu_ms_by_thermal.cold!.value).toBeCloseTo(5, 0);
+  expect(cell.cpu_ms_by_thermal.warm!.value).toBeCloseTo(15, 0);
+});
+
+test("thermal distribution is reported correctly", () => {
+  const events = [
+    ...withEvents(10, { scenario_id: "byte-axis/1MiB", thermal_class: "cold" }),
+    ...withEvents(15, { scenario_id: "byte-axis/1MiB", thermal_class: "warm" }),
+    ...withEvents(5, { scenario_id: "byte-axis/1MiB", thermal_class: "unknown" }),
+  ];
+  const cell = oneCellReport(events, plannedRecords(30)).cells[0]!;
+  expect(cell.thermal.cold).toBe(10);
+  expect(cell.thermal.warm).toBe(15);
+  expect(cell.thermal.unknown).toBe(5);
+});

--- a/bench/measurement/workload-ceiling-aggregate.ts
+++ b/bench/measurement/workload-ceiling-aggregate.ts
@@ -45,7 +45,9 @@ import {
   type WorkloadCeilingImplementation,
   type WorkloadCeilingInvocationRecord,
   type WorkloadCeilingRawEvent,
+  decodeWorkloadCeilingSweepReport,
   type WorkloadCeilingSweepCell,
+  type WorkloadCeilingSweepReport,
   type WorkloadCeilingThermalClass,
 } from "./workload-ceiling-harness.ts";
 import {
@@ -703,20 +705,27 @@ async function main(): Promise<number> {
     return 1;
   }
 
-  // Load sweep report
+  // Load the sweep report through the codec its writer enforces on the same
+  // file. `JSON.parse ... as` asserted a shape nothing had checked, so a
+  // parseable-but-malformed report fed unvalidated `achieved_bytes` /
+  // `target_bytes` / `row_count` straight into the admission gates below —
+  // and, sitting outside the try, a truncated file threw an uncaught
+  // SyntaxError instead of this clean `return 1`. The errno is reported for
+  // the same reason `loadJournal` reports it: EACCES on a real report must
+  // not read as "no report".
   const sweepPath = `${resultsDir}/sweep-${sweepId}.json`;
-  let sweepRaw: string;
+  let sweep: WorkloadCeilingSweepReport;
   try {
-    sweepRaw = await readFile(sweepPath, "utf8");
-  } catch {
-    console.error(`workload-ceiling-aggregate: cannot read sweep report ${sweepPath}`);
+    sweep = decodeWorkloadCeilingSweepReport(await readFile(sweepPath, "utf8"));
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    console.error(
+      `workload-ceiling-aggregate: cannot read sweep report ${sweepPath}` +
+        `${code === undefined ? "" : ` (${code})`}: ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+    );
     return 1;
   }
-
-  const sweep = JSON.parse(sweepRaw) as {
-    readonly sweep_id: string;
-    readonly cells: readonly WorkloadCeilingSweepCell[];
-  };
 
   if (sweep.sweep_id !== sweepId) {
     console.error(

--- a/bench/measurement/workload-ceiling-aggregate.ts
+++ b/bench/measurement/workload-ceiling-aggregate.ts
@@ -1,0 +1,848 @@
+/**
+ * Lane B deliverable: per-cell aggregation from raw events.
+ *
+ * Reduces a directory of per-invocation raw events into per-cell summaries:
+ * p50/p95/p99 CPU, outcome histograms (canonical and verbatim), zero-failure
+ * bound, hash cost (as a paired difference between the two monolithic arms),
+ * and CPU-per-MiB slope — each with its evidence-contract v2 assessment:
+ * execution outcome, evidence completeness, and CPU-sample completeness are
+ * evaluated as three SEPARATE gates (see
+ * `workload-ceiling-harness.ts`'s evidence block).
+ *
+ * Groups by `scenario_id`: the planned invocations per cell share one scenario
+ * id by design, so the repeats ARE the sample.
+ * `workload-ceiling-compare.ts` groups the same way and for the same reason —
+ * it reduces each (cell, arm) to a p50 before joining the two arms. The two
+ * modules agree about cardinality; only what they do after grouping differs.
+ *
+ * Every number this module reports comes from a tagged algorithm in
+ * `statistics.ts` — no statistic is computed inline.
+ */
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { runAsCliEntrypoint } from "./cli-entrypoint.ts";
+import {
+  clopperPearsonZeroFailureUpper,
+  madEstimate,
+  olsQr,
+  quantileEstimate,
+  WILSON_Z_BY_CONFIDENCE,
+  wilsonOneSidedUpper,
+  type DispersionEstimate,
+  type OlsQrInput,
+  type OlsQrResult,
+  type QuantileEstimate,
+  type StratifiedPair,
+  type WilsonOneSidedUpperResult,
+} from "./statistics.ts";
+import { WORKLOAD_CEILING_STUDY } from "./workload-ceiling-contract.ts";
+import {
+  decodeWorkloadCeilingInvocationRecord,
+  WORKLOAD_CEILING_CONTRACT_ID,
+  WORKLOAD_CEILING_EVIDENCE_CONTRACT_ID,
+  WORKLOAD_CEILING_IMPLEMENTATIONS,
+  WORKLOAD_CEILING_THERMAL_CLASSES,
+  WorkloadCeilingHarnessError,
+  type WorkloadCeilingImplementation,
+  type WorkloadCeilingInvocationRecord,
+  type WorkloadCeilingRawEvent,
+  type WorkloadCeilingSweepCell,
+  type WorkloadCeilingThermalClass,
+} from "./workload-ceiling-harness.ts";
+import {
+  assessWorkloadCeilingExecution,
+  deploymentKey,
+  hasResolvedDeployment,
+  isResolvedOk,
+  readEventsFromDirectory,
+  type ResolvedWorkloadCeilingRawEvent,
+  type WorkloadCeilingZeroFailureBound,
+} from "./workload-ceiling-compare.ts";
+
+/**
+ * Per-cell evidence assessment: the three v2 gates, reported together so a
+ * reader sees WHICH gate failed, not just that "the aggregate refused".
+ */
+export interface WorkloadCeilingCellEvidence {
+  /** Planned measured invocations for this cell and arm, from the journal. */
+  readonly planned_count: number;
+  /** Event files present for those invocations. */
+  readonly collected_event_count: number;
+  /** Invocations whose authoritative (Workers Observability) record resolved. */
+  readonly authoritative_event_count: number;
+  /** Authoritative events whose canonical outcome is not `success`. */
+  readonly execution_failure_count: number;
+  readonly evidence_missing_count: number;
+  readonly evidence_ambiguous_count: number;
+  /** Successful invocations carrying a finite CPU measurement. */
+  readonly finite_cpu_sample_count: number;
+  readonly cpu_sample_floor: number;
+  /**
+   * Every planned invocation has exactly one authoritative event: collected
+   * === planned, no missing, no ambiguous. An independent admission gate —
+   * never the same fact as the zero-failure bound.
+   */
+  readonly complete: boolean;
+  /** Finite successful CPU samples meet the preregistered floor. */
+  readonly cpu_complete: boolean;
+}
+
+/**
+ * Per-cell summary: CPU quantiles, outcomes, thermal distribution, failure
+ * bounds, and the evidence assessment above.
+ */
+export interface WorkloadCeilingCellSummary {
+  readonly scenario_id: string;
+  readonly implementation: WorkloadCeilingImplementation;
+  readonly target_bytes: number;
+  readonly achieved_bytes: number;
+  readonly row_count: number;
+  readonly collected_event_count: number;
+  /** Canonical outcome literal → count, over authoritative events. */
+  readonly outcomes: Readonly<Record<string, number>>;
+  /** Verbatim authoritative outcome literal → count. Provenance, not classification. */
+  readonly outcome_verbatim: Readonly<Record<string, number>>;
+  readonly thermal: Readonly<Record<WorkloadCeilingThermalClass, number>>;
+  /**
+   * Null when no successful invocation carried a CPU measurement — an
+   * expected state at the cells past the CPU wall.
+   */
+  readonly cpu_ms: {
+    readonly p50: QuantileEstimate;
+    readonly p95: QuantileEstimate;
+    readonly p99: QuantileEstimate;
+    readonly dispersion: DispersionEstimate;
+  } | null;
+  /**
+   * Quantiles over `exceededCpu` samples only. CENSORED observations — the CPU
+   * consumed before the runtime killed the invocation, not the cost of a fold
+   * that finished. Never pooled with `cpu_ms`.
+   */
+  readonly exceeded_cpu_ms: { readonly p50: QuantileEstimate } | null;
+  /** Per thermal class, when that class has finite-CPU successful samples. */
+  readonly cpu_ms_by_thermal: Readonly<
+    Partial<Record<WorkloadCeilingThermalClass, QuantileEstimate>>
+  >;
+  readonly zero_failure_upper_bound: WorkloadCeilingZeroFailureBound;
+  /**
+   * Wilson one-sided upper bound on the execution-failure rate — defined at
+   * any failure count, over authoritative events only.
+   */
+  readonly failure_upper_bound: WilsonOneSidedUpperResult;
+  readonly evidence: WorkloadCeilingCellEvidence;
+  /** Per-source CPU counts: provenance rolled up to the cell. */
+  readonly cpu_provenance: Readonly<Record<"workers_invocations_adaptive" | "none", number>>;
+  readonly script_version: string;
+  readonly compatibility_date: string;
+}
+
+/**
+ * Full axis report: per-cell summaries, hash cost, and CPU-per-MiB slope.
+ */
+export interface WorkloadCeilingAxisReport {
+  readonly contract_id: typeof WORKLOAD_CEILING_CONTRACT_ID;
+  readonly evidence_contract_id: typeof WORKLOAD_CEILING_EVIDENCE_CONTRACT_ID;
+  readonly sweep_id: string;
+  readonly axis: "byte" | "row";
+  readonly capture: typeof WORKLOAD_CEILING_STUDY.capture;
+  readonly cells: readonly WorkloadCeilingCellSummary[];
+  /**
+   * One entry per cell that has finite-CPU successful samples in BOTH monolithic arms.
+   */
+  readonly hash_cost: readonly {
+    readonly scenario_id: string;
+    readonly difference_ms: StratifiedPair[];
+  }[];
+  /**
+   * `cpu_ms ~ intercept + mib`, fitted across cells with finite-CPU samples.
+   * Unavailable — with a stated reason — when fewer than two cells resolved.
+   */
+  readonly cpu_per_mib: OlsQrResult | { readonly unavailable: string };
+}
+
+/**
+ * Pure. The per-cell evidence assessment without any refusal — the counts a
+ * blocked capture still needs to report. `events` are the collected events
+ * for one (cell, arm); `plannedCount` is the journal's non-warmup
+ * invocation count for the same (cell, arm).
+ */
+export function assessWorkloadCeilingCellEvidence(
+  events: readonly WorkloadCeilingRawEvent[],
+  plannedCount: number,
+  cpuSampleFloor: number,
+): WorkloadCeilingCellEvidence {
+  const execution = assessWorkloadCeilingExecution(events);
+  const complete =
+    events.length === plannedCount &&
+    execution.evidence_missing_count === 0 &&
+    execution.evidence_ambiguous_count === 0;
+  return {
+    planned_count: plannedCount,
+    collected_event_count: events.length,
+    authoritative_event_count: execution.authoritative_event_count,
+    execution_failure_count: execution.execution_failure_count,
+    evidence_missing_count: execution.evidence_missing_count,
+    evidence_ambiguous_count: execution.evidence_ambiguous_count,
+    finite_cpu_sample_count: execution.finite_cpu_sample_count,
+    cpu_sample_floor: cpuSampleFloor,
+    complete,
+    cpu_complete: execution.finite_cpu_sample_count >= cpuSampleFloor,
+  };
+}
+
+/**
+ * An `exceededCpu` invocation the platform still reported a CPU number for —
+ * a CENSORED observation, quantiled separately and never pooled with the cost
+ * of a fold that finished. A type guard rather than a predicate plus a cast:
+ * the cast form let the runtime `cpu_ms !== null` check and the asserted
+ * `cpu_ms: number` drift apart silently.
+ */
+const isCensoredExceededCpu = (
+  event: WorkloadCeilingRawEvent,
+): event is WorkloadCeilingRawEvent & { readonly cpu_ms: number } =>
+  event.outcome === "exceededCpu" && event.cpu_ms !== null;
+
+/**
+ * Zip two arrays by index, truncating to the shorter length.
+ * Used for pairing hash-cost samples within a cell.
+ */
+function zipByIndex<T, U>(a: readonly T[], b: readonly U[]): readonly [T, U][] {
+  const minLength = Math.min(a.length, b.length);
+  const result: [T, U][] = [];
+  for (let i = 0; i < minLength; i++) {
+    result.push([a[i]!, b[i]!]);
+  }
+  return result;
+}
+
+/**
+ * Groups events by scenario_id for a single implementation.
+ */
+function indexByScenario(
+  events: readonly WorkloadCeilingRawEvent[],
+): ReadonlyMap<string, readonly WorkloadCeilingRawEvent[]> {
+  const byScenario = new Map<string, WorkloadCeilingRawEvent[]>();
+  for (const event of events) {
+    const existing = byScenario.get(event.scenario_id);
+    if (existing) {
+      existing.push(event);
+    } else {
+      byScenario.set(event.scenario_id, [event]);
+    }
+  }
+  return byScenario;
+}
+
+/** Non-warmup journal records grouped by (implementation, scenario). */
+function plannedCountsByArmAndScenario(
+  plannedInvocations: readonly WorkloadCeilingInvocationRecord[],
+): ReadonlyMap<string, ReadonlyMap<string, number>> {
+  const byArm = new Map<string, Map<string, number>>();
+  for (const record of plannedInvocations) {
+    if (record.warmup) {
+      continue;
+    }
+    let byScenario = byArm.get(record.implementation);
+    if (byScenario === undefined) {
+      byScenario = new Map();
+      byArm.set(record.implementation, byScenario);
+    }
+    byScenario.set(record.scenario_id, (byScenario.get(record.scenario_id) ?? 0) + 1);
+  }
+  return byArm;
+}
+
+/**
+ * Builds a per-cell summary from collected events.
+ *
+ * Refuses (throws `WorkloadCeilingHarnessError`) on three capture-level
+ * violations, in order:
+ *
+ *  1. `script_version` — resolved events disagree on deployment metadata:
+ *     two runtime builds are not one measurement.
+ *  2. `evidence_completeness` — a planned invocation is uncollected, or its
+ *     authoritative record is missing or ambiguous. No report is produced
+ *     over incomplete evidence.
+ *  3. `sample_count` — the capture was PLANNED below the preregistered CPU
+ *     sample floor (a deliberately short rehearsal run). A capture planned at
+ *     or above the floor that lands short on finite CPU samples does NOT
+ *     throw: the cell's `evidence.cpu_complete` verdict is false, which
+ *     blocks admission and is reported.
+ */
+function buildCellSummary(input: {
+  readonly scenarioId: string;
+  readonly implementation: WorkloadCeilingImplementation;
+  readonly cell: WorkloadCeilingSweepCell;
+  readonly events: readonly WorkloadCeilingRawEvent[];
+  readonly plannedCount: number;
+}): WorkloadCeilingCellSummary {
+  const { scenarioId, implementation, cell, events, plannedCount } = input;
+
+  // Thermal distribution over every collected event (warm/cold is a property
+  // of the invocation, independent of evidence resolution).
+  const thermal: Record<WorkloadCeilingThermalClass, number> = {
+    warm: 0,
+    cold: 0,
+    unknown: 0,
+  };
+  for (const event of events) {
+    thermal[event.thermal_class] = (thermal[event.thermal_class] ?? 0) + 1;
+  }
+
+  // Deployment metadata: every event that HAS deployment metadata must agree.
+  // Unresolved events are skipped — they carry the sentinel, not a version
+  // the platform reported, so including them would report missing evidence as
+  // "the Worker was redeployed mid-run".
+  const deployedEvents = events.filter(hasResolvedDeployment);
+  const firstDeployed = deployedEvents[0];
+  if (firstDeployed !== undefined) {
+    for (const event of deployedEvents) {
+      if (deploymentKey(event) !== deploymentKey(firstDeployed)) {
+        throw new WorkloadCeilingHarnessError(
+          "script_version",
+          `Cell ${scenarioId} has events with mixed deployment metadata`,
+        );
+      }
+    }
+  }
+
+  // Evidence assessment (three separate gates).
+  const cpuFloor = WORKLOAD_CEILING_STUDY.capture.cpu_sample_floor_per_cell;
+  const evidence = assessWorkloadCeilingCellEvidence(events, plannedCount, cpuFloor);
+  const execution = assessWorkloadCeilingExecution(events);
+  const outcomes = execution.outcome_histogram;
+  const verbatimHistogram: Record<string, number> = {};
+  for (const event of events) {
+    if (event.evidence.status !== "resolved") {
+      continue;
+    }
+    const verbatim = event.evidence.authoritative_outcome!;
+    verbatimHistogram[verbatim] = (verbatimHistogram[verbatim] ?? 0) + 1;
+  }
+  const cpuProvenance: Record<"workers_invocations_adaptive" | "none", number> = {
+    workers_invocations_adaptive: 0,
+    none: 0,
+  };
+  for (const event of events) {
+    if (event.evidence.cpu_source === "workers-invocations-adaptive") {
+      cpuProvenance["workers_invocations_adaptive"] += 1;
+    } else {
+      cpuProvenance.none += 1;
+    }
+  }
+
+  if (!evidence.complete) {
+    const uncollected = plannedCount - events.length;
+    const reasons: string[] = [];
+    if (uncollected > 0) {
+      reasons.push(`${uncollected} uncollected`);
+    }
+    if (evidence.evidence_missing_count > 0) {
+      reasons.push(`${evidence.evidence_missing_count} missing`);
+    }
+    if (evidence.evidence_ambiguous_count > 0) {
+      reasons.push(`${evidence.evidence_ambiguous_count} ambiguous`);
+    }
+    if (reasons.length === 0) {
+      reasons.push(
+        `${events.length} collected events exceed the ${plannedCount} planned invocations`,
+      );
+    }
+    throw new WorkloadCeilingHarnessError(
+      "evidence_completeness",
+      `Cell ${scenarioId} (${implementation}) has incomplete evidence: ${reasons.join(", ")} ` +
+        `of ${plannedCount} planned invocations — every planned invocation must have ` +
+        `exactly one authoritative event, and there is no post-hoc remedy`,
+    );
+  }
+
+  if (plannedCount < cpuFloor) {
+    throw new WorkloadCeilingHarnessError(
+      "sample_count",
+      `Cell ${scenarioId} was planned at ${plannedCount} invocations, below the ` +
+        `preregistered CPU sample floor ${cpuFloor}`,
+    );
+  }
+
+  // Quantile inputs: successful invocations with finite CPU.
+  const cpuSamples = events.filter(isResolvedOk) as readonly ResolvedWorkloadCeilingRawEvent[];
+  const exceeded = events.filter(isCensoredExceededCpu);
+
+  let cpu_ms: WorkloadCeilingCellSummary["cpu_ms"] = null;
+  if (cpuSamples.length > 0) {
+    const cpuValues = cpuSamples.map((e) => e.cpu_ms);
+    cpu_ms = {
+      p50: quantileEstimate(cpuValues, 0.5, "quantile-r7-v1"),
+      p95: quantileEstimate(cpuValues, 0.95, "quantile-r7-v1"),
+      p99: quantileEstimate(cpuValues, 0.99, "quantile-r7-v1"),
+      dispersion: madEstimate(cpuValues),
+    };
+  }
+
+  // Censored CPU quantiles (exceededCpu samples only)
+  let exceeded_cpu_ms: WorkloadCeilingCellSummary["exceeded_cpu_ms"] = null;
+  if (exceeded.length > 0) {
+    exceeded_cpu_ms = {
+      p50: quantileEstimate(
+        exceeded.map((e) => e.cpu_ms),
+        0.5,
+        "quantile-r7-v1",
+      ),
+    };
+  }
+
+  // Per-thermal quantiles
+  const cpu_ms_by_thermal: Partial<Record<WorkloadCeilingThermalClass, QuantileEstimate>> = {};
+  for (const thermalClass of WORKLOAD_CEILING_THERMAL_CLASSES) {
+    const thermalResolved = cpuSamples.filter((e) => e.thermal_class === thermalClass);
+    if (thermalResolved.length > 0) {
+      cpu_ms_by_thermal[thermalClass] = quantileEstimate(
+        thermalResolved.map((e) => e.cpu_ms),
+        0.5,
+        "quantile-r7-v1",
+      );
+    }
+  }
+
+  // Zero-execution-failure bound over AUTHORITATIVE events only. Evidence
+  // missingness is not a failure and not a trial.
+  const attempts = Math.max(1, evidence.authoritative_event_count);
+  const zero_failure_upper_bound: WorkloadCeilingZeroFailureBound =
+    evidence.execution_failure_count === 0
+      ? clopperPearsonZeroFailureUpper(attempts, WORKLOAD_CEILING_STUDY.capture.confidence)
+      : {
+          invalid: "failures-present",
+          failure_count: evidence.execution_failure_count,
+        };
+
+  const z =
+    WILSON_Z_BY_CONFIDENCE[
+      WORKLOAD_CEILING_STUDY.capture.confidence as keyof typeof WILSON_Z_BY_CONFIDENCE
+    ];
+  const failure_upper_bound = wilsonOneSidedUpper(evidence.execution_failure_count, attempts, {
+    confidence: WORKLOAD_CEILING_STUDY.capture.confidence,
+    z: z!,
+  });
+
+  return {
+    scenario_id: scenarioId,
+    implementation,
+    target_bytes: cell.target_bytes,
+    achieved_bytes: cell.achieved_bytes,
+    row_count: cell.row_count,
+    collected_event_count: events.length,
+    outcomes,
+    outcome_verbatim: verbatimHistogram,
+    thermal,
+    cpu_ms,
+    exceeded_cpu_ms,
+    cpu_ms_by_thermal,
+    zero_failure_upper_bound,
+    failure_upper_bound,
+    evidence,
+    cpu_provenance: cpuProvenance,
+    // Reported from a resolved event when the cell has one: if the cell's
+    // first event happened to be unresolved, its `script_version` is the
+    // sentinel, not the version that served the cell.
+    script_version: (firstDeployed ?? events[0]!).script_version,
+    compatibility_date: (firstDeployed ?? events[0]!).compatibility_date,
+  };
+}
+
+/**
+ * Invocation order within one (cell, arm): the telemetry minute the platform
+ * attributed the invocation to.
+ *
+ * Neither of the obvious alternatives is an order. `observed_at` is the
+ * COLLECTOR's clock, stamped when the event was written, not when the
+ * invocation ran; and `readEventsFromDirectory` returns `readdir` order, which
+ * is not temporal at all. The runner spaces invocations 70 s apart and refuses
+ * to start in a minute's tail, so within one (cell, arm) each invocation has
+ * its own minute and `runtime_period` totally orders them. `run_id` breaks
+ * ties only so the result is deterministic.
+ */
+const byInvocationOrder = (a: WorkloadCeilingRawEvent, b: WorkloadCeilingRawEvent): number =>
+  a.runtime_period === b.runtime_period
+    ? a.run_id.localeCompare(b.run_id)
+    : a.runtime_period.localeCompare(b.runtime_period);
+
+/**
+ * Computes hash cost per cell (hashed minus unhashed).
+ *
+ * Pairs are by repetition ordinal within the cell, not by run_id: the two arms
+ * are separate invocations, so there is no natural pair. What makes the
+ * pairing meaningful is that the runner interleaves the arms, so the k-th
+ * control and the k-th unhashed invocation fall in the same pass.
+ *
+ * **The ordinal is taken over each arm's FULL ordered event list, and a pair
+ * is emitted only when both arms resolved that ordinal.** Filtering to usable
+ * samples first and then zipping is the tempting shape and it is wrong: the
+ * contract preregisters ~15 % adaptive-row drops, so one arm losing its 3rd
+ * invocation would silently shift every later pair to compare invocations from
+ * different passes. That corrupts the reported hash cost rather than merely
+ * widening it, and nothing downstream could see it. A dropped ordinal is left
+ * as a gap in the `pair_id` sequence instead.
+ */
+function computeHashCost(input: {
+  readonly cells: readonly WorkloadCeilingSweepCell[];
+  readonly eventsByArm: ReadonlyMap<
+    WorkloadCeilingImplementation,
+    readonly WorkloadCeilingRawEvent[]
+  >;
+}): readonly { readonly scenario_id: string; readonly difference_ms: StratifiedPair[] }[] {
+  const { cells, eventsByArm } = input;
+
+  const controlEvents = eventsByArm.get("monolithic-control") ?? [];
+  const unhashedEvents = eventsByArm.get("monolithic-control-unhashed") ?? [];
+
+  const controlByScenario = indexByScenario(controlEvents);
+  const unhashedByScenario = indexByScenario(unhashedEvents);
+
+  const result: { readonly scenario_id: string; readonly difference_ms: StratifiedPair[] }[] = [];
+
+  for (const cell of cells) {
+    const controlCellEvents = controlByScenario.get(cell.scenario_id) ?? [];
+    const unhashedCellEvents = unhashedByScenario.get(cell.scenario_id) ?? [];
+
+    const ordered = zipByIndex(
+      controlCellEvents.toSorted(byInvocationOrder),
+      unhashedCellEvents.toSorted(byInvocationOrder),
+    );
+
+    const pairs: StratifiedPair[] = [];
+    for (const [k, [hashed, unhashed]] of ordered.entries()) {
+      if (!isResolvedOk(hashed) || !isResolvedOk(unhashed)) {
+        continue;
+      }
+      pairs.push({
+        pair_id: `${cell.scenario_id}#${k}`,
+        stratum: cell.scenario_id,
+        baseline: unhashed.cpu_ms,
+        candidate: hashed.cpu_ms,
+      });
+    }
+
+    if (pairs.length === 0) {
+      continue;
+    }
+
+    result.push({ scenario_id: cell.scenario_id, difference_ms: pairs });
+  }
+
+  return result;
+}
+
+/**
+ * Computes CPU-per-MiB slope across cells.
+ *
+ * Uses monolithic-control summaries only (one per scenario_id) to avoid
+ * duplicate MiB values from other implementations.
+ */
+function computeCpuPerMib(input: {
+  readonly cells: readonly WorkloadCeilingCellSummary[];
+}): OlsQrResult | { readonly unavailable: string } {
+  const { cells } = input;
+
+  // Use monolithic-control summaries only (one per scenario_id)
+  const controlCells = cells.filter((c) => c.implementation === "monolithic-control");
+
+  // Only cells with resolved CPU numbers
+  const resolvedCells = controlCells.filter((c) => c.cpu_ms !== null);
+  if (resolvedCells.length < 2) {
+    return {
+      unavailable: "fewer than two cells resolved a CPU number",
+    };
+  }
+
+  const rows = resolvedCells.map((c) => ({
+    x: [1, c.achieved_bytes / (1024 * 1024)],
+    y: c.cpu_ms!.p50.value,
+  }));
+
+  const olsInput: OlsQrInput = {
+    columns: ["intercept", "mib"],
+    rows,
+  };
+
+  try {
+    return olsQr(olsInput);
+  } catch (error) {
+    // The reason matters: a singular design matrix and a non-finite input are
+    // different problems with the capture, and the fixed string told a reader
+    // neither.
+    return {
+      unavailable: `OLS fit failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+/**
+ * Pure. Reduces every collected event for one axis into per-cell summaries.
+ *
+ * Groups by `scenario_id`: the planned invocations share one scenario id by
+ * design, so the repeats ARE the sample. `workload-ceiling-compare.ts` groups
+ * the same way, then reduces each (cell, arm) to a p50 before joining the two
+ * arms.
+ *
+ * `plannedInvocations` is the capture journal (warmup entries included; they
+ * are filtered here). The journal is the source of truth for how many
+ * invocations were planned per cell/arm — evidence completeness is judged
+ * against it, not against whatever happened to collect.
+ *
+ * @throws WorkloadCeilingHarnessError (see `buildCellSummary`) when a cell's
+ *   resolved events disagree on deployment metadata, when a planned
+ *   invocation lacks exactly one authoritative event, or when the capture was
+ *   planned below the CPU sample floor.
+ */
+export function buildWorkloadCeilingAxisReport(input: {
+  readonly sweepId: string;
+  readonly axis: "byte" | "row";
+  readonly cells: readonly WorkloadCeilingSweepCell[];
+  readonly plannedInvocations: readonly WorkloadCeilingInvocationRecord[];
+  readonly eventsByArm: ReadonlyMap<
+    WorkloadCeilingImplementation,
+    readonly WorkloadCeilingRawEvent[]
+  >;
+}): WorkloadCeilingAxisReport {
+  const { sweepId, axis, cells, plannedInvocations, eventsByArm } = input;
+
+  const plannedByArm = plannedCountsByArmAndScenario(plannedInvocations);
+  const allSummaries: WorkloadCeilingCellSummary[] = [];
+
+  // The union of planned and collected arms, not just the collected ones. An
+  // arm the journal planned whose event directory never appeared — collect-batch
+  // crashed, or the directory ENOENT'd in the CLI — would otherwise never be
+  // visited, so its wholly-uncollected cells would never reach the
+  // evidence-completeness refusal below. A sweep missing an entire captured arm
+  // has to refuse, not produce a clean-looking report over the arms that
+  // survived.
+  const armsToSummarize = new Set<WorkloadCeilingImplementation>([
+    ...plannedByArm.keys(),
+    ...eventsByArm.keys(),
+  ] as readonly WorkloadCeilingImplementation[]);
+
+  for (const implementation of armsToSummarize) {
+    const eventsByScenario = indexByScenario(eventsByArm.get(implementation) ?? []);
+    const plannedForArm = plannedByArm.get(implementation);
+
+    for (const cell of cells) {
+      const cellEvents = eventsByScenario.get(cell.scenario_id) ?? [];
+      const plannedCount = plannedForArm?.get(cell.scenario_id) ?? 0;
+      // An arm this sweep neither planned nor collected (e.g.
+      // `chunked-candidate` before Milestone 5) has no cell here. An arm that
+      // planned or collected anything DOES get a summary — planned-but-
+      // uncollected is exactly the evidence incompleteness the report must
+      // refuse on, not silently skip.
+      if (cellEvents.length === 0 && plannedCount === 0) {
+        continue;
+      }
+
+      const summary = buildCellSummary({
+        scenarioId: cell.scenario_id,
+        implementation,
+        cell,
+        events: cellEvents,
+        plannedCount,
+      });
+      allSummaries.push(summary);
+    }
+  }
+
+  // Sort by scenario_id
+  allSummaries.sort((a, b) => a.scenario_id.localeCompare(b.scenario_id));
+
+  // Compute hash cost and slope (hash cost needs raw events for pairing)
+  const hash_cost = computeHashCost({ cells, eventsByArm });
+  const cpu_per_mib = computeCpuPerMib({ cells: allSummaries });
+
+  return {
+    contract_id: WORKLOAD_CEILING_CONTRACT_ID,
+    evidence_contract_id: WORKLOAD_CEILING_EVIDENCE_CONTRACT_ID,
+    sweep_id: sweepId,
+    axis,
+    capture: WORKLOAD_CEILING_STUDY.capture,
+    cells: allSummaries,
+    hash_cost,
+    cpu_per_mib,
+  };
+}
+
+/** Loads and decodes the capture journal — the planned-invocation source of truth. */
+async function loadJournal(
+  resultsDir: string,
+  sweepId: string,
+): Promise<readonly WorkloadCeilingInvocationRecord[]> {
+  const journalPath = `${resultsDir}/journal-${sweepId}.jsonl`;
+  let raw: string;
+  try {
+    raw = await readFile(journalPath, "utf8");
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code ?? "unknown";
+    console.error(
+      `workload-ceiling-aggregate: cannot read journal ${journalPath} (${code}) — the journal ` +
+        `is the planned-invocation count evidence completeness is judged against`,
+    );
+    throw new Error(`cannot read journal ${journalPath} (${code})`, { cause: error });
+  }
+  const lines = raw.split("\n").filter((line) => line.trim() !== "");
+  return lines.map((line) => decodeWorkloadCeilingInvocationRecord(line));
+}
+
+/**
+ * CLI entrypoint (`pnpm bench:workload-ceiling:aggregate`).
+ */
+async function main(): Promise<number> {
+  const sweepId = process.env["WORKLOAD_CEILING_SWEEP_ID"];
+  const resultsDir =
+    process.env["WORKLOAD_CEILING_RESULTS_DIR"] ?? "bench/results/workload-ceiling";
+
+  if (sweepId === undefined) {
+    console.error(
+      "workload-ceiling-aggregate: requires WORKLOAD_CEILING_SWEEP_ID — " +
+        "the sweep identifier from the capture phase",
+    );
+    return 1;
+  }
+
+  // Load sweep report
+  const sweepPath = `${resultsDir}/sweep-${sweepId}.json`;
+  let sweepRaw: string;
+  try {
+    sweepRaw = await readFile(sweepPath, "utf8");
+  } catch {
+    console.error(`workload-ceiling-aggregate: cannot read sweep report ${sweepPath}`);
+    return 1;
+  }
+
+  const sweep = JSON.parse(sweepRaw) as {
+    readonly sweep_id: string;
+    readonly cells: readonly WorkloadCeilingSweepCell[];
+  };
+
+  if (sweep.sweep_id !== sweepId) {
+    console.error(
+      `workload-ceiling-aggregate: sweep report sweep_id ${sweep.sweep_id} ` +
+        `does not match requested ${sweepId}`,
+    );
+    return 1;
+  }
+
+  // Load the journal — the planned count every completeness verdict reads.
+  const journal = await loadJournal(resultsDir, sweepId);
+
+  // Read events for each arm
+  const eventsByArm = new Map<WorkloadCeilingImplementation, readonly WorkloadCeilingRawEvent[]>();
+  for (const impl of WORKLOAD_CEILING_IMPLEMENTATIONS) {
+    const armDir = `${resultsDir}/${sweepId}/${impl}`;
+    // An arm this sweep never captured (e.g. `chunked-candidate` before
+    // Milestone 5) has no directory at all. Absence is expected and simply
+    // leaves the arm out of eventsByArm — per-cell aggregation already
+    // omits a cell's hash cost when an arm is missing.
+    //
+    // ONLY absence. Collapsing every stat rejection to "not there" would make
+    // an unreadable directory — a permission error on a real arm's captured
+    // events — look like an arm the sweep never ran, and drop it from the
+    // report with no diagnostic.
+    const armDirStatus = await stat(armDir).then(
+      () => "present" as const,
+      (error: NodeJS.ErrnoException) => error.code ?? "unknown",
+    );
+    if (armDirStatus === "ENOENT") {
+      continue;
+    }
+    if (armDirStatus !== "present") {
+      console.error(
+        `workload-ceiling-aggregate: cannot stat arm directory ${armDir} (${armDirStatus})`,
+      );
+      return 1;
+    }
+    const events = await readEventsFromDirectory(armDir);
+    eventsByArm.set(impl, events);
+  }
+
+  // Build report
+  let report: WorkloadCeilingAxisReport;
+  try {
+    report = buildWorkloadCeilingAxisReport({
+      sweepId,
+      axis: "byte", // TODO: derive from sweep config
+      cells: sweep.cells,
+      plannedInvocations: journal,
+      eventsByArm,
+    });
+  } catch (error) {
+    if (error instanceof WorkloadCeilingHarnessError) {
+      console.error(`workload-ceiling-aggregate: refused (${error.field}) — ${error.message}`);
+      return 1;
+    }
+    throw error;
+  }
+
+  // Print per-cell table
+  console.log(`Axis: ${report.axis}, cells: ${report.cells.length}`);
+  console.log("");
+  for (const cell of report.cells) {
+    console.log(`  ${cell.scenario_id} [${cell.implementation}]:`);
+    console.log(`    target: ${cell.target_bytes}B, achieved: ${cell.achieved_bytes}B`);
+    console.log(
+      `    planned: ${cell.evidence.planned_count}, authoritative: ${cell.evidence.authoritative_event_count}, ` +
+        `cpu samples: ${cell.evidence.finite_cpu_sample_count} (floor ${cell.evidence.cpu_sample_floor}), ` +
+        `execution failures: ${cell.evidence.execution_failure_count}`,
+    );
+    console.log(
+      `    outcomes: ${JSON.stringify(cell.outcomes)} (verbatim: ${JSON.stringify(cell.outcome_verbatim)})`,
+    );
+    console.log(
+      `    evidence complete: ${cell.evidence.complete}, cpu complete: ${cell.evidence.cpu_complete}`,
+    );
+    if (cell.cpu_ms) {
+      console.log(
+        `    cpu_ms p50/p95/p99: ${cell.cpu_ms.p50.value.toFixed(2)}/` +
+          `${cell.cpu_ms.p95.value.toFixed(2)}/${cell.cpu_ms.p99.value.toFixed(2)}`,
+      );
+    } else {
+      console.log("    cpu_ms: null (no finite-CPU successful samples)");
+    }
+    if (cell.exceeded_cpu_ms) {
+      console.log(
+        `    exceeded_cpu_ms p50: ${cell.exceeded_cpu_ms.p50.value.toFixed(2)} (censored)`,
+      );
+    }
+    if ("invalid" in cell.zero_failure_upper_bound) {
+      console.log(
+        `    zero-failure bound: invalid (${cell.zero_failure_upper_bound.failure_count} execution failures)`,
+      );
+    } else {
+      console.log(
+        `    zero-failure bound: ${cell.zero_failure_upper_bound.upper.toFixed(4)} ` +
+          `at ${cell.zero_failure_upper_bound.confidence} confidence`,
+      );
+    }
+  }
+
+  // Write report
+  const outDir = `${resultsDir}/${sweepId}`;
+  await mkdir(outDir, { recursive: true });
+  const outPath = `${outDir}/axis-report.json`;
+  await writeFile(outPath, JSON.stringify(report, null, 2));
+  console.log(``);
+  console.log(`wrote ${outPath}`);
+
+  const cpuIncomplete = report.cells.filter((c) => !c.evidence.cpu_complete);
+  if (cpuIncomplete.length > 0) {
+    console.error("");
+    console.error(
+      `workload-ceiling-aggregate: refused (cpu_sample_floor) — ` +
+        `${cpuIncomplete.length} cell(s) fell short of finite successful CPU samples: ` +
+        cpuIncomplete.map((c) => `${c.scenario_id}[${c.implementation}]`).join(", "),
+    );
+    console.error(
+      `The report is written for diagnosis, but admission is blocked. There is no ` +
+        `top-up: additional attempts are planned before capture, never added after ` +
+        `observing missingness.`,
+    );
+    return 1;
+  }
+  return 0;
+}
+
+await runAsCliEntrypoint(import.meta.url, main);

--- a/bench/measurement/workload-ceiling-capture.test.ts
+++ b/bench/measurement/workload-ceiling-capture.test.ts
@@ -7,6 +7,7 @@
 import { describe, test, expect, vi } from "vitest";
 import {
   MINUTE_TAIL_GUARD_SECONDS,
+  WORKLOAD_CEILING_IMPLEMENTATIONS,
   nextInvocationStart,
   collectionWindowFor,
   decodeWorkloadCeilingRunRequest,
@@ -17,6 +18,8 @@ import {
 } from "./workload-ceiling-harness.ts";
 import {
   invokeWorker,
+  parseArms,
+  parseMeasuredOverride,
   planCaptureInvocations,
   remainingCaptureInvocations,
 } from "./workload-ceiling-capture.ts";
@@ -471,5 +474,60 @@ describe("remainingCaptureInvocations", () => {
     expect(remaining.filter((p) => !p.warmup)).toHaveLength(
       planned.filter((p) => !p.warmup).length,
     );
+  });
+});
+
+/** Spies `process.exit` so a CLI guard's refusal is observable instead of terminating the worker. */
+const withExitSpy = (body: () => void): number | undefined => {
+  let code: number | undefined;
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation(((exitCode?: number) => {
+    code = exitCode;
+    throw new Error(`__exit:${exitCode}`);
+  }) as never);
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    expect(body).toThrow(/__exit:/);
+  } finally {
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  }
+  return code;
+};
+
+describe("parseMeasuredOverride", () => {
+  test("unset or blank takes the preregistered per-cell count", () => {
+    const planned = WORKLOAD_CEILING_STUDY.capture.planned_measured_invocations_per_cell;
+    expect(parseMeasuredOverride(undefined)).toBe(planned);
+    expect(parseMeasuredOverride("  ")).toBe(planned);
+  });
+
+  test("a positive integer overrides it", () => {
+    expect(parseMeasuredOverride("3")).toBe(3);
+  });
+
+  // Unguarded `parseInt` made this the quietest possible failure: NaN passes
+  // through, `pass < NaN` is false immediately, and the runner prints
+  // "Capture complete" and exits 0 having invoked nothing.
+  test.each(["abc", "0", "-1", "2.5", "NaN"])("%j is refused, not read as NaN", (raw) => {
+    expect(withExitSpy(() => parseMeasuredOverride(raw))).toBe(1);
+  });
+});
+
+describe("parseArms", () => {
+  test("every declared implementation is accepted", () => {
+    expect(parseArms(WORKLOAD_CEILING_IMPLEMENTATIONS.join(","))).toEqual([
+      ...WORKLOAD_CEILING_IMPLEMENTATIONS,
+    ]);
+  });
+
+  test("surrounding whitespace is forgiven", () => {
+    expect(parseArms(" chunked-candidate , monolithic-control ")).toEqual([
+      "chunked-candidate",
+      "monolithic-control",
+    ]);
+  });
+
+  test("an unknown arm is refused before it can reach the Worker", () => {
+    expect(withExitSpy(() => parseArms("monolithic-control,chunked"))).toBe(1);
   });
 });

--- a/bench/measurement/workload-ceiling-capture.test.ts
+++ b/bench/measurement/workload-ceiling-capture.test.ts
@@ -1,0 +1,475 @@
+/**
+ * Tests for the capture runner and batch collector (ticket 4).
+ *
+ * These tests are pure — no network, no credentials, no I/O.
+ */
+
+import { describe, test, expect, vi } from "vitest";
+import {
+  MINUTE_TAIL_GUARD_SECONDS,
+  nextInvocationStart,
+  collectionWindowFor,
+  decodeWorkloadCeilingRunRequest,
+  WORKLOAD_CEILING_CONTRACT_ID,
+  WORKLOAD_CEILING_EVIDENCE_CONTRACT_ID,
+  type WorkloadCeilingInvocationRecord,
+  type WorkloadCeilingRawEvent,
+} from "./workload-ceiling-harness.ts";
+import {
+  invokeWorker,
+  planCaptureInvocations,
+  remainingCaptureInvocations,
+} from "./workload-ceiling-capture.ts";
+import { armOutputDir, isFinishedCollection } from "./workload-ceiling-collect-batch.ts";
+import { WORKLOAD_CEILING_STUDY } from "./workload-ceiling-contract.ts";
+
+describe("planCaptureInvocations", () => {
+  const fourCells = [
+    {
+      scenario_id: "byte-512k",
+      axis: "byte" as const,
+      target_bytes: 512 * 1024,
+      achieved_bytes: 512 * 1024,
+      row_count: 245,
+      document_bytes: 2048,
+      manifest_descriptors: 8,
+      fixture_prefix: "fixtures/byte-512k",
+      incarnation: "00000000000000000000000000000000",
+      monolithic_key: "fixtures/byte-512k/monolithic.json",
+      manifest_key: "fixtures/byte-512k/manifest.json",
+      descriptor_canonical_hash: "a".repeat(64),
+    },
+    {
+      scenario_id: "byte-1m",
+      axis: "byte" as const,
+      target_bytes: 1024 * 1024,
+      achieved_bytes: 1024 * 1024,
+      row_count: 491,
+      document_bytes: 2048,
+      manifest_descriptors: 8,
+      fixture_prefix: "fixtures/byte-1m",
+      incarnation: "00000000000000000000000000000000",
+      monolithic_key: "fixtures/byte-1m/monolithic.json",
+      manifest_key: "fixtures/byte-1m/manifest.json",
+      descriptor_canonical_hash: "b".repeat(64),
+    },
+    {
+      scenario_id: "byte-2m",
+      axis: "byte" as const,
+      target_bytes: 2 * 1024 * 1024,
+      achieved_bytes: 2 * 1024 * 1024,
+      row_count: 982,
+      document_bytes: 2048,
+      manifest_descriptors: 8,
+      fixture_prefix: "fixtures/byte-2m",
+      incarnation: "00000000000000000000000000000000",
+      monolithic_key: "fixtures/byte-2m/monolithic.json",
+      manifest_key: "fixtures/byte-2m/manifest.json",
+      descriptor_canonical_hash: "c".repeat(64),
+    },
+    {
+      scenario_id: "byte-4m",
+      axis: "byte" as const,
+      target_bytes: 4 * 1024 * 1024,
+      achieved_bytes: 4 * 1024 * 1024,
+      row_count: 1964,
+      document_bytes: 2048,
+      manifest_descriptors: 8,
+      fixture_prefix: "fixtures/byte-4m",
+      incarnation: "00000000000000000000000000000000",
+      monolithic_key: "fixtures/byte-4m/monolithic.json",
+      manifest_key: "fixtures/byte-4m/manifest.json",
+      descriptor_canonical_hash: "d".repeat(64),
+    },
+  ];
+
+  const twoArms = ["monolithic-control", "monolithic-control-unhashed"] as const;
+
+  test("emits cells × arms × (warmup + measured) invocations", () => {
+    const plan = planCaptureInvocations({
+      cells: fourCells,
+      arms: twoArms,
+      warmup: 2,
+      measured: 30,
+    });
+    expect(plan).toHaveLength(4 * 2 * 32);
+  });
+
+  test("interleaves cells rather than blocking, so drift spreads evenly", () => {
+    const plan = planCaptureInvocations({
+      cells: fourCells,
+      arms: twoArms,
+      warmup: 0,
+      measured: 3,
+    });
+    // Consecutive entries must not repeat a scenario until every other has run.
+    expect(plan.slice(0, 4).map((p) => p.scenario_id)).toEqual(fourCells.map((c) => c.scenario_id));
+    // Check that the pattern continues
+    expect(plan.slice(4, 8).map((p) => p.scenario_id)).toEqual(fourCells.map((c) => c.scenario_id));
+  });
+
+  test("every warmup precedes every measured invocation of the same cell and arm", () => {
+    const plan = planCaptureInvocations({
+      cells: fourCells,
+      arms: twoArms,
+      warmup: 2,
+      measured: 5,
+    });
+    for (const cell of fourCells) {
+      for (const arm of twoArms) {
+        const own = plan.filter(
+          (p) => p.scenario_id === cell.scenario_id && p.implementation === arm,
+        );
+        expect(own.map((p) => p.warmup)).toEqual([true, true, false, false, false, false, false]);
+      }
+    }
+  });
+
+  test("index increases monotonically", () => {
+    const plan = planCaptureInvocations({
+      cells: fourCells,
+      arms: twoArms,
+      warmup: 2,
+      measured: 3,
+    });
+    for (let i = 0; i < plan.length; i++) {
+      expect(plan[i]!.index).toBe(i);
+    }
+  });
+});
+
+describe("nextInvocationStart", () => {
+  test("spaces invocations by the preregistered interval", () => {
+    const prev = new Date("2026-08-18T10:00:05.000Z");
+    const next = nextInvocationStart(prev, prev);
+    expect(next.getTime() - prev.getTime()).toBeGreaterThanOrEqual(
+      WORKLOAD_CEILING_STUDY.capture.invocation_spacing_seconds * 1000,
+    );
+  });
+
+  test("no two consecutive starts ever share a minute bucket", () => {
+    let prev: Date | null = null;
+    for (let i = 0; i < 200; i++) {
+      const next = nextInvocationStart(prev, prev ?? new Date("2026-08-18T10:00:00.000Z"));
+      if (prev !== null) {
+        expect(Math.floor(next.getTime() / 60_000)).not.toBe(Math.floor(prev.getTime() / 60_000));
+      }
+      prev = next;
+    }
+  });
+
+  test("never starts in the last 10 seconds of a minute", () => {
+    // Straddling a boundary puts a raw-datetime telemetry row in the NEXT
+    // bucket, outside the window derived from the start instant.
+    let prev: Date | null = null;
+    for (let i = 0; i < 200; i++) {
+      const next = nextInvocationStart(prev, prev ?? new Date("2026-08-18T10:00:51.000Z"));
+      expect(next.getUTCSeconds()).toBeLessThan(60 - MINUTE_TAIL_GUARD_SECONDS);
+      prev = next;
+    }
+  });
+
+  test("if candidate is in the past, returns now adjusted for guard", () => {
+    const prev = new Date("2026-08-18T10:00:00.000Z");
+    const now = new Date("2026-08-18T10:02:30.000Z"); // 2.5 minutes later
+    const next = nextInvocationStart(prev, now);
+    expect(next.getTime()).toBeGreaterThanOrEqual(now.getTime());
+    expect(next.getUTCSeconds()).toBeLessThan(60 - MINUTE_TAIL_GUARD_SECONDS);
+  });
+});
+
+describe("invokeWorker", () => {
+  const planned = {
+    scenario_id: "byte-axis/512KiB",
+    implementation: "monolithic-control" as const,
+    fixture_prefix: "fixtures/512KiB",
+    warmup: true,
+    index: 0,
+  };
+
+  // The journal's run_id must be the run_id the Worker actually received
+  // and logged as `workload_ceiling_run_id` — otherwise the ticket 6
+  // independent dashboard join (Workers Logs line ↔ collected event) can
+  // never match, and "correlation field" is reduced to a shape check.
+  test("returns the run_id it sent, so journal records correlate to invocations", async () => {
+    const bodies: string[] = [];
+    const fetchStub = vi.fn<(_url: unknown, init: RequestInit | undefined) => Promise<Response>>(
+      async (_url, init) => {
+        bodies.push(String(init?.body));
+        return new Response(JSON.stringify({ row_count: 253, isolate_cold: true }), {
+          status: 200,
+        });
+      },
+    );
+    vi.stubGlobal("fetch", fetchStub);
+    try {
+      const result = await invokeWorker("https://example.invalid/run", "secret", planned);
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+      const sent = decodeWorkloadCeilingRunRequest(bodies[0]!);
+      expect(result.runId).toBe(sent.run_id);
+      expect(result.status).toBe(200);
+      expect(result.rowCount).toBe(253);
+      expect(result.isolateCold).toBe(true);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  // A 200 the runner cannot read is a broken Worker, not a warm zero-row
+  // invocation. Defaulting it to row_count 0 / isolate_cold false would
+  // journal a "warm" sample and hide the defect behind a thermal class the
+  // study correlates against.
+  test("a 2xx whose body does not parse reports no result rather than defaults", async () => {
+    const fetchStub = vi.fn<() => Promise<Response>>(
+      async () => new Response("<html>upstream proxy error</html>", { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchStub);
+    try {
+      const result = await invokeWorker("https://example.invalid/run", "secret", planned);
+      expect(result.status).toBe(200);
+      expect(result.rowCount).toBeNull();
+      expect(result.isolateCold).toBeNull();
+      expect(result.bodyText).toBe("<html>upstream proxy error</html>");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  test("a 2xx missing isolate_cold reports no result rather than assuming warm", async () => {
+    const fetchStub = vi.fn<() => Promise<Response>>(
+      async () => new Response(JSON.stringify({ row_count: 253 }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchStub);
+    try {
+      const result = await invokeWorker("https://example.invalid/run", "secret", planned);
+      expect(result.isolateCold).toBeNull();
+      expect(result.rowCount).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  // A non-2xx must not be followed by a second POST just to read the body —
+  // every stray invocation is real telemetry that can collapse into another
+  // sample's minute bucket.
+  test("on non-2xx, reads the body from the same response without re-invoking", async () => {
+    const fetchStub = vi.fn<() => Promise<Response>>(
+      async () => new Response("fixture descriptor is missing", { status: 502 }),
+    );
+    vi.stubGlobal("fetch", fetchStub);
+    try {
+      const result = await invokeWorker("https://example.invalid/run", "secret", planned);
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+      expect(result.status).toBe(502);
+      expect(result.bodyText).toBe("fixture descriptor is missing");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe("armOutputDir", () => {
+  // Aggregate reads `<resultsDir>/<sweepId>/<arm>/` (ticket 5 spec). Events
+  // carry no sweep_id field, so if collect-batch ever writes a flat
+  // `<resultsDir>/<arm>/` again, sweeps silently mix and aggregate ENOENTs.
+  test("scopes collected events under the sweep id, as aggregate reads them", () => {
+    const dir = armOutputDir(
+      "bench/results/workload-ceiling",
+      "lane-b-rehearsal-free-20260820",
+      "monolithic-control",
+    );
+    expect(dir.endsWith("lane-b-rehearsal-free-20260820/monolithic-control")).toBe(true);
+    expect(dir.includes("/lane-b-rehearsal-free-20260820/")).toBe(true);
+  });
+});
+
+describe("isFinishedCollection", () => {
+  // Evidence-contract v2. The batch collector's idempotency question is no
+  // longer "did a usable measurement land" but "is the AUTHORITATIVE record
+  // resolved, and is anything still fixable by re-querying" — see
+  // workload-ceiling-collect-batch.ts for the full rule.
+  const event = (overrides: Partial<WorkloadCeilingRawEvent>): WorkloadCeilingRawEvent => ({
+    evidence_contract_id: WORKLOAD_CEILING_EVIDENCE_CONTRACT_ID,
+    run_id: "run-1",
+    scenario_id: "byte-axis/1MiB",
+    script_version: "027034f3-170b-466d-b1ad-914fad42024c",
+    compatibility_date: "2026-08-15",
+    runtime_period: "2026-08-24T17:35:00.000Z/2026-08-24T17:36:00.000Z",
+    colo: "EWR",
+    thermal_class: "warm",
+    outcome: "success",
+    cpu_ms: 17.767,
+    observed_at: "2026-08-24T17:53:54.083Z",
+    evidence: {
+      status: "resolved",
+      detail: null,
+      authority: "workers-observability",
+      authoritative_outcome: "ok",
+      authoritative_cpu_ms: 18,
+      authoritative_response_status: 200,
+      cpu_source: "workers-invocations-adaptive",
+      cpu_outcome_verbatim: "success",
+    },
+    ...overrides,
+  });
+
+  test("a resolved event is finished — do not re-query its window", () => {
+    expect(isFinishedCollection(event({}))).toBe(true);
+  });
+
+  test("an evidence-missing event is NOT finished — the retry pass must re-query it", () => {
+    expect(
+      isFinishedCollection(
+        event({
+          outcome: null,
+          cpu_ms: null,
+          script_version: "unresolved",
+          colo: "unknown",
+          evidence: {
+            status: "missing",
+            detail: "no workers-observability join line for run_id in window",
+            authority: "workers-observability",
+            authoritative_outcome: null,
+            authoritative_cpu_ms: null,
+            authoritative_response_status: null,
+            cpu_source: "none",
+            cpu_outcome_verbatim: null,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("a resolved success still missing its CPU row is not finished — lag is still possible", () => {
+    expect(
+      isFinishedCollection(
+        event({
+          cpu_ms: null,
+          evidence: {
+            status: "resolved",
+            detail: null,
+            authority: "workers-observability",
+            authoritative_outcome: "ok",
+            authoritative_cpu_ms: 18,
+            authoritative_response_status: 200,
+            cpu_source: "none",
+            cpu_outcome_verbatim: null,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("a resolved exceededCpu event IS finished — a kill is terminal, not lag", () => {
+    // The v1 behavior counted any non-usable measurement as unfinished; v2
+    // reads the evidence block instead. An authoritative kill cannot be
+    // un-killed by re-querying its window.
+    expect(isFinishedCollection(event({ outcome: "exceededCpu", cpu_ms: 50 }))).toBe(true);
+  });
+
+  test("nothing collected yet is not finished", () => {
+    expect(isFinishedCollection(undefined)).toBe(false);
+  });
+});
+
+describe("collectionWindowFor", () => {
+  test("spans exactly the minute containing the invocation", () => {
+    const w = collectionWindowFor(new Date("2026-08-18T10:07:31.482Z"));
+    expect(w.gte).toBe("2026-08-18T10:07:00.000Z");
+    expect(w.lt).toBe("2026-08-18T10:08:00.000Z");
+  });
+
+  test("includes a row timestamped at the bucket start", () => {
+    // The reason this is a whole-minute window and not [invoke, return]:
+    // datetime_geq is inclusive of gte, so a minute-bucketed row survives.
+    const w = collectionWindowFor(new Date("2026-08-18T10:07:31.482Z"));
+    expect(Date.parse("2026-08-18T10:07:00.000Z")).toBeGreaterThanOrEqual(Date.parse(w.gte));
+    expect(Date.parse("2026-08-18T10:07:00.000Z")).toBeLessThan(Date.parse(w.lt));
+  });
+
+  test("includes a row timestamped at the bucket end", () => {
+    const w = collectionWindowFor(new Date("2026-08-18T10:07:00.500Z"));
+    // The window ends at 10:08:00.000, exclusive
+    expect(Date.parse("2026-08-18T10:07:59.999Z")).toBeGreaterThanOrEqual(Date.parse(w.gte));
+    expect(Date.parse("2026-08-18T10:07:59.999Z")).toBeLessThan(Date.parse(w.lt));
+  });
+
+  test("handles invocation exactly at minute boundary", () => {
+    const w = collectionWindowFor(new Date("2026-08-18T10:07:00.000Z"));
+    expect(w.gte).toBe("2026-08-18T10:07:00.000Z");
+    expect(w.lt).toBe("2026-08-18T10:08:00.000Z");
+  });
+});
+
+describe("remainingCaptureInvocations", () => {
+  const cells = ["byte-axis/512KiB", "byte-axis/1MiB"].map((scenario_id) => ({
+    scenario_id,
+    axis: "byte" as const,
+    target_bytes: 524288,
+    achieved_bytes: 524288,
+    row_count: 1,
+    document_bytes: 2048,
+    manifest_descriptors: 8,
+    fixture_prefix: `fixtures/${scenario_id}`,
+    incarnation: "incarnation",
+    monolithic_key: "monolithic",
+    manifest_key: "manifest",
+    descriptor_canonical_hash: "hash",
+  }));
+  const planned = planCaptureInvocations({
+    cells,
+    arms: ["monolithic-control", "chunked-candidate"],
+    warmup: 1,
+    measured: 3,
+  });
+
+  const journalled = (invocation: (typeof planned)[number]): WorkloadCeilingInvocationRecord => ({
+    contract_id: WORKLOAD_CEILING_CONTRACT_ID,
+    sweep_id: "sweep-1",
+    // A UUID, exactly as the runner mints it — the point of the helper is that
+    // it never has to match this against anything.
+    run_id: "0a5c6f8e-6f2a-4a1e-9f0a-2c3d4e5f6a7b",
+    scenario_id: invocation.scenario_id,
+    implementation: invocation.implementation,
+    fixture_prefix: invocation.fixture_prefix,
+    warmup: invocation.warmup,
+    invoked_at: "2026-08-20T00:00:00.000Z",
+    window_gte: "2026-08-20T00:00:00.000Z",
+    window_lt: "2026-08-20T00:01:00.000Z",
+    http_status: 200,
+    row_count: 253,
+    thermal_class: "warm",
+  });
+
+  test("an empty journal leaves the whole plan outstanding", () => {
+    expect(remainingCaptureInvocations(planned, [])).toEqual(planned);
+  });
+
+  test("a complete journal leaves nothing outstanding", () => {
+    // The regression: an earlier revision matched the journal's random
+    // `run_id` against a synthetic `scenario-impl-index` key, which can never
+    // be equal — so resume re-ran every completed invocation, doubling both
+    // the attended hours and the telemetry the collector must disambiguate.
+    expect(remainingCaptureInvocations(planned, planned.map(journalled))).toEqual([]);
+  });
+
+  test("resume drops exactly the completed prefix of each slot, warmups included", () => {
+    const done = planned.slice(0, 5);
+    const remaining = remainingCaptureInvocations(planned, done.map(journalled));
+    expect(remaining).toHaveLength(planned.length - done.length);
+    expect(remaining).toEqual(planned.slice(5));
+  });
+
+  test("a slot's warmup and measured invocations are counted separately", () => {
+    // `exclusion_policy` is warmup-tagged-before-run-only, so a journalled
+    // warmup must not retire a measured invocation of the same cell and arm.
+    const oneWarmup = planned.filter((p) => p.warmup).slice(0, 1);
+    const remaining = remainingCaptureInvocations(planned, oneWarmup.map(journalled));
+    expect(remaining.filter((p) => p.warmup)).toHaveLength(
+      planned.filter((p) => p.warmup).length - 1,
+    );
+    expect(remaining.filter((p) => !p.warmup)).toHaveLength(
+      planned.filter((p) => !p.warmup).length,
+    );
+  });
+});

--- a/bench/measurement/workload-ceiling-capture.ts
+++ b/bench/measurement/workload-ceiling-capture.ts
@@ -1,0 +1,495 @@
+/**
+ * Unattended capture runner for ticket 4: invokes the deployed Worker on the
+ * preregistered schedule, appending one journal record per invocation.
+ *
+ * This CLI reads a sweep report, plans round-robin invocations across cells
+ * and arms, and executes them at the spacing required by the telemetry system.
+ * Each invocation is recorded in a JSONL journal before the next one starts,
+ * so a crashed or killed run is fully recoverable.
+ *
+ * Two invocations cannot share a telemetry minute bucket, or they collapse into
+ * one row and become impossible to resolve. This runner enforces a 70-second
+ * spacing between starts (the contract's `invocation_spacing_seconds`) and
+ * refuses to start in the last 10 seconds of any minute, so an invocation cannot
+ * straddle a boundary and land its row in the next bucket.
+ *
+ * The shared secret is read from the environment and never written to disk,
+ * logged, or included in error messages.
+ */
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+  collectionWindowFor,
+  decodeWorkloadCeilingInvocationRecord,
+  encodeWorkloadCeilingInvocationRecord,
+  encodeWorkloadCeilingRunRequest,
+  nextInvocationStart,
+  type WorkloadCeilingImplementation,
+  type WorkloadCeilingInvocationRecord,
+  type WorkloadCeilingSweepCell,
+  type WorkloadCeilingSweepReport,
+  WORKLOAD_CEILING_CONTRACT_ID,
+  type WorkloadCeilingThermalClass,
+} from "./workload-ceiling-harness.ts";
+import { WORKLOAD_CEILING_STUDY } from "./workload-ceiling-contract.ts";
+import { runAsCliEntrypoint } from "./cli-entrypoint.ts";
+
+// Required env vars for the capture runner (documented in main() JSDoc)
+// WORKLOAD_CEILING_SWEEP_ID, WORKLOAD_CEILING_SHARED_SECRET, WORKLOAD_CEILING_WORKER_URL
+
+const DEFAULT_RESULTS_DIR = "bench/results/workload-ceiling";
+const DEFAULT_ARMS = ["monolithic-control", "monolithic-control-unhashed"] as const;
+
+export interface PlannedInvocation {
+  readonly scenario_id: string;
+  readonly implementation: WorkloadCeilingImplementation;
+  readonly fixture_prefix: string;
+  readonly warmup: boolean;
+  /** Position in the global serial order. */
+  readonly index: number;
+}
+
+/**
+ * Pure. The full invocation order for a sweep.
+ *
+ * Round-robin over (cell × arm) — NOT blocked by cell. A five-hour serial run
+ * drifts through colo reassignment, platform deploys, and diurnal load; blocked
+ * ordering lands all of that drift on whichever cells occupied that stretch,
+ * which is precisely the between-cell comparison the axis exists to make.
+ * Round-robin spreads it evenly, so drift inflates variance instead of faking a
+ * trend.
+ *
+ * Warmups come first WITHIN each (cell, arm) — they exist to absorb first-read
+ * and first-isolate costs for that fixture, which is a per-fixture property.
+ */
+export const planCaptureInvocations = (input: {
+  readonly cells: readonly WorkloadCeilingSweepCell[];
+  readonly arms: readonly WorkloadCeilingImplementation[];
+  readonly warmup: number;
+  readonly measured: number;
+}): readonly PlannedInvocation[] => {
+  const result: PlannedInvocation[] = [];
+  const totalPasses = input.warmup + input.measured;
+
+  // Round-robin: for each pass, for each arm, for each cell. This ensures
+  // consecutive invocations hit different cells, spreading drift evenly.
+  // Warmups come first within each (cell, arm) pair.
+  for (let pass = 0; pass < totalPasses; pass++) {
+    for (const arm of input.arms) {
+      for (const cell of input.cells) {
+        result.push({
+          scenario_id: cell.scenario_id,
+          implementation: arm,
+          fixture_prefix: cell.fixture_prefix,
+          warmup: pass < input.warmup,
+          index: result.length,
+        });
+      }
+    }
+  }
+
+  return result;
+};
+
+/**
+ * The plan slot a record or a planned invocation belongs to. `warmup` is part
+ * of it because a slot's warmups and its measured invocations are different
+ * work, and `exclusion_policy` is `warmup-tagged-before-run-only`.
+ */
+const slotKey = (invocation: {
+  readonly scenario_id: string;
+  readonly implementation: WorkloadCeilingImplementation;
+  readonly warmup: boolean;
+}): string =>
+  `${invocation.scenario_id}\u0000${invocation.implementation}\u0000${String(invocation.warmup)}`;
+
+/**
+ * Pure. The planned invocations a journal does not already account for.
+ *
+ * A journal record cannot be matched to a planned invocation by identity:
+ * `run_id` is a UUID minted at invocation time, and the record carries no plan
+ * index. What it does carry is the slot, and the journal is append-only in
+ * execution order — so the k-th record for a slot IS the k-th planned
+ * invocation of that slot. Resume drops the first n planned invocations of
+ * each slot, where n is that slot's record count.
+ *
+ * Getting this wrong is expensive rather than wrong-looking: a resume that
+ * matches nothing re-runs every completed invocation, doubling both the
+ * attended hours and the telemetry rows the collector has to disambiguate.
+ */
+export const remainingCaptureInvocations = (
+  planned: readonly PlannedInvocation[],
+  journal: readonly WorkloadCeilingInvocationRecord[],
+): readonly PlannedInvocation[] => {
+  const outstanding = new Map<string, number>();
+  for (const record of journal) {
+    const key = slotKey(record);
+    outstanding.set(key, (outstanding.get(key) ?? 0) + 1);
+  }
+  return planned.filter((invocation) => {
+    const key = slotKey(invocation);
+    const count = outstanding.get(key) ?? 0;
+    if (count === 0) {
+      return true;
+    }
+    outstanding.set(key, count - 1);
+    return false;
+  });
+};
+
+/**
+ * A required environment variable, rejected when unset OR blank. Blank counts
+ * because the one required secret here is sent as a bearer token: an exported
+ * but empty `WORKLOAD_CEILING_SHARED_SECRET` produces `Authorization: Bearer `
+ * and a run that fails 401 on its first invocation instead of at startup.
+ */
+const assertEnv = (name: string): string => {
+  const value = process.env[name];
+  if (value === undefined || value.trim() === "") {
+    console.error(`Missing or blank required environment variable: ${name}`);
+    process.exit(1);
+  }
+  return value;
+};
+
+const parseArms = (value: string | undefined): WorkloadCeilingImplementation[] => {
+  if (value === undefined) {
+    return [...DEFAULT_ARMS];
+  }
+  const arms = value.split(",").map((s) => s.trim()) as WorkloadCeilingImplementation[];
+  for (const arm of arms) {
+    if (!["monolithic-control", "monolithic-control-unhashed", "chunked-candidate"].includes(arm)) {
+      console.error(`Invalid arm: ${arm}`);
+      process.exit(1);
+    }
+  }
+  return arms;
+};
+
+const parseResultsDir = (value: string | undefined): string => {
+  return value === undefined ? DEFAULT_RESULTS_DIR : value;
+};
+
+const generateRunId = (): string => {
+  return randomUUID();
+};
+
+const validateWorkerUrl = (url: string): void => {
+  try {
+    const parsed = new URL(url);
+    if (parsed.pathname !== "/run") {
+      console.error(`WORKLOAD_CEILING_WORKER_URL path must be /run, got: ${parsed.pathname}`);
+      process.exit(1);
+    }
+    // Note: We validate the URL is well-formed and has the correct path.
+    // The real security guarantee is the shared secret bearer token,
+    // not the hostname pattern. Free tier accounts may not have a
+    // workers.dev subdomain, so we don't enforce the hostname prefix here.
+  } catch {
+    console.error(`Invalid WORKLOAD_CEILING_WORKER_URL: ${url}`);
+    process.exit(1);
+  }
+};
+
+const loadSweepReport = async (
+  resultsDir: string,
+  sweepId: string,
+): Promise<WorkloadCeilingSweepReport> => {
+  const sweepPath = resolve(resultsDir, `sweep-${sweepId}.json`);
+  try {
+    const raw = await readFile(sweepPath, "utf-8");
+    return JSON.parse(raw) as WorkloadCeilingSweepReport;
+  } catch (error) {
+    console.error(`Failed to read sweep report from ${sweepPath}`);
+    console.error(error);
+    process.exit(1);
+  }
+};
+
+const loadExistingJournal = async (
+  resultsDir: string,
+  sweepId: string,
+): Promise<WorkloadCeilingInvocationRecord[]> => {
+  const journalPath = resolve(resultsDir, `journal-${sweepId}.jsonl`);
+  try {
+    const raw = await readFile(journalPath, "utf-8");
+    return raw
+      .trim()
+      .split("\n")
+      .map((line) => {
+        if (line.trim() === "") {
+          throw new Error("Empty line in journal");
+        }
+        return decodeWorkloadCeilingInvocationRecord(line);
+      });
+  } catch (error) {
+    const code = (error as { code?: string }).code;
+    if (code === "ENOENT") {
+      return []; // No journal yet
+    }
+    console.error(`Failed to read journal from ${journalPath}`);
+    console.error(error);
+    process.exit(1);
+  }
+};
+
+const appendJournalRecord = async (
+  resultsDir: string,
+  sweepId: string,
+  record: WorkloadCeilingInvocationRecord,
+): Promise<void> => {
+  const journalPath = resolve(resultsDir, `journal-${sweepId}.jsonl`);
+  try {
+    const line = `${encodeWorkloadCeilingInvocationRecord(record)}\n`;
+    await appendFile(journalPath, line, { mode: 0o600 });
+    // Sync is handled by Node's default file handling; for guaranteed persistence
+    // we rely on the OS and filesystem. For POSIX systems, the data is flushed
+    // on close, which happens after each write.
+  } catch (error) {
+    console.error(`Failed to append journal record to ${journalPath}`);
+    console.error(error);
+    process.exit(1);
+  }
+};
+
+export const invokeWorker = async (
+  workerUrl: string,
+  sharedSecret: string,
+  planned: PlannedInvocation,
+): Promise<{
+  readonly status: number;
+  /**
+   * `null` when the response carried no readable result — a non-2xx status, or
+   * a 2xx whose body did not parse. Never defaulted to 0 / false: a Worker
+   * that answers 200 with an unreadable body would otherwise be journalled as
+   * a warm zero-row invocation, which mislabels the thermal class the study
+   * correlates against and hides the response defect.
+   */
+  readonly rowCount: number | null;
+  readonly isolateCold: boolean | null;
+  /** The run_id sent in the request body — the same value the Worker logs as `workload_ceiling_run_id`. The journal record MUST carry this, not a fresh UUID, or the ticket 6 dashboard join can never match. */
+  readonly runId: string;
+  /** Response body text when the result was unreadable (read from the same response — never re-invoke to inspect an error). */
+  readonly bodyText?: string;
+}> => {
+  const runId = generateRunId();
+  const requestBody = encodeWorkloadCeilingRunRequest({
+    contract_id: WORKLOAD_CEILING_CONTRACT_ID,
+    run_id: runId,
+    scenario_id: planned.scenario_id,
+    implementation: planned.implementation,
+    fixture_prefix: planned.fixture_prefix,
+  });
+
+  try {
+    const response = await fetch(workerUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${sharedSecret}`,
+      },
+      body: requestBody,
+    });
+
+    const status = response.status;
+
+    // Drain the body from THIS response either way. Re-invoking to inspect a
+    // response would mint a real extra invocation whose telemetry can collapse
+    // into another sample's minute bucket.
+    let bodyText = "<no body>";
+    try {
+      bodyText = await response.text();
+    } catch {
+      // keep placeholder
+    }
+
+    if (status >= 200 && status < 300) {
+      try {
+        const body = JSON.parse(bodyText) as {
+          row_count?: number;
+          isolate_cold?: boolean;
+        };
+        if (typeof body.row_count === "number" && typeof body.isolate_cold === "boolean") {
+          return { status, rowCount: body.row_count, isolateCold: body.isolate_cold, runId };
+        }
+      } catch {
+        // fall through to the unreadable-result return below
+      }
+    }
+
+    return { status, rowCount: null, isolateCold: null, runId, bodyText };
+  } catch (error) {
+    console.error(`Failed to invoke Worker at ${workerUrl}`);
+    console.error(error);
+    throw error;
+  }
+};
+
+const formatDuration = (ms: number): string => {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m ${seconds}s`;
+  } else if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  } else {
+    return `${seconds}s`;
+  }
+};
+
+/**
+ * Time left, from the pace so far: elapsed / completed, times outstanding.
+ * (Reporting elapsed / completed on its own would label the per-invocation
+ * pace as an ETA.)
+ */
+const formatRemaining = (elapsedMs: number, completed: number, outstanding: number): string => {
+  if (completed === 0) {
+    return "unknown";
+  }
+  return formatDuration((elapsedMs / completed) * outstanding);
+};
+
+/**
+ * Sleeps until the next legal start instant and returns it. WHICH instant is
+ * legal is `nextInvocationStart`'s decision, not this function's — the
+ * spacing-plus-minute-tail rule is the study's, it is pure, and it is unit
+ * tested. A second copy here would be the copy that actually runs during a
+ * capture while the tests validated the other one.
+ */
+const waitForSlot = async (previousStart: Date | null, now: Date): Promise<Date> => {
+  const candidate = nextInvocationStart(previousStart, now);
+  const delayMs = candidate.getTime() - now.getTime();
+  if (delayMs > 0) {
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  return candidate;
+};
+
+const main = async (): Promise<number> => {
+  const sweepId = assertEnv("WORKLOAD_CEILING_SWEEP_ID");
+  const sharedSecret = assertEnv("WORKLOAD_CEILING_SHARED_SECRET");
+  const workerUrl = assertEnv("WORKLOAD_CEILING_WORKER_URL");
+  const arms = parseArms(process.env["WORKLOAD_CEILING_ARMS"]);
+  const resultsDir = parseResultsDir(process.env["WORKLOAD_CEILING_RESULTS_DIR"]);
+
+  const measuredOverride = process.env["WORKLOAD_CEILING_MEASURED_OVERRIDE"];
+  const measured = measuredOverride
+    ? parseInt(measuredOverride, 10)
+    : WORKLOAD_CEILING_STUDY.capture.planned_measured_invocations_per_cell;
+  const warmup = WORKLOAD_CEILING_STUDY.capture.warmup_invocations_per_cell;
+
+  validateWorkerUrl(workerUrl);
+
+  await mkdir(resultsDir, { recursive: true });
+
+  const sweep = await loadSweepReport(resultsDir, sweepId);
+  if (sweep.contract_id !== WORKLOAD_CEILING_CONTRACT_ID) {
+    console.error(
+      `Sweep report contract mismatch: expected ${WORKLOAD_CEILING_CONTRACT_ID}, got ${sweep.contract_id}`,
+    );
+    return 1;
+  }
+
+  const planned = planCaptureInvocations({
+    cells: sweep.cells,
+    arms,
+    warmup,
+    measured,
+  });
+
+  const existing = await loadExistingJournal(resultsDir, sweepId);
+  const remaining = remainingCaptureInvocations(planned, existing);
+
+  if (existing.length > 0) {
+    console.log(`Resuming from ${existing.length} existing journal entries`);
+  }
+  console.log(`Planned ${planned.length} invocations, ${remaining.length} remaining`);
+  console.log(`Warmup: ${warmup}, Measured: ${measured}`);
+  console.log(`Arms: ${arms.join(", ")}`);
+  console.log();
+
+  const startTime = Date.now();
+  let previousStart: Date | null = null;
+
+  for (let i = 0; i < remaining.length; i++) {
+    const plannedInvocation = remaining[i]!;
+    const elapsed = Date.now() - startTime;
+
+    console.log(
+      `[${i + 1}/${remaining.length}] ${plannedInvocation.scenario_id} / ${plannedInvocation.implementation}${plannedInvocation.warmup ? " (warmup)" : ""}`,
+    );
+    console.log(
+      `  Elapsed: ${formatDuration(elapsed)}, ETA: ${formatRemaining(elapsed, i, remaining.length - i)}`,
+    );
+
+    const startInstant = await waitForSlot(previousStart, new Date());
+
+    const { status, rowCount, isolateCold, runId, bodyText } = await invokeWorker(
+      workerUrl,
+      sharedSecret,
+      plannedInvocation,
+    );
+
+    if (status < 200 || status >= 300 || rowCount === null || isolateCold === null) {
+      console.error(
+        status < 200 || status >= 300
+          ? `Worker returned non-2xx status: ${status}`
+          : `Worker returned ${status} with a result this runner cannot read`,
+      );
+      console.error(`Response body: ${bodyText ?? "<no body>"}`);
+      console.error(
+        `Planned invocation: scenario_id=${plannedInvocation.scenario_id}, implementation=${plannedInvocation.implementation}, fixture_prefix=${plannedInvocation.fixture_prefix}, warmup=${plannedInvocation.warmup}`,
+      );
+      return 1;
+    }
+
+    const window = collectionWindowFor(startInstant);
+
+    const thermalClass: WorkloadCeilingThermalClass = isolateCold ? "cold" : "warm";
+
+    const record: WorkloadCeilingInvocationRecord = {
+      contract_id: WORKLOAD_CEILING_CONTRACT_ID,
+      sweep_id: sweepId,
+      run_id: runId,
+      scenario_id: plannedInvocation.scenario_id,
+      implementation: plannedInvocation.implementation,
+      fixture_prefix: plannedInvocation.fixture_prefix,
+      warmup: plannedInvocation.warmup,
+      invoked_at: startInstant.toISOString(),
+      window_gte: window.gte,
+      window_lt: window.lt,
+      http_status: status,
+      row_count: rowCount,
+      thermal_class: thermalClass,
+    };
+
+    await appendJournalRecord(resultsDir, sweepId, record);
+
+    previousStart = startInstant;
+  }
+
+  const totalElapsed = Date.now() - startTime;
+  const journalPath = resolve(resultsDir, `journal-${sweepId}.jsonl`);
+
+  console.log();
+  console.log(`Capture complete`);
+  console.log(`  Journal: ${journalPath}`);
+  console.log(`  Total invocations: ${remaining.length}`);
+  console.log(`  Total time: ${formatDuration(totalElapsed)}`);
+  console.log();
+  console.log(
+    `Wait ${WORKLOAD_CEILING_STUDY.capture.telemetry_settle_seconds} seconds for telemetry to settle, then run:`,
+  );
+  console.log();
+  console.log(`  WORKLOAD_CEILING_SWEEP_ID=${sweepId} \\`);
+  console.log(`  WORKLOAD_CEILING_COMPATIBILITY_DATE=<date> \\`);
+  console.log(`  pnpm bench:workload-ceiling:collect-batch`);
+
+  return 0;
+};
+
+await runAsCliEntrypoint(import.meta.url, main);

--- a/bench/measurement/workload-ceiling-capture.ts
+++ b/bench/measurement/workload-ceiling-capture.ts
@@ -25,6 +25,7 @@ import {
   encodeWorkloadCeilingInvocationRecord,
   encodeWorkloadCeilingRunRequest,
   nextInvocationStart,
+  WORKLOAD_CEILING_IMPLEMENTATIONS,
   type WorkloadCeilingImplementation,
   type WorkloadCeilingInvocationRecord,
   type WorkloadCeilingSweepCell,
@@ -153,18 +154,55 @@ const assertEnv = (name: string): string => {
   return value;
 };
 
-const parseArms = (value: string | undefined): WorkloadCeilingImplementation[] => {
+/**
+ * Validates against `WORKLOAD_CEILING_IMPLEMENTATIONS` rather than a
+ * hand-written literal list, and narrows only after validating. A repeated
+ * list drifts silently: adding a fourth arm to the const would leave this
+ * guard rejecting it with no compiler signal, and the cast-then-check order
+ * meant TypeScript saw a `WorkloadCeilingImplementation[]` that the runtime
+ * had not yet confirmed.
+ */
+export const parseArms = (value: string | undefined): WorkloadCeilingImplementation[] => {
   if (value === undefined) {
     return [...DEFAULT_ARMS];
   }
-  const arms = value.split(",").map((s) => s.trim()) as WorkloadCeilingImplementation[];
-  for (const arm of arms) {
-    if (!["monolithic-control", "monolithic-control-unhashed", "chunked-candidate"].includes(arm)) {
-      console.error(`Invalid arm: ${arm}`);
+  const arms: WorkloadCeilingImplementation[] = [];
+  for (const candidate of value.split(",").map((s) => s.trim())) {
+    if (!(WORKLOAD_CEILING_IMPLEMENTATIONS as readonly string[]).includes(candidate)) {
+      console.error(
+        `Invalid arm: ${JSON.stringify(candidate)} — must be one of ` +
+          `${WORKLOAD_CEILING_IMPLEMENTATIONS.join(", ")}`,
+      );
       process.exit(1);
     }
+    arms.push(candidate as WorkloadCeilingImplementation);
   }
   return arms;
+};
+
+/**
+ * The per-cell measured-invocation count, overridable for a shortened
+ * rehearsal.
+ *
+ * Unguarded `parseInt` made a non-numeric value the worst possible outcome
+ * for a measurement runner: `totalPasses` became NaN, `pass < NaN` was false
+ * on the first test, and the runner printed "Capture complete" and exited 0
+ * having invoked nothing. A capture that silently measures zero invocations
+ * and reports success is indistinguishable from one that ran, until the
+ * aggregate refuses hours later.
+ */
+export const parseMeasuredOverride = (value: string | undefined): number => {
+  if (value === undefined || value.trim() === "") {
+    return WORKLOAD_CEILING_STUDY.capture.planned_measured_invocations_per_cell;
+  }
+  const measured = Number(value);
+  if (!Number.isInteger(measured) || measured < 1) {
+    console.error(
+      `WORKLOAD_CEILING_MEASURED_OVERRIDE must be a positive integer; got ${JSON.stringify(value)}`,
+    );
+    process.exit(1);
+  }
+  return measured;
 };
 
 const parseResultsDir = (value: string | undefined): string => {
@@ -376,10 +414,7 @@ const main = async (): Promise<number> => {
   const arms = parseArms(process.env["WORKLOAD_CEILING_ARMS"]);
   const resultsDir = parseResultsDir(process.env["WORKLOAD_CEILING_RESULTS_DIR"]);
 
-  const measuredOverride = process.env["WORKLOAD_CEILING_MEASURED_OVERRIDE"];
-  const measured = measuredOverride
-    ? parseInt(measuredOverride, 10)
-    : WORKLOAD_CEILING_STUDY.capture.planned_measured_invocations_per_cell;
+  const measured = parseMeasuredOverride(process.env["WORKLOAD_CEILING_MEASURED_OVERRIDE"]);
   const warmup = WORKLOAD_CEILING_STUDY.capture.warmup_invocations_per_cell;
 
   validateWorkerUrl(workerUrl);

--- a/bench/measurement/workload-ceiling-capture.ts
+++ b/bench/measurement/workload-ceiling-capture.ts
@@ -22,6 +22,7 @@ import { randomUUID } from "node:crypto";
 import {
   collectionWindowFor,
   decodeWorkloadCeilingInvocationRecord,
+  decodeWorkloadCeilingSweepReport,
   encodeWorkloadCeilingInvocationRecord,
   encodeWorkloadCeilingRunRequest,
   nextInvocationStart,
@@ -230,6 +231,14 @@ const validateWorkerUrl = (url: string): void => {
   }
 };
 
+/**
+ * Reads the sweep report through the same codec its writer enforces on the
+ * same file. `JSON.parse ... as WorkloadCeilingSweepReport` type-asserted a
+ * shape nothing had checked, so a parseable-but-malformed report fed
+ * unvalidated `achieved_bytes` / `target_bytes` / `row_count` straight into
+ * the admission gates downstream — the numbers the study's conclusions rest
+ * on.
+ */
 const loadSweepReport = async (
   resultsDir: string,
   sweepId: string,
@@ -237,7 +246,7 @@ const loadSweepReport = async (
   const sweepPath = resolve(resultsDir, `sweep-${sweepId}.json`);
   try {
     const raw = await readFile(sweepPath, "utf-8");
-    return JSON.parse(raw) as WorkloadCeilingSweepReport;
+    return decodeWorkloadCeilingSweepReport(raw);
   } catch (error) {
     console.error(`Failed to read sweep report from ${sweepPath}`);
     console.error(error);

--- a/bench/measurement/workload-ceiling-cells.test.ts
+++ b/bench/measurement/workload-ceiling-cells.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import { WORKLOAD_CEILING_STUDY } from "./workload-ceiling-contract.ts";
+import { byteAxisCells, BYTE_AXIS_MANIFEST_DESCRIPTORS } from "./workload-ceiling-cells.ts";
+
+describe("byteAxisCells", () => {
+  test("byte-axis cells derive from the contract, not from a second literal", () => {
+    expect(byteAxisCells().map((c) => c.target)).toEqual([
+      ...WORKLOAD_CEILING_STUDY.collection_bytes,
+    ]);
+  });
+
+  test("every byte-axis cell uses the contract's canonical document size", () => {
+    for (const cell of byteAxisCells()) {
+      expect(cell.document_bytes).toBe(WORKLOAD_CEILING_STUDY.axis_sweeps.byte_axis.document_bytes);
+    }
+  });
+
+  test("scenario ids are stable, unique, and arm-free", () => {
+    const ids = byteAxisCells().map((c) => c.scenario_id);
+    expect(ids).toEqual(["byte-axis/512KiB", "byte-axis/1MiB", "byte-axis/2MiB", "byte-axis/4MiB"]);
+    expect(new Set(ids).size).toBe(ids.length);
+    // The arm lives in the collection directory, never in the join key — the
+    // hash-cost difference pairs the two monolithic arms BY scenario id.
+    for (const id of ids) {
+      expect(id).not.toContain("monolithic");
+    }
+  });
+
+  test("every cell has the fixed descriptor count", () => {
+    for (const cell of byteAxisCells()) {
+      expect(cell.manifest_descriptors).toBe(BYTE_AXIS_MANIFEST_DESCRIPTORS);
+    }
+  });
+
+  test("the minimum useful byte-axis target is one of the cells", () => {
+    expect(byteAxisCells().map((c) => c.target)).toContain(
+      WORKLOAD_CEILING_STUDY.minimum_useful_targets.byte_axis.collection_bytes,
+    );
+  });
+
+  test("every cell carries the byte axis discriminant", () => {
+    for (const cell of byteAxisCells()) {
+      expect(cell.axis).toBe("byte");
+    }
+  });
+});

--- a/bench/measurement/workload-ceiling-cells.ts
+++ b/bench/measurement/workload-ceiling-cells.ts
@@ -1,0 +1,70 @@
+/**
+ * The executable cell catalogs for the workload-ceiling axis sweeps.
+ *
+ * Every value here is DERIVED from `WORKLOAD_CEILING_STUDY`
+ * (`workload-ceiling-contract.ts`) — the contract is the preregistered owner of
+ * the matrix, and a second literal copy of an axis would let the two drift
+ * without any test noticing. Pure: no I/O, no clock, no storage.
+ *
+ * A cell is one point on one axis. It carries its own `scenario_id`, which is
+ * the join key `workload-ceiling-collect.ts` stamps onto every raw event and
+ * the aggregator groups by — so the id must be stable across runs, arms, and
+ * implementations. It deliberately does NOT encode the arm: the hash-cost
+ * difference (ticket 5) pairs the two monolithic arms BY scenario, and an
+ * arm-qualified id would make every pair incomplete.
+ */
+import { WORKLOAD_CEILING_STUDY } from "./workload-ceiling-contract.ts";
+import type { WorkloadCeilingFixtureSpec } from "./workload-ceiling-provision.ts";
+
+/** Every byte-axis cell fixes descriptors here — see the ticket's rationale. */
+export const BYTE_AXIS_MANIFEST_DESCRIPTORS = 8 as const;
+
+/** Fixture calibration tolerance: achieved encoded bytes within this fraction of target. */
+export const CELL_BYTE_TOLERANCE = 0.005 as const;
+
+export interface WorkloadCeilingCell {
+  readonly scenario_id: string;
+  readonly axis: "byte" | "row";
+  /** The axis quantity this cell is a point on: encoded snapshot bytes, or rows. */
+  readonly target: number;
+  readonly document_bytes: number;
+  readonly manifest_descriptors: number;
+}
+
+/** `524288` → `512KiB`, `4194304` → `4MiB`. Exact powers only; every contract cell is one. */
+export const byteLabel = (bytes: number): string => {
+  if (bytes % (1024 * 1024) === 0) {
+    return `${bytes / (1024 * 1024)}MiB`;
+  }
+  if (bytes % 1024 === 0) {
+    return `${bytes / 1024}KiB`;
+  }
+  return `${bytes}B`;
+};
+
+/**
+ * The four byte-axis cells, in ascending size. `collection_bytes` means ENCODED
+ * SNAPSHOT BYTES on this axis (`WORKLOAD_CEILING_STUDY.axis_sweeps.byte_axis`),
+ * which is what `calibrateRowCount` solves for.
+ */
+export const byteAxisCells = (): readonly WorkloadCeilingCell[] =>
+  WORKLOAD_CEILING_STUDY.collection_bytes.map((bytes) => ({
+    scenario_id: `byte-axis/${byteLabel(bytes)}`,
+    axis: "byte",
+    target: bytes,
+    document_bytes: WORKLOAD_CEILING_STUDY.axis_sweeps.byte_axis.document_bytes,
+    manifest_descriptors: BYTE_AXIS_MANIFEST_DESCRIPTORS,
+  }));
+
+/** The spec a cell provisions, once its row count has been calibrated. */
+export const cellSpec = (
+  cell: WorkloadCeilingCell,
+  rowCount: number,
+  collection: string,
+): WorkloadCeilingFixtureSpec => ({
+  scenario_id: cell.scenario_id,
+  collection,
+  row_count: rowCount,
+  document_bytes: cell.document_bytes,
+  manifest_descriptors: cell.manifest_descriptors,
+});

--- a/bench/measurement/workload-ceiling-collect-batch.test.ts
+++ b/bench/measurement/workload-ceiling-collect-batch.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for workload-ceiling-collect-batch.ts — the batch collector's
+ * retry policy and evidence-status reporting (evidence-contract v2).
+ *
+ * Pure — no network, no spawning, no I/O: the retry driver is exercised
+ * through injected `collect`/`readExisting`/`sleep` functions.
+ */
+import { describe, expect, test } from "vitest";
+import {
+  WORKLOAD_CEILING_EVIDENCE_CONTRACT_ID,
+  type WorkloadCeilingInvocationRecord,
+  type WorkloadCeilingRawEvent,
+} from "./workload-ceiling-harness.ts";
+import { collectWithRetry, isFinishedCollection } from "./workload-ceiling-collect-batch.ts";
+
+const record = (runId: string, over: Partial<WorkloadCeilingInvocationRecord> = {}) =>
+  ({
+    contract_id: "baerly.workload-ceiling/chunked-snapshot/v1",
+    sweep_id: "sweep-1",
+    run_id: runId,
+    scenario_id: "byte-axis/1MiB",
+    implementation: "monolithic-control",
+    fixture_prefix: "fixtures/1m",
+    warmup: false,
+    invoked_at: "2026-08-24T17:30:00.000Z",
+    window_gte: "2026-08-24T17:30:00.000Z",
+    window_lt: "2026-08-24T17:31:00.000Z",
+    http_status: 200,
+    row_count: 491,
+    thermal_class: "warm",
+    ...over,
+  }) as WorkloadCeilingInvocationRecord;
+
+const event = (over: {
+  readonly outcome?: string | null;
+  readonly cpu_ms?: number | null;
+  readonly status?: "resolved" | "missing" | "ambiguous";
+  readonly detail?: string | null;
+}): WorkloadCeilingRawEvent => {
+  const resolved = over.status === "resolved";
+  let authoritativeOutcome: string | null = null;
+  if (resolved && over.outcome === "success") {
+    authoritativeOutcome = "ok";
+  } else if (resolved && over.outcome != null) {
+    authoritativeOutcome = over.outcome;
+  }
+  return {
+    evidence_contract_id: WORKLOAD_CEILING_EVIDENCE_CONTRACT_ID,
+    run_id: "run-1",
+    scenario_id: "byte-axis/1MiB",
+    script_version: resolved ? "027034f3-170b-466d-b1ad-914fad42024c" : "unresolved",
+    compatibility_date: "2026-08-15",
+    runtime_period: "2026-08-24T17:30:00.000Z/2026-08-24T17:31:00.000Z",
+    colo: resolved ? "EWR" : "unknown",
+    thermal_class: "warm",
+    outcome: over.outcome ?? null,
+    cpu_ms: over.cpu_ms ?? null,
+    observed_at: "2026-08-24T17:53:54.083Z",
+    evidence: {
+      status: over.status ?? "missing",
+      detail: over.detail ?? (resolved ? null : "no join line in window"),
+      authority: "workers-observability",
+      authoritative_outcome: authoritativeOutcome,
+      authoritative_cpu_ms: null,
+      authoritative_response_status: null,
+      cpu_source: over.cpu_ms != null ? "workers-invocations-adaptive" : "none",
+      cpu_outcome_verbatim: over.cpu_ms != null ? "success" : null,
+    },
+  };
+};
+
+describe("isFinishedCollection (evidence-contract v2)", () => {
+  test("a fully resolved success is finished — never re-query its window", () => {
+    expect(
+      isFinishedCollection(event({ status: "resolved", outcome: "success", cpu_ms: 7.269 })),
+    ).toBe(true);
+  });
+
+  test("an evidence-missing event is NOT finished — the retry pass re-queries it", () => {
+    expect(isFinishedCollection(event({ status: "missing", outcome: null, cpu_ms: null }))).toBe(
+      false,
+    );
+  });
+
+  test("an evidence-ambiguous event is NOT finished", () => {
+    expect(isFinishedCollection(event({ status: "ambiguous", outcome: null, cpu_ms: null }))).toBe(
+      false,
+    );
+  });
+
+  test("a resolved success without CPU is NOT finished — its CPU row gets the one retry too", () => {
+    // CPU missingness is terminal in aggregate, but the single sanctioned
+    // collection retry applies to it: the row may simply be lagging.
+    expect(
+      isFinishedCollection(event({ status: "resolved", outcome: "success", cpu_ms: null })),
+    ).toBe(false);
+  });
+
+  test("a resolved exceededCpu IS finished — a kill is a terminal platform fact, not lag", () => {
+    // Re-querying cannot un-kill an invocation; retrying it would only burn
+    // API calls after the outcome is already authoritative.
+    expect(
+      isFinishedCollection(event({ status: "resolved", outcome: "exceededCpu", cpu_ms: 50 })),
+    ).toBe(true);
+  });
+
+  test("nothing collected yet is not finished", () => {
+    expect(isFinishedCollection(undefined)).toBe(false);
+  });
+});
+
+describe("collectWithRetry", () => {
+  const delayMs = 1234;
+
+  test("re-queries an unresolved run once, with the same record — never a new invocation", async () => {
+    const target = record("run-lagging");
+    const collected: readonly WorkloadCeilingInvocationRecord[] = [];
+    const collectCalls: WorkloadCeilingInvocationRecord[] = [];
+    let callsForTarget = 0;
+    const outcomes = await collectWithRetry([target, record("run-clean")], {
+      retries: 1,
+      retryDelayMs: delayMs,
+      readExisting: async () => undefined,
+      collect: async (r) => {
+        collectCalls.push(r);
+        if (r.run_id === "run-lagging") {
+          callsForTarget += 1;
+          // First pass: evidence missing (lag). Retry pass: resolved.
+          return callsForTarget === 1
+            ? event({ status: "missing", outcome: null, cpu_ms: null })
+            : event({ status: "resolved", outcome: "success", cpu_ms: 7 });
+        }
+        return event({ status: "resolved", outcome: "success", cpu_ms: 8 });
+      },
+      sleep: async () => {},
+    });
+    expect(collectCalls.filter((r) => r.run_id === "run-lagging")).toHaveLength(2);
+    // The retry pass re-queried the SAME run id and the SAME collection
+    // window — the journal's, not a re-derived or widened one.
+    const [first, second] = collectCalls.filter((r) => r.run_id === "run-lagging");
+    expect(second!.run_id).toBe(first!.run_id);
+    expect(second!.window_gte).toBe(first!.window_gte);
+    expect(second!.window_lt).toBe(first!.window_lt);
+    // No record outside the journal was ever queried.
+    expect(collectCalls.every((r) => r.run_id === "run-lagging" || r.run_id === "run-clean")).toBe(
+      true,
+    );
+    const lagging = outcomes.find((o) => o.run_id === "run-lagging");
+    expect(lagging?.attempts).toBe(2);
+    expect(lagging?.newly_resolved).toBe(true);
+    expect(collected).toHaveLength(0);
+  });
+
+  test("a run that recovers on the FIRST pass is reported as newly resolved", async () => {
+    // The recovery-on-re-run case: a previous invocation of the collector left
+    // an unresolved event on disk, and this run resolves it. Seeding only
+    // `pending` from that on-disk state left pass 0 with no prior entry to
+    // compare against, so `newly_resolved` was false for exactly the runs it
+    // exists to report — only pass-1 resolutions were ever counted.
+    const outcomes = await collectWithRetry([record("run-lagging")], {
+      retries: 1,
+      retryDelayMs: delayMs,
+      readExisting: async () => event({ status: "missing", outcome: null, cpu_ms: null }),
+      collect: async () => event({ status: "resolved", outcome: "success", cpu_ms: 7 }),
+      sleep: async () => {},
+    });
+    const lagging = outcomes.find((o) => o.run_id === "run-lagging");
+    expect(lagging?.newly_resolved).toBe(true);
+    expect(lagging?.attempts).toBe(1);
+  });
+
+  test("sleeps exactly once between passes, and never when nothing is unresolved", async () => {
+    const sleeps: number[] = [];
+    await collectWithRetry([record("run-clean")], {
+      retries: 1,
+      retryDelayMs: delayMs,
+      readExisting: async () => undefined,
+      collect: async () => event({ status: "resolved", outcome: "success", cpu_ms: 8 }),
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+    expect(sleeps).toEqual([]);
+
+    let calls = 0;
+    await collectWithRetry([record("run-dropped")], {
+      retries: 1,
+      retryDelayMs: delayMs,
+      readExisting: async () => undefined,
+      collect: async () => {
+        calls += 1;
+        return event({ status: "missing", outcome: null, cpu_ms: null });
+      },
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+    expect(calls).toBe(2);
+    expect(sleeps).toEqual([delayMs]);
+  });
+
+  test("no third pass, however unresolved the run stays — the retry count is preregistered", async () => {
+    let calls = 0;
+    const outcomes = await collectWithRetry([record("run-dropped")], {
+      retries: 1,
+      retryDelayMs: delayMs,
+      readExisting: async () => undefined,
+      collect: async () => {
+        calls += 1;
+        return event({ status: "missing", outcome: null, cpu_ms: null });
+      },
+      sleep: async () => {},
+    });
+    expect(calls).toBe(2);
+    expect(outcomes[0]!.evidence_status).toBe("missing");
+  });
+
+  test("a run already finished on disk is skipped, never re-queried", async () => {
+    const onDisk = event({ status: "resolved", outcome: "success", cpu_ms: 7 });
+    let collectCalls = 0;
+    const outcomes = await collectWithRetry([record("run-done")], {
+      retries: 1,
+      retryDelayMs: delayMs,
+      readExisting: async () => onDisk,
+      collect: async () => {
+        collectCalls += 1;
+        return event({ status: "resolved", outcome: "success", cpu_ms: 99 });
+      },
+      sleep: async () => {},
+    });
+    expect(collectCalls).toBe(0);
+    expect(outcomes[0]!.attempts).toBe(0);
+    expect(outcomes[0]!.evidence_status).toBe("resolved");
+  });
+
+  test("a CPU-missing success gets the retry, and stays CPU-missing if the row never lands", async () => {
+    let calls = 0;
+    const outcomes = await collectWithRetry([record("run-cpu-dropped")], {
+      retries: 1,
+      retryDelayMs: delayMs,
+      readExisting: async () => undefined,
+      collect: async () => {
+        calls += 1;
+        return event({ status: "resolved", outcome: "success", cpu_ms: null });
+      },
+      sleep: async () => {},
+    });
+    expect(calls).toBe(2);
+    const outcome = outcomes[0]!;
+    // A successful execution with CPU missingness: not a failure, not finished.
+    expect(outcome.evidence_status).toBe("resolved");
+    expect(outcome.cpu_resolved).toBe(false);
+  });
+
+  test("reports evidence-status counts the summary prints", async () => {
+    const outcomes = await collectWithRetry([record("r1"), record("r2"), record("r3")], {
+      retries: 1,
+      retryDelayMs: delayMs,
+      readExisting: async () => undefined,
+      collect: async (r) => {
+        if (r.run_id === "r1") {
+          return event({ status: "resolved", outcome: "success", cpu_ms: 1 });
+        }
+        if (r.run_id === "r2") {
+          return event({ status: "missing", outcome: null, cpu_ms: null });
+        }
+        return event({ status: "ambiguous", outcome: null, cpu_ms: null });
+      },
+      sleep: async () => {},
+    });
+    const counts = outcomes.reduce(
+      (acc, o) => {
+        acc[o.evidence_status] = (acc[o.evidence_status] ?? 0) + 1;
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
+    expect(counts).toEqual({ resolved: 1, missing: 1, ambiguous: 1 });
+  });
+});

--- a/bench/measurement/workload-ceiling-collect-batch.ts
+++ b/bench/measurement/workload-ceiling-collect-batch.ts
@@ -279,7 +279,6 @@ export const collectWithRetry = async (
       event: WorkloadCeilingRawEvent | undefined;
       attempts: number;
       newlyResolved: boolean;
-      previouslySeen: boolean;
     }
   >();
 
@@ -315,7 +314,6 @@ export const collectWithRetry = async (
         event: existing,
         attempts: 0,
         newlyResolved: false,
-        previouslySeen: true,
       });
       continue;
     }
@@ -331,7 +329,6 @@ export const collectWithRetry = async (
         event: existing,
         attempts: 0,
         newlyResolved: false,
-        previouslySeen: true,
       });
     }
     pending.push(record);
@@ -359,7 +356,6 @@ export const collectWithRetry = async (
           existing.event.evidence.status !== "resolved" &&
           collected !== undefined &&
           collected.evidence.status === "resolved",
-        previouslySeen: false,
       };
       results.set(record.run_id, entry);
       if (!isFinishedCollection(collected)) {

--- a/bench/measurement/workload-ceiling-collect-batch.ts
+++ b/bench/measurement/workload-ceiling-collect-batch.ts
@@ -1,0 +1,617 @@
+/**
+ * Batch collector for ticket 4: replays the journal against the platform's
+ * telemetry APIs, one collection window per invocation.
+ *
+ * This CLI reads a journal from the capture runner and collects BOTH
+ * telemetry sources per non-warmup entry (Workers Observability as the
+ * existence/outcome authority; `workersInvocationsAdaptive` for the CPU
+ * measurement — see `workload-ceiling-harness.ts`'s evidence block), writing
+ * raw and event files into per-arm directories.
+ *
+ * Collection is idempotent and re-runnable, and the retry policy is
+ * preregistered in `WORKLOAD_CEILING_STUDY.capture.telemetry`: after the
+ * initial pass, ONE further collection-only pass runs after a fixed delay
+ * for every run whose evidence has not resolved (or whose CPU row has not
+ * landed). Re-querying a fixed window is not a re-invocation — nothing is
+ * ever re-rolled, no run id is ever re-minted, and the
+ * warmup-tagged-only exclusion policy is untouched. A run that is still
+ * unresolved after the retry stays in the record: it blocks the capture's
+ * evidence completeness (or the cell's CPU sample floor) and there is no
+ * sanctioned remedy after the fact — no top-up, no re-invoke.
+ *
+ * The shared secret is NOT used in this phase; only Cloudflare credentials
+ * for the telemetry APIs.
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { spawn } from "node:child_process";
+import {
+  decodeWorkloadCeilingInvocationRecord,
+  decodeWorkloadCeilingRawEvent,
+  type WorkloadCeilingEvidenceStatus,
+  type WorkloadCeilingInvocationRecord,
+  type WorkloadCeilingRawEvent,
+} from "./workload-ceiling-harness.ts";
+import { WORKLOAD_CEILING_STUDY } from "./workload-ceiling-contract.ts";
+import { isResolvedOk } from "./workload-ceiling-compare.ts";
+import { runAsCliEntrypoint } from "./cli-entrypoint.ts";
+
+const REQUIRED_ENV = ["WORKLOAD_CEILING_SWEEP_ID", "WORKLOAD_CEILING_COMPATIBILITY_DATE"] as const;
+
+const DEFAULT_RESULTS_DIR = "bench/results/workload-ceiling";
+
+interface CollectionOutcome {
+  readonly scenario_id: string;
+  readonly implementation: string;
+  readonly run_id: string;
+  /** The collector ran without erroring. Says nothing about evidence resolution. */
+  readonly success: boolean;
+  /** Evidence status of the authoritative record after the final pass. */
+  readonly evidence_status: WorkloadCeilingEvidenceStatus | "not-collected";
+  /** Whether the event carries a finite CPU measurement. */
+  readonly cpu_resolved: boolean;
+  /** Collection passes that actually queried this run's window. */
+  readonly attempts: number;
+  /** Unresolved on a previous pass, resolved on this one. */
+  readonly newly_resolved?: boolean;
+  readonly outcome?: string | null;
+  readonly error?: string;
+}
+
+interface BatchCollectionSummary {
+  readonly sweep_id: string;
+  readonly total: number;
+  readonly skipped: number; // warmup entries
+  readonly succeeded: number;
+  readonly failed: number;
+  readonly evidence_resolved: number;
+  readonly evidence_missing: number;
+  readonly evidence_ambiguous: number;
+  readonly cpu_resolved: number;
+  readonly cpu_missing: number;
+  /** Records that were unresolved on a previous pass and resolved on this one. */
+  readonly newly_resolved: number;
+  readonly outcomes: readonly CollectionOutcome[];
+}
+
+/**
+ * Loads and parses the journal from the capture runner.
+ */
+async function loadJournal(
+  resultsDir: string,
+  sweepId: string,
+): Promise<WorkloadCeilingInvocationRecord[]> {
+  const journalPath = resolve(resultsDir, `journal-${sweepId}.jsonl`);
+  try {
+    const raw = await readFile(journalPath, "utf-8");
+    const lines = raw
+      .trim()
+      .split("\n")
+      .filter((line) => line.trim() !== "");
+    return lines.map((line) => {
+      try {
+        return decodeWorkloadCeilingInvocationRecord(line);
+      } catch (error) {
+        throw new Error(
+          `Failed to decode journal line: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error },
+        );
+      }
+    });
+  } catch (error) {
+    const code = (error as { code?: string }).code;
+    if (code === "ENOENT") {
+      console.error(`Journal not found: ${journalPath}`);
+      console.error(`Run the capture runner first to generate the journal.`);
+      throw error;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Groups journal entries by implementation for per-arm directory output.
+ */
+function groupByImplementation(
+  records: readonly WorkloadCeilingInvocationRecord[],
+): ReadonlyMap<string, readonly WorkloadCeilingInvocationRecord[]> {
+  const groups = new Map<string, WorkloadCeilingInvocationRecord[]>();
+  for (const record of records) {
+    let group = groups.get(record.implementation);
+    if (group === undefined) {
+      group = [];
+      groups.set(record.implementation, group);
+    }
+    group.push(record);
+  }
+  return groups;
+}
+
+/**
+ * Spawns the single-run collector for one journal entry.
+ *
+ * Returns a promise that resolves when the collector exits. The collector
+ * is spawned with all required env vars set, so it needs no additional state.
+ * This is the ONLY actor that can touch the platform in this module, and it
+ * only ever READS telemetry — the collection path has no way to invoke the
+ * Worker, which is what makes "collection-only retry" structurally true.
+ */
+function spawnCollector(
+  record: WorkloadCeilingInvocationRecord,
+  compatibilityDate: string,
+  outDir: string,
+): Promise<{ readonly success: boolean; readonly error?: string }> {
+  return new Promise((collectorResolve, _reject) => {
+    const env: Record<string, string> = {
+      ...process.env,
+      WORKLOAD_CEILING_RUN_ID: record.run_id,
+      WORKLOAD_CEILING_SCENARIO_ID: record.scenario_id,
+      WORKLOAD_CEILING_COMPATIBILITY_DATE: compatibilityDate,
+      WORKLOAD_CEILING_WINDOW_START: record.window_gte,
+      WORKLOAD_CEILING_WINDOW_END: record.window_lt,
+      WORKLOAD_CEILING_THERMAL_CLASS: record.thermal_class,
+      WORKLOAD_CEILING_OUT_DIR: outDir,
+    };
+
+    const collector = spawn(
+      "node",
+      ["--import", "./bench/register-hooks.mjs", "bench/measurement/workload-ceiling-collect.ts"],
+      {
+        env,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+
+    let stdout = "";
+    let stderr = "";
+
+    collector.stdout?.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    collector.stderr?.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    collector.on("close", (code) => {
+      const success = code === 0;
+      collectorResolve({
+        success,
+        error: success ? undefined : `exit code ${code}${stderr ? `: ${stderr.trim()}` : ""}`,
+      });
+    });
+
+    collector.on("error", (error) => {
+      collectorResolve({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  });
+}
+
+/**
+ * Reads the already-collected event for a run, or `undefined` when this run
+ * has not been collected yet (either file missing, or the event unparseable).
+ */
+async function readCollectedEvent(
+  outDir: string,
+  runId: string,
+): Promise<WorkloadCeilingRawEvent | undefined> {
+  const rawPath = resolve(outDir, `raw-${runId}.json`);
+  const eventPath = resolve(outDir, `event-${runId}.json`);
+  let eventText: string;
+  try {
+    [, eventText] = await Promise.all([readFile(rawPath), readFile(eventPath, "utf-8")]);
+  } catch {
+    return undefined;
+  }
+  try {
+    return decodeWorkloadCeilingRawEvent(eventText);
+  } catch (error) {
+    // Still "not collected" — the run is re-queried and the file overwritten,
+    // which is the recovery we want. But a file that exists and does not
+    // decode is codec drift or corruption, not an uncollected run, and
+    // repairing it silently is how a schema mismatch survives a whole sweep.
+    console.error(
+      `workload-ceiling-collect-batch: ${eventPath} exists but does not decode; ` +
+        `re-collecting and overwriting it. ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * Pure. Whether an already-present collection counts as finished, i.e.
+ * whether this pass should skip the run rather than re-query its window.
+ *
+ * Evidence-contract v2: presence of the files is NOT the criterion, and
+ * neither is "usable measurement". A collection is finished when the
+ * AUTHORITATIVE record resolved AND the run is not a success still missing
+ * its CPU row (the one state a lagging `workersInvocationsAdaptive` row can
+ * still fix). A resolved `exceededCpu` is finished — a kill is a terminal
+ * platform fact, and re-querying cannot un-kill it. A missing or ambiguous
+ * authoritative record is not finished until the preregistered retry count
+ * is exhausted.
+ */
+export const isFinishedCollection = (event: WorkloadCeilingRawEvent | undefined): boolean =>
+  event !== undefined &&
+  event.evidence.status === "resolved" &&
+  !(event.outcome === "success" && event.cpu_ms === null);
+
+/**
+ * Pure driver for the preregistered collection-retry policy. All effects are
+ * injected (`readExisting`, `collect`, `sleep`), so the policy itself is
+ * unit-testable without spawning or waiting.
+ *
+ * Invariants the driver exists to enforce:
+ *
+ *  - a run already finished on disk (per {@link isFinishedCollection}) is
+ *    never re-queried;
+ *  - an unfinished run is re-queried with its SAME journal record — the same
+ *    run id and the same fixed window — so a retry can never mint or sanction
+ *    a new invocation (and the `collect` callback is the only platform actor);
+ *  - at most `retries` retry passes run, each preceded by exactly one
+ *    `retryDelayMs` sleep (no sleep when nothing is unresolved);
+ *  - a run still unresolved after the last pass stays in the record with its
+ *    final evidence status — there is no third pass and no top-up.
+ */
+export const collectWithRetry = async (
+  records: readonly WorkloadCeilingInvocationRecord[],
+  options: {
+    readonly retries: number;
+    readonly retryDelayMs: number;
+    readonly readExisting: (
+      record: WorkloadCeilingInvocationRecord,
+    ) => Promise<WorkloadCeilingRawEvent | undefined>;
+    readonly collect: (
+      record: WorkloadCeilingInvocationRecord,
+    ) => Promise<WorkloadCeilingRawEvent | undefined>;
+    readonly sleep: (ms: number) => Promise<void>;
+  },
+): Promise<readonly CollectionOutcome[]> => {
+  const results = new Map<
+    string,
+    {
+      readonly record: WorkloadCeilingInvocationRecord;
+      success: boolean;
+      error?: string;
+      event: WorkloadCeilingRawEvent | undefined;
+      attempts: number;
+      newlyResolved: boolean;
+      previouslySeen: boolean;
+    }
+  >();
+
+  const outcomeOf = (runId: string): CollectionOutcome | undefined => {
+    const entry = results.get(runId);
+    if (entry === undefined) {
+      return undefined;
+    }
+    const evidenceStatus: CollectionOutcome["evidence_status"] =
+      entry.event !== undefined ? entry.event.evidence.status : "not-collected";
+    return {
+      scenario_id: entry.record.scenario_id,
+      implementation: entry.record.implementation,
+      run_id: entry.record.run_id,
+      success: entry.success,
+      evidence_status: evidenceStatus,
+      cpu_resolved: entry.event !== undefined && isResolvedOk(entry.event),
+      attempts: entry.attempts,
+      newly_resolved: entry.newlyResolved || undefined,
+      outcome: entry.event?.outcome ?? undefined,
+      error: entry.error,
+    };
+  };
+
+  // Initial pass: skip runs already finished on disk.
+  let pending: WorkloadCeilingInvocationRecord[] = [];
+  for (const record of records) {
+    const existing = await options.readExisting(record);
+    if (isFinishedCollection(existing)) {
+      results.set(record.run_id, {
+        record,
+        success: true,
+        event: existing,
+        attempts: 0,
+        newlyResolved: false,
+        previouslySeen: true,
+      });
+      continue;
+    }
+    if (existing !== undefined) {
+      // Present but unfinished. Seeded into `results` rather than only into
+      // `pending`, so the collection below can see the prior unresolved state
+      // and report `newly_resolved` — the recovery-on-re-run case the flag
+      // exists for. The entry is overwritten by that pass; it is a baseline,
+      // not a result.
+      results.set(record.run_id, {
+        record,
+        success: false,
+        event: existing,
+        attempts: 0,
+        newlyResolved: false,
+        previouslySeen: true,
+      });
+    }
+    pending.push(record);
+  }
+
+  let pass = 0;
+  while (true) {
+    if (pass > 0) {
+      await options.sleep(options.retryDelayMs);
+    }
+    const stillPending: WorkloadCeilingInvocationRecord[] = [];
+    for (const record of pending) {
+      const existing = results.get(record.run_id);
+      const collected = await options.collect(record);
+      const success = collected !== undefined;
+      const entry = {
+        record,
+        success,
+        error: success ? undefined : "collector failed",
+        event: collected,
+        attempts: (existing?.attempts ?? 0) + 1,
+        newlyResolved:
+          existing !== undefined &&
+          existing.event !== undefined &&
+          existing.event.evidence.status !== "resolved" &&
+          collected !== undefined &&
+          collected.evidence.status === "resolved",
+        previouslySeen: false,
+      };
+      results.set(record.run_id, entry);
+      if (!isFinishedCollection(collected)) {
+        stillPending.push(record);
+      }
+    }
+    pending = stillPending;
+    pass += 1;
+    if (pending.length === 0 || pass > options.retries) {
+      break;
+    }
+  }
+
+  return records.map((record) => outcomeOf(record.run_id)!).filter((o) => o !== undefined);
+};
+
+/**
+ * Pure. Output directory for one arm's collected events —
+ * `<resultsDir>/<sweepId>/<implementation>/`, matching the layout
+ * `workload-ceiling-aggregate.ts` reads (ticket 5's spec). The sweep-scoped
+ * subdirectory is load-bearing: collected events carry no `sweep_id` field,
+ * so directory scope is the only thing keeping sweeps separable.
+ */
+export const armOutputDir = (resultsDir: string, sweepId: string, implementation: string): string =>
+  resolve(resultsDir, sweepId, implementation);
+
+/**
+ * Runs batch collection for one implementation arm.
+ */
+async function collectArm(
+  records: readonly WorkloadCeilingInvocationRecord[],
+  compatibilityDate: string,
+  resultsDir: string,
+  sweepId: string,
+  implementation: string,
+): Promise<readonly CollectionOutcome[]> {
+  const armDir = armOutputDir(resultsDir, sweepId, implementation);
+  await mkdir(armDir, { recursive: true });
+
+  const nonWarmupRecords = records.filter((r) => !r.warmup);
+  console.log(`Collecting ${nonWarmupRecords.length} non-warmup entries for ${implementation}`);
+
+  const telemetry = WORKLOAD_CEILING_STUDY.capture.telemetry;
+  const outcomes = await collectWithRetry(nonWarmupRecords, {
+    retries: telemetry.collection_retries,
+    retryDelayMs: telemetry.collection_retry_delay_seconds * 1000,
+    readExisting: (record) => readCollectedEvent(armDir, record.run_id),
+    collect: async (record) => {
+      console.log(`  [${record.scenario_id} / ${record.run_id}]`);
+      const existing = await readCollectedEvent(armDir, record.run_id);
+      if (existing !== undefined) {
+        console.log(`    Re-collecting: previous pass was ${existing.evidence.status}`);
+      }
+      const result = await spawnCollector(record, compatibilityDate, armDir);
+      if (!result.success) {
+        console.log(`    Failed: ${result.error ?? "unknown error"}`);
+        return undefined;
+      }
+      const collected = await readCollectedEvent(armDir, record.run_id);
+      if (collected === undefined) {
+        console.log(`    Collected: UNREADABLE event`);
+      } else if (collected.evidence.status === "resolved") {
+        console.log(
+          existing === undefined
+            ? `    Collected: resolved (outcome=${String(collected.outcome)})`
+            : `    Collected: NEWLY RESOLVED`,
+        );
+      } else {
+        console.log(
+          `    Collected: ${collected.evidence.status.toUpperCase()} — ${collected.evidence.detail}`,
+        );
+      }
+      return collected;
+    },
+    sleep: async (ms) => {
+      console.log(
+        `Waiting ${Math.round(ms / 1000)}s before the one collection-only retry pass ` +
+          `(preregistered delay; re-queries unresolved windows, never re-invokes)...`,
+      );
+      await new Promise((r) => setTimeout(r, ms));
+    },
+  });
+
+  return outcomes;
+}
+
+/**
+ * Writes the batch collection summary to disk.
+ */
+async function writeSummary(
+  resultsDir: string,
+  sweepId: string,
+  summary: BatchCollectionSummary,
+): Promise<void> {
+  const summaryPath = resolve(resultsDir, `summary-${sweepId}.json`);
+  await writeFile(summaryPath, JSON.stringify(summary, null, 2));
+  console.log(`Wrote summary to ${summaryPath}`);
+}
+
+async function main(): Promise<number> {
+  // Validate required env vars
+  for (const name of REQUIRED_ENV) {
+    if (process.env[name] === undefined) {
+      console.error(`Missing required environment variable: ${name}`);
+      return 1;
+    }
+  }
+
+  const sweepId = process.env["WORKLOAD_CEILING_SWEEP_ID"]!;
+  const compatibilityDate = process.env["WORKLOAD_CEILING_COMPATIBILITY_DATE"]!;
+  const resultsDir = process.env["WORKLOAD_CEILING_RESULTS_DIR"] ?? DEFAULT_RESULTS_DIR;
+
+  console.log(`Batch collection for sweep ${sweepId}`);
+  console.log(`Results directory: ${resultsDir}`);
+  console.log();
+
+  // Load the journal
+  const records = await loadJournal(resultsDir, sweepId);
+  console.log(`Loaded ${records.length} journal entries`);
+  console.log();
+
+  // Group by implementation
+  const groups = groupByImplementation(records);
+
+  const allOutcomes: CollectionOutcome[] = [];
+  let totalSkipped = 0; // warmup entries
+  let totalSucceeded = 0;
+  let totalFailed = 0;
+  let totalEvidenceResolved = 0;
+  let totalEvidenceMissing = 0;
+  let totalEvidenceAmbiguous = 0;
+  let totalCpuResolved = 0;
+  let totalCpuMissing = 0;
+  let totalNewlyResolved = 0;
+
+  // Collect each arm
+  for (const [implementation, implRecords] of groups.entries()) {
+    const outcomes = await collectArm(
+      implRecords,
+      compatibilityDate,
+      resultsDir,
+      sweepId,
+      implementation,
+    );
+    allOutcomes.push(...outcomes);
+
+    for (const outcome of outcomes) {
+      if (outcome.success) {
+        totalSucceeded++;
+      } else {
+        totalFailed++;
+      }
+      if (outcome.evidence_status === "resolved") {
+        totalEvidenceResolved++;
+        if (outcome.newly_resolved === true) {
+          totalNewlyResolved++;
+        }
+      } else if (outcome.evidence_status === "missing") {
+        totalEvidenceMissing++;
+      } else if (outcome.evidence_status === "ambiguous") {
+        totalEvidenceAmbiguous++;
+      }
+      if (outcome.cpu_resolved) {
+        totalCpuResolved++;
+      } else {
+        totalCpuMissing++;
+      }
+    }
+  }
+
+  // Count warmup entries (they weren't collected)
+  totalSkipped = records.filter((r) => r.warmup).length;
+
+  // Write summary
+  const summary: BatchCollectionSummary = {
+    sweep_id: sweepId,
+    total: records.length,
+    skipped: totalSkipped,
+    succeeded: totalSucceeded,
+    failed: totalFailed,
+    evidence_resolved: totalEvidenceResolved,
+    evidence_missing: totalEvidenceMissing,
+    evidence_ambiguous: totalEvidenceAmbiguous,
+    cpu_resolved: totalCpuResolved,
+    cpu_missing: totalCpuMissing,
+    newly_resolved: totalNewlyResolved,
+    outcomes: allOutcomes,
+  };
+  await writeSummary(resultsDir, sweepId, summary);
+
+  // Print final status
+  console.log();
+  console.log(`Batch collection complete:`);
+  console.log(`  Total journal entries: ${summary.total}`);
+  console.log(`  Skipped (warmup): ${summary.skipped}`);
+  console.log(`  Collector succeeded / failed: ${summary.succeeded} / ${summary.failed}`);
+  console.log(
+    `  Evidence resolved: ${summary.evidence_resolved}` +
+      `${summary.newly_resolved > 0 ? ` (${summary.newly_resolved} newly resolved this run)` : ""}`,
+  );
+  console.log(
+    `  Evidence missing: ${summary.evidence_missing}, ambiguous: ${summary.evidence_ambiguous}`,
+  );
+  console.log(`  CPU resolved: ${summary.cpu_resolved}, CPU missing: ${summary.cpu_missing}`);
+
+  if (summary.evidence_missing > 0 || summary.evidence_ambiguous > 0) {
+    console.log();
+    console.log(`Unresolved evidence — the invocation happened (the journal says so) but the`);
+    console.log(`authoritative record did not resolve. The preregistered collection retry has`);
+    console.log(`already run; there is no further sanctioned pass. These runs stay in the`);
+    console.log(`record and BLOCK the capture's evidence completeness. Do NOT re-invoke, and`);
+    console.log(`do NOT top up — additional attempts may only be planned before a capture,`);
+    console.log(`never selected after observing missingness.`);
+    for (const outcome of summary.outcomes) {
+      if (outcome.evidence_status === "missing" || outcome.evidence_status === "ambiguous") {
+        console.log(
+          `  ${outcome.scenario_id} / ${outcome.implementation} / ${outcome.run_id}: ${outcome.evidence_status}`,
+        );
+      }
+    }
+  }
+
+  if (summary.cpu_missing > 0) {
+    console.log();
+    console.log(`CPU-missing runs — the invocation succeeded but workersInvocationsAdaptive`);
+    console.log(`never produced an attributable row. These are NOT execution failures; they`);
+    console.log(`leave their cells short of the CPU sample floor, which blocks admission.`);
+    for (const outcome of summary.outcomes) {
+      if (!outcome.cpu_resolved) {
+        console.log(
+          `  ${outcome.scenario_id} / ${outcome.implementation} / ${outcome.run_id}: outcome=${String(outcome.outcome)}`,
+        );
+      }
+    }
+  }
+
+  if (summary.failed > 0) {
+    console.log();
+    console.log(`Failed runs (collector errors):`);
+    for (const outcome of summary.outcomes) {
+      if (!outcome.success) {
+        console.log(
+          `  ${outcome.scenario_id} / ${outcome.implementation} / ${outcome.run_id}: ${outcome.error ?? "unknown"}`,
+        );
+      }
+    }
+    console.log();
+    console.log(`Re-run collect-batch to retry failed collections.`);
+    return 1;
+  }
+
+  return 0;
+}
+
+await runAsCliEntrypoint(import.meta.url, main);

--- a/bench/measurement/workload-ceiling-compare.test.ts
+++ b/bench/measurement/workload-ceiling-compare.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from "vitest";
 import { clopperPearsonZeroFailureUpper } from "./statistics.ts";
+import { planCaptureInvocations } from "./workload-ceiling-capture.ts";
+import { byteAxisCells } from "./workload-ceiling-cells.ts";
+import { WORKLOAD_CEILING_STUDY } from "./workload-ceiling-contract.ts";
 import {
   WORKLOAD_CEILING_EVIDENCE_CONTRACT_ID,
   WorkloadCeilingHarnessError,
   type WorkloadCeilingRawEvent,
+  type WorkloadCeilingSweepCell,
 } from "./workload-ceiling-harness.ts";
 import {
   assessWorkloadCeilingExecution,
@@ -152,6 +156,60 @@ describe("matchWorkloadCeilingEvents", () => {
     expect(matched.pairs).toHaveLength(1);
     expect(matched.pairs[0]!.control.sample_count).toBe(3);
     expect(matched.pairs[0]!.control.p50.value).toBe(2);
+  });
+
+  test("the planned capture matrix pairs every cell", () => {
+    // Drives the REAL planner rather than a hand-built event list, so the
+    // pairing logic and the capture runner cannot drift apart on cardinality
+    // again. Every planned measured invocation becomes one collected event.
+    const cells: WorkloadCeilingSweepCell[] = byteAxisCells().map((cell) => ({
+      scenario_id: cell.scenario_id,
+      axis: cell.axis,
+      target_bytes: cell.target,
+      achieved_bytes: cell.target,
+      row_count: 1,
+      document_bytes: cell.document_bytes,
+      manifest_descriptors: cell.manifest_descriptors,
+      fixture_prefix: `fixtures/${cell.scenario_id}`,
+      incarnation: "incarnation",
+      monolithic_key: "monolithic",
+      manifest_key: "manifest",
+      descriptor_canonical_hash: "hash",
+    }));
+    const planned = planCaptureInvocations({
+      cells,
+      arms: ["monolithic-control", "chunked-candidate"],
+      warmup: WORKLOAD_CEILING_STUDY.capture.warmup_invocations_per_cell,
+      measured: WORKLOAD_CEILING_STUDY.capture.planned_measured_invocations_per_cell,
+    }).filter((invocation) => !invocation.warmup);
+    // Pins the fixture itself: a planner that returned nothing would make
+    // every assertion below vacuously true.
+    expect(planned).toHaveLength(
+      cells.length * 2 * WORKLOAD_CEILING_STUDY.capture.planned_measured_invocations_per_cell,
+    );
+
+    const asEvents = (arm: string): WorkloadCeilingRawEvent[] =>
+      planned
+        .filter((invocation) => invocation.implementation === arm)
+        .map((invocation, index) =>
+          event({
+            run_id: `${arm}-${String(index)}`,
+            scenario_id: invocation.scenario_id,
+            cpu_ms: 10 + index,
+          }),
+        );
+
+    const matched = matchWorkloadCeilingEvents(
+      asEvents("monolithic-control"),
+      asEvents("chunked-candidate"),
+    );
+    expect(matched.incomplete).toEqual([]);
+    expect(matched.pairs).toHaveLength(cells.length);
+    for (const pair of matched.pairs) {
+      expect(pair.control.sample_count).toBe(
+        WORKLOAD_CEILING_STUDY.capture.planned_measured_invocations_per_cell,
+      );
+    }
   });
 
   test("a side whose own events name two deployments is reported as a mid-capture redeploy", () => {

--- a/bench/measurement/workload-ceiling-harness.test.ts
+++ b/bench/measurement/workload-ceiling-harness.test.ts
@@ -1,15 +1,21 @@
 import { describe, expect, test } from "vitest";
 import {
+  decodeWorkloadCeilingInvocationRecord,
   decodeWorkloadCeilingRawEvent,
   decodeWorkloadCeilingRunRequest,
+  decodeWorkloadCeilingSweepReport,
+  encodeWorkloadCeilingInvocationRecord,
   encodeWorkloadCeilingRawEvent,
   encodeWorkloadCeilingRunRequest,
+  encodeWorkloadCeilingSweepReport,
   unresolvedWorkloadCeilingRawEvent,
   WORKLOAD_CEILING_CONTRACT_ID,
   WORKLOAD_CEILING_EVIDENCE_CONTRACT_ID,
   WORKLOAD_CEILING_OUTCOME_CANONICALIZATIONS,
+  type WorkloadCeilingInvocationRecord,
   type WorkloadCeilingRawEvent,
   type WorkloadCeilingRunRequest,
+  type WorkloadCeilingSweepReport,
 } from "./workload-ceiling-harness.ts";
 
 const VALID_REQUEST: WorkloadCeilingRunRequest = {
@@ -346,6 +352,178 @@ describe("WorkloadCeilingRawEvent codec", () => {
   test("rejects a malformed observed_at timestamp", () => {
     const bad = JSON.stringify({ ...VALID_OK_EVENT, observed_at: "not-a-timestamp" });
     expect(() => decodeWorkloadCeilingRawEvent(bad)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+});
+
+describe("WorkloadCeilingSweepReport codec", () => {
+  const VALID_REPORT: WorkloadCeilingSweepReport = {
+    contract_id: WORKLOAD_CEILING_CONTRACT_ID,
+    sweep_id: "sweep-001",
+    collection: "items",
+    cells: [
+      {
+        scenario_id: "byte-axis/512KiB",
+        axis: "byte",
+        target_bytes: 524288,
+        achieved_bytes: 524256,
+        row_count: 245,
+        document_bytes: 2048,
+        manifest_descriptors: 8,
+        fixture_prefix: "tenants/workload-ceiling-study/collections/sweep-001/512KiB",
+        incarnation: "ab".repeat(16),
+        monolithic_key:
+          "tenants/workload-ceiling-study/collections/sweep-001/512KiB/monolithic.json",
+        manifest_key:
+          "tenants/workload-ceiling-study/collections/sweep-001/512KiB/snapshot-manifest-abcdef1234567890.json",
+        descriptor_canonical_hash: "a".repeat(64),
+      },
+    ],
+    cleanup: [
+      {
+        scenario_id: "byte-axis/512KiB",
+        fixture_prefix: "tenants/workload-ceiling-study/collections/sweep-001/512KiB",
+        written_keys: [
+          "tenants/workload-ceiling-study/collections/sweep-001/512KiB/monolithic.json",
+          "tenants/workload-ceiling-study/collections/sweep-001/512KiB/snapshot-manifest-abcdef1234567890.json",
+        ],
+        cleanup_authority: { type: "exact-key", keys: [] },
+      },
+    ],
+  };
+
+  test("round-trips a valid report through canonical serialization", () => {
+    const encoded = encodeWorkloadCeilingSweepReport(VALID_REPORT);
+    const decoded = decodeWorkloadCeilingSweepReport(encoded);
+    expect(decoded).toEqual(VALID_REPORT);
+  });
+
+  test("rejects a body with an unknown field", () => {
+    const withExtra = JSON.stringify({ ...VALID_REPORT, extra_field: "nope" });
+    expect(() => decodeWorkloadCeilingSweepReport(withExtra)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+
+  test("rejects a body missing a required field", () => {
+    const { cells: _drop, ...rest } = VALID_REPORT;
+    const missing = JSON.stringify(rest);
+    expect(() => decodeWorkloadCeilingSweepReport(missing)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+
+  test("rejects an invalid axis value", () => {
+    const badCell = JSON.stringify({
+      ...VALID_REPORT,
+      cells: [{ ...VALID_REPORT.cells[0]!, axis: "hybrid" as const }],
+    });
+    expect(() => decodeWorkloadCeilingSweepReport(badCell)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+
+  test("rejects non-canonical JSON bytes (whitespace) even when the parsed value is valid", () => {
+    const encoded = encodeWorkloadCeilingSweepReport(VALID_REPORT);
+    const withWhitespace = `${encoded} `;
+    expect(() => decodeWorkloadCeilingSweepReport(withWhitespace)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+});
+
+const INVOCATION_RECORD_REQUIRED_FIELDS = [
+  "contract_id",
+  "sweep_id",
+  "run_id",
+  "scenario_id",
+  "implementation",
+  "fixture_prefix",
+  "warmup",
+  "invoked_at",
+  "window_gte",
+  "window_lt",
+  "http_status",
+  "row_count",
+  "thermal_class",
+] as const;
+
+describe("WorkloadCeilingInvocationRecord codec", () => {
+  const VALID_RECORD: WorkloadCeilingInvocationRecord = {
+    contract_id: WORKLOAD_CEILING_CONTRACT_ID,
+    sweep_id: "sweep-001",
+    run_id: "0a5c6f8e-6f2a-4a1e-9f0a-2c3d4e5f6a7b",
+    scenario_id: "byte-axis/512KiB",
+    implementation: "monolithic-control",
+    fixture_prefix: "tenants/workload-ceiling-study/collections/sweep-001/512KiB",
+    warmup: false,
+    invoked_at: "2026-08-20T00:00:07.412Z",
+    window_gte: "2026-08-20T00:00:00Z",
+    window_lt: "2026-08-20T00:01:00Z",
+    http_status: 200,
+    row_count: 253,
+    thermal_class: "warm",
+  };
+
+  const rejects = (mutation: Record<string, unknown>): void => {
+    expect(() =>
+      decodeWorkloadCeilingInvocationRecord(JSON.stringify({ ...VALID_RECORD, ...mutation })),
+    ).toThrowError(expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }));
+  };
+
+  test("round-trips a valid record through canonical serialization", () => {
+    const encoded = encodeWorkloadCeilingInvocationRecord(VALID_RECORD);
+    expect(decodeWorkloadCeilingInvocationRecord(encoded)).toEqual(VALID_RECORD);
+  });
+
+  test("the encoded record is one line, since the journal is JSONL", () => {
+    expect(encodeWorkloadCeilingInvocationRecord(VALID_RECORD)).not.toContain("\n");
+  });
+
+  test.each([
+    ["an unknown field", { extra_field: "nope" }],
+    ["a foreign contract_id", { contract_id: "baerly.workload-ceiling/other/v1" }],
+    ["an unknown implementation", { implementation: "chunked-control" }],
+    ["an unknown thermal_class", { thermal_class: "tepid" }],
+    ["a non-boolean warmup", { warmup: "false" }],
+    ["a blank sweep_id", { sweep_id: "" }],
+    ["a blank run_id", { run_id: "" }],
+    ["a local-time invoked_at", { invoked_at: "2026-08-20T00:00:07" }],
+    ["a non-RFC-3339 window_gte", { window_gte: "2026-08-20 00:00:00Z" }],
+    ["an out-of-range http_status", { http_status: 99 }],
+    ["a non-integer http_status", { http_status: 200.5 }],
+    ["a negative row_count", { row_count: -1 }],
+    ["a fractional row_count", { row_count: 1.5 }],
+  ])("rejects %s", (_label, mutation) => {
+    rejects(mutation);
+  });
+
+  test.each(INVOCATION_RECORD_REQUIRED_FIELDS)("rejects a record missing %s", (field) => {
+    const { [field]: _omitted, ...rest } = VALID_RECORD;
+    expect(() => decodeWorkloadCeilingInvocationRecord(JSON.stringify(rest))).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+
+  test("rejects non-canonical JSON bytes even when the parsed value is valid", () => {
+    // The journal is compared line-for-line across tools; a record that parses
+    // but does not round-trip byte-for-byte would let two writers disagree
+    // about the same invocation.
+    const encoded = encodeWorkloadCeilingInvocationRecord(VALID_RECORD);
+    expect(() => decodeWorkloadCeilingInvocationRecord(`${encoded} `)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+    const reordered = JSON.stringify(Object.fromEntries(Object.entries(VALID_RECORD).toReversed()));
+    expect(reordered).not.toBe(encoded);
+    expect(() => decodeWorkloadCeilingInvocationRecord(reordered)).toThrowError(
+      expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
+    );
+  });
+
+  test("encode rejects a record carrying a field outside the exact set", () => {
+    const withExtra = { ...VALID_RECORD, colo: "SJC" } as WorkloadCeilingInvocationRecord;
+    expect(() => encodeWorkloadCeilingInvocationRecord(withExtra)).toThrowError(
       expect.objectContaining({ code: "WorkloadCeilingHarnessInvalid" }),
     );
   });

--- a/bench/measurement/workload-ceiling-harness.ts
+++ b/bench/measurement/workload-ceiling-harness.ts
@@ -115,8 +115,26 @@ export interface WorkloadCeilingEvidenceBlock {
  */
 export const WORKLOAD_CEILING_BUCKET_NAME = "baerly-storage-eval" as const;
 
+/**
+ * The arms one deployed script serves, selected per request.
+ *
+ * `monolithic-control` and `chunked-candidate` are the two SUBJECTS the study
+ * compares. `monolithic-control-unhashed` is neither: it is a measurement-only
+ * probe that reads the identical bytes at the identical key as
+ * `monolithic-control` and differs by exactly one operation — the SHA-256
+ * digest verification `loadSnapshotAsMap` performs before parsing. Its only
+ * purpose is to make the control's hash cost a difference of two
+ * platform-reported CPU numbers, because a Worker may not time itself
+ * (`bench/workload-ceiling-worker/README.md` §"Why CPU is never
+ * self-reported").
+ *
+ * It must never be handed to `workload-ceiling-compare.ts` as a side. It is
+ * not a candidate, it is not a control, and pairing it against either would
+ * report a format comparison that was really a hash measurement.
+ */
 export const WORKLOAD_CEILING_IMPLEMENTATIONS = [
   "monolithic-control",
+  "monolithic-control-unhashed",
   "chunked-candidate",
 ] as const;
 export type WorkloadCeilingImplementation = (typeof WORKLOAD_CEILING_IMPLEMENTATIONS)[number];

--- a/bench/measurement/workload-ceiling-harness.ts
+++ b/bench/measurement/workload-ceiling-harness.ts
@@ -30,6 +30,7 @@
  * behavior and it is not reachable from `packages/server/src/index.ts`.
  */
 import { canonicalJson, type CanonicalJsonValue } from "./canonical-json.ts";
+import { WORKLOAD_CEILING_STUDY } from "./workload-ceiling-contract.ts";
 
 export const WORKLOAD_CEILING_CONTRACT_ID = "baerly.workload-ceiling/chunked-snapshot/v1" as const;
 
@@ -722,3 +723,383 @@ export const unresolvedWorkloadCeilingRawEvent = (input: {
       cpu_outcome_verbatim: null,
     },
   });
+
+/** Sweep report codec for ticket 2: byte-axis cell catalog and calibrated sweep provisioning. */
+
+export interface WorkloadCeilingSweepCell {
+  readonly scenario_id: string;
+  readonly axis: "byte" | "row";
+  readonly target_bytes: number;
+  readonly achieved_bytes: number;
+  readonly row_count: number;
+  readonly document_bytes: number;
+  readonly manifest_descriptors: number;
+  readonly fixture_prefix: string;
+  readonly incarnation: string;
+  readonly monolithic_key: string;
+  readonly manifest_key: string;
+  readonly descriptor_canonical_hash: string;
+}
+
+export interface WorkloadCeilingSweepCleanup {
+  readonly scenario_id: string;
+  readonly fixture_prefix: string;
+  readonly written_keys: readonly string[];
+  readonly cleanup_authority: unknown;
+}
+
+export interface WorkloadCeilingSweepReport {
+  readonly contract_id: typeof WORKLOAD_CEILING_CONTRACT_ID;
+  readonly sweep_id: string;
+  readonly collection: string;
+  readonly cells: readonly WorkloadCeilingSweepCell[];
+  readonly cleanup: readonly WorkloadCeilingSweepCleanup[];
+}
+
+const SWEEP_CELL_FIELDS = [
+  "scenario_id",
+  "axis",
+  "target_bytes",
+  "achieved_bytes",
+  "row_count",
+  "document_bytes",
+  "manifest_descriptors",
+  "fixture_prefix",
+  "incarnation",
+  "monolithic_key",
+  "manifest_key",
+  "descriptor_canonical_hash",
+] as const;
+
+const SWEEP_CLEANUP_FIELDS = [
+  "scenario_id",
+  "fixture_prefix",
+  "written_keys",
+  "cleanup_authority",
+] as const;
+
+const SWEEP_REPORT_FIELDS = ["contract_id", "sweep_id", "collection", "cells", "cleanup"] as const;
+
+function canonicalizeSweepCell(value: unknown): WorkloadCeilingSweepCell {
+  assertExactFields(value, SWEEP_CELL_FIELDS, "sweep cell");
+  assertNonEmptyString(value["scenario_id"], "scenario_id");
+  const axis = value["axis"];
+  if (axis !== "byte" && axis !== "row") {
+    invalid("axis", `must be "byte" or "row"; got ${String(axis)}`);
+  }
+  const targetBytes = value["target_bytes"];
+  if (typeof targetBytes !== "number" || !Number.isSafeInteger(targetBytes) || targetBytes < 1) {
+    invalid("target_bytes", "must be a positive safe integer");
+  }
+  const achievedBytes = value["achieved_bytes"];
+  if (
+    typeof achievedBytes !== "number" ||
+    !Number.isSafeInteger(achievedBytes) ||
+    achievedBytes < 1
+  ) {
+    invalid("achieved_bytes", "must be a positive safe integer");
+  }
+  const rowCount = value["row_count"];
+  if (typeof rowCount !== "number" || !Number.isSafeInteger(rowCount) || rowCount < 1) {
+    invalid("row_count", "must be a positive safe integer");
+  }
+  const documentBytes = value["document_bytes"];
+  if (
+    typeof documentBytes !== "number" ||
+    !Number.isSafeInteger(documentBytes) ||
+    documentBytes < 32
+  ) {
+    invalid("document_bytes", "must be a safe integer >= 32");
+  }
+  const manifestDescriptors = value["manifest_descriptors"];
+  if (
+    typeof manifestDescriptors !== "number" ||
+    !Number.isSafeInteger(manifestDescriptors) ||
+    manifestDescriptors < 1
+  ) {
+    invalid("manifest_descriptors", "must be a positive safe integer");
+  }
+  assertNonEmptyString(value["fixture_prefix"], "fixture_prefix");
+  assertNonEmptyString(value["incarnation"], "incarnation");
+  assertNonEmptyString(value["monolithic_key"], "monolithic_key");
+  assertNonEmptyString(value["manifest_key"], "manifest_key");
+  assertNonEmptyString(value["descriptor_canonical_hash"], "descriptor_canonical_hash");
+  return {
+    scenario_id: value["scenario_id"],
+    axis,
+    target_bytes: targetBytes,
+    achieved_bytes: achievedBytes,
+    row_count: rowCount,
+    document_bytes: documentBytes,
+    manifest_descriptors: manifestDescriptors,
+    fixture_prefix: value["fixture_prefix"],
+    incarnation: value["incarnation"],
+    monolithic_key: value["monolithic_key"],
+    manifest_key: value["manifest_key"],
+    descriptor_canonical_hash: value["descriptor_canonical_hash"],
+  };
+}
+
+function canonicalizeSweepCleanup(value: unknown): WorkloadCeilingSweepCleanup {
+  assertExactFields(value, SWEEP_CLEANUP_FIELDS, "sweep cleanup");
+  assertNonEmptyString(value["scenario_id"], "scenario_id");
+  assertNonEmptyString(value["fixture_prefix"], "fixture_prefix");
+  const writtenKeys = value["written_keys"];
+  if (!Array.isArray(writtenKeys)) {
+    invalid("written_keys", "must be an array");
+  }
+  for (const key of writtenKeys) {
+    assertNonEmptyString(key, "written_keys entry");
+  }
+  return {
+    scenario_id: value["scenario_id"],
+    fixture_prefix: value["fixture_prefix"],
+    written_keys: writtenKeys as readonly string[],
+    cleanup_authority: value["cleanup_authority"],
+  };
+}
+
+function canonicalizeSweepReport(value: unknown): WorkloadCeilingSweepReport {
+  assertExactFields(value, SWEEP_REPORT_FIELDS, "sweep report");
+  if (value["contract_id"] !== WORKLOAD_CEILING_CONTRACT_ID) {
+    invalid("contract_id", `must be ${WORKLOAD_CEILING_CONTRACT_ID}`);
+  }
+  assertNonEmptyString(value["sweep_id"], "sweep_id");
+  assertNonEmptyString(value["collection"], "collection");
+  const cells = value["cells"];
+  if (!Array.isArray(cells)) {
+    invalid("cells", "must be an array");
+  }
+  const canonicalCells = cells.map(canonicalizeSweepCell);
+  const cleanup = value["cleanup"];
+  if (!Array.isArray(cleanup)) {
+    invalid("cleanup", "must be an array");
+  }
+  const canonicalCleanup = cleanup.map(canonicalizeSweepCleanup);
+  return {
+    contract_id: WORKLOAD_CEILING_CONTRACT_ID,
+    sweep_id: value["sweep_id"],
+    collection: value["collection"],
+    cells: canonicalCells,
+    cleanup: canonicalCleanup,
+  };
+}
+
+/** Canonical-JSON-serializes a validated sweep report. Rejects a field outside the exact set. */
+export const encodeWorkloadCeilingSweepReport = (report: WorkloadCeilingSweepReport): string => {
+  const canonical = canonicalizeSweepReport(report);
+  return toCanonicalJson(canonical as unknown as CanonicalJsonValue, "sweep report");
+};
+
+/** Decodes and validates a `WorkloadCeilingSweepReport`. Enforces canonical bytes. */
+export const decodeWorkloadCeilingSweepReport = (raw: string): WorkloadCeilingSweepReport => {
+  const parsed = parseJson(raw, "sweep report body");
+  const canonical = canonicalizeSweepReport(parsed);
+  const canonicalRaw = toCanonicalJson(canonical as unknown as CanonicalJsonValue, "sweep report");
+  if (canonicalRaw !== raw) {
+    invalid("sweep report body", "is not canonical JSON");
+  }
+  return canonical;
+};
+
+/**
+ * Journal codec for ticket 4: unattended capture runner and batch collector.
+ */
+
+/**
+ * One invocation the capture runner performed. Written to a JSONL journal
+ * BEFORE the next invocation starts, so a crashed or killed run leaves an
+ * exact, replayable record of everything it did.
+ *
+ * This is the join between the invoke phase and the collect phase: the collect
+ * phase performs no invocation and derives its collection window from
+ * `window_gte` / `window_lt` here, never from a clock of its own. That is what
+ * makes collection re-runnable — a second collect pass over the same journal
+ * asks the platform the identical question.
+ *
+ * `warmup: true` records an invocation excluded BEFORE it ran, per
+ * `WORKLOAD_CEILING_STUDY.capture.exclusion_policy`. It stays in the journal;
+ * exclusion is a tag, not a deletion.
+ *
+ * There is deliberately no field for the shared secret, and none for anything
+ * derived from it.
+ */
+export interface WorkloadCeilingInvocationRecord {
+  readonly contract_id: typeof WORKLOAD_CEILING_CONTRACT_ID;
+  readonly sweep_id: string;
+  readonly run_id: string;
+  readonly scenario_id: string;
+  readonly implementation: WorkloadCeilingImplementation;
+  readonly fixture_prefix: string;
+  readonly warmup: boolean;
+  readonly invoked_at: string;
+  readonly window_gte: string;
+  readonly window_lt: string;
+  readonly http_status: number;
+  /** The Worker's own reported row count — a cheap check that the fold ran over the expected fixture. */
+  readonly row_count: number;
+  readonly thermal_class: WorkloadCeilingThermalClass;
+}
+
+const INVOCATION_RECORD_FIELDS = [
+  "contract_id",
+  "sweep_id",
+  "run_id",
+  "scenario_id",
+  "implementation",
+  "fixture_prefix",
+  "warmup",
+  "invoked_at",
+  "window_gte",
+  "window_lt",
+  "http_status",
+  "row_count",
+  "thermal_class",
+] as const;
+
+function assertIsoTimestamp(value: unknown, field: string): asserts value is string {
+  assertNonEmptyString(value, field);
+  if (!OBSERVED_AT_PATTERN.test(value)) {
+    invalid(field, "must be an RFC 3339 UTC timestamp (YYYY-MM-DDTHH:mm:ss[.sss]Z)");
+  }
+}
+
+function canonicalizeInvocationRecord(value: unknown): WorkloadCeilingInvocationRecord {
+  assertExactFields(value, INVOCATION_RECORD_FIELDS, "invocation record");
+  if (value["contract_id"] !== WORKLOAD_CEILING_CONTRACT_ID) {
+    invalid("contract_id", `must be ${WORKLOAD_CEILING_CONTRACT_ID}`);
+  }
+  assertNonEmptyString(value["sweep_id"], "sweep_id");
+  assertNonEmptyString(value["run_id"], "run_id");
+  assertNonEmptyString(value["scenario_id"], "scenario_id");
+  const implementation = value["implementation"];
+  if (!(WORKLOAD_CEILING_IMPLEMENTATIONS as readonly unknown[]).includes(implementation)) {
+    invalid(
+      "implementation",
+      `must be one of ${WORKLOAD_CEILING_IMPLEMENTATIONS.join(", ")}; got ${String(implementation)}`,
+    );
+  }
+  assertNonEmptyString(value["fixture_prefix"], "fixture_prefix");
+  const warmup = value["warmup"];
+  if (typeof warmup !== "boolean") {
+    invalid("warmup", "must be a boolean");
+  }
+  assertIsoTimestamp(value["invoked_at"], "invoked_at");
+  assertIsoTimestamp(value["window_gte"], "window_gte");
+  assertIsoTimestamp(value["window_lt"], "window_lt");
+  const httpStatus = value["http_status"];
+  if (
+    typeof httpStatus !== "number" ||
+    !Number.isInteger(httpStatus) ||
+    httpStatus < 100 ||
+    httpStatus > 599
+  ) {
+    invalid("http_status", "must be an integer HTTP status code (100-599)");
+  }
+  const rowCount = value["row_count"];
+  if (typeof rowCount !== "number" || !Number.isSafeInteger(rowCount) || rowCount < 0) {
+    invalid("row_count", "must be a non-negative safe integer");
+  }
+  const thermalClass = value["thermal_class"];
+  if (!(WORKLOAD_CEILING_THERMAL_CLASSES as readonly unknown[]).includes(thermalClass)) {
+    invalid(
+      "thermal_class",
+      `must be one of ${WORKLOAD_CEILING_THERMAL_CLASSES.join(", ")}; got ${String(thermalClass)}`,
+    );
+  }
+  return {
+    contract_id: WORKLOAD_CEILING_CONTRACT_ID,
+    sweep_id: value["sweep_id"],
+    run_id: value["run_id"],
+    scenario_id: value["scenario_id"],
+    implementation: implementation as WorkloadCeilingImplementation,
+    fixture_prefix: value["fixture_prefix"],
+    warmup,
+    invoked_at: value["invoked_at"],
+    window_gte: value["window_gte"],
+    window_lt: value["window_lt"],
+    http_status: httpStatus,
+    row_count: rowCount,
+    thermal_class: thermalClass as WorkloadCeilingThermalClass,
+  };
+}
+
+/** Canonical-JSON-serializes a validated invocation record. Rejects a field outside the exact set. */
+export const encodeWorkloadCeilingInvocationRecord = (
+  record: WorkloadCeilingInvocationRecord,
+): string => {
+  const canonical = canonicalizeInvocationRecord(record);
+  return toCanonicalJson(canonical as unknown as CanonicalJsonValue, "invocation record");
+};
+
+/**
+ * Decodes and validates a `WorkloadCeilingInvocationRecord` from a journal line.
+ * Enforces canonical bytes.
+ */
+export const decodeWorkloadCeilingInvocationRecord = (
+  raw: string,
+): WorkloadCeilingInvocationRecord => {
+  const parsed = parseJson(raw, "invocation record body");
+  const canonical = canonicalizeInvocationRecord(parsed);
+  const canonicalRaw = toCanonicalJson(
+    canonical as unknown as CanonicalJsonValue,
+    "invocation record",
+  );
+  if (canonicalRaw !== raw) {
+    invalid("invocation record body", "is not canonical JSON");
+  }
+  return canonical;
+};
+
+/**
+ * Pure. The earliest instant an invocation may start, given when the previous
+ * one started.
+ *
+ * Two constraints, both from `WORKLOAD_CEILING_STUDY.capture`:
+ *
+ *  - at least `invocation_spacing_seconds` after the previous start, so no two
+ *    invocations share a telemetry minute bucket (any two instants ≥ 60 s apart
+ *    are necessarily in different buckets; 70 is skew headroom);
+ *  - not within the last `MINUTE_TAIL_GUARD_SECONDS` of a minute, so the
+ *    invocation cannot straddle a boundary and land its telemetry row in the
+ *    NEXT bucket — which would put it outside the window the runner derives
+ *    from its own start instant.
+ */
+export const MINUTE_TAIL_GUARD_SECONDS = 10 as const;
+
+export const nextInvocationStart = (previousStart: Date | null, now: Date): Date => {
+  const spacingMs = WORKLOAD_CEILING_STUDY.capture.invocation_spacing_seconds * 1000;
+  let candidate: Date;
+  if (previousStart === null) {
+    candidate = new Date(now.getTime());
+  } else {
+    candidate = new Date(previousStart.getTime() + spacingMs);
+  }
+  if (candidate < now) {
+    candidate = new Date(now.getTime());
+  }
+  const seconds = candidate.getUTCSeconds();
+  if (seconds >= 60 - MINUTE_TAIL_GUARD_SECONDS) {
+    // Move to the start of the next minute
+    candidate.setUTCSeconds(0, 0);
+    candidate.setTime(candidate.getTime() + 60_000);
+  }
+  return candidate;
+};
+
+/**
+ * Pure. The collection window for an invocation that started at `start`:
+ * the whole minute containing it.
+ *
+ * Correct whether the platform's `datetime` dimension is the raw invocation
+ * instant or the minute-bucket start — see ticket 4's pre-research. A window
+ * bounded by the actual invocation instants is correct ONLY under the raw
+ * reading, and silently loses every row under the other.
+ */
+export const collectionWindowFor = (start: Date): { readonly gte: string; readonly lt: string } => {
+  const floor = new Date(Math.floor(start.getTime() / 60_000) * 60_000);
+  return {
+    gte: floor.toISOString(),
+    lt: new Date(floor.getTime() + 60_000).toISOString(),
+  };
+};

--- a/bench/measurement/workload-ceiling-provision-sweep.test.ts
+++ b/bench/measurement/workload-ceiling-provision-sweep.test.ts
@@ -1,0 +1,63 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  encodeWorkloadCeilingSweepReport,
+  WORKLOAD_CEILING_CONTRACT_ID,
+  type WorkloadCeilingSweepReport,
+} from "./workload-ceiling-harness.ts";
+import { loadFullReport } from "./workload-ceiling-provision-sweep.ts";
+
+const REPORT: WorkloadCeilingSweepReport = {
+  contract_id: WORKLOAD_CEILING_CONTRACT_ID,
+  sweep_id: "sweep-001",
+  collection: "items",
+  cells: [],
+  cleanup: [
+    {
+      scenario_id: "byte-axis/512KiB",
+      fixture_prefix: "tenants/study/collections/sweep-001/512KiB",
+      written_keys: ["tenants/study/collections/sweep-001/512KiB/monolithic.json"],
+      cleanup_authority: { type: "exact-key", keys: [] },
+    },
+  ],
+};
+
+const inTempDir = async (name: string): Promise<string> =>
+  join(await mkdtemp(join(tmpdir(), "workload-ceiling-sweep-")), name);
+
+describe("loadFullReport", () => {
+  test("absence is null, so the first run starts from an empty report", async () => {
+    await expect(loadFullReport(await inTempDir("report.json"))).resolves.toBeNull();
+  });
+
+  test("round-trips an existing report", async () => {
+    const path = await inTempDir("report.json");
+    await writeFile(path, encodeWorkloadCeilingSweepReport(REPORT));
+    await expect(loadFullReport(path)).resolves.toEqual(REPORT);
+  });
+
+  test("a report that does not decode refuses instead of reading as absent", async () => {
+    // The orphaned-storage guard. A caller reads null as "first run" and
+    // overwrites the path with a fresh empty report, which would discard the
+    // `cleanup` entries — the only record of the keys already written to the
+    // bucket. A partially written file from an interrupted run is exactly the
+    // case that produces it.
+    const path = await inTempDir("report.json");
+    await writeFile(path, encodeWorkloadCeilingSweepReport(REPORT).slice(0, 40));
+    await expect(loadFullReport(path)).rejects.toThrow(/exists but does not decode/);
+  });
+
+  test("a report that parses but is not canonical also refuses", async () => {
+    const path = await inTempDir("report.json");
+    await writeFile(path, `${encodeWorkloadCeilingSweepReport(REPORT)} `);
+    await expect(loadFullReport(path)).rejects.toThrow(/exists but does not decode/);
+  });
+
+  test("a read failure that is not absence refuses", async () => {
+    // A directory where a file is expected: EISDIR, not ENOENT. Absence has to
+    // be ENOENT alone or an unreadable report reads as a first run.
+    await expect(loadFullReport(tmpdir())).rejects.toThrow(/cannot read/);
+  });
+});

--- a/bench/measurement/workload-ceiling-provision-sweep.ts
+++ b/bench/measurement/workload-ceiling-provision-sweep.ts
@@ -1,0 +1,248 @@
+/**
+ * Byte-axis sweep provisioning for the deployed workload-ceiling study
+ * (lane B ticket 2).
+ *
+ * Provisions all four byte-axis cells in one run, calibrating each row count
+ * to hit its ENCODED snapshot-byte target and recording the achieved size.
+ * Writes a single sweep report the ticket-4 capture runner consumes directly.
+ *
+ * Resumable: re-running with the same `sweep_id` skips cells whose report
+ * entries already exist, so a mid-sweep failure (credential expiry, network
+ * blip, etc.) doesn't force a full restart.
+ */
+import { randomUUID } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import { runAsCliEntrypoint } from "./cli-entrypoint.ts";
+import { AwsClient } from "aws4fetch";
+import { type Storage } from "@baerly/protocol";
+import { S3HttpStorage } from "@baerly/adapter-node";
+import {
+  byteAxisCells,
+  byteLabel,
+  cellSpec,
+  CELL_BYTE_TOLERANCE,
+  type WorkloadCeilingCell,
+} from "./workload-ceiling-cells.ts";
+import {
+  decodeWorkloadCeilingSweepReport,
+  encodeWorkloadCeilingSweepReport,
+  type WorkloadCeilingSweepReport,
+  WORKLOAD_CEILING_CONTRACT_ID,
+} from "./workload-ceiling-harness.ts";
+import {
+  cloudflareR2CredsFilename,
+  type CloudflareTier,
+  loadCloudflareR2CredsForTier,
+} from "../../tests/fixtures/endpoint-creds.ts";
+import { resolveWorkloadCeilingTier } from "./workload-ceiling-tier.ts";
+import {
+  assertStudyBucket,
+  calibrateRowCount,
+  provisionWorkloadCeilingFixture,
+  randomIncarnation,
+} from "./workload-ceiling-provision.ts";
+
+/**
+ * The sweep report if one exists, `null` on absence — and a hard failure on a
+ * report that exists but does not decode.
+ *
+ * The distinction is load-bearing. Callers treat `null` as "first run" and
+ * write a fresh empty report over the path, so swallowing a decode failure
+ * would discard the `cleanup` entries recorded for fixtures ALREADY written to
+ * real R2. Those entries are the only record of which keys to delete, so the
+ * silent path orphans provisioned storage with no way to find it again. A
+ * partially written file from an interrupted run is exactly the case that
+ * produces it.
+ */
+export const loadFullReport = async (
+  reportPath: string,
+): Promise<WorkloadCeilingSweepReport | null> => {
+  let raw: string;
+  try {
+    raw = await readFile(reportPath, { encoding: "utf-8" });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw new Error(`workload-ceiling-provision-sweep: cannot read ${reportPath}`, {
+      cause: error,
+    });
+  }
+  try {
+    return decodeWorkloadCeilingSweepReport(raw);
+  } catch (error) {
+    throw new Error(
+      `workload-ceiling-provision-sweep: ${reportPath} exists but does not decode. ` +
+        "Refusing to overwrite it — its cleanup entries are the only record of the " +
+        "fixture keys already written to the bucket. Repair or move the file by hand.",
+      { cause: error },
+    );
+  }
+};
+
+const COLLECTION = "items";
+
+/** Provision a single cell, appending to the report after it succeeds. */
+const provisionCell = async (input: {
+  readonly cell: WorkloadCeilingCell;
+  readonly storage: Storage;
+  readonly sweepId: string;
+  readonly reportPath: string;
+  readonly existingReport: WorkloadCeilingSweepReport | null;
+}): Promise<void> => {
+  const { cell, storage, sweepId, reportPath, existingReport } = input;
+
+  // Skip if the cell already exists in the report (resumability).
+  const exists = existingReport?.cells.some((c) => c.scenario_id === cell.scenario_id) ?? false;
+  if (exists) {
+    console.log(`skipping ${cell.scenario_id} (already provisioned)`);
+    return;
+  }
+
+  console.log(`calibrating ${cell.scenario_id} to ${byteLabel(cell.target)}...`);
+  const calibration = calibrateRowCount({
+    targetBytes: cell.target,
+    documentBytes: cell.document_bytes,
+    collection: COLLECTION,
+    tolerance: CELL_BYTE_TOLERANCE,
+  });
+  console.log(
+    `  calibrated: ${calibration.row_count} rows, ${calibration.achieved_bytes} bytes (${(calibration.relative_error * 100).toFixed(3)}% error)`,
+  );
+
+  const fixturePrefix = `tenants/workload-ceiling-study/collections/${sweepId}/${byteLabel(cell.target)}`;
+  const incarnation = randomIncarnation();
+
+  console.log(`  provisioning ${fixturePrefix} (incarnation ${incarnation})...`);
+  const result = await provisionWorkloadCeilingFixture({
+    storage,
+    spec: cellSpec(cell, calibration.row_count, COLLECTION),
+    fixturePrefix,
+    incarnation,
+  });
+
+  // Load the latest report state, append the new cell, and rewrite.
+  // This is a simple append-only file; concurrent runs are gated by the
+  // same sweep_id, which is an operator's choice to set explicitly.
+  const latest = (await loadFullReport(reportPath)) ?? {
+    contract_id: WORKLOAD_CEILING_CONTRACT_ID,
+    sweep_id: sweepId,
+    collection: COLLECTION,
+    cells: [],
+    cleanup: [],
+  };
+
+  const newCell = {
+    scenario_id: cell.scenario_id,
+    axis: cell.axis,
+    target_bytes: calibration.target_bytes,
+    achieved_bytes: calibration.achieved_bytes,
+    row_count: calibration.row_count,
+    document_bytes: cell.document_bytes,
+    manifest_descriptors: cell.manifest_descriptors,
+    fixture_prefix: fixturePrefix,
+    incarnation,
+    monolithic_key: result.fixture.monolithic_key,
+    manifest_key: result.fixture.manifest_key,
+    descriptor_canonical_hash: result.fixture.descriptor_canonical_hash,
+  };
+
+  const newCleanup = {
+    scenario_id: cell.scenario_id,
+    fixture_prefix: fixturePrefix,
+    written_keys: result.fixture.writes.map((w) => w.key),
+    cleanup_authority: result.cleanup.authority,
+  };
+
+  const updatedReport: WorkloadCeilingSweepReport = {
+    ...latest,
+    cells: [...latest.cells, newCell],
+    cleanup: [...latest.cleanup, newCleanup],
+  };
+
+  const encoded = encodeWorkloadCeilingSweepReport(updatedReport);
+  await writeFile(reportPath, encoded);
+  console.log(`  wrote report entry`);
+};
+
+async function main(): Promise<number> {
+  let tier: CloudflareTier;
+  try {
+    tier = resolveWorkloadCeilingTier(process.env);
+  } catch (error) {
+    console.error(
+      `workload-ceiling-provision-sweep: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return 1;
+  }
+  const creds = await loadCloudflareR2CredsForTier(tier);
+  if (creds === null) {
+    const credsFile = cloudflareR2CredsFilename(tier);
+    console.error(
+      `workload-ceiling-provision-sweep: no credentials/${credsFile} found ` +
+        "(tests/fixtures/endpoint-creds.ts). This script provisions fixtures " +
+        "against a real R2 bucket for the deployed workload-ceiling study; " +
+        "there is nothing to do without credentials.\n" +
+        `Set WORKLOAD_CEILING_TIER=free to use credentials/cloudflare-free.json ` +
+        `instead of credentials/cloudflare.json.`,
+    );
+    return 1;
+  }
+  console.log(
+    `workload-ceiling-provision-sweep: using ${tier} tier (credentials/${cloudflareR2CredsFilename(tier)})`,
+  );
+
+  assertStudyBucket(creds);
+
+  const signer = new AwsClient({
+    accessKeyId: creds.credentials.accessKeyId,
+    secretAccessKey: creds.credentials.secretAccessKey,
+    region: creds.region,
+    service: "s3",
+  });
+  const storage = new S3HttpStorage({
+    endpoint: creds.endpoint,
+    bucket: creds.bucket,
+    sign: (req) => signer.sign(req),
+  });
+
+  const sweepId = process.env["WORKLOAD_CEILING_SWEEP_ID"] ?? randomUUID();
+  const outDir = "bench/results/workload-ceiling";
+  const reportPath = `${outDir}/sweep-${sweepId}.json`;
+
+  console.log(`provisioning byte-axis sweep ${sweepId}`);
+  console.log(`report: ${reportPath}`);
+
+  const existingReport = await loadFullReport(reportPath);
+  if (existingReport !== null) {
+    console.log(`resuming from existing report (${existingReport.cells.length} cells done)`);
+  }
+
+  const cells = byteAxisCells();
+  for (const cell of cells) {
+    await provisionCell({ cell, storage, sweepId, reportPath, existingReport });
+  }
+
+  const final = await loadFullReport(reportPath);
+  if (final === null) {
+    throw new Error("report disappeared after provisioning");
+  }
+
+  console.log();
+  console.log("sweep complete:");
+  console.log(`  sweep_id: ${sweepId}`);
+  console.log(`  report: ${reportPath}`);
+  console.log();
+  console.log("cells:");
+  for (const cell of final.cells) {
+    console.log(
+      `  ${cell.scenario_id}: row_count=${cell.row_count}, ` +
+        `target_bytes=${cell.target_bytes}, achieved_bytes=${cell.achieved_bytes}, ` +
+        `error=${(((cell.achieved_bytes - cell.target_bytes) / cell.target_bytes) * 100).toFixed(3)}%`,
+    );
+  }
+
+  return 0;
+}
+
+await runAsCliEntrypoint(import.meta.url, main);

--- a/bench/measurement/workload-ceiling-provision.test.ts
+++ b/bench/measurement/workload-ceiling-provision.test.ts
@@ -3,9 +3,16 @@ import { snapshotHash } from "@baerly/protocol";
 import { decodeSnapshotChunk, decodeSnapshotManifest } from "@baerly/server/_internal/testing";
 import {
   buildWorkloadCeilingFixture,
+  calibrateRowCount,
+  monolithicEncodedBytes,
   WorkloadCeilingProvisionError,
   type WorkloadCeilingFixtureSpec,
 } from "./workload-ceiling-provision.ts";
+import {
+  byteAxisCells,
+  BYTE_AXIS_MANIFEST_DESCRIPTORS,
+  CELL_BYTE_TOLERANCE,
+} from "./workload-ceiling-cells.ts";
 
 const incarnation = "ab".repeat(16);
 const spec: WorkloadCeilingFixtureSpec = {
@@ -52,9 +59,9 @@ describe("buildWorkloadCeilingFixture", () => {
     const fixture = await buildWorkloadCeilingFixture(spec, "fixtures/x", incarnation);
     const monolithic = fixture.writes.find((w) => w.key === fixture.monolithic_key)!.body;
     const parsed = JSON.parse(new TextDecoder().decode(monolithic)) as {
-      rows: { _id: string; body: { payload: string } }[];
+      docs: { _id: string; body: { payload: string } }[];
     };
-    expect(parsed.rows.map((r) => r._id)).toEqual([
+    expect(parsed.docs.map((d) => d._id)).toEqual([
       "row-0",
       "row-1",
       "row-2",
@@ -63,8 +70,8 @@ describe("buildWorkloadCeilingFixture", () => {
       "row-5",
       "row-6",
     ]);
-    for (const row of parsed.rows) {
-      expect(row.body.payload.length).toBeGreaterThan(0);
+    for (const doc of parsed.docs) {
+      expect(doc.body.payload.length).toBeGreaterThan(0);
     }
   });
 
@@ -102,5 +109,59 @@ describe("spec and argument validation", () => {
     ).rejects.toSatisfy(
       (e: unknown) => e instanceof WorkloadCeilingProvisionError && e.field === "incarnation",
     );
+  });
+});
+
+describe("calibrateRowCount", () => {
+  test.each(byteAxisCells())(
+    "calibrates $scenario_id to within tolerance of its encoded target",
+    (cell) => {
+      const result = calibrateRowCount({
+        targetBytes: cell.target,
+        documentBytes: cell.document_bytes,
+        collection: "items",
+        tolerance: CELL_BYTE_TOLERANCE,
+      });
+      expect(Math.abs(result.relative_error)).toBeLessThanOrEqual(CELL_BYTE_TOLERANCE);
+      expect(result.achieved_bytes).toBe(
+        monolithicEncodedBytes(result.row_count, cell.document_bytes, "items"),
+      );
+      // Every cell must have room for the fixed descriptor count.
+      expect(result.row_count).toBeGreaterThan(BYTE_AXIS_MANIFEST_DESCRIPTORS);
+    },
+  );
+
+  test("calibration is deterministic", () => {
+    const args = {
+      targetBytes: 1024 * 1024,
+      documentBytes: 2048,
+      collection: "items",
+      tolerance: 0.005,
+    };
+    expect(calibrateRowCount(args)).toEqual(calibrateRowCount(args));
+  });
+
+  test("the naive divide overshoots, which is why calibration exists", () => {
+    // Guards the reason for this code: if these ever agree, the envelope
+    // accounting changed and the calibrator's rationale needs rereading.
+    const naive = Math.round((1024 * 1024) / 2048);
+    const calibrated = calibrateRowCount({
+      targetBytes: 1024 * 1024,
+      documentBytes: 2048,
+      collection: "items",
+      tolerance: 0.005,
+    }).row_count;
+    expect(calibrated).toBeLessThan(naive);
+  });
+
+  test("an unreachable tolerance fails loudly rather than publishing a mislabeled cell", () => {
+    const shouldThrow = () =>
+      calibrateRowCount({
+        targetBytes: 100,
+        documentBytes: 2048,
+        collection: "items",
+        tolerance: 1e-9,
+      });
+    expect(shouldThrow).toThrow(WorkloadCeilingProvisionError);
   });
 });

--- a/bench/measurement/workload-ceiling-provision.test.ts
+++ b/bench/measurement/workload-ceiling-provision.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import { snapshotHash } from "@baerly/protocol";
 import { decodeSnapshotChunk, decodeSnapshotManifest } from "@baerly/server/_internal/testing";
 import {
+  assertStudyBucket,
   buildWorkloadCeilingFixture,
   calibrateRowCount,
   monolithicEncodedBytes,
@@ -13,6 +14,7 @@ import {
   BYTE_AXIS_MANIFEST_DESCRIPTORS,
   CELL_BYTE_TOLERANCE,
 } from "./workload-ceiling-cells.ts";
+import { WORKLOAD_CEILING_BUCKET_NAME } from "./workload-ceiling-harness.ts";
 
 const incarnation = "ab".repeat(16);
 const spec: WorkloadCeilingFixtureSpec = {
@@ -163,5 +165,31 @@ describe("calibrateRowCount", () => {
         tolerance: 1e-9,
       });
     expect(shouldThrow).toThrow(WorkloadCeilingProvisionError);
+  });
+});
+
+describe("assertStudyBucket", () => {
+  // The sole preflight standing between a typo'd credentials file and
+  // fixtures written where the deployed Worker cannot see them: `env.BUCKET`
+  // is a literal in wrangler.jsonc, so a mismatch surfaces only as every
+  // `POST /run` returning a 502 `fixture descriptor is missing`, which reads
+  // as a provisioning bug. It had no test.
+  test("accepts credentials naming the bucket the Worker binds", () => {
+    expect(() => {
+      assertStudyBucket({ bucket: WORKLOAD_CEILING_BUCKET_NAME });
+    }).not.toThrow();
+  });
+
+  test("refuses any other bucket, naming both sides", () => {
+    try {
+      assertStudyBucket({ bucket: "baerly-storage-eval-2" });
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(WorkloadCeilingProvisionError);
+      expect((error as WorkloadCeilingProvisionError).message).toContain("baerly-storage-eval-2");
+      expect((error as WorkloadCeilingProvisionError).message).toContain(
+        WORKLOAD_CEILING_BUCKET_NAME,
+      );
+    }
   });
 });

--- a/bench/measurement/workload-ceiling-provision.ts
+++ b/bench/measurement/workload-ceiling-provision.ts
@@ -9,8 +9,10 @@
  * into BOTH storage shapes the study compares side by side under a single
  * `fixture_prefix`:
  *
- *  - a monolithic JSON blob (`monolithic.json`), the shape of today's
- *    shipped single-snapshot format;
+ *  - a monolithic `SnapshotBody` at its hash-verified `snapshotKey`, the shape
+ *    of today's shipped single-snapshot format — read back through
+ *    `loadSnapshotAsMap`, so the control arm pays the digest check the
+ *    shipped path pays;
  *  - the proposed manifest + chunk layout (`snapshot-manifest.ts` /
  *    `snapshot-chunk.ts`), so `monolithic-control` and `chunked-candidate`
  *    runs measure the identical data through two different storage shapes.
@@ -25,8 +27,15 @@ import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { runAsCliEntrypoint } from "./cli-entrypoint.ts";
 import { AwsClient } from "aws4fetch";
-import { encodeJsonBytes, snapshotHash, type DocumentData, type Storage } from "@baerly/protocol";
+import {
+  encodeJsonBytes,
+  snapshotHash,
+  SNAPSHOT_SCHEMA_VERSION,
+  type DocumentData,
+  type Storage,
+} from "@baerly/protocol";
 import { S3HttpStorage } from "@baerly/adapter-node";
+import { encodeSnapshotBody, snapshotKey, type SnapshotBody } from "@baerly/server";
 import {
   encodeSnapshotChunk,
   snapshotChunkKey,
@@ -36,9 +45,8 @@ import {
   snapshotManifestKey,
   type SnapshotManifest,
 } from "@baerly/server/_internal/testing";
-import { canonicalJson, hashCanonicalJson, type CanonicalJsonValue } from "./canonical-json.ts";
+import { hashCanonicalJson, type CanonicalJsonValue } from "./canonical-json.ts";
 import { createExactKeyCleanup, type ExactKeyCleanup } from "./storage-factory.ts";
-import { loadEndpointCreds } from "../../tests/fixtures/endpoint-creds.ts";
 import {
   encodeWorkloadCeilingFixtureDescriptor,
   WORKLOAD_CEILING_BUCKET_NAME,
@@ -47,6 +55,12 @@ import {
   type WorkloadCeilingFixtureDescriptor,
 } from "./workload-ceiling-harness.ts";
 import { WORKLOAD_CEILING_STUDY } from "./workload-ceiling-contract.ts";
+import {
+  cloudflareR2CredsFilename,
+  type CloudflareTier,
+  loadCloudflareR2CredsForTier,
+} from "../../tests/fixtures/endpoint-creds.ts";
+import { resolveWorkloadCeilingTier } from "./workload-ceiling-tier.ts";
 
 const INCARNATION_PATTERN = /^[0-9a-f]{32}$/;
 
@@ -100,12 +114,17 @@ interface FixtureRow {
 /** Deterministic scalar-ordered rows: `row-000`, `row-001`, ... — same input, same bytes, every run. */
 function buildRows(spec: WorkloadCeilingFixtureSpec): readonly FixtureRow[] {
   const width = String(spec.row_count - 1).length;
+  // Every id is padded to the same width, so the empty-payload envelope encodes
+  // to one length for the whole fixture. Computing it per row would put a JSON
+  // encode inside the loop, and `calibrateRowCount` calls this once per
+  // binary-search probe.
+  const bare = encodeJsonBytes({ _id: "row-".padEnd(4 + width, "0"), payload: "" }).byteLength;
+  const padLength = Math.max(0, spec.document_bytes - bare);
+  const payload = "x".repeat(padLength);
   const rows: FixtureRow[] = [];
   for (let index = 0; index < spec.row_count; index++) {
     const id = `row-${String(index).padStart(width, "0")}`;
-    const bare = encodeJsonBytes({ _id: id, payload: "" }).byteLength;
-    const padLength = Math.max(0, spec.document_bytes - bare);
-    rows.push({ _id: id, body: { _id: id, payload: "x".repeat(padLength) } });
+    rows.push({ _id: id, body: { _id: id, payload } });
   }
   return rows;
 }
@@ -168,15 +187,23 @@ export const buildWorkloadCeilingFixture = async (
   const rows = buildRows(spec);
   const writes: WorkloadCeilingFixtureWrite[] = [];
 
-  const monolithicKey = `${fixturePrefix}/monolithic.json`;
-  const monolithicValue = {
+  // The monolithic representation is a REAL snapshot: the exact SnapshotBody
+  // the shipped compactor emits, encoded by the shipped encoder, at the key
+  // grammar the shipped reader parses a digest out of. The control arm then
+  // measures `loadSnapshotAsMap` — hash verification included — rather than a
+  // bare JSON.parse that understates the format it stands in for.
+  const monolithicBody: SnapshotBody = {
+    schema_version: SNAPSHOT_SCHEMA_VERSION,
+    min_seq: 0,
+    max_seq: 0,
     collection: spec.collection,
-    rows: rows.map((row) => ({ _id: row._id, body: row.body as CanonicalJsonValue })),
+    // Already ascending by construction: `buildRows` pads every id to one
+    // constant width, so `row-000 < row-001 < …` lexicographically.
+    docs: rows.map((row) => ({ _id: row._id, body: row.body })),
   };
-  writes.push({
-    key: monolithicKey,
-    body: new TextEncoder().encode(canonicalJson(monolithicValue as unknown as CanonicalJsonValue)),
-  });
+  const monolithicBytes = encodeSnapshotBody(monolithicBody);
+  const monolithicKey = snapshotKey(fixturePrefix, 0, 0, await snapshotHash(monolithicBytes));
+  writes.push({ key: monolithicKey, body: monolithicBytes });
 
   const groups = groupRows(rows, spec.manifest_descriptors);
   const chunkDescriptors: SnapshotChunkDescriptor[] = [];
@@ -280,11 +307,138 @@ export const provisionWorkloadCeilingFixture = async (input: {
 /** A fresh 32-lowercase-hex incarnation, matching `packages/server/src/snapshot-manifest.ts`'s grammar. */
 export const randomIncarnation = (): string => randomUUID().replaceAll("-", "");
 
+/** Preflight that credentials target the correct bucket. Exported so the sweep CLI reuses it verbatim. */
+export const assertStudyBucket = (creds: { readonly bucket: string }): void => {
+  if (creds.bucket !== WORKLOAD_CEILING_BUCKET_NAME) {
+    throw new WorkloadCeilingProvisionError(
+      "bucket",
+      `credentials name bucket "${creds.bucket}", but the study Worker's wrangler.jsonc binds env.BUCKET to "${WORKLOAD_CEILING_BUCKET_NAME}". Point the credentials file at "${WORKLOAD_CEILING_BUCKET_NAME}", or change both together.`,
+    );
+  }
+};
+
+/**
+ * Encoded byte length of the monolithic representation for a given row count.
+ * The single source of "how big is this cell really", used by both the
+ * calibrator and the sweep report — so the number the report publishes is the
+ * number the calibrator optimized, not a re-derivation that could disagree.
+ */
+export const monolithicEncodedBytes = (
+  rowCount: number,
+  documentBytes: number,
+  collection: string,
+): number => {
+  const spec: WorkloadCeilingFixtureSpec = {
+    scenario_id: "calibration",
+    collection,
+    row_count: rowCount,
+    document_bytes: documentBytes,
+    manifest_descriptors: 1,
+  };
+  const rows = buildRows(spec);
+  return encodeJsonBytes({
+    schema_version: SNAPSHOT_SCHEMA_VERSION,
+    min_seq: 0,
+    max_seq: 0,
+    collection,
+    docs: rows.map((row) => ({ _id: row._id, body: row.body })),
+  }).byteLength;
+};
+
+export interface CalibrationResult {
+  readonly row_count: number;
+  readonly achieved_bytes: number;
+  readonly target_bytes: number;
+  /** `(achieved - target) / target`. Signed, so an undershoot is visible as such. */
+  readonly relative_error: number;
+}
+
+/**
+ * Pure. Solves for the row count whose ENCODED monolithic snapshot is closest to
+ * `targetBytes`.
+ *
+ * Binary search, not a division: `document_bytes` is the size of one encoded
+ * document, while a row inside a `SnapshotBody` additionally carries
+ * `{"_id":…,"body":…}` envelope, and the whole body carries a fixed header. The
+ * naive `round(target / document_bytes)` the single-fixture CLI used
+ * (`workload-ceiling-provision.ts:350`) therefore overshoots by a few percent,
+ * which makes the axis label nominal rather than measured — and
+ * `WORKLOAD_CEILING_STUDY.axis_sweeps.byte_axis.collection_bytes_measure` says
+ * "encoded-snapshot-bytes".
+ *
+ * Encoded length is monotone non-decreasing in `rowCount`, so the search
+ * converges. It is not strictly monotone in a useful sense across a power-of-ten
+ * boundary — the id pad width widens there and every id grows a byte at once —
+ * which is why the result carries its achieved size and relative error rather
+ * than promising an exact hit.
+ *
+ * @throws WorkloadCeilingProvisionError when no row count lands within
+ *   `tolerance`; a silent miss would publish a mislabeled axis point.
+ */
+export const calibrateRowCount = (input: {
+  readonly targetBytes: number;
+  readonly documentBytes: number;
+  readonly collection: string;
+  readonly tolerance: number;
+}): CalibrationResult => {
+  // Upper bound: every row's encoded contribution is at least
+  // `document_bytes` — padding only ever brings the bare row UP to that size,
+  // and the snapshot envelope only adds — so `ceil(target / document_bytes)`
+  // rows already exceed the target. Bounding on the floor of 32 that
+  // `assertSpec` enforces would also be correct but is 64x looser at the
+  // study's 2048-byte documents, and each extra probe builds and JSON-encodes
+  // every row just to read the result's byteLength.
+  let hi = Math.max(1, Math.ceil(input.targetBytes / input.documentBytes));
+  let lo = 1;
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    const encoded = monolithicEncodedBytes(mid, input.documentBytes, input.collection);
+    if (encoded < input.targetBytes) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+
+  // The search finds the first row count at or above target. Evaluate both
+  // lo and lo - 1 (if lo > 1) and keep whichever has smaller absolute error.
+  const loBytes = monolithicEncodedBytes(lo, input.documentBytes, input.collection);
+  const loError = Math.abs((loBytes - input.targetBytes) / input.targetBytes);
+  let bestRow = lo;
+  let bestBytes = loBytes;
+  let bestError = loError;
+
+  if (lo > 1) {
+    const prevRow = lo - 1;
+    const prevBytes = monolithicEncodedBytes(prevRow, input.documentBytes, input.collection);
+    const prevError = Math.abs((prevBytes - input.targetBytes) / input.targetBytes);
+    if (prevError < bestError || (prevError === bestError && prevRow < bestRow)) {
+      bestRow = prevRow;
+      bestBytes = prevBytes;
+      bestError = prevError;
+    }
+  }
+
+  if (bestError > input.tolerance) {
+    throw new WorkloadCeilingProvisionError(
+      "tolerance",
+      `no row count within ${input.tolerance * 100}% of ${input.targetBytes} bytes (best: ${bestRow} rows, ${bestBytes} bytes, ${(bestError * 100).toFixed(3)}% error)`,
+    );
+  }
+
+  return {
+    row_count: bestRow,
+    achieved_bytes: bestBytes,
+    target_bytes: input.targetBytes,
+    relative_error: (bestBytes - input.targetBytes) / input.targetBytes,
+  };
+};
+
 /**
  * CLI entrypoint (`pnpm bench:workload-ceiling:provision`). Real R2
- * provisioning, so it requires `credentials/cloudflare.json` (the
- * `loadEndpointCreds` convention, `tests/fixtures/endpoint-creds.ts`) — the
- * same file shape and skip-honestly posture the credential-gated test
+ * provisioning, so it requires `credentials/cloudflare.json` (or
+ * `credentials/cloudflare-free.json` when `WORKLOAD_CEILING_TIER=free`) —
+ * the same file shape and skip-honestly posture the credential-gated test
  * suites use, except here absence is a script failure rather than a skip:
  * there is nothing useful this script can do without a real bucket.
  *
@@ -295,31 +449,36 @@ export const randomIncarnation = (): string => randomUUID().replaceAll("-", "");
  * so a later cleanup step can reconstruct exactly which keys to remove.
  */
 async function main(): Promise<number> {
-  const creds = await loadEndpointCreds("cloudflare.json");
-  if (creds === null) {
+  let tier: CloudflareTier;
+  try {
+    tier = resolveWorkloadCeilingTier(process.env);
+  } catch (error) {
     console.error(
-      "workload-ceiling-provision: no credentials/cloudflare.json found " +
-        "(tests/fixtures/endpoint-creds.ts). This script provisions fixtures " +
-        "against a real R2 bucket for the deployed workload-ceiling study; " +
-        "there is nothing to do without credentials.",
+      `workload-ceiling-provision: ${error instanceof Error ? error.message : String(error)}`,
     );
     return 1;
   }
+  const creds = await loadCloudflareR2CredsForTier(tier);
+  if (creds === null) {
+    const credsFile = cloudflareR2CredsFilename(tier);
+    console.error(
+      `workload-ceiling-provision: no credentials/${credsFile} found ` +
+        `(tests/fixtures/endpoint-creds.ts). This script provisions fixtures ` +
+        "against a real R2 bucket for the deployed workload-ceiling study; " +
+        "there is nothing to do without credentials.\n" +
+        `Set WORKLOAD_CEILING_TIER=free to use credentials/cloudflare-free.json ` +
+        `instead of credentials/cloudflare.json.`,
+    );
+    return 1;
+  }
+  console.log(
+    `workload-ceiling-provision: using ${tier} tier (credentials/${cloudflareR2CredsFilename(tier)})`,
+  );
 
   // Preflight the one coupling nothing else enforces: the deployed Worker's
   // `env.BUCKET` binding is a literal in wrangler.jsonc, so fixtures written
   // to any other bucket are invisible to it. Refuse before writing anything.
-  if (creds.bucket !== WORKLOAD_CEILING_BUCKET_NAME) {
-    console.error(
-      `workload-ceiling-provision: credentials/cloudflare.json names bucket ` +
-        `"${creds.bucket}", but the study Worker's wrangler.jsonc binds ` +
-        `env.BUCKET to "${WORKLOAD_CEILING_BUCKET_NAME}". Provisioning into a ` +
-        `different bucket would make every POST /run fail with a 502 ` +
-        `"fixture descriptor is missing". Point the credentials file at ` +
-        `"${WORKLOAD_CEILING_BUCKET_NAME}", or change both together.`,
-    );
-    return 1;
-  }
+  assertStudyBucket(creds);
 
   const signer = new AwsClient({
     accessKeyId: creds.credentials.accessKeyId,

--- a/bench/measurement/workload-ceiling-smoke.ts
+++ b/bench/measurement/workload-ceiling-smoke.ts
@@ -1,0 +1,152 @@
+/**
+ * Automated smoke runner for the workload-ceiling study harness: chains
+ * provision → (manual Worker invocation) → collect → validate. It is the
+ * single-invocation debugging tool for the deployed harness, and the
+ * verbatim GraphQL response it leaves under
+ * `bench/results/workload-ceiling/smoke-control/` is the provenance source
+ * cited in `docs/superpowers/programs/increase-workload-ceiling/runbooks/lane-b-preflight.md`.
+ *
+ * The Worker invocation itself is NOT automated: it needs the shared
+ * secret, which this repo never persists to disk or env (see
+ * `bench/workload-ceiling-worker/README.md` §"Token scope"). Everything
+ * else — provisioning the fixture, capturing a tight collection window
+ * around the operator's own invocation, collecting telemetry, and
+ * validating correlation fields — is automated here.
+ *
+ * Prerequisites (manual, not automated by this script):
+ *  1. Worker deployed: `node bench/workload-ceiling-worker/deploy.mjs deploy --name baerly-storage`
+ *  2. Shared secret set: `node bench/workload-ceiling-worker/deploy.mjs secret put WORKLOAD_CEILING_SHARED_SECRET --name baerly-storage`
+ *  3. `credentials/cloudflare.json` (R2, for provisioning — shape read by
+ *     `loadEndpointCreds` in `tests/fixtures/endpoint-creds.ts`) and
+ *     `credentials/cloudflare-deploy.json` (Workers API, for collection —
+ *     see `bench/workload-ceiling-worker/README.md`).
+ *
+ * Set `WORKLOAD_CEILING_TIER=free` to use `credentials/cloudflare-free.json`
+ * and `credentials/cloudflare-deploy-free.json` instead.
+ *
+ * Usage: `pnpm bench:workload-ceiling:smoke`
+ *        WORKLOAD_CEILING_TIER=free pnpm bench:workload-ceiling:smoke
+ */
+import { spawn } from "node:child_process";
+import { mkdir, readFile, readdir } from "node:fs/promises";
+import { createInterface } from "node:readline/promises";
+import { runAsCliEntrypoint } from "./cli-entrypoint.ts";
+
+const RESULTS_DIR = "bench/results/workload-ceiling";
+const SMOKE_DIR = `${RESULTS_DIR}/smoke-control`;
+const COMPATIBILITY_DATE = "2026-08-15";
+
+function run(
+  command: string,
+  args: readonly string[],
+  env: Record<string, string> = {},
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: "inherit",
+      env: { ...process.env, ...env },
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} ${args.join(" ")} exited with code ${code}`));
+      }
+    });
+  });
+}
+
+interface FixtureReport {
+  readonly run_id: string;
+  readonly fixture_prefix: string;
+  readonly spec: { readonly scenario_id: string };
+}
+
+async function readLatestFixtureReport(): Promise<FixtureReport> {
+  const entries = await readdir(RESULTS_DIR);
+  const reportFile = entries
+    .filter((name) => name.startsWith("fixture-") && name.endsWith(".json"))
+    .toSorted()
+    .at(-1);
+  if (reportFile === undefined) {
+    throw new Error(`no fixture report found in ${RESULTS_DIR} — did provisioning fail?`);
+  }
+  const raw = await readFile(`${RESULTS_DIR}/${reportFile}`, "utf8");
+  return JSON.parse(raw) as FixtureReport;
+}
+
+async function main(): Promise<number> {
+  try {
+    return await runSmoke();
+  } catch (error) {
+    console.error(
+      `workload-ceiling-smoke: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return 1;
+  }
+}
+
+async function runSmoke(): Promise<number> {
+  console.log("=== Lane A smoke test ===\n");
+
+  const tierEnv = process.env["WORKLOAD_CEILING_TIER"];
+  if (tierEnv !== undefined) {
+    console.log(`Using ${tierEnv} tier credentials\n`);
+  }
+
+  console.log("Step 1: provisioning minimal fixture...");
+  await run("pnpm", ["bench:workload-ceiling:provision"]);
+  const fixture = await readLatestFixtureReport();
+  console.log(`  run_id: ${fixture.run_id}`);
+  console.log(`  fixture_prefix: ${fixture.fixture_prefix}\n`);
+
+  console.log("Step 2: invoke the Worker (manual — this script cannot hold the shared secret).");
+  console.log("Run this in another shell, replacing <secret> and <account-id>:\n");
+  console.log(`  curl -X POST "https://baerly-storage.<account-id>.workers.dev/run" \\`);
+  console.log(`    -H "Authorization: Bearer <secret>" \\`);
+  console.log(`    -H "Content-Type: application/json" \\`);
+  console.log(`    -d '{`);
+  console.log(`      "contract_id": "baerly.workload-ceiling/chunked-snapshot/v1",`);
+  console.log(`      "run_id": "${fixture.run_id}",`);
+  console.log(`      "scenario_id": "${fixture.spec.scenario_id}",`);
+  console.log(`      "implementation": "monolithic-control",`);
+  console.log(`      "fixture_prefix": "${fixture.fixture_prefix}"`);
+  console.log(`    }'\n`);
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const windowStart = new Date().toISOString();
+  await rl.question("Press Enter once the curl command above has returned HTTP 200... ");
+  const windowEnd = new Date().toISOString();
+  rl.close();
+  console.log(`\nCollection window: ${windowStart} .. ${windowEnd}\n`);
+
+  console.log("Step 3: collecting telemetry...");
+  await mkdir(SMOKE_DIR, { recursive: true });
+  const collectEnv: Record<string, string> = {
+    WORKLOAD_CEILING_RUN_ID: fixture.run_id,
+    WORKLOAD_CEILING_SCENARIO_ID: fixture.spec.scenario_id,
+    WORKLOAD_CEILING_COMPATIBILITY_DATE: COMPATIBILITY_DATE,
+    WORKLOAD_CEILING_WINDOW_START: windowStart,
+    WORKLOAD_CEILING_WINDOW_END: windowEnd,
+    WORKLOAD_CEILING_OUT_DIR: SMOKE_DIR,
+  };
+  if (tierEnv !== undefined) {
+    collectEnv["WORKLOAD_CEILING_TIER"] = tierEnv;
+  }
+  await run("pnpm", ["bench:workload-ceiling:collect"], collectEnv);
+  console.log("  collection complete\n");
+
+  console.log("Step 4: validating correlation fields...");
+  await run("pnpm", ["bench:workload-ceiling:validate-smoke"], {
+    WORKLOAD_CEILING_RUN_ID: fixture.run_id,
+    WORKLOAD_CEILING_OUT_DIR: SMOKE_DIR,
+  });
+
+  console.log("\n=== Lane A smoke test complete ===");
+  console.log(`run_id: ${fixture.run_id}`);
+  console.log(`results: ${SMOKE_DIR}`);
+  return 0;
+}
+
+await runAsCliEntrypoint(import.meta.url, main);

--- a/bench/measurement/workload-ceiling-validate-smoke.test.ts
+++ b/bench/measurement/workload-ceiling-validate-smoke.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "vitest";
+import {
+  WORKLOAD_CEILING_EVIDENCE_CONTRACT_ID,
+  type WorkloadCeilingRawEvent,
+} from "./workload-ceiling-harness.ts";
+import { validateWorkloadCeilingRawEvent } from "./workload-ceiling-validate-smoke.ts";
+
+const resolvedEvidence = {
+  status: "resolved" as const,
+  detail: null,
+  authority: "workers-observability" as const,
+  authoritative_outcome: "ok",
+  authoritative_cpu_ms: 12,
+  authoritative_response_status: 200,
+  cpu_source: "workers-invocations-adaptive" as const,
+  cpu_outcome_verbatim: "success",
+};
+
+const okEvent: WorkloadCeilingRawEvent = {
+  evidence_contract_id: WORKLOAD_CEILING_EVIDENCE_CONTRACT_ID,
+  run_id: "12345678-1234-1234-1234-123456789abc",
+  scenario_id: "byte-axis/default/hot-key",
+  script_version: "a1b2c3d4",
+  compatibility_date: "2026-08-15",
+  runtime_period: "2026-08-18T00:00:00Z/2026-08-18T00:01:00Z",
+  colo: "DFW",
+  thermal_class: "unknown",
+  outcome: "success",
+  cpu_ms: 12.5,
+  observed_at: "2026-08-18T00:01:30Z",
+  evidence: resolvedEvidence,
+};
+
+// Verbatim from the lane-a smoke control event
+// (bench/results/workload-ceiling/smoke-control/event-20e4c62f-….json) and
+// the lane-b rehearsal events — the platform's actual wire shapes. The
+// synthetic okEvent above must not be the only form that validates.
+const realPlatformEvent: WorkloadCeilingRawEvent = {
+  evidence_contract_id: WORKLOAD_CEILING_EVIDENCE_CONTRACT_ID,
+  run_id: "e49e9d9e-4144-4347-b5cc-303596720ed9",
+  scenario_id: "byte-axis/512KiB",
+  script_version: "bf21bd73-a366-4fa5-965d-9599100093f2",
+  compatibility_date: "2026-08-15",
+  runtime_period: "2026-08-20T06:19:00.000Z/2026-08-20T06:20:00.000Z",
+  colo: "SEA",
+  thermal_class: "warm",
+  outcome: "success",
+  cpu_ms: 9.518,
+  observed_at: "2026-08-20T06:38:44.027Z",
+  evidence: resolvedEvidence,
+};
+
+describe("validateWorkloadCeilingRawEvent", () => {
+  test("passes every field for a well-formed ok event", () => {
+    const results = validateWorkloadCeilingRawEvent(okEvent);
+    expect(results.every((r) => r.passed)).toBe(true);
+  });
+
+  test("passes every field for a verbatim platform event (dashed UUID script_version, millisecond runtime_period)", () => {
+    const results = validateWorkloadCeilingRawEvent(realPlatformEvent);
+    const failures = results.filter((r) => !r.passed);
+    expect(failures.map((r) => r.field)).toEqual([]);
+  });
+
+  test("accepts the dashed-UUID script_version the GraphQL API actually returns", () => {
+    // Verified literal from lane-b-preflight.md Q1: scriptVersion dimensions
+    // arrive as dashed UUIDs, not bare hex hashes.
+    const results = validateWorkloadCeilingRawEvent({
+      ...okEvent,
+      script_version: "b3043d69-ddf5-49d3-b6ab-80850bcd1935",
+    });
+    const result = results.find((r) => r.field === "script_version");
+    expect(result?.passed).toBe(true);
+  });
+
+  test("still rejects a garbage script_version", () => {
+    const results = validateWorkloadCeilingRawEvent({
+      ...okEvent,
+      script_version: "not-a-version!!",
+    });
+    const result = results.find((r) => r.field === "script_version");
+    expect(result?.passed).toBe(false);
+  });
+
+  test("rejects a non-UUID run_id", () => {
+    const results = validateWorkloadCeilingRawEvent({ ...okEvent, run_id: "not-a-uuid" });
+    const runIdResult = results.find((r) => r.field === "run_id");
+    expect(runIdResult?.passed).toBe(false);
+  });
+
+  test("rejects a compatibility_date that doesn't match wrangler.jsonc", () => {
+    const results = validateWorkloadCeilingRawEvent({
+      ...okEvent,
+      compatibility_date: "2025-01-01",
+    });
+    const result = results.find((r) => r.field === "compatibility_date");
+    expect(result?.passed).toBe(false);
+  });
+
+  test("rejects an inverted runtime_period", () => {
+    const results = validateWorkloadCeilingRawEvent({
+      ...okEvent,
+      runtime_period: "2026-08-18T00:01:00Z/2026-08-18T00:00:00Z",
+    });
+    const result = results.find((r) => r.field === "runtime_period");
+    expect(result?.passed).toBe(false);
+  });
+
+  test("rejects a colo that isn't a 3-letter code", () => {
+    const results = validateWorkloadCeilingRawEvent({ ...okEvent, colo: "dallas" });
+    const result = results.find((r) => r.field === "colo");
+    expect(result?.passed).toBe(false);
+  });
+
+  test("requires a finite non-negative cpu_ms when outcome is success", () => {
+    const results = validateWorkloadCeilingRawEvent({ ...okEvent, cpu_ms: -1 });
+    const result = results.find((r) => r.field === "cpu_ms");
+    expect(result?.passed).toBe(false);
+  });
+
+  test("a null outcome (unresolved evidence) fails validation on the outcome field", () => {
+    // A `null` outcome is not a platform outcome; a smoke event carrying one
+    // has not been validated as a sample of anything.
+    const results = validateWorkloadCeilingRawEvent({ ...okEvent, outcome: null });
+    const result = results.find((r) => r.field === "outcome");
+    expect(result?.passed).toBe(false);
+  });
+
+  test("a successful outcome without a CPU number fails CPU completeness, not the outcome", () => {
+    // The evidence-missingness shape: execution fine, CPU row never landed.
+    // The outcome field passes; the cpu_ms field is what fails.
+    const results = validateWorkloadCeilingRawEvent({
+      ...okEvent,
+      cpu_ms: null,
+      evidence: { ...resolvedEvidence, cpu_source: "none", cpu_outcome_verbatim: null },
+    });
+    const outcome = results.find((r) => r.field === "outcome");
+    const cpu = results.find((r) => r.field === "cpu_ms");
+    expect(outcome?.passed).toBe(true);
+    expect(cpu?.passed).toBe(false);
+  });
+
+  test("rejects an observed_at that isn't ISO 8601", () => {
+    const results = validateWorkloadCeilingRawEvent({ ...okEvent, observed_at: "not-a-date" });
+    const result = results.find((r) => r.field === "observed_at");
+    expect(result?.passed).toBe(false);
+  });
+});

--- a/bench/measurement/workload-ceiling-validate-smoke.test.ts
+++ b/bench/measurement/workload-ceiling-validate-smoke.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   WORKLOAD_CEILING_EVIDENCE_CONTRACT_ID,
   type WorkloadCeilingRawEvent,
@@ -51,6 +51,28 @@ const realPlatformEvent: WorkloadCeilingRawEvent = {
 };
 
 describe("validateWorkloadCeilingRawEvent", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  // The failing side of this gate had no test: `WORKLOAD_CEILING_REQUIRE_THERMAL`
+  // was never set by any test, so the one branch that can reject an
+  // unclassified capture never ran. A validator whose refusal path is
+  // untested accepts everything.
+  test("an unclassified thermal_class fails only when the capture requires classification", () => {
+    const unclassified = { ...okEvent, thermal_class: "unknown" as const };
+    const fieldOf = (event: WorkloadCeilingRawEvent) =>
+      validateWorkloadCeilingRawEvent(event).find((r) => r.field === "thermal_class/classified");
+
+    expect(fieldOf(unclassified)?.passed).toBe(true);
+
+    vi.stubEnv("WORKLOAD_CEILING_REQUIRE_THERMAL", "1");
+    expect(fieldOf(unclassified)?.passed).toBe(false);
+    expect(fieldOf(unclassified)?.message).toMatch(/isolate_cold/);
+    expect(fieldOf({ ...okEvent, thermal_class: "warm" })?.passed).toBe(true);
+    expect(fieldOf({ ...okEvent, thermal_class: "cold" })?.passed).toBe(true);
+  });
+
   test("passes every field for a well-formed ok event", () => {
     const results = validateWorkloadCeilingRawEvent(okEvent);
     expect(results.every((r) => r.passed)).toBe(true);

--- a/bench/measurement/workload-ceiling-validate-smoke.ts
+++ b/bench/measurement/workload-ceiling-validate-smoke.ts
@@ -1,0 +1,173 @@
+/**
+ * Post-collection correlation-field validator for the deployed
+ * workload-ceiling smoke run (Lane A, ticket 3/4 of
+ * `docs/superpowers/programs/increase-workload-ceiling/`).
+ *
+ * `workload-ceiling-collect.ts` already round-trips its output through
+ * {@link decodeWorkloadCeilingRawEvent}, so a malformed event never reaches
+ * disk. What this script checks is the *content* the strict codec doesn't:
+ * that `run_id` looks like the UUID provisioning generated, that
+ * `compatibility_date` actually matches the deployed Worker's
+ * `wrangler.jsonc`, that `cpu_ms` is sane when `outcome` is a success,
+ * etc. — the correlation fields a maintainer would otherwise have to eyeball in
+ * `event-<runId>.json` by hand after every smoke run.
+ */
+import { readFile } from "node:fs/promises";
+import { runAsCliEntrypoint } from "./cli-entrypoint.ts";
+import {
+  decodeWorkloadCeilingRawEvent,
+  WORKLOAD_CEILING_KNOWN_OUTCOMES,
+  WORKLOAD_CEILING_SUCCESS_OUTCOME,
+  WORKLOAD_CEILING_THERMAL_CLASSES,
+  type WorkloadCeilingRawEvent,
+} from "./workload-ceiling-harness.ts";
+
+/** The `wrangler.jsonc` value `bench/workload-ceiling-worker/README.md` §"Runbook" pins the collector to. */
+const EXPECTED_COMPATIBILITY_DATE = "2026-08-15";
+
+interface ValidationResult {
+  readonly field: string;
+  readonly passed: boolean;
+  readonly message: string;
+}
+
+function validateField(field: string, passed: boolean, message: string): ValidationResult {
+  return { field, passed, message };
+}
+
+/** Pure. One row per correlation field; callers decide how to report failures. */
+export function validateWorkloadCeilingRawEvent(
+  event: WorkloadCeilingRawEvent,
+): readonly ValidationResult[] {
+  return [
+    validateField(
+      "run_id",
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(event.run_id),
+      "must be a UUID (provisioning generates one via randomUUID unless overridden)",
+    ),
+    validateField("scenario_id", event.scenario_id.trim().length > 0, "must be non-empty"),
+    validateField(
+      "script_version",
+      /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]+)$/i.test(
+        event.script_version,
+      ),
+      "must be a hex version hash or dashed UUID — the GraphQL scriptVersion " +
+        "dimension returns dashed UUIDs (verified in lane-b-preflight.md Q1)",
+    ),
+    validateField(
+      "compatibility_date",
+      event.compatibility_date === EXPECTED_COMPATIBILITY_DATE,
+      `must equal "${EXPECTED_COMPATIBILITY_DATE}" (bench/workload-ceiling-worker/wrangler.jsonc)`,
+    ),
+    validateField(
+      "runtime_period",
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(
+        event.runtime_period,
+      ) &&
+        (() => {
+          const [start, end] = event.runtime_period.split("/") as [string, string];
+          return Date.parse(start) < Date.parse(end);
+        })(),
+      "must be a `<start>/<end>` ISO 8601 interval with start before end " +
+        "(fractional seconds allowed — the collector emits .000Z instants)",
+    ),
+    validateField(
+      "colo",
+      /^[A-Z]{3}$/.test(event.colo),
+      "must be a 3-letter Cloudflare datacenter code",
+    ),
+    validateField(
+      "thermal_class",
+      (WORKLOAD_CEILING_THERMAL_CLASSES as readonly string[]).includes(event.thermal_class),
+      `must be one of ${WORKLOAD_CEILING_THERMAL_CLASSES.join(", ")}`,
+    ),
+    validateField(
+      "thermal_class/classified",
+      process.env["WORKLOAD_CEILING_REQUIRE_THERMAL"] !== "1" || event.thermal_class !== "unknown",
+      'must be "warm" or "cold" for a capture run (set WORKLOAD_CEILING_REQUIRE_THERMAL=1); ' +
+        '"unknown" means the invoker did not relay the Worker\'s isolate_cold flag',
+    ),
+    validateField(
+      "outcome",
+      event.outcome !== null &&
+        (WORKLOAD_CEILING_KNOWN_OUTCOMES as readonly string[]).includes(event.outcome),
+      event.outcome === null
+        ? "must be a platform outcome — the authoritative evidence did not resolve " +
+            "(see the event's evidence block; blocks evidence completeness)"
+        : `must be one of ${WORKLOAD_CEILING_KNOWN_OUTCOMES.join(", ")}`,
+    ),
+    validateField(
+      "cpu_ms",
+      event.outcome === WORKLOAD_CEILING_SUCCESS_OUTCOME
+        ? event.cpu_ms !== null && Number.isFinite(event.cpu_ms) && event.cpu_ms >= 0
+        : true,
+      `must be a finite, non-negative number when outcome is "${WORKLOAD_CEILING_SUCCESS_OUTCOME}" — ` +
+        "a success without CPU fails CPU completeness (it is not an execution failure)",
+    ),
+    validateField(
+      "observed_at",
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(event.observed_at),
+      "must be an ISO 8601 timestamp",
+    ),
+  ];
+}
+
+/**
+ * CLI entrypoint (`pnpm bench:workload-ceiling:validate-smoke`). Reads the
+ * `event-<runId>.json` a prior `workload-ceiling-collect.ts` run wrote and
+ * asserts every correlation field is present and well-formed.
+ *
+ * Required env: `WORKLOAD_CEILING_RUN_ID` (the same run ID passed to
+ * provision/collect).
+ * Optional: `WORKLOAD_CEILING_OUT_DIR` (must match the collector's — default
+ * `bench/results/workload-ceiling/smoke-control`).
+ */
+async function main(): Promise<number> {
+  const runId = process.env["WORKLOAD_CEILING_RUN_ID"];
+  if (runId === undefined || runId.trim() === "") {
+    console.error("workload-ceiling-validate-smoke: requires WORKLOAD_CEILING_RUN_ID");
+    return 1;
+  }
+
+  const outDir =
+    process.env["WORKLOAD_CEILING_OUT_DIR"] ?? "bench/results/workload-ceiling/smoke-control";
+  const eventPath = `${outDir}/event-${runId}.json`;
+
+  let raw: string;
+  try {
+    raw = await readFile(eventPath, "utf8");
+  } catch {
+    console.error(`workload-ceiling-validate-smoke: cannot read ${eventPath}`);
+    return 1;
+  }
+
+  let event: WorkloadCeilingRawEvent;
+  try {
+    event = decodeWorkloadCeilingRawEvent(raw);
+  } catch (error) {
+    console.error(
+      `workload-ceiling-validate-smoke: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return 1;
+  }
+
+  const validations = validateWorkloadCeilingRawEvent(event);
+  const failed = validations.filter((v) => !v.passed);
+  if (failed.length > 0) {
+    console.error("workload-ceiling-validate-smoke: validation failures:");
+    for (const f of failed) {
+      console.error(`  - ${f.field}: ${f.message}`);
+    }
+    return 1;
+  }
+
+  console.log(`workload-ceiling-validate-smoke: all ${validations.length} validations passed`);
+  console.log(`  run_id: ${event.run_id}`);
+  console.log(`  scenario_id: ${event.scenario_id}`);
+  console.log(`  outcome: ${event.outcome}`);
+  console.log(`  cpu_ms: ${event.cpu_ms}`);
+  console.log(`  colo: ${event.colo}`);
+  return 0;
+}
+
+await runAsCliEntrypoint(import.meta.url, main);

--- a/bench/workload-ceiling-worker/README.md
+++ b/bench/workload-ceiling-worker/README.md
@@ -170,10 +170,13 @@ Never delete the bucket or an unresolved prefix.
 ## Runbook — one smoke run
 
 `workersInvocationsAdaptive` rows are minute-bucketed aggregates. Two
-invocations inside the same minute collapse into one row with summed CPU —
-the collector's request-count assertion treats such a row as unresolved, so
-space the two invocations at least one minute apart and give each its own
-explicit collection window:
+invocations inside the same minute collapse into one row with summed CPU.
+The collector reads such a row as CPU-measurement missingness
+(`cpu_source: "none"`) rather than as an unresolved invocation — the event
+still resolves from Workers Observability, it just carries no `cpu_ms`. A
+row attributable to a different `scriptVersion` or `coloCode` is read the
+same way. Either loses the measurement, so space invocations at least one
+minute apart and give each its own explicit collection window:
 
 0. Confirm `credentials/cloudflare.json` names the bucket
    `baerly-storage-eval`. Provisioning writes fixtures to whatever bucket that

--- a/bench/workload-ceiling-worker/README.md
+++ b/bench/workload-ceiling-worker/README.md
@@ -40,28 +40,31 @@ isolate — the limit is enforced by the runtime around the isolate, and an
 in-process timer measures wall time, not the runtime's own CPU accounting.
 Reporting a self-timed number here would be exactly the kind of synthesized
 evidence `workload-ceiling-harness.ts`'s codec exists to refuse. The study
-instead retrieves the platform's own number through the GraphQL Analytics
-API's `workersInvocationsAdaptive` dataset, which reports per-invocation
-`status` (the outcome, e.g. success, or an exceeded-resources / exception /
-disconnect classification) and CPU time.
+instead retrieves the platform's own numbers from two telemetry sources
+(evidence contract v2): Workers Observability is the authority for
+per-invocation existence and execution outcome (`$workers.outcome` on the
+fetch-summary line, whose success literal is `ok`), and the GraphQL Analytics
+API's `workersInvocationsAdaptive` dataset supplies the CPU measurement
+(`sum.cpuTimeUs`, microsecond resolution) — that dataset demonstrably drops
+rows permanently, which the study records as CPU-measurement missingness
+rather than execution failure.
 
 ## Join mechanism
 
 Workers Analytics does not carry a caller-supplied correlation ID per row.
-The plan's Step 10 language ("deploy a uniquely named study Worker") assumes
-a fresh per-run deployment, whose `scriptName` alone would disambiguate
-invocations. This harness instead reuses one already-deployed, fixed-name
-Worker (`baerly-storage`, overwritten in place by `deploy.mjs` for each
-smoke run — see §"Token scope" for why), so disambiguation for Task 8's one
-authorized smoke run rests on `workload-ceiling-collect.ts` querying
-`workersInvocationsAdaptive` filtered by that fixed `scriptName` plus a
-narrow `datetime` window bounding the single invocation, rather than on the
-name itself. The Workers Logs line emitted in step 4 above (`run_id` /
-`scenario_id` / `implementation`) is the independent check that the
-telemetry row collected in that window is in fact this run. A later,
-bulk multi-run study (out of this plan's scope) would need per-run
-uniqueness back, since a shared name plus overlapping windows could no
-longer disambiguate concurrent invocations.
+This harness reuses one already-deployed, fixed-name Worker
+(`baerly-storage`, overwritten in place by `deploy.mjs` — see §"Token scope"
+for why). Disambiguation therefore rests on the Worker emitting its join
+identifiers (`run_id` / `scenario_id` / `implementation` /
+`isolate_cold`, step 4 above) exactly once per invocation as a structured
+Workers Logs line: under evidence contract v2 the collector joins that line
+to the platform fetch-summary line by their shared `requestId`, giving one
+authoritative per-invocation record (existence + outcome) however many
+invocations share the script name. The CPU measurement still comes from
+`workersInvocationsAdaptive` bounded by a narrow `datetime` window, so
+overlapping windows still cannot attribute a CPU row — the capture
+protocol's global 70 s spacing exists to keep one invocation per minute
+bucket.
 
 ## Platform documentation this rests on
 
@@ -78,8 +81,10 @@ directly here per that step's requirement.
 - R2 bucket binding (`r2_buckets`, `env.BUCKET`):
   <https://developers.cloudflare.com/r2/api/workers/workers-api-reference/>
 - GraphQL Analytics API — query shape, `*Adaptive` raw-row datasets,
-  `workersInvocationsAdaptive` dimensions/metrics (`cpuTime`, `status`,
-  `scriptName`, `coloCode`, `scriptVersion`):
+  `workersInvocationsAdaptive` dimensions/metrics (`cpuTimeUs`, `status`,
+  `scriptName`, `coloCode`, `scriptVersion`) — note the docs below use the
+  field name `cpuTime`, but the live `AccountWorkersInvocationsAdaptiveSum`
+  schema (confirmed by introspection) names it `cpuTimeUs`:
   <https://developers.cloudflare.com/analytics/graphql-api/>,
   <https://developers.cloudflare.com/analytics/graphql-api/tutorials/querying-workers-metrics/>
 - Workers observability / metrics and invocation status classification:
@@ -95,19 +100,40 @@ directly here per that step's requirement.
 
 Step 10 of Task 8 — one authorized deployed smoke run — is deliberately
 **not** performed by this repository's automated gates (`pnpm verify`,
-`pnpm test`), and requires `CF_API_TOKEN` / `CF_ACCOUNT_ID` or
-`credentials/cloudflare-deploy.json` to be provisioned first (see below).
+`pnpm test`), and requires `CF_API_TOKEN` / `CF_ACCOUNT_ID` or a credentials
+file to be provisioned first (see below).
+
+Set `WORKLOAD_CEILING_TIER=free` to use `credentials/cloudflare-deploy-free.json`
+instead of `credentials/cloudflare-deploy.json`. Note that the `-free`
+suffix names a credential set, never a verified Workers plan tier — and a
+verified plan tier still never implies an enforced CPU ceiling. `cf-free`
+evidence comes from the `limits.cpu_ms` block in `wrangler.jsonc`, which
+needs a Paid plan; see `lane-b-preflight.md` § Q4 and
+`WORKLOAD_CEILING_STUDY.cpu_envelope` before treating any output as `cf-free`.
+
+The workers.dev URL is `https://<name>.<subdomain>.workers.dev/run`, where
+`<subdomain>` is per-account. The `-free` account's subdomain happens to be
+literally `baerly-storage` (derived from the account name), so the live URL
+is the doubled `https://baerly-storage.baerly-storage.workers.dev/run`.
+Discover yours with:
+
+```sh
+GET /accounts/<account_id>/workers/subdomain   # { "result": { "subdomain": … } }
+```
+
+(as done 2026-08-20; works with the deploy token's Account:Read scope)
 
 `deploy.mjs` wraps `wrangler` so auth never has to live in shell env or a
 global dotfile — never `wrangler login`. It resolves `CLOUDFLARE_API_TOKEN` /
 `CLOUDFLARE_ACCOUNT_ID` the same way `../measurement/workload-ceiling-collect.ts`
 does: `CF_API_TOKEN` + `CF_ACCOUNT_ID` env vars if both are set, otherwise a
-repo-scoped `credentials/cloudflare-deploy.json` (gitignored —
-`{ "api_token": "...", "account_id": "..." }`, read by
-`loadCloudflareDeployCreds` in `tests/fixtures/endpoint-creds.ts`). Either
-way the resolved credentials are injected only into the spawned `wrangler`
-child's environment, never printed or written elsewhere. Once one of those
-two sources is available:
+repo-scoped `credentials/cloudflare-deploy.json` (or
+`credentials/cloudflare-deploy-free.json` when `WORKLOAD_CEILING_TIER=free`,
+gitignored — `{ "api_token": "...", "account_id": "..." }`, read by
+`loadCloudflareDeployCredsForTier` in `tests/fixtures/endpoint-creds.ts`).
+Either way the resolved credentials are injected only into the spawned
+`wrangler` child's environment, never printed or written elsewhere. Once one
+of those two sources is available:
 
 ```sh
 node bench/workload-ceiling-worker/deploy.mjs deploy --name baerly-storage
@@ -173,10 +199,15 @@ explicit collection window:
    pnpm bench:workload-ceiling:compare`.
 
 The per-implementation directories in steps 4–5 are mandatory, not
-housekeeping: `workload-ceiling-compare.ts` joins two event directories,
-one per side, and both implementations reuse the same `scenario_id`s —
-collected into one shared directory, every scenario arrives twice there
-and is evicted as a duplicate, leaving zero pairs and an exit 1.
+housekeeping: the directory IS the side. `workload-ceiling-compare.ts`
+reads one directory per implementation and both implementations reuse the
+same `scenario_id`s, so a shared directory hands the control side every
+candidate event as well. Compare pools each side's events per scenario, so
+it would not reject them — it would report a control p50 computed over
+both arms and a ratio of that against itself.
 
 Never rely on the default 10-minute window — it will span both invocations
-and both sides will record `missing-terminal-event`.
+and both sides will record CPU-measurement missingness (a collapsed
+`workersInvocationsAdaptive` row supplies no attributable CPU; under evidence
+contract v2 the invocation's existence and outcome still resolve from Workers
+Observability, but the sample carries no number).

--- a/bench/workload-ceiling-worker/src/index.test.ts
+++ b/bench/workload-ceiling-worker/src/index.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test, vi } from "vitest";
 import type { Storage } from "@baerly/protocol";
+// oxlint-disable-next-line no-duplicate-imports
+import { snapshotHash } from "@baerly/protocol";
+import { encodeSnapshotBody } from "@baerly/server";
 import worker, { type WorkloadCeilingWorkerEnv } from "./index.ts";
 
 vi.mock("@baerly/adapter-cloudflare", () => ({
@@ -165,17 +168,23 @@ interface RunResult {
 
 describe("Success path with mocked storage", () => {
   test("succeeds on monolithic-control implementation", async () => {
+    const snapshotBody = encodeSnapshotBody({
+      schema_version: 1,
+      min_seq: 0,
+      max_seq: 0,
+      collection: "test-collection",
+      docs: [{ _id: "doc1" as const, body: { _id: "doc1" as const, data: "value" } }],
+    });
+    const monolithicKey = `${fixturePrefix}/snapshot/L9/000000000000-000000000000-${await snapshotHash(snapshotBody)}.json`;
     const mockStorage = createMockStorage({
       [`${fixturePrefix}/fixture.json`]: encodeWorkloadCeilingFixtureDescriptor({
         contract_id: "baerly.workload-ceiling/chunked-snapshot/v1",
         collection: "test-collection",
-        monolithic_key: `${fixturePrefix}/monolithic.json`,
+        monolithic_key: monolithicKey,
         manifest_key: `${fixturePrefix}/manifest.json`,
         log_seq_start: 0,
       }),
-      [`${fixturePrefix}/monolithic.json`]: JSON.stringify({
-        rows: [{ _id: "doc1" as const, body: { _id: "doc1" as const, data: "value" } }],
-      }),
+      [monolithicKey]: snapshotBody,
     });
 
     mockR2BindingStorage.mockReturnValue(mockStorage);
@@ -191,6 +200,101 @@ describe("Success path with mocked storage", () => {
     expect(result.run_id).toBe("test-run-id");
     expect(result.scenario_id).toBe("test-scenario");
     expect(result.implementation).toBe("monolithic-control");
+  });
+
+  test("the two monolithic arms read the identical key and return the identical row count", async () => {
+    const snapshotBody = encodeSnapshotBody({
+      schema_version: 1,
+      min_seq: 0,
+      max_seq: 0,
+      collection: "test-collection",
+      docs: [
+        { _id: "doc1" as const, body: { _id: "doc1" as const, data: "value" } },
+        { _id: "doc2" as const, body: { _id: "doc2" as const, data: "value2" } },
+      ],
+    });
+    const monolithicKey = `${fixturePrefix}/snapshot/L9/000000000000-000000000000-${await snapshotHash(snapshotBody)}.json`;
+    const mockStorage = createMockStorage({
+      [`${fixturePrefix}/fixture.json`]: encodeWorkloadCeilingFixtureDescriptor({
+        contract_id: "baerly.workload-ceiling/chunked-snapshot/v1",
+        collection: "test-collection",
+        monolithic_key: monolithicKey,
+        manifest_key: `${fixturePrefix}/manifest.json`,
+        log_seq_start: 0,
+      }),
+      [monolithicKey]: snapshotBody,
+    });
+
+    mockR2BindingStorage.mockReturnValue(mockStorage);
+
+    const hashed = await worker.fetch(
+      authedPostRun(
+        encodeWorkloadCeilingRunRequest({ ...validRequest, implementation: "monolithic-control" }),
+      ),
+      env("secret"),
+    );
+    const unhashed = await worker.fetch(
+      authedPostRun(
+        encodeWorkloadCeilingRunRequest({
+          ...validRequest,
+          implementation: "monolithic-control-unhashed",
+        }),
+      ),
+      env("secret"),
+    );
+    expect(hashed.status).toBe(200);
+    expect(unhashed.status).toBe(200);
+    expect(((await unhashed.json()) as RunResult).row_count).toBe(
+      ((await hashed.json()) as RunResult).row_count,
+    );
+  });
+
+  test("the control arm rejects a body whose digest does not match its key", async () => {
+    const snapshotBody = encodeSnapshotBody({
+      schema_version: 1,
+      min_seq: 0,
+      max_seq: 0,
+      collection: "test-collection",
+      docs: [{ _id: "doc1" as const, body: { _id: "doc1" as const, data: "value" } }],
+    });
+    // Use a key with a different hash than the body's actual hash.
+    // The control arm will reject the hash mismatch; the unhashed probe
+    // will accept the body since it doesn't verify the hash.
+    const wrongHash = "a".repeat(64);
+    const monolithicKey = `${fixturePrefix}/snapshot/L9/000000000000-000000000000-${wrongHash}.json`;
+    const mockStorage = createMockStorage({
+      [`${fixturePrefix}/fixture.json`]: encodeWorkloadCeilingFixtureDescriptor({
+        contract_id: "baerly.workload-ceiling/chunked-snapshot/v1",
+        collection: "test-collection",
+        monolithic_key: monolithicKey,
+        manifest_key: `${fixturePrefix}/manifest.json`,
+        log_seq_start: 0,
+      }),
+      // Store a valid snapshot body, but the key has the wrong hash.
+      [monolithicKey]: snapshotBody,
+    });
+
+    mockR2BindingStorage.mockReturnValue(mockStorage);
+
+    // Same key, different hash — the control must 502 and the unhashed probe
+    // must NOT, which is the whole difference between the two arms.
+    const hashed = await worker.fetch(
+      authedPostRun(
+        encodeWorkloadCeilingRunRequest({ ...validRequest, implementation: "monolithic-control" }),
+      ),
+      env("secret"),
+    );
+    const unhashed = await worker.fetch(
+      authedPostRun(
+        encodeWorkloadCeilingRunRequest({
+          ...validRequest,
+          implementation: "monolithic-control-unhashed",
+        }),
+      ),
+      env("secret"),
+    );
+    expect(hashed.status).toBe(502);
+    expect(unhashed.status).toBe(200);
   });
 
   // The candidate representation is the study's whole subject, and it is the
@@ -327,5 +431,93 @@ describe("Fixture descriptor rejection", () => {
       env("secret"),
     );
     expect(response.status).toBe(502);
+  });
+});
+
+/**
+ * The fixture the thermal tests fold: one document, read through the
+ * monolithic arm. Its content is irrelevant to warm/cold — it exists only so
+ * the handler reaches a 200 and reports `isolate_cold`.
+ */
+async function thermalFixtureFiles(): Promise<Record<string, string | Uint8Array>> {
+  const snapshotBody = encodeSnapshotBody({
+    schema_version: 1,
+    min_seq: 0,
+    max_seq: 0,
+    collection: "test-collection",
+    docs: [{ _id: "doc1" as const, body: { _id: "doc1" as const, data: "value" } }],
+  });
+  const monolithicKey = `${fixturePrefix}/snapshot/L9/000000000000-000000000000-${await snapshotHash(snapshotBody)}.json`;
+  return {
+    [`${fixturePrefix}/fixture.json`]: encodeWorkloadCeilingFixtureDescriptor({
+      contract_id: "baerly.workload-ceiling/chunked-snapshot/v1",
+      collection: "test-collection",
+      monolithic_key: monolithicKey,
+      manifest_key: `${fixturePrefix}/manifest.json`,
+      log_seq_start: 0,
+    }),
+    [monolithicKey]: snapshotBody,
+  };
+}
+
+/**
+ * A handler bound to a FRESH module instance, i.e. an isolate that has served
+ * nothing yet.
+ *
+ * `index.ts`'s request counter is module-scope by design — it has to survive
+ * across requests for `isolate_cold` to mean anything — so a test that wants
+ * to observe an isolate's FIRST request has to evaluate the module again
+ * rather than reset a variable. Doing it this way is what keeps these tests
+ * independent of where they sit in the file: the alternative, asserting
+ * against the shared top-level import, passes or fails on whether some
+ * earlier test happened to warm it.
+ *
+ * `vi.resetModules()` re-runs the `@baerly/adapter-cloudflare` mock factory
+ * too, so the storage mock is re-bound on the new instance the fresh handler
+ * closes over — not on the stale one the top-level import captured.
+ */
+async function freshIsolate(files: Record<string, string | Uint8Array>) {
+  vi.resetModules();
+  const { r2BindingStorage: freshBinding } = await import("@baerly/adapter-cloudflare");
+  vi.mocked(freshBinding).mockReturnValue(createMockStorage(files));
+  const { default: freshWorker } = await import("./index.ts");
+  return freshWorker;
+}
+
+describe("Thermal classification (warm/cold detection)", () => {
+  test("the first request an isolate serves is cold, and the next is not", async () => {
+    const freshWorker = await freshIsolate(await thermalFixtureFiles());
+
+    const first = await freshWorker.fetch(
+      authedPostRun(encodeWorkloadCeilingRunRequest(validRequest)),
+      env("secret"),
+    );
+    const second = await freshWorker.fetch(
+      authedPostRun(encodeWorkloadCeilingRunRequest(validRequest)),
+      env("secret"),
+    );
+
+    await expect(first.json()).resolves.toMatchObject({ isolate_cold: true });
+    await expect(second.json()).resolves.toMatchObject({ isolate_cold: false });
+  });
+
+  test("an unauthorized request still warms the isolate", async () => {
+    // A rejected probe pays isolate start-up like any other request, so the
+    // counter has to advance BEFORE the auth check. Otherwise the next real
+    // invocation reports cold against an isolate that is already warm, and
+    // the study's thermal axis silently mislabels it.
+    const freshWorker = await freshIsolate(await thermalFixtureFiles());
+
+    const unauthorized = await freshWorker.fetch(
+      authedPostRun(encodeWorkloadCeilingRunRequest(validRequest)),
+      env("wrong"),
+    );
+    expect(unauthorized.status).toBe(401);
+
+    const authorized = await freshWorker.fetch(
+      authedPostRun(encodeWorkloadCeilingRunRequest(validRequest)),
+      env("secret"),
+    );
+    await expect(authorized.json()).resolves.toMatchObject({ isolate_cold: false });
   });
 });

--- a/bench/workload-ceiling-worker/src/index.ts
+++ b/bench/workload-ceiling-worker/src/index.ts
@@ -26,16 +26,24 @@
  * `../../measurement/workload-ceiling-collect.ts`. See README.md for the
  * platform documentation this rests on.
  *
- * The two `implementation` values read the SAME logical row set through two
- * different storage shapes that `workload-ceiling-provision.ts` writes side
- * by side under one `fixture_prefix`:
+ * The three `implementation` values read the SAME logical row set through
+ * different storage shapes and read paths, all written side by side under one
+ * `fixture_prefix` by `workload-ceiling-provision.ts`:
  *
- *  - `monolithic-control` — a single JSON blob (`fixture.json`'s
- *    `monolithic_key`), the shape of today's shipped single-snapshot format.
+ *  - `monolithic-control` — today's shipped single-snapshot format at
+ *    `fixture.json`'s `monolithic_key`, read through the shipped
+ *    `loadSnapshotAsMap`, SHA-256 verification included, so what the study
+ *    measures is what a caller would run.
+ *  - `monolithic-control-unhashed` — the identical bytes at the identical
+ *    key, differing by exactly one operation: the digest verification.
+ *    A Worker may not time itself, so the cost of that verification has to
+ *    be a difference of two platform-reported CPU numbers. It is a
+ *    measurement-only probe, not a subject — see
+ *    `WORKLOAD_CEILING_IMPLEMENTATIONS` where the arm is declared.
  *  - `chunked-candidate` — the proposed manifest + chunk layout, read
  *    through `openSnapshotView` (`packages/server/src/snapshot-view.ts`).
  *
- * Both feed the identical fold subject, so the comparison isolates the
+ * All three feed the identical fold subject, so a comparison isolates the
  * storage-shape cost, not a difference in what gets computed.
  */
 import type { DocumentData, Storage } from "@baerly/protocol";

--- a/bench/workload-ceiling-worker/src/index.ts
+++ b/bench/workload-ceiling-worker/src/index.ts
@@ -40,6 +40,7 @@
  */
 import type { DocumentData, Storage } from "@baerly/protocol";
 import { r2BindingStorage } from "@baerly/adapter-cloudflare";
+import { loadSnapshotAsMap } from "@baerly/server";
 import {
   foldChunkedSnapshotReference,
   openSnapshotView,
@@ -54,6 +55,20 @@ import {
   type WorkloadCeilingRunRequest,
 } from "../../measurement/workload-ceiling-harness.ts";
 import { constantTimeEqual } from "./constant-time-equal.ts";
+
+/**
+ * Requests this ISOLATE has served, module scope so it is per-isolate and
+ * survives across requests. Read once per request, before the first `await`,
+ * so two concurrent requests in one isolate cannot both observe zero.
+ *
+ * This is not a self-reported measurement and does not contradict README.md
+ * §"Why CPU is never self-reported". No clock is read: the value is a boolean
+ * about this isolate's own history, which the platform exposes nowhere and
+ * which nothing outside the isolate can observe. CPU is different in kind —
+ * an in-isolate CPU number is wall time misreported as the runtime's own
+ * accounting, and the platform DOES publish the real one.
+ */
+let isolateRequestsServed = 0;
 
 export interface WorkloadCeilingWorkerEnv {
   readonly BUCKET: R2Bucket;
@@ -93,15 +108,51 @@ function parseFixtureDescriptor(bytes: Uint8Array): WorkloadCeilingFixtureDescri
   }
 }
 
+/** The one Map → rows conversion, shared by every arm so its cost cancels in the comparison. */
+const toReferenceRows = (materialized: Map<string, DocumentData>): readonly ReferenceRow[] =>
+  [...materialized].map(([_id, body]) => ({ _id, body }));
+
+/**
+ * The control arm: the SHIPPED monolithic read path, verbatim. `loadSnapshotAsMap`
+ * verifies the body's SHA-256 against the digest embedded in the key before any
+ * field is parsed, which is precisely the hash cost this arm exists to include.
+ */
 async function loadMonolithicRows(
   storage: Storage,
   key: string,
+  collection: string,
+  signal: AbortSignal,
+): Promise<readonly ReferenceRow[]> {
+  try {
+    return toReferenceRows(await loadSnapshotAsMap(storage, key, collection, signal));
+  } catch (error) {
+    signal.throwIfAborted();
+    throw new WorkloadCeilingWorkerError(
+      502,
+      `monolithic fixture is unreadable: ${describeError(error)}`,
+    );
+  }
+}
+
+/**
+ * The unhashed probe: identical bytes, identical key, identical decode — minus
+ * the digest comparison. Deliberately a duplicate of `loadSnapshotAsMap`'s tail
+ * rather than a flag threaded through the production reader: the production
+ * reader must not grow a "skip verification" mode for a bench arm's benefit.
+ */
+async function loadMonolithicRowsUnhashed(
+  storage: Storage,
+  key: string,
+  collection: string,
   signal: AbortSignal,
 ): Promise<readonly ReferenceRow[]> {
   const stored = await storage.get(key, { signal });
   if (stored === null) {
     throw new WorkloadCeilingWorkerError(502, `monolithic fixture body is missing: ${key}`);
   }
+  // Everything loadSnapshotAsMap does EXCEPT `await snapshotHash(got.body)` and
+  // the comparison against the key digest. Keep the rest byte-for-byte
+  // equivalent — a divergence here shows up as hash cost that is not hash cost.
   let parsed: unknown;
   try {
     parsed = JSON.parse(new TextDecoder().decode(stored.body));
@@ -114,16 +165,26 @@ async function loadMonolithicRows(
   if (
     parsed === null ||
     typeof parsed !== "object" ||
-    Array.isArray(parsed) ||
-    !("rows" in parsed) ||
-    !Array.isArray((parsed as { rows: unknown }).rows)
+    !("schema_version" in parsed) ||
+    !("collection" in parsed) ||
+    !("docs" in parsed) ||
+    !Array.isArray((parsed as { docs?: unknown }).docs)
   ) {
-    throw new WorkloadCeilingWorkerError(
-      502,
-      "monolithic fixture body must be an object with a rows array",
-    );
+    throw new WorkloadCeilingWorkerError(502, "monolithic fixture body is not a snapshot");
   }
-  return (parsed as { rows: readonly ReferenceRow[] }).rows;
+  const body = parsed as {
+    schema_version: number;
+    collection: string;
+    docs: readonly { _id: string; body: DocumentData }[];
+  };
+  if (body.collection !== collection) {
+    throw new WorkloadCeilingWorkerError(502, "monolithic fixture body collection does not match");
+  }
+  const out = new Map<string, DocumentData>();
+  for (const row of body.docs) {
+    out.set(row._id, row.body);
+  }
+  return toReferenceRows(out);
 }
 
 async function loadChunkedRows(
@@ -131,6 +192,7 @@ async function loadChunkedRows(
   descriptor: WorkloadCeilingFixtureDescriptor,
   signal: AbortSignal,
 ): Promise<readonly ReferenceRow[]> {
+  const { collection } = descriptor;
   // A manifest or chunk the descriptor references but the bucket does not hold
   // is a broken upstream fixture — the same 502 the monolithic branch reports
   // for its missing body, so an operator reads one status class for "your
@@ -142,7 +204,7 @@ async function loadChunkedRows(
     const view = await openSnapshotView({
       storage,
       manifestKey: descriptor.manifest_key,
-      collection: descriptor.collection,
+      collection,
       expectedLogSeqStart: descriptor.log_seq_start,
       signal,
     });
@@ -171,7 +233,21 @@ async function runControlledFold(
   let rows: readonly ReferenceRow[];
   switch (request.implementation) {
     case "monolithic-control": {
-      rows = await loadMonolithicRows(storage, descriptor.monolithic_key, signal);
+      rows = await loadMonolithicRows(
+        storage,
+        descriptor.monolithic_key,
+        descriptor.collection,
+        signal,
+      );
+      break;
+    }
+    case "monolithic-control-unhashed": {
+      rows = await loadMonolithicRowsUnhashed(
+        storage,
+        descriptor.monolithic_key,
+        descriptor.collection,
+        signal,
+      );
       break;
     }
     case "chunked-candidate": {
@@ -213,6 +289,9 @@ export default {
       return jsonResponse(404, { error: "not found: POST /run only" });
     }
 
+    const isolateCold = isolateRequestsServed === 0;
+    isolateRequestsServed++;
+
     // Fail CLOSED, at the handler — auth policy lives here, not in the
     // comparator (`constant-time-equal.ts` deliberately pins empty-vs-empty
     // → true as comparator semantics). Without the secret-side checks an
@@ -247,6 +326,7 @@ export default {
         workload_ceiling_run_id: runRequest.run_id,
         workload_ceiling_scenario_id: runRequest.scenario_id,
         workload_ceiling_implementation: runRequest.implementation,
+        workload_ceiling_isolate_cold: isolateCold,
       }),
     );
 
@@ -262,6 +342,7 @@ export default {
         scenario_id: runRequest.scenario_id,
         implementation: runRequest.implementation,
         row_count: result.row_count,
+        isolate_cold: isolateCold,
       });
     } catch (error) {
       const status = error instanceof WorkloadCeilingWorkerError ? error.status : 500;

--- a/bench/workload-ceiling-worker/wrangler.jsonc
+++ b/bench/workload-ceiling-worker/wrangler.jsonc
@@ -32,6 +32,29 @@
     },
   ],
 
+  // NO `limits` block, deliberately — this is the COST-CURVE config, the one
+  // Lanes B/C/D capture against. Under a 10 ms `cpu_ms` cap the upper cells
+  // would terminate as `exceededCpu`, whose `cpu_ms` is censored and excluded
+  // from the resolved quantiles by `../measurement/workload-ceiling-aggregate.ts` —
+  // silently deleting the top half of each axis, which is the half
+  // `docs/spec/scale-ceilings.md` is least certain about.
+  //
+  // The CPU-WALL PROBE (`plans/tickets/lane-b-ticket-6a-cpu-wall-probe.md`) is
+  // the other half of the study and needs the opposite config. It is deployed
+  // by uncommenting exactly this block, deploying, running the probe, then
+  // re-commenting it and redeploying before Lanes B/C/D start:
+  //
+  //   "limits": { "cpu_ms": 10 },   // WORKLOAD_CEILING_STUDY.cpu_envelope.cf_free_cpu_ms
+  //
+  // Two deploys, two `script_version`s, and that is correct — they are two
+  // measurements, not one. Nothing needs to police the hand-edit: each capture
+  // records its serving version and the aggregator refuses a sweep whose events
+  // disagree on `script_version`. `limits` requires the Standard Usage Model
+  // (Workers Paid); on Free the versions upload is rejected with error 100328,
+  // "CPU limits are not supported for the Free plan" (observed 2026-08-24 on
+  // a Free-plan account, wrangler 4.83.0 — the ticket's predicted 10205 is
+  // not the code the API actually returns). The rejection mints no version, so a
+  // failed attempt leaves the serving script untouched.
   "observability": {
     "enabled": true,
     "head_sampling_rate": 1,

--- a/package.json
+++ b/package.json
@@ -234,7 +234,8 @@
     "bench:workload-ceiling:capture": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-capture.ts",
     "bench:workload-ceiling:collect-batch": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-collect-batch.ts",
     "bench:workload-ceiling:collect": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-collect.ts",
-    "bench:workload-ceiling:compare": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-compare.ts"
+    "bench:workload-ceiling:compare": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-compare.ts",
+    "bench:workload-ceiling:aggregate": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-aggregate.ts"
   },
   "dependencies": {
     "@logtape/logtape": "2.3.1"

--- a/package.json
+++ b/package.json
@@ -231,6 +231,7 @@
     "bench:collection-fanout": "node --import ./bench/register-hooks.mjs bench/collection-fanout.ts",
     "bench:workload-ceiling:provision": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-provision.ts",
     "bench:workload-ceiling:provision-sweep": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-provision-sweep.ts",
+    "bench:workload-ceiling:collect-batch": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-collect-batch.ts",
     "bench:workload-ceiling:collect": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-collect.ts",
     "bench:workload-ceiling:compare": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-compare.ts"
   },

--- a/package.json
+++ b/package.json
@@ -231,6 +231,7 @@
     "bench:collection-fanout": "node --import ./bench/register-hooks.mjs bench/collection-fanout.ts",
     "bench:workload-ceiling:provision": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-provision.ts",
     "bench:workload-ceiling:provision-sweep": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-provision-sweep.ts",
+    "bench:workload-ceiling:capture": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-capture.ts",
     "bench:workload-ceiling:collect-batch": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-collect-batch.ts",
     "bench:workload-ceiling:collect": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-collect.ts",
     "bench:workload-ceiling:compare": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-compare.ts"

--- a/package.json
+++ b/package.json
@@ -235,7 +235,8 @@
     "bench:workload-ceiling:collect-batch": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-collect-batch.ts",
     "bench:workload-ceiling:collect": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-collect.ts",
     "bench:workload-ceiling:compare": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-compare.ts",
-    "bench:workload-ceiling:aggregate": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-aggregate.ts"
+    "bench:workload-ceiling:aggregate": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-aggregate.ts",
+    "bench:workload-ceiling:validate-smoke": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-validate-smoke.ts"
   },
   "dependencies": {
     "@logtape/logtape": "2.3.1"

--- a/package.json
+++ b/package.json
@@ -230,6 +230,7 @@
     "bench:write-amp-stress": "node --import ./bench/register-hooks.mjs bench/write-amp-stress.ts",
     "bench:collection-fanout": "node --import ./bench/register-hooks.mjs bench/collection-fanout.ts",
     "bench:workload-ceiling:provision": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-provision.ts",
+    "bench:workload-ceiling:provision-sweep": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-provision-sweep.ts",
     "bench:workload-ceiling:collect": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-collect.ts",
     "bench:workload-ceiling:compare": "node --import ./bench/register-hooks.mjs bench/measurement/workload-ceiling-compare.ts"
   },

--- a/tsconfig.cloudflare.json
+++ b/tsconfig.cloudflare.json
@@ -24,13 +24,12 @@
   },
   "include": [
     "packages/adapter-cloudflare/src",
+    "bench/workload-ceiling-worker/src",
     "tests/fixtures/mock-execution-context.ts",
     "tests/integration/public-surface.test.ts",
     "tests/integration/s3-worker-e2e.test.ts",
     "tests/setup/http-conformance-worker.ts",
-    "tests/setup/r2-binding.ts",
-    "bench/workload-ceiling-worker/src/index.ts",
-    "bench/workload-ceiling-worker/src/index.test.ts"
+    "tests/setup/r2-binding.ts"
   ],
   // `extends` would otherwise inherit the root program's exclusions, which are
   // exactly this program's includes.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -76,12 +76,11 @@
     "tests/fixtures/check-acceptance",
 
     "packages/adapter-cloudflare/src",
+    "bench/workload-ceiling-worker/src",
     "tests/fixtures/mock-execution-context.ts",
     "tests/integration/public-surface.test.ts",
     "tests/integration/s3-worker-e2e.test.ts",
     "tests/setup/http-conformance-worker.ts",
-    "tests/setup/r2-binding.ts",
-    "bench/workload-ceiling-worker/src/index.ts",
-    "bench/workload-ceiling-worker/src/index.test.ts"
+    "tests/setup/r2-binding.ts"
   ]
 }


### PR DESCRIPTION
Refs #161, #162, both merged. This was the last of the three stacked PRs; the diff shown here is against `main`.

## What & why

Lands the bench-only capture tooling for the workload-ceiling study: the byte-axis cell catalog and fixture calibration, the sweep provisioner, the capture runner and its journal, the batched telemetry collector, the per-cell aggregator, and the Lane A smoke runner. Nothing here ships to users — the diff is `bench/` plus two `tsconfig` includes and `package.json` scripts. It makes the program's citations of `cpu_envelope` and `configured_cpu_ms` real rather than branch-only, and unblocks the `cf-free` preregistration amendment and the locality producer.

The shared evidence vocabulary landed in #161 and the matched-comparison cardinality fix in #162. What remains here is additive: 13 new modules and their tests, plus the Worker gaining a third arm.

## Key points

- The `monolithic-control-unhashed` arm is a measurement-only probe, not a subject: a Worker may not time itself, so the control's SHA-256 verification cost has to be a difference of two platform-reported CPU numbers. Handing it to the comparison as a side would report a format comparison that was really a hash measurement.
- The monolithic control reads the shipped path with hash verification rather than a bench-local reimplementation, so what the study measures is what a caller would run.
- Resume matches on the slot — (scenario_id, implementation, warmup) — and drops each slot's completed prefix, because the journal is append-only in execution order and carries no plan index. `warmup` is part of the slot: the exclusion policy is `warmup-tagged-before-run-only`, so a journalled warmup must not retire a measured invocation.
- `invokeWorker` returns `rowCount` / `isolateCold` as nullable rather than defaulting them, so an unreadable response aborts the run instead of entering the journal as a warm zero-row invocation and mislabelling the thermal axis.
- `isolate_cold` is tested by evaluating a fresh module instance. The counter is module-scope by design — it has to survive across requests to mean anything — so asserting against the shared import passes or fails on whether an earlier test warmed it.
- Hash cost pairs by invocation ordinal over each arm's full list, with a pair emitted only when both arms resolved that ordinal. A preregistered ~15% telemetry-drop rate makes filter-then-zip compare invocations from different passes. The lists are ordered by `runtime_period`, since `observed_at` is the collector's clock and `readEventsFromDirectory` returns readdir order.
- Fixture calibration failure is fatal, and an undecodable sweep report is refused rather than treated as an empty sweep: either one would silently relabel the axis the study reports against. Both readers of the sweep report now go through `decodeWorkloadCeilingSweepReport` — the same codec its writer enforces on the same file — so a parseable-but-malformed report cannot feed unvalidated `achieved_bytes` / `target_bytes` / `row_count` into the admission gates.
- A sweep whose planned arm collected nothing is refused rather than reported over the arms that survived — an arm that produced zero events is a capture that did not happen, not a result.
- `WORKLOAD_CEILING_MEASURED_OVERRIDE` requires a positive integer. Unguarded `parseInt` made a typo the quietest failure a measurement runner has: `totalPasses` became NaN, the pass loop never ran, and the runner printed "Capture complete" and exited 0 having invoked nothing.
- `parseArms` validates against `WORKLOAD_CEILING_IMPLEMENTATIONS` rather than a repeated literal list, and narrows only after validating — this PR is itself the one that adds a third arm.
- `wrangler.jsonc` deliberately carries no `limits` block: this is the cost-curve config. The CPU-wall probe needs the opposite, so the block is committed as a comment to uncomment for that deploy. On Free the versions upload is rejected with error 100328, which mints no version, so a failed attempt leaves the serving script untouched.
- `bench/workload-ceiling-worker/src` moves into the Workers program as a directory, so a new module there is typechecked without editing both tsconfigs.
- The byte axis is measured through the encoder that writes it. `monolithicEncodedBytes` — the calibrator's objective and the sweep report's `achieved_bytes` — built its own body literal, while the provisioner wrote `encodeSnapshotBody`. The two agree today, by coincidence: one field added to `SnapshotBody` would land on the write path only, and `achieved_bytes` would stop being the size of the stored object while still being published as the axis coordinate. Both paths now share one body builder, and a test pins the calibrator's number to the monolithic write's `body.byteLength` for a real cell.
- The batch collector persists the collector's own failure detail. `spawnCollector` returns the exit code plus captured stderr, but the callback logged it and returned `undefined`, so `summary-<sweepId>.json` recorded a bare "collector failed" for every collector error and diagnosing a failed arm meant reading terminal scrollback that no longer exists.

## Verification

| Command | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3919 passed, 105 skipped |
| `pnpm test:adapter-cloudflare` | 162 passed, 2 skipped |
| `pnpm bundle-sizes` | ok (14 entries) |
| `pnpm build:agent` | clean |

`verify:agent` and `pnpm test:agent bench/measurement` are green at every one of the 13 commits, not just the tip — re-measured after the rebase onto `main`.

Not run: the credentialed capture itself, which needs Cloudflare account access and ~6.5 attended hours.

## Notes for reviewers

The commits are ordered so each one is independently green; reviewing them in order is the intended path. `remainingCaptureInvocations` in `workload-ceiling-capture.ts` is the piece worth reading closely — its tests are written to fail against the earlier filter.

`tsconfig.json` collides with #159 (`docs/workload-ceiling-rebaseline`): this branch moves the Worker include to a directory and drops two now-redundant lines; that branch inserts a `bench/results` exclude a few lines above. Whichever lands second may need a one-line rebase.

The admission predicate (`satisfiesWorkloadCeilingAdmission`) is still unreachable — no tool constructs a `WorkloadCeilingStudyEvidence`. It is the largest remaining evidence-integrity gap and it is tracked in #168, blocked on this stack landing and on the `cf-free` preregistration amendment.

Deferred bench-tooling follow-ups: #163, #164, #165, #166, #167.


