### PR TITLE
fix(bench): pair capture cells, not invocations, in the matched comparison

### DIFF
--- a/bench/measurement/workload-ceiling-compare.test.ts
+++ b/bench/measurement/workload-ceiling-compare.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   assessWorkloadCeilingExecution,
   buildWorkloadCeilingComparisonReport,
+  isResolvedOk,
   matchWorkloadCeilingEvents,
   readEventsFromDirectory,
 } from "./workload-ceiling-compare.ts";
@@ -64,6 +65,31 @@ const evidenceMissing = (over: Partial<WorkloadCeilingRawEvent>): WorkloadCeilin
     evidence: {
       status: "missing",
       detail: "no workers-observability join line for run_id in window",
+      authority: "workers-observability",
+      authoritative_outcome: null,
+      authoritative_cpu_ms: null,
+      authoritative_response_status: null,
+      cpu_source: "none",
+      cpu_outcome_verbatim: null,
+    },
+    ...over,
+  });
+
+/**
+ * An invocation whose authoritative record arrived but did not resolve to
+ * exactly one correlatable event — produced in practice by
+ * `workload-ceiling-collect.ts` (duplicate join lines, a summary line
+ * missing required fields, or two sources disagreeing about the outcome).
+ */
+const evidenceAmbiguous = (over: Partial<WorkloadCeilingRawEvent>): WorkloadCeilingRawEvent =>
+  event({
+    script_version: "unresolved",
+    colo: "unknown",
+    outcome: null,
+    cpu_ms: null,
+    evidence: {
+      status: "ambiguous",
+      detail: "2 join lines carry this run_id in one window",
       authority: "workers-observability",
       authoritative_outcome: null,
       authoritative_cpu_ms: null,
@@ -206,6 +232,57 @@ describe("assessWorkloadCeilingExecution", () => {
     expect(assessment.evidence_ambiguous_count).toBe(0);
     expect(assessment.finite_cpu_sample_count).toBe(1);
     expect(assessment.outcome_histogram).toEqual({ success: 2, exceededCpu: 1 });
+  });
+
+  test("an ambiguous record is neither authoritative nor an execution failure", () => {
+    // `evidence_ambiguous_count` was asserted only as `0` before, so the
+    // branch that increments it never ran. An ambiguous invocation is an
+    // evidence fact: it must not enter the zero-failure denominator, and it
+    // must not be counted as a failure either.
+    const assessment = assessWorkloadCeilingExecution([
+      event({ run_id: "r1", scenario_id: "s1" }),
+      evidenceAmbiguous({ run_id: "r2", scenario_id: "s2" }),
+      evidenceAmbiguous({ run_id: "r3", scenario_id: "s3" }),
+    ]);
+    expect(assessment.evidence_ambiguous_count).toBe(2);
+    expect(assessment.evidence_missing_count).toBe(0);
+    expect(assessment.authoritative_event_count).toBe(1);
+    expect(assessment.execution_failure_count).toBe(0);
+    expect(assessment.finite_cpu_sample_count).toBe(1);
+    expect(assessment.outcome_histogram).toEqual({ success: 1 });
+  });
+
+  test("finite_cpu_sample_count agrees with isResolvedOk over the same events", () => {
+    // The drift the shared predicate exists to prevent: the assessment used
+    // to re-implement the success-plus-finite-CPU test inline.
+    const events = [
+      event({ run_id: "r1", scenario_id: "s1" }),
+      cpuMissingSuccess({ run_id: "r2", scenario_id: "s2" }),
+      event({ run_id: "r3", scenario_id: "s3", outcome: "exceededCpu", cpu_ms: 50 }),
+      evidenceMissing({ run_id: "r4", scenario_id: "s4" }),
+      evidenceAmbiguous({ run_id: "r5", scenario_id: "s5" }),
+      event({ run_id: "r6", scenario_id: "s6", cpu_ms: 12.5 }),
+    ];
+    expect(assessWorkloadCeilingExecution(events).finite_cpu_sample_count).toBe(
+      events.filter(isResolvedOk).length,
+    );
+  });
+
+  test("an unclassified evidence status is refused, not counted as authoritative", () => {
+    // Guards the fall-through: a fourth status would otherwise be treated as
+    // a resolved Bernoulli trial and inflate the zero-failure denominator.
+    const rogue = {
+      ...event({ run_id: "r1", scenario_id: "s1" }),
+      outcome: null,
+      evidence: { ...event({}).evidence, status: "provisional" },
+    } as unknown as WorkloadCeilingRawEvent;
+    try {
+      assessWorkloadCeilingExecution([rogue]);
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(WorkloadCeilingHarnessError);
+      expect((error as WorkloadCeilingHarnessError).field).toBe("evidence.status");
+    }
   });
 
   test("a missing adaptive row with successful observability is not an execution failure", () => {

--- a/bench/measurement/workload-ceiling-compare.test.ts
+++ b/bench/measurement/workload-ceiling-compare.test.ts
@@ -6,6 +6,7 @@ import {
   type WorkloadCeilingRawEvent,
 } from "./workload-ceiling-harness.ts";
 import {
+  assessWorkloadCeilingExecution,
   buildWorkloadCeilingComparisonReport,
   matchWorkloadCeilingEvents,
   readEventsFromDirectory,
@@ -25,9 +26,9 @@ const event = (over: Partial<WorkloadCeilingRawEvent>): WorkloadCeilingRawEvent 
   observed_at: "2026-08-18T00:00:00Z",
   evidence: {
     status: "resolved",
-    detail: "one authoritative record",
+    detail: null,
     authority: "workers-observability",
-    authoritative_outcome: "success",
+    authoritative_outcome: "ok",
     authoritative_cpu_ms: 10,
     authoritative_response_status: 200,
     cpu_source: "workers-invocations-adaptive",
@@ -35,6 +36,43 @@ const event = (over: Partial<WorkloadCeilingRawEvent>): WorkloadCeilingRawEvent 
   },
   ...over,
 });
+
+/** A successful invocation whose adaptive CPU row never landed — the rehearsal's missingness shape. */
+const cpuMissingSuccess = (over: Partial<WorkloadCeilingRawEvent>): WorkloadCeilingRawEvent =>
+  event({
+    cpu_ms: null,
+    evidence: {
+      status: "resolved",
+      detail: null,
+      authority: "workers-observability",
+      authoritative_outcome: "ok",
+      authoritative_cpu_ms: 7,
+      authoritative_response_status: 200,
+      cpu_source: "none",
+      cpu_outcome_verbatim: null,
+    },
+    ...over,
+  });
+
+/** An invocation whose authoritative record never arrived. */
+const evidenceMissing = (over: Partial<WorkloadCeilingRawEvent>): WorkloadCeilingRawEvent =>
+  event({
+    script_version: "unresolved",
+    colo: "unknown",
+    outcome: null,
+    cpu_ms: null,
+    evidence: {
+      status: "missing",
+      detail: "no workers-observability join line for run_id in window",
+      authority: "workers-observability",
+      authoritative_outcome: null,
+      authoritative_cpu_ms: null,
+      authoritative_response_status: null,
+      cpu_source: "none",
+      cpu_outcome_verbatim: null,
+    },
+    ...over,
+  });
 
 const reportInput = (
   matched: ReturnType<typeof matchWorkloadCeilingEvents>,
@@ -57,7 +95,8 @@ describe("matchWorkloadCeilingEvents", () => {
     );
     expect(matched.pairs).toHaveLength(1);
     expect(matched.incomplete).toEqual([]);
-    expect(matched.pairs[0]!.control.cpu_ms).toBe(10);
+    expect(matched.pairs[0]!.control.p50.value).toBe(10);
+    expect(matched.pairs[0]!.candidate.p50.value).toBe(20);
   });
 
   test.each([
@@ -69,16 +108,38 @@ describe("matchWorkloadCeilingEvents", () => {
     expect(matched.incomplete).toEqual([{ scenario_id: "s1", reason }]);
   });
 
-  test("duplicate scenarios are evicted and reported on the side they occur", () => {
+  test("repeated invocations of one scenario are the sample, not a rejection", () => {
+    // The regression this module exists to prevent: the capture runner emits
+    // n invocations per cell per arm, ALL carrying that cell's one
+    // scenario_id. An earlier revision keyed a Map on scenario_id and evicted
+    // the repeats, so a real capture produced zero pairs after every hour of
+    // platform time was already spent.
     const matched = matchWorkloadCeilingEvents(
-      [event({ scenario_id: "s1", cpu_ms: 1 }), event({ scenario_id: "s1", cpu_ms: 2 })],
-      [event({ scenario_id: "s1", cpu_ms: 3 })],
+      [
+        event({ scenario_id: "s1", cpu_ms: 1 }),
+        event({ scenario_id: "s1", cpu_ms: 2 }),
+        event({ scenario_id: "s1", cpu_ms: 3 }),
+      ],
+      [event({ scenario_id: "s1", cpu_ms: 10 })],
+    );
+    expect(matched.incomplete).toEqual([]);
+    expect(matched.pairs).toHaveLength(1);
+    expect(matched.pairs[0]!.control.sample_count).toBe(3);
+    expect(matched.pairs[0]!.control.p50.value).toBe(2);
+  });
+
+  test("a side whose own events name two deployments is reported as a mid-capture redeploy", () => {
+    const matched = matchWorkloadCeilingEvents(
+      [
+        event({ scenario_id: "s1", cpu_ms: 1, script_version: "v1" }),
+        event({ scenario_id: "s1", cpu_ms: 2, script_version: "v2" }),
+      ],
+      [event({ scenario_id: "s1", cpu_ms: 3, script_version: "v1" })],
     );
     expect(matched.pairs).toEqual([]);
-    expect(matched.incomplete).toContainEqual({
-      scenario_id: "s1",
-      reason: "duplicate-scenario",
-    });
+    expect(matched.incomplete).toEqual([
+      { scenario_id: "s1", reason: "mixed-deployment-within-side" },
+    ]);
   });
 
   test("deployment metadata mismatch rejects the pair", () => {
@@ -91,7 +152,7 @@ describe("matchWorkloadCeilingEvents", () => {
     ]);
   });
 
-  test("a null cpu_ms on either side rejects the pair as unresolved-cpu", () => {
+  test("a side with no finite-CPU success at all rejects the pair as unresolved-cpu", () => {
     const matched = matchWorkloadCeilingEvents(
       [event({ scenario_id: "s1", cpu_ms: 10 })],
       [event({ scenario_id: "s1", cpu_ms: null, outcome: "exceededCpu" })],
@@ -99,16 +160,79 @@ describe("matchWorkloadCeilingEvents", () => {
     expect(matched.incomplete).toEqual([{ scenario_id: "s1", reason: "unresolved-cpu" }]);
   });
 
-  test("a non-ok outcome carrying a partial cpu_ms still rejects the pair", () => {
+  test("one unusable invocation does not reject a side that has other samples", () => {
+    // The counterpart of the rule above, and the reason it is a SIDE-level
+    // gate: at 40 planned invocations per cell a single censored or
+    // telemetry-dropped one must narrow the sample, not delete the cell.
+    const matched = matchWorkloadCeilingEvents(
+      [
+        event({ scenario_id: "s1", cpu_ms: 10 }),
+        event({ scenario_id: "s1", cpu_ms: 12 }),
+        event({ scenario_id: "s1", cpu_ms: 900, outcome: "exceededCpu" }),
+      ],
+      [event({ scenario_id: "s1", cpu_ms: 20 })],
+    );
+    expect(matched.incomplete).toEqual([]);
+    expect(matched.pairs[0]!.control.sample_count).toBe(2);
+    expect(matched.pairs[0]!.control.collected_event_count).toBe(3);
+    expect(matched.pairs[0]!.control.p50.value).toBe(11);
+  });
+
+  test("a non-ok outcome carrying a partial cpu_ms is never a sample", () => {
     // The platform reports a partial CPU number alongside `exceededCpu`, and
     // the harness codec preserves that shape — so cpu_ms being non-null is
-    // not evidence the invocation resolved.
+    // not evidence the invocation resolved. With it excluded, this side has
+    // no samples left and the cell is rejected.
     const matched = matchWorkloadCeilingEvents(
       [event({ scenario_id: "s1", cpu_ms: 10 })],
       [event({ scenario_id: "s1", cpu_ms: 50, outcome: "exceededCpu" })],
     );
     expect(matched.pairs).toEqual([]);
     expect(matched.incomplete).toEqual([{ scenario_id: "s1", reason: "unresolved-cpu" }]);
+  });
+});
+
+describe("assessWorkloadCeilingExecution", () => {
+  test("separates execution failures from evidence missingness and CPU missingness", () => {
+    const assessment = assessWorkloadCeilingExecution([
+      event({ run_id: "r1", scenario_id: "s1" }),
+      cpuMissingSuccess({ run_id: "r2", scenario_id: "s2" }),
+      evidenceMissing({ run_id: "r3", scenario_id: "s3" }),
+      event({ run_id: "r4", scenario_id: "s4", outcome: "exceededCpu", cpu_ms: 50 }),
+    ]);
+    expect(assessment.authoritative_event_count).toBe(3);
+    expect(assessment.execution_failure_count).toBe(1);
+    expect(assessment.evidence_missing_count).toBe(1);
+    expect(assessment.evidence_ambiguous_count).toBe(0);
+    expect(assessment.finite_cpu_sample_count).toBe(1);
+    expect(assessment.outcome_histogram).toEqual({ success: 2, exceededCpu: 1 });
+  });
+
+  test("a missing adaptive row with successful observability is not an execution failure", () => {
+    const assessment = assessWorkloadCeilingExecution([
+      cpuMissingSuccess({ run_id: "r1", scenario_id: "s1" }),
+    ]);
+    expect(assessment.execution_failure_count).toBe(0);
+    expect(assessment.authoritative_event_count).toBe(1);
+    expect(assessment.finite_cpu_sample_count).toBe(0);
+  });
+
+  test("adding successful events never erases an observed failure", () => {
+    const oneFailure = assessWorkloadCeilingExecution([
+      event({ run_id: "r1", scenario_id: "s1", outcome: "exceededCpu", cpu_ms: 50 }),
+    ]);
+    // The "top-up" scenario: however many clean successes are appended —
+    // before or after observing the failure — the failure count and the
+    // evidence gaps stay what they are. There is no post-hoc remedy.
+    const toppedUp = assessWorkloadCeilingExecution([
+      ...Array.from({ length: 39 }, (_, i) =>
+        event({ run_id: `r${100 + i}`, scenario_id: `s${i}` }),
+      ),
+      event({ run_id: "r1", scenario_id: "s1", outcome: "exceededCpu", cpu_ms: 50 }),
+      evidenceMissing({ run_id: "r2", scenario_id: "s2" }),
+    ]);
+    expect(toppedUp.execution_failure_count).toBe(oneFailure.execution_failure_count);
+    expect(toppedUp.evidence_missing_count).toBe(1);
   });
 });
 
@@ -146,17 +270,44 @@ describe("buildWorkloadCeilingComparisonReport", () => {
   });
 
   test("failure budget is computed over ALL collected events, not surviving pairs", () => {
-    // Duplicate s1 on the control side evicts it from pairing, but all
-    // three control attempts still count toward the failure budget.
-    const controlAll = [...control, event({ scenario_id: "s1", cpu_ms: 99 })];
+    // s3 has no candidate side, so it never pairs — but its control attempt
+    // still counts toward the failure budget, which is assessed over every
+    // invocation the capture actually made.
+    const controlAll = [...control, event({ scenario_id: "s3", cpu_ms: 99 })];
     const matched = matchWorkloadCeilingEvents(controlAll, candidate);
-    expect(matched.pairs).toHaveLength(1); // only s2 survives
+    expect(matched.pairs).toHaveLength(2);
+    expect(matched.incomplete).toEqual([{ scenario_id: "s3", reason: "missing-candidate" }]);
     const report = buildWorkloadCeilingComparisonReport(
       reportInput(matched, controlAll, candidate),
     );
     expect(report.zero_failure_upper_bound.control).toEqual(
       clopperPearsonZeroFailureUpper(3, 0.95),
     );
+  });
+
+  test("the pooled quantiles ignore samples from cells that never paired", () => {
+    // s3's 900 ms control sample is real and counts against the failure
+    // budget, but it belongs to no pair — folding it into the pooled
+    // distribution would let an unmatched cell move a number the matched
+    // comparison reports.
+    const controlAll = [...control, event({ scenario_id: "s3", cpu_ms: 900 })];
+    const report = buildWorkloadCeilingComparisonReport(
+      reportInput(matchWorkloadCeilingEvents(controlAll, candidate), controlAll, candidate),
+    );
+    expect(report.control_cpu_ms.p99.sample_size).toBe(2);
+    expect(report.control_cpu_ms.p99.value).toBeLessThan(900);
+  });
+
+  test("the pooled quantiles read every invocation of a paired cell, not its p50", () => {
+    // The two views the report carries are different on purpose: `pairs` is
+    // per-cell, `control_cpu_ms` is the pooled sample across paired cells.
+    const controlAll = [...control, event({ scenario_id: "s1", cpu_ms: 30 })];
+    const report = buildWorkloadCeilingComparisonReport(
+      reportInput(matchWorkloadCeilingEvents(controlAll, candidate), controlAll, candidate),
+    );
+    expect(report.control_cpu_ms.p50.sample_size).toBe(3);
+    expect(report.pairs).toHaveLength(2);
+    expect(report.pairs[0]!.control.p50.value).toBe(20); // s1: median of 10 and 30
   });
 
   test("a non-ok event carrying a partial cpu_ms counts as a failure, not a success", () => {
@@ -186,12 +337,34 @@ describe("buildWorkloadCeilingComparisonReport", () => {
     );
   });
 
-  test("a side with unresolved events is marked invalid, never given an anti-conservative bound", () => {
-    // One exceededCpu attempt on the control side only. The zero-failure
-    // formula (1 - c^(1/n)) has no honest reading at F > 0 — with the
-    // current N−F denominator MORE failures would tighten it — so the
-    // control side must be reported as invalid by name, while the
-    // all-resolved candidate side still gets its valid bound.
+  test("evidence missingness neither fails a side nor widens its zero-failure denominator", () => {
+    // The evidence-contract v2 split: an invocation whose authoritative record
+    // never arrived is not an execution failure, so it cannot invalidate the
+    // bound — but it is not a success either, so it must not enter the
+    // denominator. The bound is computed over AUTHORITATIVE events only.
+    const controlAll = [...control, evidenceMissing({ scenario_id: "s3" })];
+    const matched = matchWorkloadCeilingEvents(controlAll, candidate);
+    const report = buildWorkloadCeilingComparisonReport(
+      reportInput(matched, controlAll, candidate),
+    );
+    expect(report.zero_failure_upper_bound.control).toEqual(
+      clopperPearsonZeroFailureUpper(2, 0.95),
+    );
+  });
+
+  test("a CPU-missing success keeps a valid bound while contributing no sample", () => {
+    const controlAll = [...control, cpuMissingSuccess({ scenario_id: "s3" })];
+    const matched = matchWorkloadCeilingEvents(controlAll, candidate);
+    expect(matched.incomplete).toContainEqual({ scenario_id: "s3", reason: "missing-candidate" });
+    const report = buildWorkloadCeilingComparisonReport(
+      reportInput(matched, controlAll, candidate),
+    );
+    expect(report.zero_failure_upper_bound.control).toEqual(
+      clopperPearsonZeroFailureUpper(3, 0.95),
+    );
+  });
+
+  test("an exceededCpu side is marked invalid by name, while the clean side keeps its bound", () => {
     const controlAll = [
       ...control,
       event({ scenario_id: "s3", cpu_ms: null, outcome: "exceededCpu" }),

--- a/bench/measurement/workload-ceiling-compare.ts
+++ b/bench/measurement/workload-ceiling-compare.ts
@@ -149,21 +149,54 @@ export function assessWorkloadCeilingExecution(
   let ambiguous = 0;
   let finiteCpu = 0;
   for (const event of events) {
-    if (event.evidence.status === "missing") {
-      missing += 1;
-      continue;
+    switch (event.evidence.status) {
+      case "missing": {
+        missing += 1;
+        continue;
+      }
+      case "ambiguous": {
+        ambiguous += 1;
+        continue;
+      }
+      case "resolved": {
+        break;
+      }
+      default: {
+        // A fourth evidence status must be classified here deliberately.
+        // Reaching the authoritative path by fall-through would count an
+        // unclassified record as a Bernoulli trial and assert a histogram
+        // entry over a genuine `null` outcome — inflating the denominator of
+        // the zero-failure bound with an invocation whose result nobody
+        // established.
+        const unclassified: never = event.evidence.status;
+        throw new WorkloadCeilingHarnessError(
+          "evidence.status",
+          `unclassified evidence status ${JSON.stringify(unclassified)}`,
+        );
+      }
     }
-    if (event.evidence.status === "ambiguous") {
-      ambiguous += 1;
-      continue;
+    // `resolved` implies a non-null outcome in the codec
+    // (`workload-ceiling-harness.ts`), but the flat event type does not say
+    // so, and this function also runs over hand-built events. Assert the
+    // invariant rather than silencing it with `!`.
+    const outcome = event.outcome;
+    if (outcome === null) {
+      throw new WorkloadCeilingHarnessError(
+        "outcome",
+        'must be a platform outcome when evidence.status is "resolved"',
+      );
     }
     authoritative += 1;
-    histogram[event.outcome!] = (histogram[event.outcome!] ?? 0) + 1;
-    if (event.outcome !== WORKLOAD_CEILING_SUCCESS_OUTCOME) {
+    histogram[outcome] = (histogram[outcome] ?? 0) + 1;
+    if (outcome !== WORKLOAD_CEILING_SUCCESS_OUTCOME) {
       failures += 1;
       continue;
     }
-    if (event.cpu_ms !== null && Number.isFinite(event.cpu_ms)) {
+    // The one definition of "usable measurement", not a second copy of it:
+    // `finite_cpu_sample_count` has to stay equal to
+    // `events.filter(isResolvedOk).length`, which is what this module's
+    // docstring promises the pairing path and this assessment share.
+    if (isResolvedOk(event)) {
       finiteCpu += 1;
     }
   }

--- a/bench/measurement/workload-ceiling-compare.ts
+++ b/bench/measurement/workload-ceiling-compare.ts
@@ -2,84 +2,231 @@
  * Matched comparison for the deployed workload-ceiling study (parent plan
  * Task 8 Step 7).
  *
- * Joins `monolithic-control` and `chunked-candidate` raw events
- * (`workload-ceiling-harness.ts`, produced by `workload-ceiling-collect.ts`)
- * by `scenario_id` PLUS deployment metadata — `compatibility_date` and
- * `script_version` must agree, because this study's Worker
- * (`bench/workload-ceiling-worker/src/index.ts`) serves both
+ * **The paired unit is a CELL, not an invocation.** The capture runner emits
+ * `WORKLOAD_CEILING_STUDY.capture.planned_measured_invocations_per_cell`
+ * invocations per cell per arm, all carrying that cell's single
+ * `scenario_id` (`workload-ceiling-cells.ts` mints one id per cell and
+ * deliberately does not encode the arm). So each side of a scenario arrives
+ * as a SAMPLE, and this module reduces it to one cell statistic — the r7 p50
+ * over that side's finite-CPU successful invocations, plus its MAD — before
+ * joining. Pairing raw invocations would be both unmatched (nothing links
+ * the k-th control invocation to the k-th candidate one) and, at n = 40 per
+ * side, statistically indefensible.
+ *
+ * Joins `monolithic-control` and `chunked-candidate` cell statistics
+ * (`workload-ceiling-harness.ts` events, produced by
+ * `workload-ceiling-collect.ts`) by `scenario_id` PLUS deployment metadata —
+ * `compatibility_date` and `script_version` must agree, because this study's
+ * Worker (`bench/workload-ceiling-worker/src/index.ts`) serves both
  * implementations from the SAME deployed script, branching on the request's
- * `implementation` field. Two events under the same scenario but different
- * deployment metadata were not measured on the same runtime build and are
- * NOT a valid pair.
+ * `implementation` field. Deployment agreement is now checked in two places,
+ * because a sample has an inside: WITHIN a side, whose events must all name
+ * one deployment, and ACROSS the two sides. Events measured on different
+ * runtime builds are NOT a valid pair.
  *
  * Every number this module reports comes from a tagged algorithm in
- * `statistics.ts` — p50/p95/p99 via `quantileEstimate`, the paired
- * candidate/control ratio via `pairedRatioBootstrap`, and the zero-failure
+ * `statistics.ts` — p50/p95/p99 via `quantileEstimate`, per-cell dispersion
+ * via `madEstimate`, the paired candidate/control ratio via
+ * `pairedRatioBootstrap`, and the zero-failure
  * upper bound on unresolved/failed invocations via
  * `clopperPearsonZeroFailureUpper` — computed per side ONLY over sides that
  * observed zero unresolved invocations; a side with any failure is marked
  * `{ invalid: "failures-present", failure_count }` instead, because the
  * zero-failure formula has no honest extension to F > 0 (see
  * {@link WorkloadCeilingZeroFailureBoundInvalid}). An incomplete pair (missing a side,
- * mismatched deployment metadata, or either side failing to resolve to a
- * usable `ok` measurement) is rejected from the paired statistics rather than
+ * mismatched deployment metadata, or either side yielding no usable `ok`
+ * measurement) is rejected from the paired statistics rather than
  * silently imputed, and is reported separately.
  */
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { runAsCliEntrypoint } from "./cli-entrypoint.ts";
 import {
   clopperPearsonZeroFailureUpper,
+  madEstimate,
   pairedRatioBootstrap,
   quantileEstimate,
   type BootstrapResult,
   type ClopperPearsonZeroFailureResult,
+  type DispersionEstimate,
   type PairedValue,
   type QuantileEstimate,
 } from "./statistics.ts";
 import {
   decodeWorkloadCeilingRawEvent,
   WORKLOAD_CEILING_SUCCESS_OUTCOME,
+  WORKLOAD_CEILING_UNRESOLVED_SCRIPT_VERSION,
   WorkloadCeilingHarnessError,
   type WorkloadCeilingRawEvent,
 } from "./workload-ceiling-harness.ts";
 
-function deploymentKey(event: WorkloadCeilingRawEvent): string {
+export function deploymentKey(event: WorkloadCeilingRawEvent): string {
   return `${event.compatibility_date}|${event.script_version}`;
 }
 
 /**
- * The single definition of "this invocation resolved to a usable
- * measurement": the collection window produced a CPU number AND the platform
- * classified the invocation as a success.
+ * True when the event carries no deployment metadata to agree or disagree
+ * about — the authoritative record never resolved, so `script_version` is
+ * the sentinel rather than a version the platform reported.
  *
- * The `cpu_ms !== null` half alone is NOT sufficient. A non-success outcome can
- * still carry a partial CPU number — the platform reports one for
- * `exceededCpu`, and `workload-ceiling-harness.ts` preserves that shape
- * deliberately. Both the pairing logic and the per-side failure-budget count
- * MUST read this one predicate: a side that observed a real failed
- * invocation must never receive a valid-looking zero-failure bound, which is
- * exactly what counting such an event as a success would produce.
+ * Callers comparing `deploymentKey` across a cell MUST skip these. An
+ * unresolved event is an evidence-completeness fact, not evidence that two
+ * runtime builds served one capture, and conflating the two turns a couple
+ * of missing telemetry records into a spurious "the Worker was redeployed
+ * mid-run" verdict.
  */
-const isResolvedOk = (event: WorkloadCeilingRawEvent): event is ResolvedWorkloadCeilingRawEvent =>
-  event.cpu_ms !== null && event.outcome === WORKLOAD_CEILING_SUCCESS_OUTCOME;
+export const hasResolvedDeployment = (event: WorkloadCeilingRawEvent): boolean =>
+  event.script_version !== WORKLOAD_CEILING_UNRESOLVED_SCRIPT_VERSION;
 
-/** A WorkloadCeilingRawEvent whose collection window resolved to exactly one single-request invocation. */
+/**
+ * The single definition of "this invocation resolved to a usable
+ * MEASUREMENT": the authoritative platform record resolved AND classified
+ * the invocation as a success AND the CPU source supplied a finite number.
+ *
+ * Each half is load-bearing:
+ *
+ *  - a `null` outcome (evidence missing or ambiguous) is not a sample of
+ *    anything — the invocation's execution result was never established;
+ *  - a non-success outcome can still carry a partial CPU number — the
+ *    platform reports one for `exceededCpu`, and `workload-ceiling-harness.ts`
+ *    preserves that shape deliberately. Pooling it would understate the cost
+ *    of an invocation that never finished;
+ *  - a success whose adaptive CPU row never landed (the rehearsal's
+ *    missingness shape) is a real success and NOT an execution failure, but
+ *    it contributes no quantile sample.
+ *
+ * Both the pairing logic and the execution assessment below read predicates
+ * from this module so those three concepts never drift apart again.
+ */
+export const isResolvedOk = (
+  event: WorkloadCeilingRawEvent,
+): event is ResolvedWorkloadCeilingRawEvent =>
+  event.outcome === WORKLOAD_CEILING_SUCCESS_OUTCOME &&
+  event.cpu_ms !== null &&
+  Number.isFinite(event.cpu_ms);
+
+/** A WorkloadCeilingRawEvent whose collection resolved to exactly one single-request invocation with a finite CPU measurement. */
 export type ResolvedWorkloadCeilingRawEvent = Omit<WorkloadCeilingRawEvent, "cpu_ms"> & {
   readonly cpu_ms: number;
 };
 
+/**
+ * The three-way execution/evidence assessment every consumer of collected
+ * events shares. Computed over a list of events (one per collected
+ * invocation):
+ *
+ *  - `authoritative_event_count` — invocations whose Workers Observability
+ *    record resolved. This is the denominator of the zero-execution-failure
+ *    bound: only an invocation whose outcome the platform actually reported
+ *    is a Bernoulli trial.
+ *  - `execution_failure_count` — authoritative events whose canonical
+ *    outcome is not `"success"`. A missing CPU row, a missing authoritative
+ *    record, or an ambiguous one never lands here — those are evidence and
+ *    CPU-completeness facts, gated separately.
+ *  - `evidence_missing_count` / `evidence_ambiguous_count` — authoritative
+ *    records that never arrived or did not resolve to exactly one
+ *    correlatable event.
+ *  - `finite_cpu_sample_count` — successful invocations carrying a finite
+ *    CPU measurement (the quantile sample pool).
+ *  - `outcome_histogram` — canonical outcomes over authoritative events.
+ */
+export interface WorkloadCeilingExecutionAssessment {
+  readonly authoritative_event_count: number;
+  readonly execution_failure_count: number;
+  readonly evidence_missing_count: number;
+  readonly evidence_ambiguous_count: number;
+  readonly finite_cpu_sample_count: number;
+  readonly outcome_histogram: Readonly<Record<string, number>>;
+}
+
+/** Pure. The shared three-way assessment described above. */
+export function assessWorkloadCeilingExecution(
+  events: readonly WorkloadCeilingRawEvent[],
+): WorkloadCeilingExecutionAssessment {
+  const histogram: Record<string, number> = {};
+  let authoritative = 0;
+  let failures = 0;
+  let missing = 0;
+  let ambiguous = 0;
+  let finiteCpu = 0;
+  for (const event of events) {
+    if (event.evidence.status === "missing") {
+      missing += 1;
+      continue;
+    }
+    if (event.evidence.status === "ambiguous") {
+      ambiguous += 1;
+      continue;
+    }
+    authoritative += 1;
+    histogram[event.outcome!] = (histogram[event.outcome!] ?? 0) + 1;
+    if (event.outcome !== WORKLOAD_CEILING_SUCCESS_OUTCOME) {
+      failures += 1;
+      continue;
+    }
+    if (event.cpu_ms !== null && Number.isFinite(event.cpu_ms)) {
+      finiteCpu += 1;
+    }
+  }
+  return {
+    authoritative_event_count: authoritative,
+    execution_failure_count: failures,
+    evidence_missing_count: missing,
+    evidence_ambiguous_count: ambiguous,
+    finite_cpu_sample_count: finiteCpu,
+    outcome_histogram: histogram,
+  };
+}
+
+/**
+ * One side of one cell, reduced to the statistics a matched comparison joins
+ * on. `p50` is the paired value; `dispersion` travels with it so a reader can
+ * see whether the two sides' medians are separated by more than their own
+ * spread.
+ *
+ * `sample_count` is reported rather than gated: the preregistered
+ * `cpu_sample_floor_per_cell` is owned by `workload-ceiling-aggregate.ts`,
+ * and a second copy of that gate here would be a second thing to keep in
+ * sync. What this module guarantees is only that the count is nonzero and
+ * visible in the persisted report.
+ */
+export interface WorkloadCeilingCellStatistic {
+  readonly scenario_id: string;
+  /** Invocations collected for this (cell, side), before any gate. */
+  readonly collected_event_count: number;
+  /** Finite-CPU successful invocations — the pool `p50` and `dispersion` summarize. */
+  readonly sample_count: number;
+  /**
+   * That pool, in collection order. Persisted because it is what every number
+   * on this side rests on, and because the pooled report quantiles are taken
+   * over these rather than over the per-cell p50s — a p99 across four cell
+   * medians is just the largest of four numbers.
+   */
+  readonly cpu_ms_samples: readonly number[];
+  readonly p50: QuantileEstimate;
+  readonly dispersion: DispersionEstimate;
+  /** The one deployment every event on this side that resolved a version named. */
+  readonly deployment_key: string;
+}
+
 export interface WorkloadCeilingComparisonPair {
   readonly scenario_id: string;
-  readonly control: ResolvedWorkloadCeilingRawEvent;
-  readonly candidate: ResolvedWorkloadCeilingRawEvent;
+  readonly control: WorkloadCeilingCellStatistic;
+  readonly candidate: WorkloadCeilingCellStatistic;
 }
 
 export interface WorkloadCeilingIncompletePair {
   readonly scenario_id: string;
+  /**
+   * `mixed-deployment-within-side` is the redeploy-mid-capture case: one
+   * side's own events name two runtime builds, so the side has no single
+   * deployment to compare against the other. `unresolved-cpu` is now a
+   * property of the SIDE, not of one event — it means the side produced zero
+   * finite-CPU successful invocations, so there is nothing to take a p50 of.
+   */
   readonly reason:
     | "missing-control"
     | "missing-candidate"
-    | "duplicate-scenario"
+    | "mixed-deployment-within-side"
     | "deployment-metadata-mismatch"
     | "unresolved-cpu";
 }
@@ -89,58 +236,103 @@ export interface WorkloadCeilingMatchedComparison {
   readonly incomplete: readonly WorkloadCeilingIncompletePair[];
 }
 
-function indexByScenario(
+/** Groups a side's events by `scenario_id`, preserving collection order within a cell. */
+function groupByScenario(
   events: readonly WorkloadCeilingRawEvent[],
-  incomplete: WorkloadCeilingIncompletePair[],
-): Map<string, WorkloadCeilingRawEvent> {
-  const byScenario = new Map<string, WorkloadCeilingRawEvent>();
-  const duplicates = new Set<string>();
+): Map<string, WorkloadCeilingRawEvent[]> {
+  const byScenario = new Map<string, WorkloadCeilingRawEvent[]>();
   for (const event of events) {
-    if (byScenario.has(event.scenario_id)) {
-      duplicates.add(event.scenario_id);
+    const bucket = byScenario.get(event.scenario_id);
+    if (bucket === undefined) {
+      byScenario.set(event.scenario_id, [event]);
       continue;
     }
-    byScenario.set(event.scenario_id, event);
-  }
-  for (const scenarioId of duplicates) {
-    byScenario.delete(scenarioId);
-    incomplete.push({ scenario_id: scenarioId, reason: "duplicate-scenario" });
+    bucket.push(event);
   }
   return byScenario;
 }
 
 /**
- * Pure. Joins by `scenario_id`, then by deployment metadata, then requires
- * both sides to satisfy {@link isResolvedOk}. Every rejection is reported by
- * name — this function never drops a scenario silently.
+ * The distinct deployments a side's events name. Events whose evidence never
+ * resolved carry the `unresolved` sentinel rather than a version, so they are
+ * skipped — see {@link hasResolvedDeployment}.
+ */
+const deploymentsNamedBy = (events: readonly WorkloadCeilingRawEvent[]): Set<string> =>
+  new Set(events.filter(hasResolvedDeployment).map(deploymentKey));
+
+/**
+ * Pure. Reduces one side of one cell to its statistic, or returns the
+ * rejection reason literal explaining why it has none.
+ */
+function summarizeCellSide(
+  scenarioId: string,
+  events: readonly WorkloadCeilingRawEvent[],
+): WorkloadCeilingCellStatistic | "mixed-deployment-within-side" | "unresolved-cpu" {
+  const deployments = deploymentsNamedBy(events);
+  if (deployments.size > 1) {
+    return "mixed-deployment-within-side";
+  }
+  const samples = events.filter(isResolvedOk).map((event) => event.cpu_ms);
+  if (samples.length === 0 || deployments.size === 0) {
+    return "unresolved-cpu";
+  }
+  return {
+    scenario_id: scenarioId,
+    collected_event_count: events.length,
+    sample_count: samples.length,
+    cpu_ms_samples: samples,
+    p50: quantileEstimate(samples, 0.5, "quantile-r7-v1"),
+    dispersion: madEstimate(samples),
+    deployment_key: [...deployments][0]!,
+  };
+}
+
+/**
+ * Pure. Groups each side's events by `scenario_id`, reduces each (cell, side)
+ * to a {@link WorkloadCeilingCellStatistic}, and joins the two sides by
+ * scenario and deployment. Every rejection is reported by name — this
+ * function never drops a scenario silently.
+ *
+ * Gate order per scenario: both sides present → each side names one
+ * deployment → each side has at least one CPU sample → the two sides name the
+ * SAME deployment.
  */
 export function matchWorkloadCeilingEvents(
   controlEvents: readonly WorkloadCeilingRawEvent[],
   candidateEvents: readonly WorkloadCeilingRawEvent[],
 ): WorkloadCeilingMatchedComparison {
   const incomplete: WorkloadCeilingIncompletePair[] = [];
-  const controlByScenario = indexByScenario(controlEvents, incomplete);
-  const candidateByScenario = indexByScenario(candidateEvents, incomplete);
+  const controlByScenario = groupByScenario(controlEvents);
+  const candidateByScenario = groupByScenario(candidateEvents);
 
   const scenarioIds = new Set([...controlByScenario.keys(), ...candidateByScenario.keys()]);
   const pairs: WorkloadCeilingComparisonPair[] = [];
   for (const scenarioId of [...scenarioIds].toSorted()) {
-    const control = controlByScenario.get(scenarioId);
-    const candidate = candidateByScenario.get(scenarioId);
-    if (control === undefined) {
+    const controlSide = controlByScenario.get(scenarioId);
+    const candidateSide = candidateByScenario.get(scenarioId);
+    if (controlSide === undefined) {
       incomplete.push({ scenario_id: scenarioId, reason: "missing-control" });
       continue;
     }
-    if (candidate === undefined) {
+    if (candidateSide === undefined) {
       incomplete.push({ scenario_id: scenarioId, reason: "missing-candidate" });
       continue;
     }
-    if (deploymentKey(control) !== deploymentKey(candidate)) {
-      incomplete.push({ scenario_id: scenarioId, reason: "deployment-metadata-mismatch" });
+    const control = summarizeCellSide(scenarioId, controlSide);
+    const candidate = summarizeCellSide(scenarioId, candidateSide);
+    if (typeof control === "string" || typeof candidate === "string") {
+      // A side that named two deployments is reported as such even when the
+      // other side merely lacks samples: a redeploy mid-capture is the more
+      // actionable fact, and it explains the missing samples often enough.
+      const reason =
+        control === "mixed-deployment-within-side" || candidate === "mixed-deployment-within-side"
+          ? "mixed-deployment-within-side"
+          : "unresolved-cpu";
+      incomplete.push({ scenario_id: scenarioId, reason });
       continue;
     }
-    if (!isResolvedOk(control) || !isResolvedOk(candidate)) {
-      incomplete.push({ scenario_id: scenarioId, reason: "unresolved-cpu" });
+    if (control.deployment_key !== candidate.deployment_key) {
+      incomplete.push({ scenario_id: scenarioId, reason: "deployment-metadata-mismatch" });
       continue;
     }
     pairs.push({ scenario_id: scenarioId, control, candidate });
@@ -152,18 +344,21 @@ export function matchWorkloadCeilingEvents(
 }
 
 /**
- * A side of the comparison whose collected events include at least one
- * invocation that did not resolve to a usable measurement — either
- * `cpu_ms: null`, or a non-success outcome that still carried a partial CPU
- * number (see {@link isResolvedOk}). The zero-failure Clopper-Pearson
- * formula (`1 − c^(1/n)`) is valid only at zero observed failures: `n`
- * counts successes, so plugging any success-count-derived denominator in
- * at F > 0 is anti-conservative (more failures would TIGHTEN the bound —
- * the opposite of the intended failure-budget reading), and the general
- * F > 0 bound needs a Beta inverse (bisection over the Binomial CDF),
- * deliberately out of scope for a bench tool. Reported by name — never
- * dropped silently, and never filled in with a number the formula cannot
- * honestly produce.
+ * A side of the comparison whose authoritative events include at least one
+ * invocation the platform classified as a non-success outcome (e.g.
+ * `exceededCpu` — which can still carry a partial CPU number; see
+ * {@link isResolvedOk}). The zero-failure Clopper-Pearson formula
+ * (`1 − c^(1/n)`) is valid only at zero observed failures: `n` counts
+ * successes, so plugging any success-count-derived denominator in at F > 0
+ * is anti-conservative (more failures would TIGHTEN the bound — the opposite
+ * of the intended failure-budget reading), and the general F > 0 bound needs
+ * a Beta inverse (bisection over the Binomial CDF), deliberately out of scope
+ * for a bench tool. Reported by name — never dropped silently, and never
+ * filled in with a number the formula cannot honestly produce.
+ *
+ * Evidence missingness does NOT land here (see
+ * {@link assessWorkloadCeilingExecution}): a missing authoritative record is
+ * not an execution failure. It blocks evidence completeness instead.
  */
 export interface WorkloadCeilingZeroFailureBoundInvalid {
   readonly invalid: "failures-present";
@@ -176,9 +371,28 @@ export type WorkloadCeilingZeroFailureBound =
   | WorkloadCeilingZeroFailureBoundInvalid;
 
 export interface WorkloadCeilingComparisonReport {
+  /** Paired CELLS, not paired invocations — see the module header. */
   readonly pair_count: number;
   readonly incomplete_count: number;
   readonly incomplete: readonly WorkloadCeilingIncompletePair[];
+  /**
+   * The per-cell statistics the ratio below is computed from, persisted so a
+   * reader can see which cells carried the comparison and on how many samples
+   * each side rests.
+   */
+  readonly pairs: readonly WorkloadCeilingComparisonPair[];
+  /**
+   * Quantiles over the POOLED finite-CPU samples of every paired cell on this
+   * side — a mixture across cells of different sizes, deliberately: it is the
+   * "how expensive does an invocation get anywhere in the matrix"
+   * distribution the budget line is read against. The per-cell view is
+   * `pairs`; nothing here is a per-cell estimate.
+   *
+   * Samples from a cell that failed to pair are excluded, because the whole
+   * report describes the matched comparison — an unmatched cell must not move
+   * a number the matched sides are compared on. Those invocations still count
+   * against `zero_failure_upper_bound`, which is assessed over every attempt.
+   */
   readonly control_cpu_ms: {
     readonly p50: QuantileEstimate;
     readonly p95: QuantileEstimate;
@@ -192,11 +406,12 @@ export interface WorkloadCeilingComparisonReport {
   readonly paired_candidate_over_control_ratio: BootstrapResult<"paired-ratio-bootstrap-v1">;
   /**
    * Over ALL collected events on each side, including incomplete/unresolved
-   * ones — the study's failure budget. Valid ONLY for a side on which every
-   * event satisfies {@link isResolvedOk}: a side with ≥ 1 failure carries
-   * `{ invalid: "failures-present", failure_count }` instead of a bound
-   * (see {@link WorkloadCeilingZeroFailureBoundInvalid} for why the
-   * zero-failure formula has no honest F > 0 reading).
+   * ones — but split per evidence-contract v2: the bound is computed over
+   * AUTHORITATIVE events only (invocations whose execution outcome the
+   * platform actually reported), and it is invalidated by real execution
+   * failures, never by evidence missingness. Valid ONLY for a side with zero
+   * execution failures: a side with ≥ 1 carries
+   * `{ invalid: "failures-present", failure_count }` instead of a bound.
    */
   readonly zero_failure_upper_bound: {
     readonly control: WorkloadCeilingZeroFailureBound;
@@ -211,20 +426,24 @@ const quantiles = (values: readonly number[]) => ({
 });
 
 /**
- * Per-side failure-budget assessment. F = 0 → the exact one-sided
- * zero-failure bound (attempts clamped to ≥ 1 so an empty event list still
- * yields the maximally-wide n = 1 bound rather than throwing); F > 0 → the
- * explicit invalidity marker, never an anti-conservative number.
+ * Per-side execution assessment. F = 0 → the exact one-sided zero-failure
+ * bound over the AUTHORITATIVE event count (clamped to ≥ 1 so an empty event
+ * list still yields the maximally-wide n = 1 bound rather than throwing;
+ * evidence-missing events contribute neither a trial nor a success); F > 0 →
+ * the explicit invalidity marker, never an anti-conservative number.
  */
 const zeroFailureUpperBound = (
   events: readonly WorkloadCeilingRawEvent[],
   confidence: number,
 ): WorkloadCeilingZeroFailureBound => {
-  const failures = events.filter((event) => !isResolvedOk(event)).length;
-  if (failures > 0) {
-    return { invalid: "failures-present", failure_count: failures };
+  const assessment = assessWorkloadCeilingExecution(events);
+  if (assessment.execution_failure_count > 0) {
+    return { invalid: "failures-present", failure_count: assessment.execution_failure_count };
   }
-  return clopperPearsonZeroFailureUpper(Math.max(1, events.length), confidence);
+  return clopperPearsonZeroFailureUpper(
+    Math.max(1, assessment.authoritative_event_count),
+    confidence,
+  );
 };
 
 /**
@@ -234,6 +453,10 @@ const zeroFailureUpperBound = (
  * matching, so a run that failed to resolve on one side still counts
  * against that side: it surfaces there as an explicit failures-present
  * marker, since the zero-failure bound itself is only computed at F = 0.
+ *
+ * The bootstrap resamples CELLS. `inclusion_unit` says so, and it is the
+ * honest unit: the two arms are independent samples within a cell, so the
+ * per-cell p50 ratio is the only quantity that is actually paired.
  */
 export function buildWorkloadCeilingComparisonReport(input: {
   readonly matched: WorkloadCeilingMatchedComparison;
@@ -247,25 +470,24 @@ export function buildWorkloadCeilingComparisonReport(input: {
   if (matched.pairs.length === 0) {
     throw new WorkloadCeilingHarnessError("pairs", "no complete pairs to compare");
   }
-  const controlValues = matched.pairs.map((pair) => pair.control.cpu_ms);
-  const candidateValues = matched.pairs.map((pair) => pair.candidate.cpu_ms);
   const pairedValues: PairedValue[] = matched.pairs.map((pair) => ({
     pair_id: pair.scenario_id,
-    baseline: pair.control.cpu_ms,
-    candidate: pair.candidate.cpu_ms,
+    baseline: pair.control.p50.value,
+    candidate: pair.candidate.p50.value,
   }));
 
   return {
     pair_count: matched.pairs.length,
     incomplete_count: matched.incomplete.length,
     incomplete: matched.incomplete,
-    control_cpu_ms: quantiles(controlValues),
-    candidate_cpu_ms: quantiles(candidateValues),
+    pairs: matched.pairs,
+    control_cpu_ms: quantiles(matched.pairs.flatMap((pair) => pair.control.cpu_ms_samples)),
+    candidate_cpu_ms: quantiles(matched.pairs.flatMap((pair) => pair.candidate.cpu_ms_samples)),
     paired_candidate_over_control_ratio: pairedRatioBootstrap(pairedValues, {
       seed: input.seed,
       resamples: input.resamples,
       confidence: input.confidence,
-      inclusion_unit: "complete-pair",
+      inclusion_unit: "complete-pair-cell",
     }),
     zero_failure_upper_bound: {
       control: zeroFailureUpperBound(input.controlEvents, input.confidence),
@@ -349,7 +571,13 @@ async function main(): Promise<number> {
     resamples: Number(process.env["WORKLOAD_CEILING_BOOTSTRAP_RESAMPLES"] ?? 2000),
   });
 
-  console.log(`pairs: ${report.pair_count}, incomplete: ${report.incomplete_count}`);
+  console.log(`paired cells: ${report.pair_count}, incomplete: ${report.incomplete_count}`);
+  for (const pair of report.pairs) {
+    console.log(
+      `  ${pair.scenario_id}: control p50=${pair.control.p50.value} (n=${pair.control.sample_count}) ` +
+        `candidate p50=${pair.candidate.p50.value} (n=${pair.candidate.sample_count})`,
+    );
+  }
   console.log(
     `control cpu_ms p50/p95/p99: ${report.control_cpu_ms.p50.value}/${report.control_cpu_ms.p95.value}/${report.control_cpu_ms.p99.value}`,
   );


### PR DESCRIPTION
Refs #160. Stacked on #161 — review that first, and the diff shown here is against it.

## What & why

The paired unit is a CELL, not an invocation. The capture runner emits `planned_measured_invocations_per_cell` invocations per cell per arm, all carrying that cell's single `scenario_id`, so each side of a scenario arrives as a sample. `matchWorkloadCeilingEvents` treated a second event under one scenario as `duplicate-scenario` and rejected the pair — a real capture would have produced zero pairs after every hour it ran, and nothing would have caught it before the run. Each side is now reduced to one cell statistic (the r7 p50 over that side's finite-CPU successful invocations, plus its MAD) before joining.

Two statistics downstream of that change behavior with it. The zero-failure upper bound is now invalidated only by execution failures, with `authoritative_event_count` as its denominator, so an evidence-missing invocation no longer invalidates the side — it narrows the trial count instead. And the pooled `control_cpu_ms` / `candidate_cpu_ms` quantiles read every raw invocation across the paired cells, not the per-cell statistic, so the report carries both the paired view and the pooled distribution.

## Key points

- Suffixing the scenario id per invocation was rejected: it satisfies the pairing logic and breaks per-cell grouping downstream.
- This module groups the events itself rather than consuming the aggregate's summaries. The aggregate already imports this module, and inverting that would need a cycle plus a sweep report and journal on this CLI, which today reads only two event directories.
- Deployment agreement is checked within a side as well as across the two, because a sample has an inside: one side naming two `script_version`s is a mid-capture redeploy, reported as `mixed-deployment-within-side`.
- Events whose authoritative record never resolved are skipped by that check. Conflating unresolved telemetry with disagreeing telemetry turns a couple of missing records into a spurious "the Worker was redeployed mid-run" verdict.
- `assessWorkloadCeilingExecution` gives every consumer one three-way split of execution failure, evidence missingness, and CPU missingness, so the pairing logic and the failure-budget count cannot drift apart on what counts as a success. It reads `isResolvedOk` rather than re-implementing it, which is what that predicate's docstring promises and what keeps `finite_cpu_sample_count` equal to `events.filter(isResolvedOk).length`.
- The evidence-status dispatch is an exhaustive switch. The earlier fall-through treated any status that was not `missing` or `ambiguous` as authoritative, so a fourth status would enter the zero-failure denominator as a Bernoulli trial and assert a histogram entry keyed on a `null` outcome. Both defensive throws are covered: the unclassified status, and a `resolved` event carrying a `null` outcome.
- The preregistered `cpu_sample_floor_per_cell` stays owned by the aggregate; this module reports `sample_count` per side rather than duplicating the gate.
- Two module-header citations (`workload-ceiling-cells.ts`, `workload-ceiling-aggregate.ts`) resolve only once #160 lands. Rewording them for this PR and reverting later would leave the final text worse.

## Verification

| Command | Result |
| --- | --- |
| `pnpm verify:agent` | clean |
| `pnpm test:agent` | 3770 passed, 105 skipped |
| `pnpm test:adapter-cloudflare` | 162 passed, 2 skipped |
| `pnpm bundle-sizes` | ok (14 entries) |
| `pnpm build:agent` | clean |

The tests were also run against the pre-fix implementation: 10 fail, including `expected [{ scenario_id: 's1', reason: 'duplicate-scenario' }, …] to deeply equal []` — the zero-pairs failure mode this PR exists to prevent.

## Notes for reviewers

`matchWorkloadCeilingEvents` and the module header are the whole PR; the header states the cardinality contract the rest of the pipeline shares with it.

The test that plans a real capture matrix and asserts every cell pairs lands with the capture runner in #160, since it needs the runner and the cell catalog to exist.

The raw event is still not a discriminated union on `evidence.status`, which is what would make the invariant checks in `assessWorkloadCeilingExecution` unnecessary rather than merely explicit. That is a codec-shape change rippling through every consumer and the already-captured event files, so it wants its own PR: #163.

